### PR TITLE
fix(workspace): hide single-agent menu in fleet mode

### DIFF
--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -796,6 +796,7 @@ export function WorkspaceAgentFront<
     [authHeaders, requestHeaders, workspaceId],
   )
   const fleetModeEnabled = addressedAgentSelection && isPluginTabsLayout
+  const singleAgentSkillsActionEnabled = skillsActionEnabled && !fleetModeEnabled
   const useAgentSelection = useAddressedAgentSelectionProp ?? useDefaultAddressedAgentSelection
   const addressedAgents = useAgentSelection({
     apiBaseUrl,
@@ -1394,7 +1395,7 @@ export function WorkspaceAgentFront<
       && !addressedAgents.loading
       && !addressedAgents.agents.some((agent) => agent.agentTypeId === parsedAgentOverlay.agentTypeId))
     if (
-      (leftOverlay === "skills" && !skillsActionEnabled)
+      (leftOverlay === "skills" && !singleAgentSkillsActionEnabled)
       || (leftOverlay === "plugins" && !pluginsActionEnabled)
       || agentOverlayMissing
       || (leftOverlay !== null
@@ -1406,7 +1407,7 @@ export function WorkspaceAgentFront<
     ) {
       setLeftOverlay(null)
     }
-  }, [addressedAgents.agents, addressedAgents.loading, appLeftOverlayActions, leftOverlay, pluginOverlayActionIds, pluginsActionEnabled, skillsActionEnabled])
+  }, [addressedAgents.agents, addressedAgents.loading, appLeftOverlayActions, leftOverlay, pluginOverlayActionIds, pluginsActionEnabled, singleAgentSkillsActionEnabled])
   const effectiveNavOpen = navEnabled && navOpen
   const [surfaceOpen, setSurfaceOpen] = useStoredBooleanState(
     // Key must NOT match resolvedSurfaceStorageKey (which stores the dockview
@@ -2484,7 +2485,7 @@ export function WorkspaceAgentFront<
         onClick: () => setLeftOverlay((cur) => cur === action.id ? null : action.id),
       })
     }
-    if (skillsActionEnabled) {
+    if (singleAgentSkillsActionEnabled) {
       actions.push({
         id: "skills",
         label: "Agent",
@@ -2495,7 +2496,7 @@ export function WorkspaceAgentFront<
     }
     assertUniqueAppLeftActionIds(actions)
     return actions
-  }, [appLeftActions, appLeftOverlayActions, leftOverlay, pluginAppLeftActions, skillsActionEnabled])
+  }, [appLeftActions, appLeftOverlayActions, leftOverlay, pluginAppLeftActions, singleAgentSkillsActionEnabled])
   const openAppLeftChats = useCallback(() => {
     setLeftOverlay(null)
   }, [])
@@ -2535,7 +2536,7 @@ export function WorkspaceAgentFront<
       headerInsetEnd={!surfaceOpen}
     />
   ) : null
-  const leftOverlayNode = pluginLeftOverlayNode ?? customLeftOverlayNode ?? agentLeftOverlayNode ?? (leftOverlay === "skills" && skillsActionEnabled ? (
+  const leftOverlayNode = pluginLeftOverlayNode ?? customLeftOverlayNode ?? agentLeftOverlayNode ?? (leftOverlay === "skills" && singleAgentSkillsActionEnabled ? (
     <AgentPage
       onClose={() => setLeftOverlay(null)}
       headerInsetStart={mobileShellActive}

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -680,6 +680,9 @@ describe("WorkspaceAgentFront", () => {
       expect(screen.getByRole("button", { name: "New chat with Beta" })).toBeInTheDocument()
       expect(screen.getAllByText("Alpha one").length).toBeGreaterThan(0)
     })
+    // Fleet cards own Agent-specific settings; the generic single-Agent menu
+    // must not compete with them in the primary navigation.
+    expect(within(screen.getByLabelText("App navigation")).queryByRole("button", { name: "Agent" })).not.toBeInTheDocument()
     // Chats nest under their Agent: the addressed Agent (Alpha) starts
     // disclosed, other owners' chats appear only after expanding their row.
     expect(screen.getAllByText("Alpha one").length).toBeGreaterThan(0)
@@ -1210,9 +1213,33 @@ describe("WorkspaceAgentFront", () => {
     await waitFor(() => expect(document.querySelector('[data-boring-workspace-part="agent-page"]')).not.toBeNull())
 
     unmount()
-    render(<WorkspaceAgentFront {...props} />)
+    const restored = render(<WorkspaceAgentFront {...props} />)
 
     await waitFor(() => expect(document.querySelector('[data-boring-workspace-part="agent-page"]')).not.toBeNull())
+
+    // The persisted generic Agent overlay belongs to single-Agent mode. A fleet
+    // must ignore and clear it rather than flashing the wrong settings surface.
+    restored.unmount()
+    const useAgentSelection = () => ({
+      agents: [
+        { agentTypeId: "alpha", label: "Alpha" },
+        { agentTypeId: "beta", label: "Beta" },
+      ],
+      selectedAgentTypeId: "alpha",
+      loading: false,
+      error: undefined,
+      selectAgentTypeId: vi.fn(),
+    })
+    render(
+      <WorkspaceAgentFront
+        {...props}
+        addressedAgentSelection
+        useAddressedAgentSelection={useAgentSelection}
+      />,
+    )
+
+    expect(document.querySelector('[data-boring-workspace-part="agent-page"]')).toBeNull()
+    expect(within(screen.getByLabelText("App navigation")).queryByRole("button", { name: "Agent" })).not.toBeInTheDocument()
   })
 
   it.each([


### PR DESCRIPTION
Closes #1278

## What changed
- hides the generic single-Agent menu when addressed fleet mode is active
- ignores and clears a persisted generic Agent overlay in fleet mode
- preserves the menu and overlay in single-Agent mode

## Verification
- WorkspaceAgentFront tests: 91/91 passed
- workspace typecheck passed
- Claude Code + Fable review: PASS, no blocker/high/medium findings