### PR TITLE
fix(chat): recover from stale runtime sessions

### DIFF
--- a/packages/agent/src/front/chat/PiChatPanel.tsx
+++ b/packages/agent/src/front/chat/PiChatPanel.tsx
@@ -2,6 +2,8 @@
 
 import type { ChangeEvent, KeyboardEvent as ReactKeyboardEvent, ReactNode } from 'react'
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Button } from '@hachej/boring-ui-kit'
+import { AgentGatewayErrorCode } from '../../shared/gateway/errors'
 import type { PromptInputFilePart } from '../primitives/prompt-input'
 import { ArtifactOpenProvider } from '../ArtifactOpenContext'
 import {
@@ -176,6 +178,8 @@ export interface PiChatPanelProps<
   allowPromptDuringInitialHydration?: boolean
   workspaceWarmupStatus?: ChatPanelWorkspaceWarmupStatus
   onSessionReset?: () => void | Promise<void>
+  /** Creates and selects a session when the host controls sessionId. */
+  onCreateSession?: () => void | Promise<void>
   onBeforeSubmit?: (draft: string, context: ChatSubmitContext) => false | void | boolean | Promise<false | void | boolean>
   onReloadAgentPlugins?: () => Promise<AgentPluginReloadResult | string>
   onCommandResult?: (message: string) => void
@@ -242,6 +246,7 @@ export function PiChatPanel<
   allowPromptDuringInitialHydration = false,
   workspaceWarmupStatus,
   onSessionReset,
+  onCreateSession,
   onBeforeSubmit,
   onReloadAgentPlugins,
   onCommandResult,
@@ -537,12 +542,43 @@ export function PiChatPanel<
     setLocalNotices((previous) => previous.filter((notice) => notice.id !== id))
   }, [])
 
+  const createSessionInFlightRef = useRef<Promise<void> | null>(null)
+  const [creatingSession, setCreatingSession] = useState(false)
   const createSession = useCallback(() => {
-    if (externalSessionId) return
-    void sessions.create().catch((error) => {
-      addLocalNotice({ id: 'session-create-error', level: 'error', text: errorMessage(error, 'Could not create a chat session.'), dismissible: true })
-    })
-  }, [addLocalNotice, externalSessionId, sessions.create])
+    if (createSessionInFlightRef.current) return createSessionInFlightRef.current
+    if (externalSessionId && !onCreateSession) return Promise.resolve()
+    setCreatingSession(true)
+    const operation = (async () => {
+      // Defer invocation so synchronous host failures enter the same cleanup path.
+      await Promise.resolve()
+      if (externalSessionId) await onCreateSession?.()
+      else await sessions.create()
+    })().catch((error) => {
+        addLocalNotice({ id: 'session-create-error', level: 'error', text: errorMessage(error, 'Could not create a chat session.'), dismissible: true })
+      })
+      .finally(() => {
+        if (createSessionInFlightRef.current === operation) createSessionInFlightRef.current = null
+        setCreatingSession(false)
+      })
+    createSessionInFlightRef.current = operation
+    return operation
+  }, [addLocalNotice, externalSessionId, onCreateSession, sessions.create])
+
+  const renderRuntimeNoticeAction = useCallback((notice: PiChatRuntimeNotice) => {
+    const hostAction = renderNoticeAction?.(notice)
+    if (hostAction != null) return hostAction
+    if (
+      notice.errorCode === AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH
+      && (!externalSessionId || onCreateSession)
+    ) {
+      return (
+        <Button type="button" size="sm" variant="outline" disabled={creatingSession} onClick={createSession}>
+          {creatingSession ? 'Starting new chat…' : 'Start new chat'}
+        </Button>
+      )
+    }
+    return null
+  }, [createSession, creatingSession, externalSessionId, onCreateSession, renderNoticeAction])
 
   useEffect(() => {
     if (externalSessionId || sessionsLoading || sessionsError || activeSessionId || sessionList.length > 0) return
@@ -1244,7 +1280,7 @@ export function PiChatPanel<
               onMentionActivate={activateAssistantMention}
               runtimeNotices={runtimeNotices}
               onDismissNotice={clearLocalNotice}
-              renderNoticeAction={renderNoticeAction}
+              renderNoticeAction={renderRuntimeNoticeAction}
               onScrollToBottomReady={(scrollToBottom) => {
                 scrollToBottomRef.current = scrollToBottom
               }}

--- a/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
+++ b/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
@@ -3,6 +3,7 @@ import { act, createEvent, fireEvent, render, screen, waitFor, within } from '@t
 import { readFileSync } from 'node:fs'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import type { SessionSummary } from '../../../shared/session'
+import { AgentGatewayErrorCode } from '../../../shared/gateway/errors'
 import { createInitialPiChatState, type PiChatState } from '../pi/piChatReducer'
 import type { RemotePiSession, RemotePiSessionOptions } from '../pi/remotePiSession'
 import { activeSessionStorageKey, scopedComposerStorageKey, type ActiveSessionStorageLike } from '../session'
@@ -515,6 +516,69 @@ describe('PiChatPanel sandbox shell', () => {
 
     // A rejected send never admits a server turn, so it must not report one.
     expect(onTurnComplete).not.toHaveBeenCalled()
+  })
+
+  test('offers a new chat when a run is rejected by a stale runtime pin', async () => {
+    const remote = new FakeRemotePiSession(remoteState({ status: 'idle' }))
+    remote.prompt.mockRejectedValue(Object.assign(new Error('This chat belongs to a previous runtime configuration and can no longer be changed.'), {
+      errorCode: AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH,
+    }))
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      const method = init?.method ?? 'GET'
+      if (url.includes('/api/v1/agents/default/sessions?') && method === 'GET') return jsonResponse([session('pi-1')])
+      if (url.endsWith('/api/v1/agents/default/sessions') && method === 'POST') return jsonResponse(session('pi-current', 'Current runtime chat'), 201)
+      throw new Error(`unexpected fetch ${url}`)
+    })
+    render(
+      <PiChatPanel
+        serverResourcesEnabled={false}
+        storageScope="scope-a"
+        fetch={fetchMock as unknown as typeof fetch}
+        createRemoteSession={remoteFactory(remote)}
+      />,
+    )
+
+    const textarea = await screen.findByLabelText('Agent prompt') as HTMLTextAreaElement
+    fireEvent.change(textarea, { target: { value: 'continue old chat' } })
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+
+    const action = await screen.findByRole('button', { name: 'Start new chat' })
+    fireEvent.click(action)
+    fireEvent.click(action)
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/agents/default/sessions',
+      expect.objectContaining({ method: 'POST' }),
+    ))
+    await waitFor(() => expect(document.querySelector('[data-pi-chat-session-id="pi-current"]')).toBeTruthy())
+    expect(fetchMock.mock.calls.filter((call) => String(call[0]).endsWith('/sessions') && call[1]?.method === 'POST')).toHaveLength(1)
+  })
+
+  test('uses the host session creator for a runtime mismatch in controlled-session mode', async () => {
+    const remote = new FakeRemotePiSession(remoteState({
+      status: 'error',
+      notices: [{
+        id: 'terminal-session-error',
+        level: 'error',
+        text: 'This chat belongs to a previous runtime configuration and can no longer be changed.',
+        errorCode: AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH,
+      }],
+    }))
+    const onCreateSession = vi.fn().mockResolvedValue(undefined)
+    render(
+      <PiChatPanel
+        sessionId="pi-1"
+        showSessions={false}
+        serverResourcesEnabled={false}
+        storageScope="scope-a"
+        createRemoteSession={remoteFactory(remote)}
+        onCreateSession={onCreateSession}
+      />,
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Start new chat' }))
+    await waitFor(() => expect(onCreateSession).toHaveBeenCalledTimes(1))
   })
 
   test('fires onTurnComplete per turn-settle event, including back-to-back queued turns', async () => {

--- a/packages/agent/src/front/chat/pi/__tests__/remotePiSession.test.ts
+++ b/packages/agent/src/front/chat/pi/__tests__/remotePiSession.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { ErrorCode } from '../../../../shared/error-codes'
+import { AgentGatewayErrorCode } from '../../../../shared/gateway/errors'
 import type { PiChatEvent, PiChatSnapshot } from '../../../../shared/chat'
+import { RUNTIME_SCOPE_MISMATCH_MESSAGE } from '../../gatewayResponseError'
 import { PI_CHAT_CURSOR_AHEAD_CODE, PI_CHAT_REPLAY_GAP_CODE } from '../piChatStream'
 import { RemotePiSession, piChatErrorCode } from '../remotePiSession'
 
@@ -564,6 +566,35 @@ describe('RemotePiSession', () => {
     session.dispose()
   })
 
+  it('suspends without reconnecting when an existing session belongs to another runtime scope', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith('/state')) {
+        return jsonResponse({
+          error: {
+            code: AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH,
+            message: 'session is pinned to a different runtime scope',
+          },
+        }, 409)
+      }
+      throw new Error(`unexpected URL ${url}`)
+    }) as unknown as MockFetch
+    const session = createSession(fetchMock)
+
+    await waitUntil(() => session.getState().connection.state === 'suspended')
+    await new Promise((resolve) => setTimeout(resolve, 25))
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(session.getState()).toMatchObject({ hydrated: true, status: 'error' })
+    expect(session.getDebugState().suspended).toBe(true)
+    expect(session.getState().notices).toContainEqual(expect.objectContaining({
+      id: 'terminal-session-error',
+      errorCode: AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH,
+      text: RUNTIME_SCOPE_MISMATCH_MESSAGE,
+    }))
+
+    session.dispose()
+  })
+
   it('shows a protocol runtime notice and does not open events for unsupported /state protocol versions', async () => {
     const fetchMock = vi.fn(async (url: string) => {
       if (url.endsWith('/state')) return jsonResponse({ ...snapshot(), protocolVersion: 2 })
@@ -767,12 +798,15 @@ describe('RemotePiSession', () => {
     session.dispose()
   })
 
-  it('piChatErrorCode ignores non-canonical/missing codes and reads a plain canonical errorCode', () => {
+  it('piChatErrorCode ignores unknown codes and reads shared or gateway errorCode values', () => {
     expect(piChatErrorCode(new Error('boom'))).toBeUndefined()
     expect(piChatErrorCode(undefined)).toBeUndefined()
     // A non-canonical code must NOT be surfaced as a host action key.
     expect(piChatErrorCode(Object.assign(new Error('x'), { errorCode: 'NOT_A_REAL_CODE' }))).toBeUndefined()
     expect(piChatErrorCode(Object.assign(new Error('x'), { errorCode: ErrorCode.enum.SESSION_LOCKED }))).toBe(ErrorCode.enum.SESSION_LOCKED)
+    expect(piChatErrorCode(Object.assign(new Error('x'), {
+      errorCode: AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH,
+    }))).toBe(AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH)
   })
 
   it('clears optimistic queued follow-ups from the stop receipt before a queue echo arrives', async () => {

--- a/packages/agent/src/front/chat/pi/piChatReducer.ts
+++ b/packages/agent/src/front/chat/pi/piChatReducer.ts
@@ -99,6 +99,7 @@ export type PiChatReducerAction =
   | { type: 'connection-state'; state: PiChatConnectionState }
   | { type: 'heartbeat'; now?: number }
   | { type: 'protocol-error'; error: ChatError }
+  | { type: 'terminal-session-error'; message: string; errorCode: string }
   | { type: 'clear-notice'; id: string }
 
 export interface CreatePiChatStateOptions {
@@ -179,6 +180,20 @@ export function piChatReducer(state: PiChatState, action: PiChatReducerAction): 
           level: 'error',
           text: action.error.message,
           dismissible: true,
+        }),
+      }
+    case 'terminal-session-error':
+      return {
+        ...state,
+        status: 'error',
+        hydrated: true,
+        connection: { ...state.connection, state: 'suspended' },
+        retryNotice: undefined,
+        notices: upsertNotice(state.notices, {
+          id: 'terminal-session-error',
+          level: 'error',
+          text: action.message,
+          errorCode: action.errorCode,
         }),
       }
     case 'clear-notice':

--- a/packages/agent/src/front/chat/pi/remotePiSession.ts
+++ b/packages/agent/src/front/chat/pi/remotePiSession.ts
@@ -1,4 +1,9 @@
 import { ErrorCode } from '../../../shared/error-codes'
+import {
+  errorResponseCode,
+  gatewayResponseErrorFromBody,
+  isRuntimeScopeMismatchError,
+} from '../gatewayResponseError'
 import type {
   CommandReceipt,
   FollowUpPayload,
@@ -341,6 +346,10 @@ export class RemotePiSession {
       this.connectEvents(snapshot.seq, generation)
     } catch (error) {
       if (!this.isHydrationActive(generation, hydrationRunId) || isAbortError(error)) return
+      if (isRuntimeScopeMismatchError(error)) {
+        this.dispatchTerminalSessionError(error)
+        return
+      }
       this.dispatchProtocolError(errorMessage(error, 'Failed to hydrate Pi chat session state.'))
       this.scheduleReconnect(generation)
     }
@@ -421,8 +430,18 @@ export class RemotePiSession {
           markOpen()
           return
         }
-        this.dispatchProtocolError(routeErrorMessage(body, `Pi chat event stream failed with HTTP ${response.status}.`))
-        this.scheduleReconnect(generation)
+        const responseError = gatewayResponseErrorFromBody(
+          response.status,
+          body,
+          `Pi chat event stream failed with HTTP ${response.status}.`,
+          'events',
+        )
+        if (isRuntimeScopeMismatchError(responseError)) {
+          this.dispatchTerminalSessionError(responseError)
+        } else {
+          this.dispatchProtocolError(responseError.message)
+          this.scheduleReconnect(generation)
+        }
         markOpen()
         return
       }
@@ -565,7 +584,7 @@ export class RemotePiSession {
     try {
       const response = await this.fetchImpl(url, { ...init, signal: controller.signal })
       const body = await safeReadJson(response)
-      if (!response.ok) throw new RemotePiSessionHttpError(response.status, routeErrorMessage(body, `HTTP ${response.status}`), body, routeErrorCode(body))
+      if (!response.ok) throw gatewayResponseErrorFromBody(response.status, body, `HTTP ${response.status}`, url)
       return body
     } catch (error) {
       // Distinguish our own timeout abort from a dispose-driven abort: a
@@ -644,6 +663,21 @@ export class RemotePiSession {
     this.store.dispatch({ type: 'protocol-error', error }, { flush: true })
   }
 
+  private dispatchTerminalSessionError(error: unknown): void {
+    if (this.disposed) return
+    const errorCode = errorResponseCode(error)
+    if (!errorCode) {
+      this.dispatchProtocolError(errorMessage(error, 'Chat session is unavailable.'))
+      return
+    }
+    this.suspendStream()
+    this.store.dispatch({
+      type: 'terminal-session-error',
+      message: errorMessage(error, 'Chat session is unavailable.'),
+      errorCode,
+    }, { flush: true })
+  }
+
   private recordEventType(type: string): void {
     this.recentEventTypes.push(type)
     if (this.recentEventTypes.length > EVENT_TYPE_RING_LIMIT) this.recentEventTypes.shift()
@@ -709,27 +743,12 @@ export function createRemotePiSession(options: RemotePiSessionOptions): RemotePi
   return new RemotePiSession(options)
 }
 
-class RemotePiSessionHttpError extends Error {
-  constructor(readonly status: number, message: string, readonly body: unknown, readonly errorCode?: string) {
-    super(message)
-    this.name = 'RemotePiSessionHttpError'
-  }
-}
-
 /**
- * Extract the stable, CANONICAL server error code (a member of the shared ErrorCode
- * enum, e.g. `SESSION_LOCKED`) from an error thrown by a command call (prompt/follow-up/
- * etc). Returns undefined for non-HTTP errors, bodies without a code, or non-canonical
- * codes. This is the agent's generic seam: callers map a code to UI (a notice action)
- * WITHOUT the agent knowing what the code means.
+ * Extract a stable shared or AgentGateway server error code from a rejected chat
+ * operation. Hosts use it to attach recovery actions without parsing error text.
  */
 export function piChatErrorCode(error: unknown): string | undefined {
-  if (error instanceof RemotePiSessionHttpError) return error.errorCode
-  // Also accept a plain `errorCode` carried on any thrown value, so callers that
-  // re-wrap or synthesize a command error can still surface a stable code — but only
-  // when it's a canonical ErrorCode, never an arbitrary string.
-  const parsed = ErrorCode.safeParse((error as { errorCode?: unknown } | null)?.errorCode)
-  return parsed.success ? parsed.data : undefined
+  return errorResponseCode(error)
 }
 
 function toOptimisticUserMessage(payload: PromptPayload | FollowUpPayload): OptimisticUserMessage {
@@ -770,16 +789,6 @@ function routeErrorMessage(body: unknown, fallback: string): string {
   const error = (body as Record<string, unknown>).error
   const payload = typeof error === 'object' && error !== null ? error as Record<string, unknown> : body as Record<string, unknown>
   return typeof payload.message === 'string' && payload.message ? payload.message : fallback
-}
-
-function routeErrorCode(body: unknown): string | undefined {
-  if (typeof body !== 'object' || body === null) return undefined
-  const error = (body as Record<string, unknown>).error
-  const payload = typeof error === 'object' && error !== null ? error as Record<string, unknown> : body as Record<string, unknown>
-  // Only surface a CANONICAL code: hosts treat notice.errorCode as a stable action
-  // key, so a malformed/legacy body must not leak an arbitrary string.
-  const parsed = ErrorCode.safeParse(payload.code)
-  return parsed.success ? parsed.data : undefined
 }
 
 function errorMessage(error: unknown, fallback: string): string {

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -1918,7 +1918,13 @@ export function WorkspaceAgentFront<
     const createReason = placementDirection
       ? `split:${afterId}:${placementDirection}`
       : "manual"
-    const created = resolvedCreate(createReason, ownerAgentTypeId)
+    let created: ReturnType<typeof resolvedCreate>
+    try {
+      created = resolvedCreate(createReason, ownerAgentTypeId)
+    } catch (error) {
+      settleIfOwner()
+      throw error
+    }
     void Promise.resolve(created).then((session) => {
       const id = createdSessionId(session)
       // Some session providers signal creation through a later sessions update.
@@ -2171,6 +2177,7 @@ export function WorkspaceAgentFront<
       requestHeaders: resolvedRequestHeaders,
       remoteSessionOptions: chatRemoteSessionOptions,
       showSessions: false,
+      onCreateSession: () => createChatSession(sessionRef.agentTypeId ?? selectedAgentTypeId),
       onReloadAgentPlugins: chatParams?.onReloadAgentPlugins ?? (() => reloadAgentPluginsForSession({ agentTypeId: sessionRef.agentTypeId ?? selectedAgentTypeId, sessionId })),
       toolRenderers: { ...pluginToolRenderers, ...(chatToolRenderers ?? {}) },
       bridgeEndpoint: null,
@@ -2211,7 +2218,7 @@ export function WorkspaceAgentFront<
       ...(resolvedHotReloadEnabled !== undefined ? { hotReloadEnabled: resolvedHotReloadEnabled } : {}),
     }
     },
-    [apiBaseUrl, chatParams, chatRemoteSessionOptions, delayAutoSubmitDraft, resolvedRequestHeaders, surfaceDispatch, extraCommands, workspaceWarmupStatus, hydrateMessages, emptySessionIds, resolvedHotReloadEnabled, pluginToolRenderers, reloadAgentPluginsForSession, selectedAgentTypeId, sessionSourceIsCurrent, workspaceId],
+    [apiBaseUrl, chatParams, chatRemoteSessionOptions, createChatSession, delayAutoSubmitDraft, resolvedRequestHeaders, surfaceDispatch, extraCommands, workspaceWarmupStatus, hydrateMessages, emptySessionIds, resolvedHotReloadEnabled, pluginToolRenderers, reloadAgentPluginsForSession, selectedAgentTypeId, sessionSourceIsCurrent, workspaceId],
   )
   const centerParams = useMemo(
     () => makeCenterParams(chatSessionKey),


### PR DESCRIPTION
Closes #1238

## What changed
- treats `AGENT_SESSION_RUNTIME_SCOPE_MISMATCH` as a terminal session state instead of reconnecting forever
- preserves the stable gateway error code in the runtime notice
- offers **Start new chat** and routes controlled workspace sessions through the workspace session creator
- coalesces repeated create clicks and safely handles synchronous creator failures

This is the immediate recovery slice: it does not repin or mutate the historical session. Read-only transcript/fork semantics remain follow-up work.

## Verification
- `pnpm --filter @hachej/boring-agent typecheck`
- `pnpm --filter @hachej/boring-agent exec vitest run src/front/chat/pi/__tests__/remotePiSession.test.ts src/front/chat/__tests__/PiChatPanel.test.tsx` (94 tests)
- `pnpm --filter @hachej/boring-workspace typecheck`
- `pnpm --filter @hachej/boring-workspace exec vitest run src/app/front/__tests__/WorkspaceAgentFront.test.tsx` (91 tests)
- agent package build + build artifact assertions
- fresh-context reviewer pass; lifecycle, controlled-session wiring, and duplicate-creation findings resolved