### PR TITLE
fix(ui-review): stabilize command palette exploration and replay

### DIFF
--- a/tools/ui-review/scripts/explore-review-spec.ts
+++ b/tools/ui-review/scripts/explore-review-spec.ts
@@ -53,7 +53,7 @@ try {
     await validateReproduceOwnership({ outputRoot, selected: selected as never, manifest, origin, targetUrl: origin, spec })
     const replayRoot = await mkdtemp(join(tmpdir(), `boring-ui-review-replay-${viewport.viewport.name}.`))
     await runBombadil(["browser", "test", manifest.targetUrl, spec.exploration.bombadilSpecPath, "--output-path", replayRoot, "--headless", "--width", String(manifest.viewport.width), "--height", String(manifest.viewport.height), "--device-scale-factor", String(manifest.viewport.deviceScaleFactor), "--instrument-javascript", "inline", "--reproduce", bundleArgument], outputRoot)
-    await verifyReproducedFinalState(replayRoot, manifest)
+    await verifyReproducedFinalState(replayRoot, manifest, spec)
     console.log(`verified Bombadil replay final state: ${selected.id}`)
   }
 } finally { await stop(server) }

--- a/tools/ui-review/src/__tests__/exploration.test.ts
+++ b/tools/ui-review/src/__tests__/exploration.test.ts
@@ -13,6 +13,7 @@ import {
   validateReproduceOwnership as validateOwnershipForSpec,
   verifyReproducedFinalState,
 } from "../core/replay"
+import { workspaceCommandPaletteSpec } from "../review-specs/workspace-command-palette/spec"
 import { isSafeCommandPaletteControl } from "../review-specs/workspace-command-palette/scenarioActions"
 import { testSpec, testStagingPolicy } from "./fixtures"
 
@@ -127,7 +128,7 @@ describe("Bombadil exploration staging", () => {
 
   it("verifies replay final normalized state and screenshot, not exit alone", async () => {
     const raw = await fixture([entry(1, { screenshot: "expected", palette: { dialogVisible: true } })])
-    const [expected] = await parseBombadilTrace(raw)
+    const [expected] = await parseBombadilTrace(raw, testSpec.exploration?.normalizeReplayState)
     await expect(verifyReproducedFinalState(raw, {
       schemaVersion: 1,
       stateId: "state",
@@ -145,7 +146,7 @@ describe("Bombadil exploration staging", () => {
       sourceScreenshotName: "1.png",
       actionCount: 1,
       hashCurrent: 1,
-    })).resolves.toBeUndefined()
+    }, testSpec)).resolves.toBeUndefined()
     await expect(verifyReproducedFinalState(raw, {
       schemaVersion: 1,
       stateId: "state",
@@ -163,15 +164,73 @@ describe("Bombadil exploration staging", () => {
       sourceScreenshotName: "1.png",
       actionCount: 1,
       hashCurrent: 1,
-    })).rejects.toThrow("UI_REVIEW_REPRODUCE_STATE_MISMATCH")
+    }, testSpec)).rejects.toThrow("UI_REVIEW_REPRODUCE_STATE_MISMATCH")
+  })
+
+  it("replays transient command-palette metadata changes but rejects durable changes", async () => {
+    const transient = {
+      dialogVisible: true,
+      mode: "Commands",
+      query: "",
+      workspaceReady: false,
+      lastActionWasPaletteOpen: true,
+      lastActionWasInitial: false,
+      controls: [{ name: "palette-mode-commands", point: { x: 10.25, y: 20.5 } }],
+    }
+    const expectedRoot = await fixture([entry(1, { screenshot: "stable", palette: transient })])
+    const normalize = workspaceCommandPaletteSpec.exploration!.normalizeReplayState
+    const [expected] = await parseBombadilTrace(expectedRoot, normalize)
+    const manifest = {
+      schemaVersion: 1 as const,
+      stateId: "state",
+      scenarioId: workspaceCommandPaletteSpec.id,
+      scenarioSpecRevision: workspaceCommandPaletteSpec.specRevision,
+      fixtureResetId: workspaceCommandPaletteSpec.fixtureResetId,
+      origin: "http://localhost:5380",
+      targetUrl: "http://localhost:5380/?fresh=1",
+      viewport,
+      expectedNormalizedStateSignature: expected!.normalizedStateSignature,
+      expectedScreenshotDigest: expected!.screenshotDigest,
+      expectedScreenshotPHash: expected!.screenshotPHash,
+      maximumScreenshotPHashDistance: 8,
+      traceDigest: "a".repeat(64),
+      sourceScreenshotName: "1.png",
+      actionCount: 1,
+      hashCurrent: 1,
+    }
+    const replayRoot = await fixture([entry(1, {
+      screenshot: "stable",
+      palette: {
+        ...transient,
+        workspaceReady: true,
+        lastActionWasPaletteOpen: false,
+        lastActionWasInitial: true,
+        controls: [{ name: "palette-mode-commands", point: { x: 11.75, y: 20.5 } }],
+      },
+    })])
+    await expect(verifyReproducedFinalState(
+      replayRoot,
+      manifest,
+      workspaceCommandPaletteSpec,
+    )).resolves.toBeUndefined()
+
+    const durableMismatchRoot = await fixture([entry(1, {
+      screenshot: "stable",
+      palette: { ...transient, mode: "Files" },
+    })])
+    await expect(verifyReproducedFinalState(
+      durableMismatchRoot,
+      manifest,
+      workspaceCommandPaletteSpec,
+    )).rejects.toThrow("UI_REVIEW_REPRODUCE_STATE_MISMATCH")
   })
 })
 
 describe("command palette action safety", () => {
   it("allows only named non-submitting local palette controls", () => {
     expect(isSafeCommandPaletteControl({ tagName: "button", label: "Search catalogs and commands", insideDialog: false })).toBe(true)
-    expect(isSafeCommandPaletteControl({ tagName: "button", label: "Search", insideDialog: false })).toBe(true)
-    expect(isSafeCommandPaletteControl({ tagName: "button", label: "Search⌘K", insideDialog: false })).toBe(true)
+    expect(isSafeCommandPaletteControl({ tagName: "button", label: "Search", insideDialog: false })).toBe(false)
+    expect(isSafeCommandPaletteControl({ tagName: "button", label: "Search⌘K", insideDialog: false })).toBe(false)
     expect(isSafeCommandPaletteControl({ tagName: "button", label: "Open app navigation", insideDialog: false })).toBe(true)
     expect(isSafeCommandPaletteControl({ tagName: "button", label: "Commands", insideDialog: true })).toBe(true)
     expect(isSafeCommandPaletteControl({ tagName: "button", label: "Files", insideDialog: true })).toBe(true)

--- a/tools/ui-review/src/__tests__/registry.test.ts
+++ b/tools/ui-review/src/__tests__/registry.test.ts
@@ -61,22 +61,59 @@ describe("UI review spec registry", () => {
   it("selects a painted command-palette Wait for replay", () => {
     const select = uiReviewSpecs.get("workspace-command-palette").exploration!.selectReplayState
     const states = [
-      { ordinal: 19, viewport: { name: "desktop" }, action: "Wait", screenshotDigest: "painted", screenshotBytes: 200, normalizedState: { palette: { workspaceReady: true, dialogVisible: true, mode: "Commands" } } },
-      { ordinal: 14, viewport: { name: "desktop" }, action: "Wait", screenshotDigest: "closed", screenshotBytes: 100, normalizedState: { palette: { workspaceReady: true, dialogVisible: false, mode: "none" } } },
-      { ordinal: 16, viewport: { name: "desktop" }, action: { Click: {} }, screenshotDigest: "skeleton", screenshotBytes: 95, normalizedState: { palette: { workspaceReady: true, dialogVisible: true, mode: "Chats" } } },
-      { ordinal: 17, viewport: { name: "desktop" }, action: "Wait", screenshotDigest: "skeleton", screenshotBytes: 95, normalizedState: { palette: { workspaceReady: true, dialogVisible: true, mode: "Chats" } } },
+      { ordinal: 19, viewport: { name: "desktop" }, action: "Wait", screenshotDigest: "painted", screenshotBytes: 80, screenshotPHash: "ffffffffffffffff", normalizedState: { palette: { dialogVisible: true, mode: "Commands" } } },
+      { ordinal: 14, viewport: { name: "desktop" }, action: "Wait", screenshotDigest: "closed", screenshotBytes: 100, screenshotPHash: "0000000000000000", normalizedState: { palette: { dialogVisible: false, mode: "none" } } },
+      { ordinal: 16, viewport: { name: "desktop" }, action: { Click: {} }, screenshotDigest: "jitter", screenshotBytes: 95, screenshotPHash: "0000000000000001", normalizedState: { palette: { dialogVisible: true, mode: "Chats" } } },
+      { ordinal: 17, viewport: { name: "desktop" }, action: "Wait", screenshotDigest: "jitter", screenshotBytes: 95, screenshotPHash: "0000000000000001", normalizedState: { palette: { dialogVisible: true, mode: "Chats" } } },
     ] as unknown as UiReviewExplorationState[]
 
     expect(select(states)).toBe(states[0])
     expect(select(states.slice(1))).toBeUndefined()
 
     const mobileStates = [
-      { ordinal: 17, viewport: { name: "mobile" }, action: "Wait", screenshotDigest: "painted", screenshotBytes: 200, normalizedState: { palette: { workspaceReady: true, dialogVisible: true, mode: null } } },
-      { ordinal: 14, viewport: { name: "mobile" }, action: "Wait", screenshotDigest: "closed", screenshotBytes: 100, normalizedState: { palette: { workspaceReady: true, dialogVisible: false, mode: null } } },
-      { ordinal: 15, viewport: { name: "mobile" }, action: { Click: {} }, screenshotDigest: "skeleton", screenshotBytes: 100, normalizedState: { palette: { workspaceReady: true, dialogVisible: true, mode: null } } },
-      { ordinal: 16, viewport: { name: "mobile" }, action: "Wait", screenshotDigest: "skeleton", screenshotBytes: 100, normalizedState: { palette: { workspaceReady: true, dialogVisible: true, mode: null } } },
+      { ordinal: 17, viewport: { name: "mobile" }, action: "Wait", screenshotDigest: "painted", screenshotBytes: 80, screenshotPHash: "ffffffffffffffff", normalizedState: { palette: { dialogVisible: true, mode: null } } },
+      { ordinal: 14, viewport: { name: "mobile" }, action: "Wait", screenshotDigest: "closed", screenshotBytes: 100, screenshotPHash: "0000000000000000", normalizedState: { palette: { dialogVisible: false, mode: null } } },
+      { ordinal: 15, viewport: { name: "mobile" }, action: { Click: {} }, screenshotDigest: "jitter", screenshotBytes: 100, screenshotPHash: "0000000000000001", normalizedState: { palette: { dialogVisible: true, mode: null } } },
+      { ordinal: 16, viewport: { name: "mobile" }, action: "Wait", screenshotDigest: "jitter", screenshotBytes: 100, screenshotPHash: "0000000000000001", normalizedState: { palette: { dialogVisible: true, mode: null } } },
     ] as unknown as UiReviewExplorationState[]
     expect(select(mobileStates)).toBe(mobileStates[0])
+  })
+
+  it("normalizes transient command-palette orchestration out of replay identity", () => {
+    const normalize = uiReviewSpecs.get("workspace-command-palette").exploration!.normalizeReplayState!
+    const durable = {
+      path: "/",
+      palette: {
+        dialogVisible: true,
+        mode: "Commands",
+        query: "",
+        workspaceReady: false,
+        lastActionWasPaletteOpen: true,
+        lastActionWasInitial: false,
+        controls: [{ name: "open-command-palette", point: { x: 10.25, y: 20.5 } }],
+      },
+    }
+    expect(normalize(durable)).toEqual(normalize({
+      ...durable,
+      palette: {
+        ...durable.palette,
+        workspaceReady: true,
+        lastActionWasPaletteOpen: false,
+        lastActionWasInitial: true,
+        controls: [{ name: "open-command-palette", point: { x: 11.75, y: 20.5 } }],
+      },
+    }))
+    expect(normalize(durable)).not.toEqual(normalize({
+      ...durable,
+      palette: { ...durable.palette, mode: "Files" },
+    }))
+    expect(normalize(durable)).not.toEqual(normalize({
+      ...durable,
+      palette: {
+        ...durable.palette,
+        controls: [{ name: "palette-mode-files", point: { x: 10.25, y: 20.5 } }],
+      },
+    }))
   })
 
   it.each(["https://example.com", "../workspace", "workspace/spec", "javascript:alert(1)"])(

--- a/tools/ui-review/src/core/contracts.ts
+++ b/tools/ui-review/src/core/contracts.ts
@@ -32,6 +32,8 @@ export type UiReviewState = {
   screenshotPath: string
   screenshotDigest: string
   screenshotBytes: number
+  /** Perceptual image hash for exploration/replay stability checks. */
+  screenshotPHash?: string
   source?: "known" | "bombadil"
   normalizedStateSignature?: string
   reproducePath?: string

--- a/tools/ui-review/src/core/exploration.ts
+++ b/tools/ui-review/src/core/exploration.ts
@@ -35,6 +35,7 @@ export function createUiReviewStagingPolicy(spec: UiReviewSpec) {
 
 export type UiReviewSelectionState = UiReviewState & {
   source: "bombadil"
+  screenshotPHash: string
   ordinal: number
   action: unknown
   hashCurrent: string | number | null
@@ -82,7 +83,10 @@ export async function stageBombadilSelection(input: {
   rawViolations: Array<{ ordinal: number; violations: unknown[] }>
 }> {
   const policy = createUiReviewStagingPolicy(input.spec)
-  const entries = await parseBombadilTrace(input.rawRoot)
+  const entries = await parseBombadilTrace(
+    input.rawRoot,
+    input.spec.exploration?.normalizeReplayState,
+  )
   const rawViolations = entries.flatMap((entry) => (
     entry.violations.length > 0 ? [{ ordinal: entry.ordinal, violations: entry.violations }] : []
   ))
@@ -177,6 +181,7 @@ export async function stageBombadilSelection(input: {
       screenshotPath,
       screenshotDigest: entry.screenshotDigest,
       screenshotBytes: entry.screenshotBytes,
+      screenshotPHash: entry.screenshotPHash,
       source: "bombadil",
       ordinal: entry.ordinal,
       action: entry.action,

--- a/tools/ui-review/src/core/replay.ts
+++ b/tools/ui-review/src/core/replay.ts
@@ -29,8 +29,12 @@ export type UiReviewReproduceManifest = {
 export async function verifyReproducedFinalState(
   replayRoot: string,
   expected: UiReviewReproduceManifest,
+  spec: UiReviewSpec,
 ): Promise<void> {
-  const final = (await parseBombadilTrace(replayRoot)).at(-1)
+  const final = (await parseBombadilTrace(
+    replayRoot,
+    spec.exploration?.normalizeReplayState,
+  )).at(-1)
   if (!final) throw new Error(`UI_REVIEW_REPRODUCE_EMPTY:${expected.stateId}`)
   if (final.normalizedStateSignature !== expected.expectedNormalizedStateSignature) {
     throw new Error(`UI_REVIEW_REPRODUCE_STATE_MISMATCH:${expected.stateId}`)
@@ -96,7 +100,9 @@ export async function validateReproduceOwnership(input: {
     }
     return { name: snapshot.name, value: snapshot.value }
   })
-  if (sha256Json(normalizeManifestState(final.state.url, snapshots)) !== selected.normalizedStateSignature) {
+  const normalizedState = normalizeManifestState(final.state.url, snapshots)
+  const replayState = spec.exploration?.normalizeReplayState?.(normalizedState) ?? normalizedState
+  if (sha256Json(replayState) !== selected.normalizedStateSignature) {
     throw new Error(`UI_REVIEW_REPRODUCE_TRACE_SIGNATURE_INVALID:${selected.id}`)
   }
 }

--- a/tools/ui-review/src/core/reviewSpec.ts
+++ b/tools/ui-review/src/core/reviewSpec.ts
@@ -76,6 +76,8 @@ export type UiReviewSpec = {
   exploration?: {
     bombadilSpecPath: string
     ready?(page: Page, timeoutMs: number): Promise<void>
+    /** Removes scenario-owned orchestration metadata from replay identity. */
+    normalizeReplayState?(state: Record<string, unknown>): Record<string, unknown>
     selectReplayState(states: readonly UiReviewExplorationState[]): UiReviewExplorationState | undefined
   }
 }

--- a/tools/ui-review/src/core/trace.ts
+++ b/tools/ui-review/src/core/trace.ts
@@ -23,7 +23,10 @@ export type BombadilTraceEntry = {
   categories: string[]
 }
 
-export async function parseBombadilTrace(rawRoot: string): Promise<BombadilTraceEntry[]> {
+export async function parseBombadilTrace(
+  rawRoot: string,
+  normalizeReplayState: (state: Record<string, unknown>) => Record<string, unknown> = (state) => state,
+): Promise<BombadilTraceEntry[]> {
   const contents = await readFile(resolve(rawRoot, "trace.jsonl"), "utf8")
   const lines = contents.split(/\r?\n/).filter((line) => line.trim())
   const entries: BombadilTraceEntry[] = []
@@ -53,7 +56,7 @@ export async function parseBombadilTrace(rawRoot: string): Promise<BombadilTrace
       return { name: snapshot.name, value: snapshot.value }
     })
     const violations = parsed.violations
-    const normalizedState = normalizeManifestState(parsed.state.url, snapshots)
+    const normalizedState = normalizeReplayState(normalizeManifestState(parsed.state.url, snapshots))
     entries.push({
       ordinal: index + 1,
       rawLine,

--- a/tools/ui-review/src/review-specs/workspace-command-palette/bombadil.spec.ts
+++ b/tools/ui-review/src/review-specs/workspace-command-palette/bombadil.spec.ts
@@ -65,7 +65,9 @@ const palette = extract((state): SafePaletteState => {
   const dialogs = visibleElements('[role="dialog"], [aria-modal="true"]')
     .filter((element, index, all) => all.indexOf(element) === index)
   const dialog = dialogs[0] ?? null
-  const searchControls = Array.from(state.document.querySelectorAll("button"))
+  const searchControls = Array.from(state.document.querySelectorAll(
+    'button[aria-label="Search catalogs and commands"], button[data-boring-app-left-nav-key="search"]',
+  ))
   const allowed: Array<{ name: string; point: Point }> = []
   const maybeAdd = (element: Element, insideDialog: boolean): void => {
     const label = normalizedText(element)

--- a/tools/ui-review/src/review-specs/workspace-command-palette/scenarioActions.ts
+++ b/tools/ui-review/src/review-specs/workspace-command-palette/scenarioActions.ts
@@ -18,5 +18,4 @@ export function isSafeCommandPaletteControl(control: ScenarioControl): boolean {
   if (control.insideDialog) return control.label === "Commands" || control.label === "Files"
   return control.label === "Open app navigation"
     || control.label === "Search catalogs and commands"
-    || /^Search(?:⌘K|CtrlK)?$/.test(control.label)
 }

--- a/tools/ui-review/src/review-specs/workspace-command-palette/spec.ts
+++ b/tools/ui-review/src/review-specs/workspace-command-palette/spec.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path"
 import { expect } from "@playwright/test"
 import type { UiReviewSpec } from "../../core/reviewSpec"
 import type { UiReviewViewport } from "../../core/contracts"
+import { hexadecimalHammingDistance } from "../../core/imageHash"
 import { observeBrowserDocument } from "../../core/browserObservation"
 import { observeCommandPaletteSurface } from "./browserObservation"
 import { COMMAND_PALETTE_HARD_GATE_CONTRACT, evaluateCommandPaletteHardGates, validateCommandPaletteHardGateReport, type UiHardGateSnapshot } from "./hardGates"
@@ -15,7 +16,7 @@ const viewports: UiReviewViewport[] = [
 
 export const workspaceCommandPaletteSpec: UiReviewSpec = {
   id: "workspace-command-palette",
-  specRevision: "workspace-command-palette-v2",
+  specRevision: "workspace-command-palette-v3",
   fixtureResetId: "workspace-playground-e2e-fresh-v1",
   rubricVersion: "impeccable-v1",
   target: {
@@ -83,10 +84,29 @@ export const workspaceCommandPaletteSpec: UiReviewSpec = {
   },
   exploration: {
     bombadilSpecPath: resolve(import.meta.dirname, "bombadil.spec.ts"),
+    normalizeReplayState: (state) => {
+      const palette = state.palette
+      if (!palette || typeof palette !== "object" || Array.isArray(palette)) return state
+      const durablePalette = { ...palette } as Record<string, unknown>
+      delete durablePalette.workspaceReady
+      delete durablePalette.lastActionWasPaletteOpen
+      delete durablePalette.lastActionWasInitial
+      durablePalette.controls = Array.isArray(durablePalette.controls)
+        ? durablePalette.controls.flatMap((control) => (
+            control && typeof control === "object" && !Array.isArray(control)
+              && typeof (control as Record<string, unknown>).name === "string"
+              ? [(control as Record<string, unknown>).name]
+              : []
+          ))
+        : []
+      return { ...state, palette: durablePalette }
+    },
     ready: async (page, timeoutMs) => {
       await Promise.all([
         expect(page.getByRole("main", { name: "Chat" })).toBeVisible({ timeout: timeoutMs }),
-        expect(page.locator("button").filter({ hasText: /^Search/ }).first()).toBeVisible({ timeout: timeoutMs }),
+        expect(page.locator(
+          'button[aria-label="Search catalogs and commands"], button[data-boring-app-left-nav-key="search"]',
+        ).first()).toBeVisible({ timeout: timeoutMs }),
       ])
     },
     selectReplayState: (states) => {
@@ -103,20 +123,21 @@ export const workspaceCommandPaletteSpec: UiReviewSpec = {
       const waits = dialogStates
         .filter((state) => state.action === "Wait")
         .sort((left, right) => left.ordinal - right.ordinal)
-      // The first Wait after opening can observe the dialog in the DOM before
-      // Chromium has painted it. Keep the short replayable Wait path from the
-      // Bombadil spec, but require its encoded screenshot to grow beyond the
-      // latest hydrated closed-workspace frame so the overlay is actually in it.
-      const painted = waits.find((state) => {
+      // DOM visibility can precede paint. Prefer the latest replayable Wait
+      // whose screenshot differs from a prior post-bootstrap closed state;
+      // encoded PNG byte size is not a monotonic paint signal.
+      const painted = [...waits].reverse().find((state) => {
         const closed = ordered.filter((candidate) => {
           const palette = candidate.normalizedState.palette as Record<string, unknown> | undefined
-          return candidate.ordinal < state.ordinal
-            && palette?.workspaceReady === true
-            && palette.dialogVisible === false
+          return candidate.ordinal > 2
+            && candidate.ordinal < state.ordinal
+            && palette?.dialogVisible === false
         }).at(-1)
         return closed !== undefined
           && state.screenshotDigest !== closed.screenshotDigest
-          && state.screenshotBytes > closed.screenshotBytes
+          && typeof state.screenshotPHash === "string"
+          && typeof closed.screenshotPHash === "string"
+          && hexadecimalHammingDistance(state.screenshotPHash, closed.screenshotPHash) > 4
       })
       return painted
     },


### PR DESCRIPTION
## Summary

- replaces PNG byte-size paint inference with meaningful perceptual-hash distance and selects the latest stable dialog Wait
- limits exploration/readiness to stable command-palette trigger identities instead of unrelated `Search` buttons
- adds scenario-owned replay normalization that removes timing/action coordinates while preserving durable control names and product state
- requires the scenario spec during replay verification so staging, ownership, and replay use one identity policy
- bumps the command-palette review spec revision

## Regression coverage

- painted overlay may encode smaller than the closed workspace
- minor visual jitter is not accepted as paint
- control coordinate/timing differences replay successfully
- control names and durable palette mode changes still fail identity
- generic unrelated Search buttons are not actionable

## Validation

- UI Review tools: **69 passed**
- UI Review tools typecheck: passed
- thermonuclear review: **APPROVE / no material findings**

Closes #1280
