### PR TITLE
fix(ui-review): discover mobile palette controls before readiness

### DIFF
--- a/tools/ui-review/src/review-specs/workspace-command-palette/bombadil.spec.ts
+++ b/tools/ui-review/src/review-specs/workspace-command-palette/bombadil.spec.ts
@@ -65,8 +65,8 @@ const palette = extract((state): SafePaletteState => {
   const dialogs = visibleElements('[role="dialog"], [aria-modal="true"]')
     .filter((element, index, all) => all.indexOf(element) === index)
   const dialog = dialogs[0] ?? null
-  const searchControls = Array.from(state.document.querySelectorAll(
-    'button[aria-label="Search catalogs and commands"], button[data-boring-app-left-nav-key="search"]',
+  const rootControls = Array.from(state.document.querySelectorAll(
+    'button[aria-label="Search catalogs and commands"], button[data-boring-app-left-nav-key="search"], button[aria-label="Open app navigation"]',
   ))
   const allowed: Array<{ name: string; point: Point }> = []
   const maybeAdd = (
@@ -94,8 +94,13 @@ const palette = extract((state): SafePaletteState => {
     })
   }
 
-  if (!dialog && workspaceReady) {
-    for (const search of searchControls) maybeAdd(search, false, "command-palette-trigger")
+  if (!dialog) {
+    for (const control of rootControls) {
+      const identity = control.matches(
+        'button[aria-label="Search catalogs and commands"], button[data-boring-app-left-nav-key="search"]',
+      ) ? "command-palette-trigger" : undefined
+      maybeAdd(control, false, identity)
+    }
   }
   if (dialog && visible(dialog)) {
     for (const element of dialog.querySelectorAll("button")) maybeAdd(element, true)


### PR DESCRIPTION
## Summary

- discovers the stable mobile navigation trigger alongside palette search triggers
- does not gate exact, non-mutating root controls on fragile Resource Timing readiness
- preserves the stable identity safety policy added by #1282

## Evidence

The #1282 CI artifact proved desktop now explores and replays the palette successfully. Mobile produced 100 states with `controls: []`: cached/fresh mobile loading never satisfied the Resource Timing-derived `workspaceReady` predicate, and the narrowed root query omitted the navigation trigger needed to reveal Search.

## Validation

- UI Review tools: 69 passed
- UI Review tools typecheck: passed

Closes #1280
