### PR TITLE
fix(ui-review): admit stable palette trigger identity

### DIFF
--- a/tools/ui-review/src/__tests__/exploration.test.ts
+++ b/tools/ui-review/src/__tests__/exploration.test.ts
@@ -231,6 +231,12 @@ describe("command palette action safety", () => {
     expect(isSafeCommandPaletteControl({ tagName: "button", label: "Search catalogs and commands", insideDialog: false })).toBe(true)
     expect(isSafeCommandPaletteControl({ tagName: "button", label: "Search", insideDialog: false })).toBe(false)
     expect(isSafeCommandPaletteControl({ tagName: "button", label: "Search⌘K", insideDialog: false })).toBe(false)
+    expect(isSafeCommandPaletteControl({
+      tagName: "button",
+      label: "Search⌘K",
+      insideDialog: false,
+      identity: "command-palette-trigger",
+    })).toBe(true)
     expect(isSafeCommandPaletteControl({ tagName: "button", label: "Open app navigation", insideDialog: false })).toBe(true)
     expect(isSafeCommandPaletteControl({ tagName: "button", label: "Commands", insideDialog: true })).toBe(true)
     expect(isSafeCommandPaletteControl({ tagName: "button", label: "Files", insideDialog: true })).toBe(true)

--- a/tools/ui-review/src/review-specs/workspace-command-palette/bombadil.spec.ts
+++ b/tools/ui-review/src/review-specs/workspace-command-palette/bombadil.spec.ts
@@ -69,7 +69,11 @@ const palette = extract((state): SafePaletteState => {
     'button[aria-label="Search catalogs and commands"], button[data-boring-app-left-nav-key="search"]',
   ))
   const allowed: Array<{ name: string; point: Point }> = []
-  const maybeAdd = (element: Element, insideDialog: boolean): void => {
+  const maybeAdd = (
+    element: Element,
+    insideDialog: boolean,
+    identity?: "command-palette-trigger",
+  ): void => {
     const label = normalizedText(element)
     if (!visible(element) || !isSafeCommandPaletteControl({
       tagName: element.tagName,
@@ -78,6 +82,7 @@ const palette = extract((state): SafePaletteState => {
       href: element.getAttribute("href"),
       formAction: element.getAttribute("formaction"),
       insideDialog,
+      identity,
     })) return
     allowed.push({
       name: insideDialog
@@ -90,7 +95,7 @@ const palette = extract((state): SafePaletteState => {
   }
 
   if (!dialog && workspaceReady) {
-    for (const search of searchControls) maybeAdd(search, false)
+    for (const search of searchControls) maybeAdd(search, false, "command-palette-trigger")
   }
   if (dialog && visible(dialog)) {
     for (const element of dialog.querySelectorAll("button")) maybeAdd(element, true)

--- a/tools/ui-review/src/review-specs/workspace-command-palette/scenarioActions.ts
+++ b/tools/ui-review/src/review-specs/workspace-command-palette/scenarioActions.ts
@@ -5,6 +5,7 @@ export type ScenarioControl = {
   href?: string | null
   formAction?: string | null
   insideDialog: boolean
+  identity?: "command-palette-trigger"
 }
 
 const DESTRUCTIVE_OR_EXTERNAL = /\b(delete|remove|destroy|reset|sign[ -]?out|log[ -]?out|publish|send|submit|open externally|external)\b/i
@@ -16,6 +17,7 @@ export function isSafeCommandPaletteControl(control: ScenarioControl): boolean {
   if (control.href?.trim() || control.formAction?.trim()) return false
   if (DESTRUCTIVE_OR_EXTERNAL.test(control.label)) return false
   if (control.insideDialog) return control.label === "Commands" || control.label === "Files"
-  return control.label === "Open app navigation"
+  return control.identity === "command-palette-trigger"
+    || control.label === "Open app navigation"
     || control.label === "Search catalogs and commands"
 }


### PR DESCRIPTION
## Summary

- carries the stable command-palette trigger identity from the exact DOM selector into the scenario safety policy
- permits the real `Search⌘K` trigger only when selected by that stable identity
- keeps generic label-only Search buttons denied

## Cause

#1281 narrowed discovery to stable trigger selectors, but the independent label policy still rejected the trigger's rendered `Search⌘K` text. CI artifacts showed every explored state had `controls: []`, so Bombadil never opened the palette and replay selection necessarily failed.

## Validation

- UI Review tools: 69 passed
- UI Review tools typecheck: passed

Closes #1280
