### PR TITLE
#1270 test(ask-user): cover production bridge policy

### DIFF
--- a/plugins/ask-user/src/server/__tests__/askUserBridgeHandlers.test.ts
+++ b/plugins/ask-user/src/server/__tests__/askUserBridgeHandlers.test.ts
@@ -1,11 +1,16 @@
 // @vitest-environment node
 
+import Fastify, { type FastifyInstance } from "fastify"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import {
+  createBrowserBridgeAuthPolicy,
   createWorkspaceBridgeRegistry,
+  InMemoryWorkspaceBridgeIdempotencyStore,
+  workspaceBridgeHttpRoutes,
   WorkspaceBridgeErrorCode,
   type WorkspaceBridgeCallContext,
 } from "@hachej/boring-workspace/server"
+import { createQuestionsClient } from "../../front/client"
 import { ASK_USER_BRIDGE_CAPABILITIES, ASK_USER_BRIDGE_OPS } from "../../shared"
 import { AskUserRuntime } from "../askUserRuntime"
 import { createAskUserBridgeHandlers } from "../askUserBridgeHandlers"
@@ -16,6 +21,7 @@ const controllers: AbortController[] = []
 
 afterEach(() => {
   for (const controller of controllers.splice(0)) controller.abort()
+  vi.unstubAllGlobals()
 })
 
 function runtimeContext(overrides: Partial<WorkspaceBridgeCallContext> = {}): WorkspaceBridgeCallContext {
@@ -53,7 +59,83 @@ function fixture() {
   return { store, runtime, registry }
 }
 
+async function productionPolicyApp() {
+  const { store, runtime, registry } = fixture()
+  const app = Fastify()
+  await app.register(workspaceBridgeHttpRoutes, {
+    registry,
+    ownerWorkspaceId: "workspace-1",
+    idempotencyStore: new InMemoryWorkspaceBridgeIdempotencyStore(),
+    browserAuthPolicy: createBrowserBridgeAuthPolicy({
+      getPrincipal: () => ({ userId: "user-1" }),
+      authorizeWorkspace: ({ workspaceId, definition }) => ({
+        allowed: workspaceId === "workspace-1",
+        capabilities: definition.requiredCapabilities,
+      }),
+      allowedOrigins: ["https://app.example.test"],
+      requireCsrfHeader: true,
+    }),
+  })
+  return { app, store, runtime }
+}
+
+function injectFetch(app: FastifyInstance) {
+  return async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const url = new URL(String(input), "https://app.example.test")
+    const headers = Object.fromEntries(new Headers(init?.headers).entries())
+    headers.origin ??= "https://app.example.test"
+    const response = await app.inject({
+      method: (init?.method ?? "GET") as "GET" | "POST",
+      url: `${url.pathname}${url.search}`,
+      headers,
+      payload: init?.body ? String(init.body) : undefined,
+    })
+    return new Response(response.body, {
+      status: response.statusCode,
+      headers: response.headers as Record<string, string>,
+    })
+  }
+}
+
 describe("plugin-owned ask-user WorkspaceBridge handlers", () => {
+  it("keeps the real browser client compatible with the production bridge policy", async () => {
+    const { app, runtime, store } = await productionPolicyApp()
+    vi.stubGlobal("fetch", injectFetch(app))
+    try {
+      const awaitingAnswer = runtime.ask({
+        sessionId: "s1",
+        title: "Production policy question",
+        schema,
+        ownerPrincipalId: "user-1",
+      })
+      const question = await vi.waitFor(async () => {
+        const pending = await store.getPending("s1")
+        expect(pending).not.toBeNull()
+        return pending!
+      })
+
+      const client = createQuestionsClient({ headers: { "x-boring-workspace-id": "workspace-1" } })
+      await expect(client.pending("s1")).resolves.toMatchObject({ questionId: question.questionId })
+      await expect(client.submit(question, { answer: "continue" })).resolves.toMatchObject({ status: "answered" })
+      await expect(awaitingAnswer).resolves.toMatchObject({ status: "answered", answer: { values: { answer: "continue" } } })
+
+      const missingCsrf = createQuestionsClient({
+        headers: { "x-boring-workspace-id": "workspace-1", "x-csrf-token": "" },
+      })
+      await expect(missingCsrf.pending("s1")).rejects.toMatchObject({ statusCode: 401 })
+
+      const wrongOrigin = createQuestionsClient({
+        headers: { "x-boring-workspace-id": "workspace-1", origin: "https://evil.example.test" },
+      })
+      await expect(wrongOrigin.pending("s1")).rejects.toMatchObject({ statusCode: 401 })
+
+      const wrongWorkspace = createQuestionsClient({ headers: { "x-boring-workspace-id": "workspace-2" } })
+      await expect(wrongWorkspace.pending("s1")).rejects.toMatchObject({ statusCode: 403 })
+    } finally {
+      await app.close()
+    }
+  })
+
   it("handles request -> pending -> browser answer through ask-user.v1 ops", async () => {
     const { store, registry } = fixture()
     const controller = new AbortController()


### PR DESCRIPTION
Closes #1270.

## What changed

Adds a production-policy integration test that runs the real ask-user browser client through:

- real `workspaceBridgeHttpRoutes`
- strict `createBrowserBridgeAuthPolicy`
- real ask-user bridge handlers/runtime/store
- atomic bridge idempotency

The test proves the valid pending → answer lifecycle succeeds and verifies missing CSRF, wrong origin, and wrong workspace fail with the expected 401/403 responses.

## Validation

- focused test: 6/6 passed
- `git diff --check`: passed
- independent review: SHIP, no blockers

Package typecheck was attempted from a linked worktree but stale built exports in the coordination checkout produced unrelated missing-export errors. CI installs/builds the branch normally and is authoritative.
