### PR TITLE
refactor(workspace): remove legacy global Agent contribution path

### DIFF
--- a/packages/workspace/src/app/server/__tests__/createWorkspaceAgentServer.test.ts
+++ b/packages/workspace/src/app/server/__tests__/createWorkspaceAgentServer.test.ts
@@ -1094,20 +1094,118 @@ describe("createWorkspaceAgentServer plugin runtime options", () => {
     })
 
     expect(agentServerMock.captureResolvedRuntimeScope).toHaveBeenCalledTimes(1)
-    const [agentOptions] = agentServerMock.captureResolvedRuntimeScope.mock
-      .calls[0] as unknown as [
-      { pi?: { packages?: unknown[] } },
-    ]
-    // Static set: bundled @hachej/boring-pi skill (when resolvable) +
-    // factory-plugin contributions + host-supplied entries.
-    expect(agentOptions.pi?.packages).toContainEqual(
+    const [routeOptions] = agentServerMock.captureResolvedRuntimeScope.mock.calls[0] as unknown as [{
+      authorizedScope: object
+      pi?: { packages?: unknown[] }
+    }]
+    const [hostOptions] = agentServerMock.createAgentHost.mock.calls.at(-1) as unknown as [{
+      resolveDirectRuntimeScopeForTest(input: { agentTypeId: string; scope: object }): Promise<{
+        identity: string
+        pi?: { packages?: unknown[] }
+      }>
+    }]
+    // Host entries remain global; plugin entries are projected through the
+    // default Agent's normalized contribution rather than the route options.
+    expect(routeOptions.pi?.packages).toContainEqual(
       expect.objectContaining({ skills: ["skills/boring-plugin-authoring"] }),
     )
-    expect(agentOptions.pi?.packages).toContainEqual({
-      source: "npm:plugin-pi",
-      extensions: ["./a.ts", "./b.ts"],
+    expect(routeOptions.pi?.packages).toContain("npm:host-pi")
+    const runtime = await hostOptions.resolveDirectRuntimeScopeForTest({
+      agentTypeId: "default",
+      scope: routeOptions.authorizedScope,
     })
-    expect(agentOptions.pi?.packages).toContain("npm:host-pi")
+    expect(runtime.pi?.packages).toEqual([
+      expect.objectContaining({ skills: ["skills/boring-plugin-authoring"] }),
+      { source: "npm:plugin-pi", extensions: ["./a.ts", "./b.ts"] },
+      "npm:host-pi",
+    ])
+    // In the v1 standalone composition Pi package inventory lived in the
+    // global base and was not part of contribution binding identity. Compare
+    // against that portable reference shape instead of pinning an
+    // environment-sensitive digest.
+    await createWorkspaceAgentServer({
+      workspaceRoot: "/tmp/workspace-pi-forwarding",
+      logger: false,
+      provisionWorkspace: false,
+      pi: {
+        packages: [
+          "npm:host-pi",
+          { source: "npm:plugin-pi", extensions: ["./b.ts", "./a.ts"] },
+        ],
+      },
+      plugins: [{ id: "plugin-pi", contentDigest: "plugin-pi-content-v1" }],
+    })
+    const [referenceRoute] = agentServerMock.captureResolvedRuntimeScope.mock.calls.at(-1) as unknown as [{
+      authorizedScope: object
+    }]
+    const [referenceHost] = agentServerMock.createAgentHost.mock.calls.at(-1) as unknown as [{
+      resolveDirectRuntimeScopeForTest(input: { agentTypeId: string; scope: object }): Promise<{ identity: string }>
+    }]
+    const legacyReference = await referenceHost.resolveDirectRuntimeScopeForTest({
+      agentTypeId: "default",
+      scope: referenceRoute.authorizedScope,
+    })
+    expect(runtime.identity).toBe(legacyReference.identity)
+  })
+
+  test("projects defaults through the standalone Agent composition and honors exclusions", async () => {
+    const defaultTool = {
+      name: "default_tool",
+      description: "default tool",
+      parameters: { type: "object", properties: {} },
+      async execute() { return { content: [] } },
+    }
+    const defaultPlugin = {
+      id: "default-agent-plugin",
+      systemPrompt: "DEFAULT_AGENT_PROMPT",
+      agentTools: [defaultTool],
+      piPackages: ["npm:default-agent"],
+      extensionPaths: ["/plugins/default-agent.ts"],
+      skills: [{ name: "default-skill", source: "/plugins/default-skill" }],
+    }
+    const resolve = async (excludeDefaults: string[] = []) => {
+      await createWorkspaceAgentServer({
+        workspaceRoot: await makeTempDir("boring-default-agent-projection-"),
+        logger: false,
+        provisionWorkspace: false,
+        externalPlugins: false,
+        defaults: [defaultPlugin],
+        excludeDefaults,
+        piResourceAuthorizedRoots: ["/plugins"],
+      })
+      const [routeOptions] = agentServerMock.captureResolvedRuntimeScope.mock.calls.at(-1) as unknown as [{
+        authorizedScope: object
+      }]
+      const [hostOptions] = agentServerMock.createAgentHost.mock.calls.at(-1) as unknown as [{
+        resolveDirectRuntimeScopeForTest(input: { agentTypeId: string; scope: object }): Promise<{
+          extraTools?: Array<{ name: string }>
+          systemPromptAppend?: string
+          pi?: {
+            packages?: unknown[]
+            extensionPaths?: string[]
+            getHotReloadableResources?(): { additionalSkillPaths?: string[] }
+          }
+        }>
+      }]
+      return await hostOptions.resolveDirectRuntimeScopeForTest({
+        agentTypeId: "default",
+        scope: routeOptions.authorizedScope,
+      })
+    }
+
+    const included = await resolve()
+    expect(included.extraTools?.map((tool) => tool.name)).toContain("default_tool")
+    expect(included.systemPromptAppend).toContain("DEFAULT_AGENT_PROMPT")
+    expect(included.pi?.packages).toContain("npm:default-agent")
+    expect(included.pi?.extensionPaths).toContain("/plugins/default-agent.ts")
+    expect(included.pi?.getHotReloadableResources?.().additionalSkillPaths
+      ?.some((path) => path.includes("default-agent-plugin/default-skill"))).toBe(true)
+
+    const excluded = await resolve(["default-agent-plugin"])
+    expect(excluded.extraTools?.map((tool) => tool.name) ?? []).not.toContain("default_tool")
+    expect(excluded.systemPromptAppend ?? "").not.toContain("DEFAULT_AGENT_PROMPT")
+    expect(excluded.pi?.packages ?? []).not.toContain("npm:default-agent")
+    expect(excluded.pi?.extensionPaths ?? []).not.toContain("/plugins/default-agent.ts")
   })
 
   test("getHotReloadableResources reflects package.json#pi changes between calls", async () => {
@@ -2559,7 +2657,11 @@ describe("beforeReload triggers directory-source re-resolve", () => {
 
     try {
       const [runtime] = agentServerMock.captureResolvedRuntimeScope.mock.calls.at(-1) as unknown as [{
-        getFilesystemBindings?(ctx: { scope: { workspaceScopeId: string; authSubjectId: string }; requestId: string }): Promise<Array<{ filesystem: string }> | undefined>
+        applyReload?(): Promise<void>
+        getFilesystemBindings?(ctx: { scope: { workspaceScopeId: string; authSubjectId: string }; requestId: string }): Promise<Array<{
+          filesystem: string
+          operations: { read(input: { filesystem: string; path: string }): Promise<{ content: string }> }
+        }> | undefined>
         getSkillResourceSnapshot?(ctx: { scope: { workspaceScopeId: string; authSubjectId: string }; requestId: string }): Promise<{
           generation: string
           managedSkills: Array<{ name: string; resource: { filesystem: string; path: string } }>

--- a/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
+++ b/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
@@ -58,7 +58,7 @@ import {
 import Fastify, { type FastifyInstance, type FastifyRequest } from "fastify"
 import { existsSync, lstatSync, mkdirSync, readFileSync, readdirSync } from "node:fs"
 import { createHash } from "node:crypto"
-import { basename, dirname, isAbsolute, join, posix, resolve } from "node:path"
+import { basename, dirname, isAbsolute, join, resolve } from "node:path"
 import { homedir } from "node:os"
 import { createRequire } from "node:module"
 import { fileURLToPath } from "node:url"
@@ -121,8 +121,8 @@ import {
   discoverPackageResourceRecords,
   enumerateExternalSkillFiles,
   packageResourceHandlesPath,
-  packageResourceSystemPrompt,
   resolveWorkspacePackageResourceSnapshot,
+  selectAgentPackageResourceView,
   type ResolvedWorkspacePackageResourceRegistry,
 } from "../../server/plugins/packageResources"
 
@@ -600,6 +600,8 @@ interface NormalizedAgentRuntimeContribution {
   readonly runtimePlugins: readonly WorkspaceRuntimeProvisioningInput[]
   readonly agentOptions: AgentSpecPluginArtifactProjection["agentOptions"]
   readonly includeAllDiscoveredPluginResources: boolean
+  /** Preserves persisted runtime pins from the pre-normalization standalone host. */
+  readonly standaloneIdentityV1: boolean
 }
 
 export const AGENT_RUNTIME_IDENTITY_ERROR_CODE = "BORING_AGENT_RUNTIME_IDENTITY_INCOMPLETE"
@@ -777,6 +779,7 @@ export function projectAgentSpecPluginArtifacts(
   agent: AgentHostAgentSpec,
   artifacts: readonly ResolvedWorkspacePluginArtifact[],
   workspaceScopedArtifacts: readonly ResolvedWorkspacePluginArtifact[] = [],
+  defaultPlugins: Pick<ServerBootstrapOptions, "defaults" | "excludeDefaults"> = {},
 ): AgentSpecPluginArtifactProjection {
   const byId = new Map<string, ResolvedWorkspacePluginArtifact>()
   for (const artifact of artifacts) {
@@ -786,12 +789,13 @@ export function projectAgentSpecPluginArtifacts(
     byId.set(artifact.id, artifact)
   }
 
-  const requested = "legacyDefault" in agent ? [] : (agent.plugins ?? [])
-  const selected: ResolvedWorkspacePluginArtifact[] = []
-  const selectedIds = new Set<string>()
+  const selectAll = "legacyDefault" in agent
+  const requested = selectAll ? [] : (agent.plugins ?? [])
+  const selected: ResolvedWorkspacePluginArtifact[] = selectAll ? [...artifacts] : []
+  const selectedIds = new Set(selected.map((artifact) => artifact.id))
   const workspaceScopedIds = new Set(workspaceScopedArtifacts.map((artifact) => artifact.id))
   const requestedIds = new Set<string>()
-  for (const artifact of workspaceScopedArtifacts) {
+  for (const artifact of selectAll ? [] : workspaceScopedArtifacts) {
     if (selectedIds.has(artifact.id)) continue
     const canonical = byId.get(artifact.id)
     if (!canonical) {
@@ -818,7 +822,10 @@ export function projectAgentSpecPluginArtifacts(
     selected.push(artifact)
   }
 
-  const projected = bootstrapServer({ plugins: selected.map((artifact) => artifact.plugin) })
+  const projected = bootstrapServer({
+    ...(selectAll ? defaultPlugins : {}),
+    plugins: selected.map((artifact) => artifact.plugin),
+  })
   return {
     artifacts: selected,
     runtimePlugins: projected.runtimePlugins,
@@ -1243,11 +1250,6 @@ export async function createWorkspaceAgentServer(
   const readonlyWorkspacePolicy = resolvedReadonlyWorkspacePaths.length > 0
     ? normalizeRuntimeReadonlyFilesystemPolicy(resolvedReadonlyWorkspacePaths)
     : undefined
-  // Resolved early: `legacyGlobalPluginAgentContributions` below must key off
-  // the RESOLVED fleet, not `opts.agents`'s presence — with BORING_AGENT_FLEET=1
-  // and no explicit `opts.agents`, the resolved fleet has 6 agents even though
-  // the option was omitted, and must not inherit the legacy global-contribution
-  // route shape (gh-1106 slice 3 fix round 1, M3).
   // Everything fleet-related stays behind the flag check, including the
   // `process.cwd()` fallback: with BORING_AGENT_FLEET unset this seam must do
   // no eager work at all (gh-1107 slice 1 fix round: flag-off purity).
@@ -1266,7 +1268,7 @@ export async function createWorkspaceAgentServer(
     workspaceRoot,
     ...(discoveredPackages ? { discoveredPackages } : {}),
   })
-  const isLegacyDefaultFleet = agents.length === 1 && "legacyDefault" in agents[0]!
+  const standaloneDefaultIdentityV1 = agents.length === 1 && "legacyDefault" in agents[0]!
   const bridge = createInMemoryBridge()
   const resolvedMode = opts.runtimeModeAdapter?.id ?? opts.mode ?? autoDetectMode()
   const modeAdapter = opts.runtimeModeAdapter ?? createSandboxRuntimeModeAdapter(
@@ -1317,11 +1319,6 @@ export async function createWorkspaceAgentServer(
     installPluginAuthoring: pluginAuthoringEnabled,
   })
   const defaultPluginPackagePaths = pluginCollection.defaultPluginPackagePaths
-  // The legacy one-Agent composition (no explicit fleet, flag off) keeps its
-  // route options byte-for-byte compatible; any resolved multi-agent fleet
-  // (explicit `opts.agents`, or BORING_AGENT_FLEET=1) is scoped per Agent.
-  // Keyed off the RESOLVED fleet, not `opts.agents`'s presence (M3 fix).
-  const legacyGlobalPluginAgentContributions = isLegacyDefaultFleet
   const ctx: WorkspaceAgentServerPluginContext = { workspaceRoot, bridge }
   const allPluginEntries: WorkspacePluginEntry[] = [
     ...defaultPluginPackagePaths
@@ -1340,25 +1337,16 @@ export async function createWorkspaceAgentServer(
   })
 
   // Static app resources are global to every Agent. Plugin Agent resources are
-  // added later from the app-owned normalized contribution for that Agent.
-  // Plugin package.json#pi resources remain dynamic for legacyDefault only.
+  // added later from the normalized contribution for that Agent.
   const workspacePackagePiPackage = pluginAuthoringEnabled ? createBoringPiPackageSource(workspaceRoot) : undefined
   const builtInBoringPiSkillPaths = pluginAuthoringEnabled ? resolveBoringPiSkillPaths(workspaceRoot) : []
   const baseStaticPiSkillPaths = [
     ...builtInBoringPiSkillPaths,
-    ...(legacyGlobalPluginAgentContributions
-      ? pluginCollection.agentOptions.pi?.additionalSkillPaths ?? []
-      : [join(workspaceRoot, ".agents", "skills"), ...(opts.pi?.additionalSkillPaths ?? [])]),
+    join(workspaceRoot, ".agents", "skills"),
+    ...(opts.pi?.additionalSkillPaths ?? []),
   ]
-  const baseStaticPiPackages = [
-    workspacePackagePiPackage,
-    ...(legacyGlobalPluginAgentContributions
-      ? pluginCollection.agentOptions.pi?.packages ?? []
-      : opts.pi?.packages ?? []),
-  ]
-  const baseStaticPiExtensionPaths = legacyGlobalPluginAgentContributions
-    ? pluginCollection.agentOptions.pi?.extensionPaths ?? []
-    : opts.pi?.extensionPaths ?? []
+  const baseStaticPiPackages = [workspacePackagePiPackage, ...(opts.pi?.packages ?? [])]
+  const baseStaticPiExtensionPaths = opts.pi?.extensionPaths ?? []
 
   // Boring plugin discovery: scan external workspace/global extension
   // collections plus internal app/plugin-provided sources. Source kind is
@@ -1384,21 +1372,16 @@ export async function createWorkspaceAgentServer(
   // arrays the harness already captured.
   interface PackageResourceSnapshot {
     readonly registry: ResolvedWorkspacePackageResourceRegistry
-    readonly binding?: RuntimeFilesystemBinding
+    readonly diagnostics: readonly { source: string; message: string; pluginId?: string }[]
   }
   let currentPackageResourceSnapshot: PackageResourceSnapshot | undefined
   let packageResourceDiagnostics: Array<{ source: string; message: string; pluginId?: string }> = []
-  // Always empty: the dynamic package.json#pi snapshot is resolved per-reload
-  // via getHotReloadablePiResources instead. Kept only so the static prompt
-  // concatenation below has a stable (currently absent) systemPromptAppend slot.
-  const staticPluginPackagePiSnapshot = emptyPackageJsonPiSnapshot()
   const staticPiSkillPaths = [...baseStaticPiSkillPaths]
   const staticPiPackages = compactPiPackages(baseStaticPiPackages)
   const staticPiExtensionPaths = [...baseStaticPiExtensionPaths]
 
-  const getHotReloadablePiResources = () => {
+  const getHotReloadablePiResources = (registry = currentPackageResourceSnapshot?.registry) => {
     const discovered = readWorkspacePluginPackagePiSnapshot(refreshBoringPluginDirs())
-    const registry = currentPackageResourceSnapshot?.registry
     return {
       ...discovered,
       additionalSkillPaths: uniqueStrings([
@@ -1497,10 +1480,8 @@ export async function createWorkspaceAgentServer(
         && canonicalDefaultPluginPackagePaths.has(resolve(artifact.entry.dir)),
       )
     : []
-  const rebuildPackageResourceRegistry = async (): Promise<void> => {
-    const ambientSkillsEnabled = (legacyGlobalPluginAgentContributions
-      ? pluginCollection.agentOptions.pi?.noSkills
-      : opts.pi?.noSkills) === false
+  const resolvePackageResourceSnapshot = async (): Promise<PackageResourceSnapshot> => {
+    const ambientSkillsEnabled = opts.pi?.noSkills === false
     const sharedSkillPaths = await enumerateExternalSkillFiles([
       ...baseStaticPiSkillPaths,
       ...(ambientSkillsEnabled ? [join(homedir(), ".pi", "agent", "skills")] : []),
@@ -1509,15 +1490,14 @@ export async function createWorkspaceAgentServer(
       declared: allPluginAgentProjection.packageResources,
       scanned: await discoverPackageResourceRecords(refreshBoringPluginDirs()),
       sharedSkillPaths,
-      createBinding: (mounts) => runtimeHost.createAgentResourceFilesystemBinding(
-        AGENT_RESOURCES_FILESYSTEM_ID,
-        mounts,
-      ),
     })
+    return snapshot
+  }
+  const commitPackageResourceSnapshot = (snapshot: PackageResourceSnapshot): void => {
     currentPackageResourceSnapshot = snapshot
     packageResourceDiagnostics = [...snapshot.diagnostics]
   }
-  await rebuildPackageResourceRegistry()
+  commitPackageResourceSnapshot(await resolvePackageResourceSnapshot())
   const normalizedRuntimeContributions = new Map<string, NormalizedAgentRuntimeContribution>()
   const resolvedFleetCompiler: AgentFleetCompiler = {
     async compile({ agents: fleet }) {
@@ -1526,26 +1506,12 @@ export async function createWorkspaceAgentServer(
         : fleet
       return compiled.map((agent) => {
         const legacyDefault = "legacyDefault" in agent
-        const projection = legacyDefault
-          ? {
-              artifacts: pluginCollection.resolvedPluginArtifacts,
-              runtimePlugins: legacyGlobalPluginAgentContributions ? [] : allPluginAgentProjection.runtimePlugins,
-              agentOptions: legacyGlobalPluginAgentContributions
-                ? { extraTools: [], systemPromptAppend: undefined, pi: {} }
-                : {
-                    extraTools: allPluginAgentProjection.agentTools,
-                    systemPromptAppend: allPluginAgentProjection.systemPromptAppend || undefined,
-                    pi: {
-                      packages: allPluginAgentProjection.piPackages,
-                      extensionPaths: allPluginAgentProjection.extensionPaths,
-                    },
-                  },
-            }
-          : projectAgentSpecPluginArtifacts(
-              agent,
-              pluginCollection.resolvedPluginArtifacts,
-              workspaceScopedDefaultArtifacts,
-            )
+        const projection = projectAgentSpecPluginArtifacts(
+          agent,
+          pluginCollection.resolvedPluginArtifacts,
+          workspaceScopedDefaultArtifacts,
+          { defaults: opts.defaults, excludeDefaults: opts.excludeDefaults },
+        )
         const pluginIds = projection.artifacts.map((artifact) => artifact.id)
         const resolvedPolicy = {
           ...("resolvedPolicy" in agent && agent.resolvedPolicy && typeof agent.resolvedPolicy === "object"
@@ -1553,17 +1519,21 @@ export async function createWorkspaceAgentServer(
             : {}),
           pluginIds,
         }
-        const includeAllDiscoveredPluginResources = legacyDefault && !legacyGlobalPluginAgentContributions
+        const includeAllDiscoveredPluginResources = legacyDefault
+        const identityProjection = standaloneDefaultIdentityV1 && legacyDefault
+          ? { artifacts: projection.artifacts, runtimePlugins: [], agentOptions: { extraTools: [], pi: {} } }
+          : projection
         normalizedRuntimeContributions.set(agent.agentTypeId, {
           ...agentRuntimeContributionIdentityInput({
             agent,
             resolvedPolicy,
-            projection,
-            includeAllDiscoveredPluginResources,
+            projection: identityProjection,
+            includeAllDiscoveredPluginResources: standaloneDefaultIdentityV1 ? false : includeAllDiscoveredPluginResources,
           }),
           runtimePlugins: projection.runtimePlugins,
           agentOptions: projection.agentOptions,
           includeAllDiscoveredPluginResources,
+          standaloneIdentityV1: standaloneDefaultIdentityV1 && legacyDefault,
         })
         return { ...agent, resolvedPolicy }
       })
@@ -1583,21 +1553,14 @@ export async function createWorkspaceAgentServer(
   const basePi: WorkspaceAgentPiOptions & {
     getHotReloadableResources?: () => WorkspacePluginPackagePiSnapshot
   } = {
-    ...(legacyGlobalPluginAgentContributions ? pluginCollection.agentOptions.pi : opts.pi),
+    ...opts.pi,
     additionalSkillPaths: staticPiSkillPaths,
     packages: staticPiPackages,
     extensionPaths: staticPiExtensionPaths,
     extensionFactories: opts.pi?.extensionFactories,
-    ...(legacyGlobalPluginAgentContributions
-      ? { getHotReloadableResources: getHotReloadablePiResources }
-      : {}),
   }
-  const baseExtraTools = [
-    ...(opts.extraTools ?? []),
-    ...uiTools,
-    ...(legacyGlobalPluginAgentContributions ? pluginCollection.agentOptions.extraTools ?? [] : []),
-  ]
-  const baseSystemPromptAppend = [
+  const baseExtraTools = [...(opts.extraTools ?? []), ...uiTools]
+  const appSystemPromptParts = [
     workspaceFsCapability === "strong" ? buildWorkspaceContextPrompt({ pluginAuthoringEnabled }) : undefined,
     pluginAuthoringEnabled ? buildBoringSystemPrompt({
       scaffoldCommand: "boring-ui-plugin scaffold",
@@ -1608,13 +1571,18 @@ export async function createWorkspaceAgentServer(
         opts.provisionWorkspace !== false,
       ),
     }) : undefined,
-    legacyGlobalPluginAgentContributions
-      ? pluginCollection.agentOptions.systemPromptAppend
-      : opts.systemPromptAppend,
-    staticPluginPackagePiSnapshot.systemPromptAppend,
+  ]
+  const baseSystemPromptAppend = [
+    ...appSystemPromptParts,
+    opts.systemPromptAppend,
+  ].filter(Boolean).join("\n\n") || undefined
+  const standaloneIdentityV1SystemPromptAppend = [
+    ...appSystemPromptParts,
+    pluginCollection.agentOptions.systemPromptAppend,
   ].filter(Boolean).join("\n\n") || undefined
   const refreshWorkspaceAgentResources = async (input?: {
     availabilityPrechecked?: boolean
+    packageResourceSnapshot?: PackageResourceSnapshot
   }): Promise<WorkspaceReloadHookResult | undefined> => {
     if (!input?.availabilityPrechecked) {
       await assertAgentReloadAvailable(pluginCollection.agentReloadBlockers)
@@ -1625,7 +1593,7 @@ export async function createWorkspaceAgentServer(
     const rebuild = await rebuildPlugins()
     let packageResourceRebuildDiagnostics: Array<{ source: string; message: string; pluginId?: string }> = []
     try {
-      await rebuildPackageResourceRegistry()
+      commitPackageResourceSnapshot(input?.packageResourceSnapshot ?? await resolvePackageResourceSnapshot())
     } catch {
       packageResourceRebuildDiagnostics = [{
         source: "package-resource-registry",
@@ -1758,11 +1726,14 @@ export async function createWorkspaceAgentServer(
             userId: verifiedClaim.authSubjectId,
             requestId,
           }) ?? []
-          const packageBinding = currentPackageResourceSnapshot?.binding
-          return [
-            ...callerBindings,
-            ...(legacyGlobalPluginAgentContributions && packageBinding ? [packageBinding] : []),
-          ]
+          const packageRegistry = currentPackageResourceSnapshot?.registry
+          const packageBinding = standaloneDefaultIdentityV1 && packageRegistry?.readonlyMounts.length
+            ? await runtimeHost.createAgentResourceFilesystemBinding(
+                AGENT_RESOURCES_FILESYSTEM_ID,
+                packageRegistry.readonlyMounts,
+              )
+            : undefined
+          return [...callerBindings, ...(packageBinding ? [packageBinding] : [])]
         },
       }
     },
@@ -1776,70 +1747,96 @@ export async function createWorkspaceAgentServer(
       scopeIssuer.context(authorizedScope)
       const contribution = normalizedRuntimeContributions.get(agentTypeId)
       if (!contribution) throw new Error(`Agent runtime contribution was not compiled: ${agentTypeId}`)
+      // Reload resolves one immutable package candidate before admission. The
+      // same candidate drives digest, prompt, locator, binding, and commit.
+      const stagedPackageResourceSnapshot = intent.operation === "reload"
+        ? await resolvePackageResourceSnapshot()
+        : undefined
+      const getEffectivePackageResourceSnapshot = () =>
+        stagedPackageResourceSnapshot ?? currentPackageResourceSnapshot
 
       const selectedSkillPaths = contribution.runtimePlugins.flatMap((plugin) =>
         (plugin.skills ?? []).map((skill) => join(runtimeLayout.skills, plugin.id, skill.name)),
       )
+      const selectedSourceSkillPaths = contribution.runtimePlugins.flatMap((plugin) =>
+        (plugin.skills ?? []).map((skill) => skill.source instanceof URL ? fileURLToPath(skill.source) : skill.source),
+      )
       const selectedPluginIds = new Set(contribution.artifacts.map((artifact) => artifact.pluginId))
-      const resourceRegistry = currentPackageResourceSnapshot?.registry
-      const selectedPackageSkills = resourceRegistry?.skills
-        .filter((skill) => skill.packageName !== "shared/pi-agent"
-          && skill.pluginIds.some((pluginId) => selectedPluginIds.has(pluginId))) ?? []
-      const agentPackageSkills = legacyGlobalPluginAgentContributions
-        ? resourceRegistry?.skills ?? []
-        : selectedPackageSkills
-      const selectedPackageSkillPaths = selectedPackageSkills.map((skill) => skill.mountRoot)
-      const agentPackageSkillByFile = new Map(agentPackageSkills.map((skill) => [skill.skillFile, skill.resource]))
-      const agentPackageMounts = [...new Map(agentPackageSkills.map((skill) => [
-        posix.dirname(skill.resource.path),
-        { logicalRoot: posix.dirname(skill.resource.path), sourceRoot: skill.mountRoot },
-      ])).values()]
-      const agentPackageBinding = legacyGlobalPluginAgentContributions
-        ? currentPackageResourceSnapshot?.binding
-        : agentPackageMounts.length > 0
-          ? await runtimeHost.createAgentResourceFilesystemBinding(AGENT_RESOURCES_FILESYSTEM_ID, agentPackageMounts)
+      const getAgentPackageResourceView = () => {
+        const registry = getEffectivePackageResourceSnapshot()?.registry
+        return registry ? selectAgentPackageResourceView(registry, {
+          pluginIds: selectedPluginIds,
+          includeAll: contribution.includeAllDiscoveredPluginResources,
+        }) : undefined
+      }
+      const createAgentPackageBinding = async () => {
+        const view = getAgentPackageResourceView()
+        return view && view.readonlyMounts.length > 0
+          ? await runtimeHost.createAgentResourceFilesystemBinding(
+              AGENT_RESOURCES_FILESYSTEM_ID,
+              view.readonlyMounts,
+            )
           : undefined
-      const agentManagedPackageSkills = agentPackageSkills.flatMap((skill) => skill.name ? [{
-        name: skill.name,
-        description: skill.description ?? "",
-        resource: skill.resource,
-        invocable: false as const,
-        source: skill.packageName,
-      }] : [])
-      const locateAgentPackageSkill = (filePath: string) => agentPackageSkillByFile.get(resolve(filePath))
-      const selectedPackagePrompt = mergePromptContents(resourceRegistry?.systemPrompts
-        .filter((prompt) => prompt.pluginIds.some((pluginId) => selectedPluginIds.has(pluginId)))
-        .map((prompt) => prompt.content) ?? [])
+      }
+      const locateAgentPackageSkill = (filePath: string) => getAgentPackageResourceView()?.locateSkill(filePath)
       const resolvedBasePi = basePi
       const selectedPi = contribution.agentOptions.pi
+      const staticPiResources = contribution.standaloneIdentityV1
+        ? {
+            packages: compactPiPackages([
+              workspacePackagePiPackage,
+              ...(selectedPi?.packages ?? []),
+              ...(basePi.packages ?? []).filter((entry) => entry !== workspacePackagePiPackage),
+            ]),
+            extensionPaths: uniqueStrings([
+              ...(selectedPi?.extensionPaths ?? []),
+              ...(basePi.extensionPaths ?? []),
+            ]),
+          }
+        : {
+            packages: compactPiPackages([
+              ...(basePi.packages ?? []),
+              ...(selectedPi?.packages ?? []),
+            ]),
+            extensionPaths: uniqueStrings([
+              ...(basePi.extensionPaths ?? []),
+              ...(selectedPi?.extensionPaths ?? []),
+            ]),
+          }
+      const identityBaseExtraTools = contribution.standaloneIdentityV1
+        ? [...baseExtraTools, ...(pluginCollection.agentOptions.extraTools ?? [])]
+        : baseExtraTools
       const baseBindingInputs = jsonIdentityValue({
-        systemPromptAppend: baseSystemPromptAppend ?? null,
+        systemPromptAppend: contribution.standaloneIdentityV1
+          ? standaloneIdentityV1SystemPromptAppend ?? null
+          : baseSystemPromptAppend ?? null,
         piHarnessPolicy: {
           noContextFiles: resolvedBasePi.noContextFiles ?? null,
           noSkills: resolvedBasePi.noSkills ?? null,
         },
-        toolContractOrder: baseExtraTools.map(toolContractDigest),
+        toolContractOrder: identityBaseExtraTools.map(toolContractDigest),
       }, "baseRuntimeBindingInputs")
       const getBaseHotResources = resolvedBasePi.getHotReloadableResources
       const getHotReloadableResources = getBaseHotResources
         || selectedSkillPaths.length > 0
-        || selectedPackageSkillPaths.length > 0
+        || getEffectivePackageResourceSnapshot()
         || contribution.includeAllDiscoveredPluginResources
         ? () => {
             const baseHot: Partial<WorkspacePluginPackagePiSnapshot> = getBaseHotResources?.() ?? {}
             const discovered = contribution.includeAllDiscoveredPluginResources
-              ? getHotReloadablePiResources()
+              ? getHotReloadablePiResources(getEffectivePackageResourceSnapshot()?.registry)
               : emptyPackageJsonPiSnapshot()
             const baseSkillPaths = (baseHot.additionalSkillPaths ?? []).filter((path) =>
               contribution.includeAllDiscoveredPluginResources || path !== runtimeLayout.skills,
             )
+            const packageView = getAgentPackageResourceView()
             return {
               ...baseHot,
               ...discovered,
               additionalSkillPaths: uniqueStrings([
                 ...baseSkillPaths,
                 ...selectedSkillPaths,
-                ...selectedPackageSkillPaths,
+                ...(packageView?.additionalSkillPaths ?? []),
                 ...discovered.additionalSkillPaths,
               ]),
               packages: compactPiPackages([
@@ -1854,14 +1851,12 @@ export async function createWorkspaceAgentServer(
           }
         : undefined
       const baseDynamicPrompt = opts.systemPromptDynamic
-      const loadSystemPromptAppend = baseDynamicPrompt || getHotReloadableResources || selectedPackagePrompt || contribution.includeAllDiscoveredPluginResources
+      const loadSystemPromptAppend = baseDynamicPrompt || getHotReloadableResources || getEffectivePackageResourceSnapshot()
         ? async () => mergePromptContents([
             await baseDynamicPrompt?.(),
             getHotReloadableResources?.().systemPromptAppend,
             contribution.includeAllDiscoveredPluginResources ? aggregatePluginPrompts(boringAssetManager) : undefined,
-            contribution.includeAllDiscoveredPluginResources && currentPackageResourceSnapshot
-              ? packageResourceSystemPrompt(currentPackageResourceSnapshot.registry)
-              : selectedPackagePrompt,
+            ...(getAgentPackageResourceView()?.systemPrompts ?? []),
           ])
         : undefined
 
@@ -1890,25 +1885,29 @@ export async function createWorkspaceAgentServer(
         .join("\n\n") || undefined
       const buildResourceDigestInput = async () => {
         const hotResources = getHotReloadableResources?.()
+        // Provisioned runtime skill paths are outputs of applyReload. Hash the
+        // admitted source paths instead so reload does not invalidate its own
+        // post-effect resource fence.
+        const packageRoots = getEffectivePackageResourceSnapshot()?.registry.handledPackageRoots ?? []
+        const digestHotSkillPaths = (hotResources?.additionalSkillPaths ?? []).filter((path) =>
+          !packageResourceHandlesPath(path, [runtimeLayout.skills, ...packageRoots]),
+        )
         const additionalSkillPaths = uniqueStrings([
             ...(resolvedBasePi.additionalSkillPaths ?? []),
             ...(selectedPi?.additionalSkillPaths ?? []),
-            ...(hotResources?.additionalSkillPaths ?? []),
+            ...selectedSourceSkillPaths,
+            ...digestHotSkillPaths,
           ])
         const packages = compactPiPackages([
-            ...(basePi.packages ?? []),
-            ...(selectedPi?.packages ?? []),
+            ...staticPiResources.packages,
             ...(hotResources?.packages ?? []),
+            ...packageRoots.map((source) => ({ source })),
           ])
         const extensionPaths = uniqueStrings([
-            ...(basePi.extensionPaths ?? []),
-            ...(selectedPi?.extensionPaths ?? []),
+            ...staticPiResources.extensionPaths,
             ...(hotResources?.extensionPaths ?? []),
           ])
-        const dynamicSystemPromptAppend = [
-          await baseDynamicPrompt?.(),
-          hotResources?.systemPromptAppend,
-        ].filter((part): part is string => Boolean(part)).join("\n\n") || undefined
+        const dynamicSystemPromptAppend = await loadSystemPromptAppend?.()
         return createPiResourceDigestInput({
           piCwd: workspaceRoot,
           noSkills: selectedPi?.noSkills ?? resolvedBasePi.noSkills,
@@ -1923,10 +1922,11 @@ export async function createWorkspaceAgentServer(
             ...defaultPluginPackagePaths,
             ...resolveBoringPluginDirs().map((source) => source.rootDir),
             runtimeLayout.skills,
+            ...selectedSourceSkillPaths,
             ...builtInBoringPiSkillPaths,
             ...[localPiPackageRoot(workspacePackagePiPackage)]
               .filter((path): path is string => Boolean(path)),
-            ...(currentPackageResourceSnapshot?.registry.handledPackageRoots ?? []),
+            ...(getEffectivePackageResourceSnapshot()?.registry.handledPackageRoots ?? []),
             ...(opts.piResourceAuthorizedRoots ?? []),
           ]),
         })
@@ -1950,16 +1950,10 @@ export async function createWorkspaceAgentServer(
             ...(resolvedBasePi.additionalSkillPaths ?? []),
             ...(selectedPi?.additionalSkillPaths ?? []),
           ]),
-          packages: compactPiPackages([
-            ...(basePi.packages ?? []),
-            ...(selectedPi?.packages ?? []),
-          ]),
-          extensionPaths: uniqueStrings([
-            ...(basePi.extensionPaths ?? []),
-            ...(selectedPi?.extensionPaths ?? []),
-          ]),
+          packages: staticPiResources.packages,
+          extensionPaths: staticPiResources.extensionPaths,
           ...(getHotReloadableResources ? { getHotReloadableResources } : {}),
-          ...(agentPackageBinding ? { locateSkillResource: locateAgentPackageSkill } : {}),
+          locateSkillResource: locateAgentPackageSkill,
         },
         extraTools: [
           ...baseExtraTools,
@@ -1975,20 +1969,17 @@ export async function createWorkspaceAgentServer(
             userId: scope.authSubjectId,
             requestId,
           }) ?? []
-          return [
-            ...callerBindings,
-            ...(agentPackageBinding ? [agentPackageBinding] : []),
-          ]
+          const packageBinding = await createAgentPackageBinding()
+          return [...callerBindings, ...(packageBinding ? [packageBinding] : [])]
         },
         getSkillResourceSnapshot: async () => {
-          const skillRegistry = currentPackageResourceSnapshot?.registry
-          if (!skillRegistry) return undefined
-          // Snapshot and binding are derived from the same selected package
-          // skills, so one Agent can never receive another Agent's locator.
+          const view = getAgentPackageResourceView()
+          if (!view) return undefined
+          const binding = await createAgentPackageBinding()
           return {
-            generation: skillRegistry.generation,
-            managedSkills: agentManagedPackageSkills,
-            locateSkill: agentPackageBinding ? locateAgentPackageSkill : () => undefined,
+            generation: view.generation,
+            managedSkills: view.managedSkills,
+            locateSkill: binding ? view.locateSkill : () => undefined,
           }
         },
         ...(intent.operation === "reload"
@@ -1996,7 +1987,10 @@ export async function createWorkspaceAgentServer(
               async applyReload(input?: { runtimeBundle: RuntimeProvisionerContext["runtimeBundle"] }) {
                 await assertAgentReloadAvailable(pluginCollection.agentReloadBlockers)
                 if (input) await runRuntimeProvisioning(input.runtimeBundle)
-                const result = await refreshWorkspaceAgentResources({ availabilityPrechecked: true })
+                const result = await refreshWorkspaceAgentResources({
+                  availabilityPrechecked: true,
+                  packageResourceSnapshot: stagedPackageResourceSnapshot,
+                })
                 return result && {
                   diagnostics: result.diagnostics,
                   restartWarnings: result.restart_warnings,

--- a/packages/workspace/src/server/__tests__/createWorkspaceAgentServer.test.ts
+++ b/packages/workspace/src/server/__tests__/createWorkspaceAgentServer.test.ts
@@ -11,6 +11,7 @@ import { mkdtemp, readFile, rm, writeFile, mkdir } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { afterEach, beforeEach, expect, test, describe } from "vitest"
+import type { AgentHarnessFactory } from "@hachej/boring-agent/server"
 import {
   collectWorkspaceAgentServerPlugins,
   createWorkspaceAgentServer,
@@ -370,8 +371,21 @@ describe("createWorkspaceAgentServer — plugin provisioning", () => {
 
       const res = await app.inject({ method: "GET", url: "/api/v1/agents/default/skills" })
       expect(res.statusCode, res.body).toBe(200)
-      const skillNames: string[] = res.json().skills.map((s: { name: string }) => s.name)
-      expect(skillNames).toContain("boring-plugin-authoring")
+      const skills = res.json().skills as Array<{
+        name: string
+        resource?: { filesystem: string; path: string }
+      }>
+      const authoring = skills.find((skill) => skill.name === "boring-plugin-authoring")
+      expect(authoring?.resource).toMatchObject({ filesystem: "agent_resources" })
+      const file = await app.inject({
+        method: "GET",
+        url: `/api/v1/files?${new URLSearchParams({
+          filesystem: authoring!.resource!.filesystem,
+          path: authoring!.resource!.path,
+        })}`,
+      })
+      expect(file.statusCode, file.body).toBe(200)
+      expect(file.json().content).toContain("boring-plugin-authoring")
     } finally {
       await app.close()
     }
@@ -476,6 +490,173 @@ describe("createWorkspaceAgentServer — plugin provisioning", () => {
       await app.close()
     }
   }, 15_000)
+
+  test("reload atomically admits package skill and prompt changes through the Host fence", async () => {
+    const workspaceRoot = await makeTempDir("boring-package-resource-route-reload-")
+    const packageRoot = await makeTempDir("boring-package-resource-source-")
+    const writeManifest = async (skills: string[], systemPrompt: string) => {
+      await writeFile(join(packageRoot, "package.json"), JSON.stringify({
+        name: "@example/reload-resource",
+        pi: { skills, systemPrompt },
+      }), "utf8")
+    }
+    await mkdir(join(packageRoot, "skills", "authoring"), { recursive: true })
+    await writeFile(join(packageRoot, "skills", "authoring", "SKILL.md"), [
+      "---",
+      "name: reload-authoring",
+      "description: Initial package skill.",
+      "---",
+      "# Authoring",
+    ].join("\n"), "utf8")
+    await writeManifest(["skills/authoring"], "Initial package prompt.")
+
+    const sessions = new Map<string, {
+      id: string
+      title: string
+      createdAt: string
+      updatedAt: string
+      turnCount: number
+    }>()
+    let activeSystemPrompt = ""
+    const harnessFactory: AgentHarnessFactory = async (input) => {
+      const refreshPrompt = async () => {
+        activeSystemPrompt = [input.systemPromptAppend, await input.systemPromptDynamic?.()]
+          .filter(Boolean)
+          .join("\n\n")
+      }
+      await refreshPrompt()
+      return {
+        id: "package-resource-reload-harness",
+        placement: "server" as const,
+        sessions: {
+          async list() { return [...sessions.values()] },
+          async create(_ctx: unknown, init?: { title?: string }) {
+            const now = new Date().toISOString()
+            const session = {
+              id: `session-${sessions.size + 1}`,
+              title: init?.title ?? "Untitled",
+              createdAt: now,
+              updatedAt: now,
+              turnCount: 0,
+            }
+            sessions.set(session.id, session)
+            return session
+          },
+          async load(_ctx: unknown, sessionId: string) {
+            const session = sessions.get(sessionId)
+            if (!session) throw new Error("session not found")
+            return { ...session, messages: [] }
+          },
+          async delete(_ctx: unknown, sessionId: string) { sessions.delete(sessionId) },
+        },
+        getSystemPrompt() { return activeSystemPrompt },
+        async reloadSession() { await refreshPrompt(); return true },
+        async getSlashCommands() { return [] },
+        async *sendMessage() {},
+      }
+    }
+
+    const app = await createWorkspaceAgentServer({
+      workspaceRoot,
+      mode: "direct",
+      logger: false,
+      harnessFactory,
+      plugins: [serverApi.defineServerPlugin({
+        id: "reload-package-resource",
+        contentDigest: "reload-package-resource-v1",
+        packageResources: [{
+          packageName: "@example/reload-resource",
+          packageRoot,
+        }],
+      })],
+    })
+
+    try {
+      const ready = await app.inject({ method: "GET", url: "/api/v1/agents/default/ready-status" })
+      expect(ready.statusCode, ready.body).toBe(200)
+      const created = await app.inject({
+        method: "POST",
+        url: "/api/v1/agents/default/sessions",
+        payload: {},
+      })
+      expect(created.statusCode, created.body).toBe(201)
+      const sessionId = created.json().sessionId as string
+      const readSystemPrompt = async () => {
+        const response = await app.inject({
+          method: "GET",
+          url: `/api/v1/agents/default/sessions/${sessionId}/system-prompt`,
+        })
+        expect(response.statusCode, response.body).toBe(200)
+        return response.json().systemPrompt as string
+      }
+      expect(await readSystemPrompt()).toContain("Initial package prompt.")
+
+      await mkdir(join(packageRoot, "skills", "reviewing"), { recursive: true })
+      await writeFile(join(packageRoot, "skills", "reviewing", "SKILL.md"), [
+        "---",
+        "name: reload-reviewing",
+        "description: Added package skill.",
+        "---",
+        "# Reviewing",
+      ].join("\n"), "utf8")
+      await writeManifest(["skills/authoring", "skills/reviewing"], "Updated package prompt.")
+
+      const skillReload = await app.inject({
+        method: "POST",
+        url: "/api/v1/agents/default/reload",
+        payload: { requestId: "package-skill-route-reload" },
+      })
+      expect(skillReload.statusCode, skillReload.body).toBe(200)
+      const skills = await app.inject({ method: "GET", url: "/api/v1/agents/default/skills" })
+      expect(skills.statusCode, skills.body).toBe(200)
+      const reviewing = (skills.json().skills as Array<{
+        name: string
+        resource?: { filesystem: string; path: string }
+      }>).find((skill) => skill.name === "reload-reviewing")
+      expect(reviewing?.resource).toEqual({
+        filesystem: "agent_resources",
+        path: "packages/@example/reload-resource/skills/reviewing/SKILL.md",
+      })
+      const file = await app.inject({
+        method: "GET",
+        url: `/api/v1/files?${new URLSearchParams(reviewing!.resource!)}`,
+      })
+      expect(file.statusCode, file.body).toBe(200)
+      expect(file.json().content).toContain("reload-reviewing")
+
+      await writeManifest(["skills/reviewing"], "Skill removal package prompt.")
+      const removalReload = await app.inject({
+        method: "POST",
+        url: "/api/v1/agents/default/reload",
+        payload: { requestId: "package-removal-route-reload" },
+      })
+      expect(removalReload.statusCode, removalReload.body).toBe(200)
+      const afterRemoval = await app.inject({ method: "GET", url: "/api/v1/agents/default/skills" })
+      expect(afterRemoval.statusCode, afterRemoval.body).toBe(200)
+      expect((afterRemoval.json().skills as Array<{ name: string }>).map((skill) => skill.name))
+        .not.toContain("reload-authoring")
+      const removedFile = await app.inject({
+        method: "GET",
+        url: `/api/v1/files?${new URLSearchParams({
+          filesystem: "agent_resources",
+          path: "packages/@example/reload-resource/skills/authoring/SKILL.md",
+        })}`,
+      })
+      expect(removedFile.statusCode).toBeGreaterThanOrEqual(400)
+
+      await writeManifest(["skills/reviewing"], "Prompt-only package update.")
+      const promptReload = await app.inject({
+        method: "POST",
+        url: "/api/v1/agents/default/reload",
+        payload: { requestId: "package-prompt-route-reload" },
+      })
+      expect(promptReload.statusCode, promptReload.body).toBe(200)
+      expect(await readSystemPrompt()).toContain("Prompt-only package update.")
+      expect(await readSystemPrompt()).not.toContain("Skill removal package prompt.")
+    } finally {
+      await app.close()
+    }
+  }, 30_000)
 
   test("collects plugin provisioning declarations and seeds the workspace", async () => {
     const workspaceRoot = await makeTempDir("boring-workspace-provisioned-")

--- a/packages/workspace/src/server/plugins/__tests__/packageResources.test.ts
+++ b/packages/workspace/src/server/plugins/__tests__/packageResources.test.ts
@@ -9,6 +9,7 @@ import {
   PACKAGE_RESOURCE_CONFLICT_CODE,
   PACKAGE_RESOURCE_INVALID_CODE,
   resolveWorkspacePackageResources,
+  selectAgentPackageResourceView,
 } from '../packageResources'
 
 const roots: string[] = []
@@ -267,6 +268,31 @@ describe('resolveWorkspacePackageResources', () => {
     expect(registry.additionalSkillPaths).not.toContain(sharedRoot)
     expect(registry.handledPackageRoots).toHaveLength(1)
 
+    const selected = selectAgentPackageResourceView(registry, {
+      pluginIds: new Set(['direct']),
+      includeAll: false,
+    })
+    expect(selected.skills.map((skill) => skill.packageName)).toEqual([
+      '@example/plugin',
+      'shared/pi-agent',
+    ])
+    expect(selected.locateSkill(sharedFile)).toEqual({
+      filesystem: AGENT_RESOURCES_FILESYSTEM_ID,
+      path: 'shared/pi-agent/shared-authoring/SKILL.md',
+    })
+    const isolated = selectAgentPackageResourceView(registry, {
+      pluginIds: new Set(['unrelated']),
+      includeAll: false,
+    })
+    expect(isolated.skills.map((skill) => skill.packageName)).toEqual(['shared/pi-agent'])
+    expect(isolated.locateSkill(join(packageRoot, 'skills', 'authoring', 'SKILL.md'))).toBeUndefined()
+    const catchAll = selectAgentPackageResourceView(registry, {
+      pluginIds: new Set(),
+      includeAll: true,
+    })
+    expect(catchAll.skills).toHaveLength(2)
+    expect(catchAll.systemPrompts).toEqual(['Use authoring.'])
+
     await writeFile(join(packageRoot, 'package.json'), JSON.stringify({
       name: '@example/plugin',
       pi: { skills: ['skills/authoring'], systemPrompt: 'Use updated authoring.' },
@@ -276,6 +302,13 @@ describe('resolveWorkspacePackageResources', () => {
       options: { sharedSkillPaths: [{ id: 'shared-authoring', skillFile: sharedFile }] },
     })
     expect(updated.generation).not.toBe(registry.generation)
+  })
+
+  test("rejects the host-shared reserved package name", async () => {
+    const root = await tempRoot()
+    const packageRoot = await packageFixture(root, { name: "shared/pi-agent" })
+    await expect(resolveOne(packageRoot, { packageName: "shared/pi-agent" }))
+      .rejects.toMatchObject({ code: PACKAGE_RESOURCE_INVALID_CODE })
   })
 
   test.each([

--- a/packages/workspace/src/server/plugins/packageResources.ts
+++ b/packages/workspace/src/server/plugins/packageResources.ts
@@ -83,6 +83,57 @@ export interface ResolvedWorkspacePackageResourceRegistry {
   locateSkill(filePath: string): AgentSkillResource | undefined
 }
 
+export interface ResolvedAgentPackageResourceView {
+  readonly generation: string
+  readonly skills: readonly ResolvedAgentPackageSkill[]
+  readonly managedSkills: readonly ResolvedAgentManagedSkill[]
+  readonly additionalSkillPaths: readonly string[]
+  readonly readonlyMounts: readonly AgentResourceReadonlyMount[]
+  readonly systemPrompts: readonly string[]
+  locateSkill(filePath: string): AgentSkillResource | undefined
+}
+
+/**
+ * Selects one internally-consistent Agent view from an immutable registry.
+ * Shared host skills are global; package skills and prompts follow plugin grants.
+ */
+export function selectAgentPackageResourceView(
+  registry: ResolvedWorkspacePackageResourceRegistry,
+  policy: { readonly pluginIds: ReadonlySet<string>; readonly includeAll: boolean },
+): ResolvedAgentPackageResourceView {
+  const selectedSkills = registry.skills.filter((skill) =>
+    skill.packageName === 'shared/pi-agent'
+    || policy.includeAll
+    || skill.pluginIds.some((pluginId) => policy.pluginIds.has(pluginId)),
+  )
+  const selectedResourcePaths = new Set(selectedSkills.map((skill) => skill.resource.path))
+  return Object.freeze({
+    generation: registry.generation,
+    skills: selectedSkills,
+    managedSkills: selectedSkills.flatMap((skill) => skill.name ? [{
+      name: skill.name,
+      description: skill.description ?? '',
+      resource: skill.resource,
+      invocable: false as const,
+      source: skill.packageName,
+    }] : []),
+    additionalSkillPaths: [...new Set(selectedSkills
+      .filter((skill) => skill.packageName !== 'shared/pi-agent')
+      .map((skill) => skill.mountRoot))],
+    readonlyMounts: selectedSkills.map((skill) => ({
+      logicalRoot: posix.dirname(skill.resource.path),
+      sourceRoot: skill.mountRoot,
+    })),
+    systemPrompts: registry.systemPrompts
+      .filter((prompt) => policy.includeAll || prompt.pluginIds.some((pluginId) => policy.pluginIds.has(pluginId)))
+      .map((prompt) => prompt.content),
+    locateSkill(filePath: string) {
+      const resource = registry.locateSkill(filePath)
+      return resource && selectedResourcePaths.has(resource.path) ? resource : undefined
+    },
+  })
+}
+
 function invalid(packageName: string, reason: string): WorkspacePackageResourceRegistryError {
   return new WorkspacePackageResourceRegistryError(
     PACKAGE_RESOURCE_INVALID_CODE,
@@ -205,6 +256,9 @@ export async function resolveWorkspacePackageResources(
   }>()
 
   for (const contribution of contributions) {
+    if (contribution.packageName === 'shared/pi-agent') {
+      throw invalid(contribution.packageName, 'package name is reserved for host-owned shared skills')
+    }
     const requestedRoot = packageRootPath(contribution.packageRoot, contribution.packageName)
     const canonicalRoot = await realpath(requestedRoot).catch(() => {
       throw invalid(contribution.packageName, 'packageRoot is not readable')
@@ -417,11 +471,11 @@ export async function enumerateExternalSkillFiles(
   return [...files.values()]
 }
 
-export async function resolveWorkspacePackageResourceSnapshot<TBinding>(input: {
+export async function resolveWorkspacePackageResourceSnapshot<TBinding = never>(input: {
   readonly declared: readonly WorkspacePackageResourceRecord[]
   readonly scanned: readonly WorkspacePackageResourceRecord[]
   readonly sharedSkillPaths?: readonly { readonly id: string; readonly skillFile: string }[]
-  readonly createBinding: (mounts: readonly AgentResourceReadonlyMount[]) => Promise<TBinding>
+  readonly createBinding?: (mounts: readonly AgentResourceReadonlyMount[]) => Promise<TBinding>
 }): Promise<{
   readonly registry: ResolvedWorkspacePackageResourceRegistry
   readonly binding?: TBinding
@@ -444,7 +498,7 @@ export async function resolveWorkspacePackageResourceSnapshot<TBinding>(input: {
   const registry = await resolveWorkspacePackageResources([...input.declared, ...accepted], {
     sharedSkillPaths: input.sharedSkillPaths,
   })
-  const binding = registry.readonlyMounts.length > 0
+  const binding = registry.readonlyMounts.length > 0 && input.createBinding
     ? await input.createBinding(registry.readonlyMounts)
     : undefined
   return Object.freeze({ registry, ...(binding ? { binding } : {}), diagnostics })


### PR DESCRIPTION
## Summary

- routes the default `legacyDefault` Agent through the same normalized per-Agent contribution path as explicit fleet Agents
- removes `legacyGlobalPluginAgentContributions` and its duplicate global branches
- keeps host-provided Pi resources global while applying plugin resources at Agent runtime scope
- preserves standalone and fleet Pi ordering plus persisted standalone runtime identity
- derives package-resource bindings, locators, managed-skill snapshots, and prompts from one canonical per-Agent resource view
- hashes immutable plugin skill sources rather than reload-mutated provisioning outputs
- keeps the standalone browser Files API able to open advertised `agent_resources` locators

## Thermonuclear review fixes

Three independent thermonuclear passes found and drove fixes for:

- reload invalidating its own resource digest fence
- scanned/shared package resources escaping the selected binding
- stale generation + locator snapshots after reload
- standalone runtime identity and Pi ordering drift
- `opts.defaults` contributions being dropped
- browser Files API losing standalone `agent_resources`

Final thermonuclear verdict: **no material findings / no remaining merge blockers**.

## Validation

- Workspace full suite: **2,115 passed, 10 skipped**
- focused composition/resource/provisioning suites: **105 passed**
- Workspace source typecheck: passed
- Workspace production build: passed
- Vercel-like provisioning regression: passed
- real Healio Infomaniak smoke: package skill reads through `agent_resources`, successful `query_data`, **81.7% / 98 of 120**

Closes #1268
