### PR TITLE
Polish CLI workspace hard-reload transition

### DIFF
--- a/packages/cli/index.html
+++ b/packages/cli/index.html
@@ -10,15 +10,69 @@
       href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap"
       rel="stylesheet"
     />
+    <script>
+      try {
+        const saved = JSON.parse(localStorage.getItem("boring-ui-v2:preferences") || "null")?.state?.theme
+        document.documentElement.dataset.theme = saved === "light" || saved === "dark"
+          ? saved
+          : matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"
+      } catch {
+        document.documentElement.dataset.theme = "dark"
+      }
+    </script>
+    <style>
+      :root { color-scheme: dark; --boot-bg: #0f1115; --boot-sidebar: #0d0f13; --boot-fg: #eef1f7; --boot-border: #252932; --boot-skeleton: #20242c; --boot-muted: #9aa3b2; background: var(--boot-bg); }
+      :root[data-theme="light"] { color-scheme: light; --boot-bg: #fbfaf8; --boot-sidebar: #f7f6f3; --boot-fg: #25231f; --boot-border: #e7e4de; --boot-skeleton: #efede9; --boot-muted: #77716a; }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--boot-bg); color: var(--boot-fg); font-family: Geist, system-ui, sans-serif; }
+      .boot-shell { display: flex; min-height: 100vh; overflow: hidden; background: var(--boot-bg); }
+      .boot-sidebar { width: 268px; flex: none; padding: 16px; border-right: 1px solid var(--boot-border); background: var(--boot-sidebar); }
+      .boot-brand, .boot-row { display: flex; align-items: center; gap: 12px; }
+      .boot-brand { height: 32px; padding-left: 32px; }
+      .boot-list { display: grid; gap: 8px; margin-top: 16px; }
+      .boot-main { display: flex; min-width: 0; flex: 1; flex-direction: column; }
+      .boot-header { display: flex; height: 44px; flex: none; align-items: center; justify-content: space-between; padding: 0 16px; border-bottom: 1px solid var(--boot-border); }
+      .boot-transcript { display: grid; width: 100%; max-width: 680px; flex: 1; align-content: start; gap: 28px; margin: 0 auto; padding: 32px 16px; }
+      .boot-message { display: flex; gap: 12px; }
+      .boot-copy { display: grid; min-width: 0; flex: 1; gap: 10px; }
+      .boot-user { width: min(72%, 30rem); height: 44px; justify-self: end; border-radius: 12px; }
+      .boot-composer { width: calc(100% - 24px); max-width: 656px; height: 56px; flex: none; margin: 0 auto 44px; border-radius: 12px; }
+      .boot-skeleton { background: var(--boot-skeleton); animation: boot-pulse 1.8s ease-in-out infinite; }
+      .boot-icon { width: 28px; height: 28px; flex: none; border-radius: 8px; }
+      .boot-line { height: 12px; border-radius: 4px; }
+      .boot-help { position: fixed; right: 16px; bottom: 16px; max-width: 30rem; color: var(--boot-muted); font-size: 14px; opacity: 0; animation: boot-help 0s 12s forwards; }
+      .boot-sr { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
+      @keyframes boot-pulse { 50% { opacity: .55; } }
+      @keyframes boot-help { to { opacity: 1; } }
+      @media (max-width: 700px) { .boot-sidebar { display: none; } }
+      @media (prefers-reduced-motion: reduce) { .boot-skeleton { animation: none; } }
+    </style>
   </head>
   <body>
     <div id="root">
-      <div style="min-height:100vh;display:grid;place-items:center;background:#0f1115;color:#eef1f7;font-family:Geist,system-ui,sans-serif">
-        <div style="text-align:center;max-width:30rem;padding:2rem">
-          <div style="font-weight:600;margin-bottom:.5rem">Loading CLI workspace…</div>
-          <div style="font-size:.875rem;color:#9aa3b2">If this stays here, the browser did not load the app bundle. Hard-refresh or open the workspace URL directly.</div>
-        </div>
-      </div>
+      <section class="boot-shell" role="status" aria-live="polite" aria-busy="true" aria-label="Loading CLI workspace">
+        <span class="boot-sr">Loading CLI workspace…</span>
+        <aside class="boot-sidebar" aria-hidden="true">
+          <div class="boot-brand"><span class="boot-skeleton boot-icon"></span><span class="boot-skeleton boot-line" style="width:96px"></span></div>
+          <div class="boot-list">
+            <span class="boot-skeleton boot-line" style="width:64px"></span>
+            <span class="boot-skeleton" style="height:32px;border-radius:6px"></span>
+            <span class="boot-skeleton" style="width:84%;height:32px;border-radius:6px"></span>
+            <span class="boot-skeleton" style="width:92%;height:32px;border-radius:6px"></span>
+          </div>
+        </aside>
+        <main class="boot-main" aria-hidden="true">
+          <header class="boot-header"><span class="boot-skeleton boot-line" style="width:128px"></span><span class="boot-skeleton" style="width:28px;height:28px;border-radius:6px"></span></header>
+          <div class="boot-transcript">
+            <div class="boot-message"><span class="boot-skeleton boot-icon"></span><span class="boot-copy"><span class="boot-skeleton boot-line" style="width:96px"></span><span class="boot-skeleton boot-line"></span><span class="boot-skeleton boot-line" style="width:80%"></span></span></div>
+            <span class="boot-skeleton boot-user"></span>
+            <div class="boot-message"><span class="boot-skeleton boot-icon"></span><span class="boot-copy"><span class="boot-skeleton boot-line" style="width:80px"></span><span class="boot-skeleton" style="height:80px;border-radius:8px"></span><span class="boot-skeleton boot-line" style="width:60%"></span></span></div>
+          </div>
+          <div class="boot-skeleton boot-composer"></div>
+        </main>
+        <div class="boot-help">If loading does not finish, hard-refresh or open the workspace URL directly.</div>
+      </section>
+      <noscript>This workspace requires JavaScript.</noscript>
     </div>
     <script type="module" src="/src/front/main.tsx"></script>
   </body>

--- a/packages/cli/src/front/App.test.tsx
+++ b/packages/cli/src/front/App.test.tsx
@@ -63,6 +63,26 @@ describe("CliWorkspaceShell", () => {
     document.title = ""
   })
 
+  test("keeps workspace geometry visible while metadata loads", async () => {
+    let resolveMeta: ((response: Response) => void) | undefined
+    globalThis.fetch = vi.fn(() => new Promise<Response>((resolve) => {
+      resolveMeta = resolve
+    })) as typeof fetch
+
+    const { container } = render(<CliWorkspaceShell />)
+
+    expect(container.querySelector('[data-boring-workspace-part="workspace-loading-shell"]')).not.toBeNull()
+    expect(screen.getByText("Loading CLI workspace…")).not.toBeNull()
+
+    resolveMeta?.(new Response(JSON.stringify({ projectName: "Seneca" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }))
+
+    await waitFor(() => expect(workspaceAgentFrontSpy).toHaveBeenCalled())
+    expect(container.querySelector('[data-boring-workspace-part="workspace-loading-shell"]')).toBeNull()
+  })
+
   function mockWorkspacesMode(workspacesByCall: Array<Array<{ id: string; name: string; path: string; available: boolean }>>) {
     let call = 0
     globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {

--- a/packages/cli/src/front/App.tsx
+++ b/packages/cli/src/front/App.tsx
@@ -393,7 +393,13 @@ export function CliWorkspaceShell() {
 
 
   if (!metaLoaded) {
-    return <div className="h-screen w-screen bg-background" />
+    return (
+      <WorkspaceSingleton.WorkspaceLoadingState
+        title="Loading CLI workspace…"
+        description="Preparing the workspace shell."
+        status="Loading workspace metadata"
+      />
+    )
   }
 
   if (workspacesMode) {
@@ -404,14 +410,11 @@ export function CliWorkspaceShell() {
       // show a loading state while the poll above resolves it instead of an error screen.
       if (activeWorkspaceId) {
         return (
-          <div className="flex h-screen w-screen items-center justify-center bg-background text-foreground">
-            <div className="max-w-md rounded-2xl border border-border bg-card p-6 text-center shadow-sm">
-              <h1 className="text-lg font-semibold">Loading workspace…</h1>
-              <p className="mt-2 text-sm text-muted-foreground">
-                Preparing <code>{activeWorkspaceId}</code>. This can take a moment on first load.
-              </p>
-            </div>
-          </div>
+          <WorkspaceSingleton.WorkspaceLoadingState
+            title="Loading workspace…"
+            description={`Preparing ${activeWorkspaceId}. This can take a moment on first load.`}
+            status="Waiting for the workspace runtime"
+          />
         )
       }
       // The workspace registry list hasn't successfully loaded yet (first fetch
@@ -421,11 +424,11 @@ export function CliWorkspaceShell() {
       // though the API does return workspaces.
       if (!workspacesLoaded && workspaces.length === 0) {
         return (
-          <div className="flex h-screen w-screen items-center justify-center bg-background text-foreground">
-            <div className="max-w-md rounded-2xl border border-border bg-card p-6 text-center shadow-sm">
-              <h1 className="text-lg font-semibold">Loading workspaces…</h1>
-            </div>
-          </div>
+          <WorkspaceSingleton.WorkspaceLoadingState
+            title="Loading workspaces…"
+            description="Reading the local workspace registry."
+            status="Finding workspaces"
+          />
         )
       }
       const hasUnavailableWorkspaces = workspaces.length > 0

--- a/packages/cli/src/front/indexHtml.test.ts
+++ b/packages/cli/src/front/indexHtml.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, test } from "vitest"
+
+describe("CLI first paint", () => {
+  test("uses workspace shell geometry before the app bundle loads", () => {
+    const html = readFileSync(new URL("../../index.html", import.meta.url), "utf8")
+
+    expect(html).toContain('class="boot-shell"')
+    expect(html).toContain('class="boot-sidebar"')
+    expect(html).toContain('class="boot-transcript"')
+    expect(html).toContain('class="boot-skeleton boot-composer"')
+    expect(html).toContain('aria-label="Loading CLI workspace"')
+    expect(html).toContain('localStorage.getItem("boring-ui-v2:preferences")')
+    expect(html).toContain(':root[data-theme="light"]')
+    expect(html).toContain("If loading does not finish")
+  })
+})


### PR DESCRIPTION
Closes #1271

## What changed
- replace the centered static fallback with a workspace-shaped first-paint skeleton
- bootstrap the persisted/system theme before first paint to avoid a light/dark flash
- reuse the canonical workspace loading shell while metadata and registry requests resolve
- retain delayed bundle-failure guidance and accessible status semantics

## Proof
- `pnpm exec vitest run src/front/App.test.tsx src/front/indexHtml.test.ts` — 13 passed
- `pnpm typecheck` — passed
- `pnpm build:front` — passed
- real Seneca hard reload on source-built CLI: stable shell skeleton → progressively hydrated shell → chat, ready in 2.26s warm
- Seneca Automations panel opened; `/api/v1/boring-automation/automations` returned 200 in 4ms

## Visual proof
- first paint: `/tmp/seneca-1271-final-01.png`
- hydrated loading shell: `/tmp/seneca-1271-final-03.png`
- automation panel: `/tmp/seneca-1271-automation.png`