### PR TITLE
fix(workspace): omit route-owned Agent create input

### DIFF
--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -1227,10 +1227,10 @@ export function WorkspaceAgentFront<
     const attempt = { workspaceId, agentTypeId: selectedAgentTypeId }
     autoSubmitSessionCreateRef.current = attempt
     setAutoSubmitSessionAgentTypeId(attempt.agentTypeId)
-    void Promise.resolve(remoteSessionApi.create({
-      ...automaticSessionCreateInput(defaultSessionTitle),
-      agentTypeId: attempt.agentTypeId,
-    }))
+    const createInput = automaticSessionCreateInput(defaultSessionTitle)
+    void Promise.resolve(remoteSessionApi.create(
+      fleetModeEnabled ? { ...createInput, agentTypeId: attempt.agentTypeId } : createInput,
+    ))
       .then((session) => {
         if (autoSubmitSessionCreateRef.current !== attempt || autoSubmitSessionWorkspaceRef.current !== attempt.workspaceId) return
         if (typeof (session as { id?: unknown } | null | undefined)?.id !== "string") {
@@ -1245,7 +1245,7 @@ export function WorkspaceAgentFront<
         setAutoSubmitSessionAgentTypeId(undefined)
         setAutoSubmitSessionId(undefined)
       })
-  }, [autoSubmitSessionId, defaultSessionTitle, remoteSessionApi.create, selectedAgentTypeId, sessionApi, workspaceId])
+  }, [autoSubmitSessionId, defaultSessionTitle, fleetModeEnabled, remoteSessionApi.create, selectedAgentTypeId, sessionApi, workspaceId])
   const effectiveActiveSessionId = autoSubmitSessionId !== undefined ? autoSubmitSessionId ?? null : resolvedActiveId
   const effectiveActiveSessionAgentTypeId = autoSubmitSessionId !== undefined
     ? autoSubmitSessionAgentTypeId ?? selectedAgentTypeId
@@ -1272,7 +1272,7 @@ export function WorkspaceAgentFront<
       sessionCreation.cancel((task) => task.phase === "queued" && task.dedupeKey === "initial-auto")
       return coordinateRemoteCreate(
         dedupeKey,
-        ownerAgentTypeId ? { agentTypeId: ownerAgentTypeId } : undefined,
+        fleetModeEnabled && ownerAgentTypeId ? { agentTypeId: ownerAgentTypeId } : undefined,
       ).catch((error) => {
         // A canceled queued boot create resolves without running its own error
         // path. Re-arm boot creation if the user-owned request failed.
@@ -1285,7 +1285,7 @@ export function WorkspaceAgentFront<
     }
     const created = onCreateSession ? onCreateSession() : localSessionStore.create()
     return Promise.resolve(created).then((session) => validateCreatedSession<TSession>(session))
-  }, [coordinateRemoteCreate, localSessionStore, onCreateSession, remoteSessionsPending, selectedAgentTypeId, sessionApi, sessionCreation, workspaceId])
+  }, [coordinateRemoteCreate, fleetModeEnabled, localSessionStore, onCreateSession, remoteSessionsPending, selectedAgentTypeId, sessionApi, sessionCreation, workspaceId])
   const resolvedRename = useCallback((id: string, title: string, sessionAgentTypeId?: string) => {
     if (!sessionSourceIsCurrent() || remoteSessionsPending || !sessionApi?.rename) return undefined
     return sessionApi.rename(id, title, sessionAgentTypeId)

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -1774,6 +1774,40 @@ describe("WorkspaceAgentFront", () => {
     })
   })
 
+  it("does not send route-owned Agent identity in a non-fleet session create", async () => {
+    const user = userEvent.setup()
+    const create = vi.fn(async () => ({ id: "created", agentTypeId: "default", title: "Created session" }))
+    const RecoveryChat = (props: WorkspaceChatPanelProps) => (
+      <button type="button" onClick={() => void props.onCreateSession?.()}>
+        Recover stale chat
+      </button>
+    )
+
+    render(
+      <WorkspaceAgentFront
+        workspaceId="non-fleet-stale-recovery"
+        chatPanel={RecoveryChat}
+        useSessions={(options) => ({
+          sourceIdentity: options.sourceIdentity,
+          sessions: [{ id: "stale", agentTypeId: "default", title: "Stale session" }],
+          activeSessionId: "stale",
+          activeSessionAgentTypeId: "default",
+          activeSession: { id: "stale", agentTypeId: "default", title: "Stale session" },
+          loading: false,
+          workspaceId: options.workspaceId,
+          switch: vi.fn(),
+          delete: vi.fn(),
+          create,
+        })}
+        persistenceEnabled={false}
+      />,
+    )
+
+    await user.click(screen.getByRole("button", { name: "Recover stale chat" }))
+    await waitFor(() => expect(create).toHaveBeenCalledOnce())
+    expect(create).toHaveBeenCalledWith()
+  })
+
   it("keeps an async returned created pane while controlled sessions catch up", async () => {
     const user = userEvent.setup()
 
@@ -2306,8 +2340,8 @@ describe("WorkspaceAgentFront", () => {
         activeSessionId,
         activeSession: sessions.find((session) => session.id === activeSessionId) ?? null,
         switch: vi.fn(),
-        create: async () => {
-          createSession()
+        create: async (input?: { title?: string; resumeSessionId?: string }) => {
+          createSession(input)
           const session = { id: "sess-fresh", title: "Fresh session" }
           setSessions((current) => [session, ...current])
           setActiveSessionId(session.id)
@@ -2334,6 +2368,7 @@ describe("WorkspaceAgentFront", () => {
     await waitFor(() => {
       expect(createSession).toHaveBeenCalledOnce()
     })
+    expect(createSession.mock.calls[0]?.[0]).not.toHaveProperty("agentTypeId")
     await waitFor(() => {
       expect(getCapturedChatProps()?.sessionId).toBe("sess-fresh")
     })


### PR DESCRIPTION
Closes #1287.

## What changed

- omits `agentTypeId` from non-fleet session create payloads because the agent-scoped route owns that identity
- retains addressed ownership routing for fleet creates
- covers stale-chat recovery and auth-return auto-submit non-fleet creation

## Verification

- Workspace front suite: 92 passed
- `pnpm --filter @hachej/boring-workspace typecheck`
- fresh-context review: APPROVED after expanding the fix to auth-return auto-submit

## Downstream reproduction

Healio 0.1.99 real Infomaniak smoke reproduced the prior failure as HTTP 400 on `POST /api/v1/agents/default/sessions` with `{agentTypeId:"default"}`, followed by `AGENT_SESSION_RUNTIME_SCOPE_MISMATCH` on the stale session.
