### PR TITLE
fix(ui-review): distinguish mobile navigation dialog

### DIFF
--- a/tools/ui-review/src/__tests__/exploration.test.ts
+++ b/tools/ui-review/src/__tests__/exploration.test.ts
@@ -14,7 +14,11 @@ import {
   verifyReproducedFinalState,
 } from "../core/replay"
 import { workspaceCommandPaletteSpec } from "../review-specs/workspace-command-palette/spec"
-import { isSafeCommandPaletteControl } from "../review-specs/workspace-command-palette/scenarioActions"
+import {
+  createSafeCommandPaletteActions,
+  isCommandPaletteDialogName,
+  isSafeCommandPaletteControl,
+} from "../review-specs/workspace-command-palette/scenarioActions"
 import { testSpec, testStagingPolicy } from "./fixtures"
 
 const UI_REVIEW_STAGING_POLICY = testStagingPolicy
@@ -227,6 +231,29 @@ describe("Bombadil exploration staging", () => {
 })
 
 describe("command palette action safety", () => {
+  it("opens an exact root control without Resource Timing readiness", () => {
+    const trigger = { name: "open-command-palette", point: { x: 24, y: 24 } }
+    expect(createSafeCommandPaletteActions({
+      dialogVisible: false,
+      inputFocused: false,
+      lastActionWasPaletteOpen: false,
+      lastActionWasInitial: false,
+      controls: [trigger],
+    })).toEqual(["Wait", { Click: trigger }])
+    expect(createSafeCommandPaletteActions({
+      dialogVisible: false,
+      inputFocused: false,
+      lastActionWasPaletteOpen: false,
+      lastActionWasInitial: true,
+      controls: [trigger],
+    })).toEqual(["Wait"])
+  })
+
+  it("distinguishes the palette from the mobile navigation dialog", () => {
+    expect(isCommandPaletteDialogName("Command Palette")).toBe(true)
+    expect(isCommandPaletteDialogName("App navigation")).toBe(false)
+  })
+
   it("allows only named non-submitting local palette controls", () => {
     expect(isSafeCommandPaletteControl({ tagName: "button", label: "Search catalogs and commands", insideDialog: false })).toBe(true)
     expect(isSafeCommandPaletteControl({ tagName: "button", label: "Search", insideDialog: false })).toBe(false)

--- a/tools/ui-review/src/review-specs/workspace-command-palette/bombadil.spec.ts
+++ b/tools/ui-review/src/review-specs/workspace-command-palette/bombadil.spec.ts
@@ -2,7 +2,6 @@ import { always } from "@antithesishq/bombadil"
 import {
   actions,
   extract,
-  type Action,
   type Point,
 } from "@antithesishq/bombadil/browser"
 import {
@@ -12,7 +11,7 @@ import {
   noUnhandledPromiseRejections,
 } from "@antithesishq/bombadil/browser/defaults/properties"
 import { observeCommandPaletteDocument } from "./browserObservation.ts"
-import { isSafeCommandPaletteControl } from "./scenarioActions.ts"
+import { createSafeCommandPaletteActions, isCommandPaletteDialogName, isSafeCommandPaletteControl } from "./scenarioActions.ts"
 import { COMMAND_PALETTE_TOUCH_EXEMPTIONS } from "./touchPolicy.ts"
 
 export {
@@ -55,6 +54,11 @@ const palette = extract((state): SafePaletteState => {
     element.getAttribute("aria-label") ?? element.textContent ?? ""
   ).replace(/\s+/g, " ").trim()
   const visibleElements = (selector: string): Element[] => Array.from(state.document.querySelectorAll(selector)).filter(visible)
+  const accessibleName = (element: Element): string => {
+    const labelledBy = element.getAttribute("aria-labelledby")?.trim().split(/\s+/) ?? []
+    return element.getAttribute("aria-label")
+      ?? labelledBy.map((id) => state.document.getElementById(id)?.textContent ?? "").join(" ").replace(/\s+/g, " ").trim()
+  }
   const completedResources = state.window.performance.getEntriesByType("resource")
     .map((entry) => entry.name)
   const workspaceReady = state.document.fonts.status === "loaded"
@@ -64,7 +68,7 @@ const palette = extract((state): SafePaletteState => {
     && completedResources.some((url) => url.includes("/api/v1/ui/state"))
   const dialogs = visibleElements('[role="dialog"], [aria-modal="true"]')
     .filter((element, index, all) => all.indexOf(element) === index)
-  const dialog = dialogs[0] ?? null
+  const dialog = dialogs.find((element) => isCommandPaletteDialogName(accessibleName(element))) ?? null
   const rootControls = Array.from(state.document.querySelectorAll(
     'button[aria-label="Search catalogs and commands"], button[data-boring-app-left-nav-key="search"], button[aria-label="Open app navigation"]',
   ))
@@ -172,29 +176,4 @@ export const command_palette_has_at_most_one_modal = always(() => palette.curren
 export const command_palette_focus_stays_visible = always(() => !palette.current.focusedControlInvalid)
 export const command_palette_mobile_touch_targets_are_sized = always(() => palette.current.undersizedTouchTargets.length === 0)
 
-export const commandPaletteSafeActions = actions((): Action[] => {
-  if (!palette.current.workspaceReady || palette.current.lastActionWasInitial) return ["Wait"]
-  const openPalette = palette.current.controls.find((control) => control.name === "open-command-palette")
-  if (!palette.current.dialogVisible && openPalette) {
-    const click: Action = { Click: { name: openPalette.name, point: openPalette.point } }
-    return ["Wait", click]
-  }
-  const openNavigation = palette.current.controls.find((control) => control.name === "open-app-navigation")
-  if (!palette.current.dialogVisible && openNavigation) {
-    const click: Action = { Click: { name: openNavigation.name, point: openNavigation.point } }
-    return ["Wait", click]
-  }
-  if (palette.current.dialogVisible && palette.current.lastActionWasPaletteOpen) return ["Wait"]
-  const generated: Action[] = ["Wait"]
-  for (const control of palette.current.controls) {
-    generated.push({ Click: control })
-  }
-  if (palette.current.dialogVisible) generated.push({ PressKey: { code: 27 } })
-  if (palette.current.inputFocused) {
-    generated.push(
-      { TypeText: { text: ">", delayMillis: 0 } },
-      { TypeText: { text: "no-matching-fixture-command", delayMillis: 0 } },
-    )
-  }
-  return generated
-})
+export const commandPaletteSafeActions = actions(() => createSafeCommandPaletteActions(palette.current))

--- a/tools/ui-review/src/review-specs/workspace-command-palette/scenarioActions.ts
+++ b/tools/ui-review/src/review-specs/workspace-command-palette/scenarioActions.ts
@@ -8,7 +8,26 @@ export type ScenarioControl = {
   identity?: "command-palette-trigger"
 }
 
+type ScenarioActionControl = { name: string; point: { x: number; y: number } }
+export type ScenarioAction =
+  | "Wait"
+  | { Click: ScenarioActionControl }
+  | { PressKey: { code: number } }
+  | { TypeText: { text: string; delayMillis: number } }
+
+export type ScenarioActionState = {
+  dialogVisible: boolean
+  inputFocused: boolean
+  lastActionWasPaletteOpen: boolean
+  lastActionWasInitial: boolean
+  controls: ScenarioActionControl[]
+}
+
 const DESTRUCTIVE_OR_EXTERNAL = /\b(delete|remove|destroy|reset|sign[ -]?out|log[ -]?out|publish|send|submit|open externally|external)\b/i
+
+export function isCommandPaletteDialogName(name: string): boolean {
+  return /^command palette$/i.test(name.trim())
+}
 
 /** Pure policy used by the Bombadil scenario and unit fixtures. */
 export function isSafeCommandPaletteControl(control: ScenarioControl): boolean {
@@ -20,4 +39,24 @@ export function isSafeCommandPaletteControl(control: ScenarioControl): boolean {
   return control.identity === "command-palette-trigger"
     || control.label === "Open app navigation"
     || control.label === "Search catalogs and commands"
+}
+
+export function createSafeCommandPaletteActions(state: ScenarioActionState): ScenarioAction[] {
+  if (state.lastActionWasInitial) return ["Wait"]
+  const openPalette = state.controls.find((control) => control.name === "open-command-palette")
+  if (!state.dialogVisible && openPalette) return ["Wait", { Click: openPalette }]
+  const openNavigation = state.controls.find((control) => control.name === "open-app-navigation")
+  if (!state.dialogVisible && openNavigation) return ["Wait", { Click: openNavigation }]
+  if (state.dialogVisible && state.lastActionWasPaletteOpen) return ["Wait"]
+
+  const generated: ScenarioAction[] = ["Wait"]
+  for (const control of state.controls) generated.push({ Click: control })
+  if (state.dialogVisible) generated.push({ PressKey: { code: 27 } })
+  if (state.inputFocused) {
+    generated.push(
+      { TypeText: { text: ">", delayMillis: 0 } },
+      { TypeText: { text: "no-matching-fixture-command", delayMillis: 0 } },
+    )
+  }
+  return generated
 }


### PR DESCRIPTION
Closes #1285.

## What changed

- identifies the command palette by its accessible dialog name instead of treating the mobile navigation sheet as the palette
- extracts the bounded Bombadil action plan into a pure policy
- allows exact, scenario-owned root controls to act without fragile Resource Timing readiness while retaining the initial settling wait and strict allowlist
- adds regressions for pre-readiness root activation and mobile-navigation dialog exclusion

## Verification

- `pnpm --filter @hachej/boring-ui-review-tools test` — 71 passed
- `pnpm --filter @hachej/boring-ui-review-tools typecheck`
- `pnpm --filter @hachej/boring-ui-review-tools ui:review:ci` — desktop and mobile exploration/replay plus Playwright review passed
- fresh-context reviewer: APPROVED
