### PR TITLE
fix(ui-review): retry Chromium startup timeout

### DIFF
--- a/tools/ui-review/scripts/explore-review-spec.ts
+++ b/tools/ui-review/scripts/explore-review-spec.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { setTimeout as sleep } from "node:timers/promises"
 import { chromium } from "@playwright/test"
+import { resetBombadilOutputDirectory, runWithBombadilStartupRetry } from "../src/core/bombadilProcess"
 import { createUiReviewStagingPolicy, assertStagingBounds, stageBombadilSelection, writeSelection, type UiReviewSelection } from "../src/core/exploration"
 import { readReproduceManifest, validateReproduceOwnership, verifyReproducedFinalState } from "../src/core/replay"
 import { getUiReviewSpec } from "../src/registry"
@@ -121,10 +122,27 @@ async function warmTarget(): Promise<void> {
   } finally { await browser.close() }
 }
 async function runBombadil(args: string[], cwd: string): Promise<void> {
-  await new Promise<void>((resolveRun, reject) => {
-    const child = spawn(bombadil, args, { cwd, env: process.env, stdio: "inherit" })
-    child.on("error", reject)
-    child.on("exit", (code) => code === 0 || code === 2 ? resolveRun() : reject(new Error(`UI_REVIEW_BOMBADIL_FAILED:${code ?? "unknown"}`)))
+  const outputIndex = args.indexOf("--output-path")
+  const outputPath = outputIndex >= 0 ? args[outputIndex + 1] : undefined
+  if (!outputPath) throw new Error("UI_REVIEW_BOMBADIL_OUTPUT_PATH_MISSING")
+  await runWithBombadilStartupRetry({
+    runAttempt: () => new Promise((resolveRun, reject) => {
+      const child = spawn(bombadil, args, { cwd, env: process.env, stdio: ["ignore", "inherit", "pipe"] })
+      let stderr = ""
+      child.stderr.setEncoding("utf8")
+      child.stderr.on("data", (chunk: string) => {
+        if (!process.stderr.write(chunk)) {
+          child.stderr.pause()
+          process.stderr.once("drain", () => child.stderr.resume())
+        }
+        stderr = `${stderr}${chunk}`.slice(-64 * 1024)
+      })
+      child.on("error", reject)
+      child.on("close", (code) => resolveRun({ code, stderr }))
+    }),
+    resetOutput: () => resetBombadilOutputDirectory(cwd, outputPath),
+    waitBeforeRetry: () => sleep(1_000),
+    onRetry: () => console.warn("UI_REVIEW_BOMBADIL_STARTUP_RETRY"),
   })
 }
 async function stop(server: ChildProcess): Promise<void> {

--- a/tools/ui-review/src/__tests__/exploration.test.ts
+++ b/tools/ui-review/src/__tests__/exploration.test.ts
@@ -1,7 +1,12 @@
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
+import {
+  isRetryableBombadilStartupFailure,
+  resetBombadilOutputDirectory,
+  runWithBombadilStartupRetry,
+} from "../core/bombadilProcess"
 import {
   createUiReviewStagingPolicy,
   parseBombadilTrace,
@@ -29,6 +34,66 @@ const validateReproduceOwnership = (input: Omit<Parameters<typeof validateOwners
 const viewport = { name: "mobile", width: 390, height: 844, deviceScaleFactor: 1 } as const
 
 describe("Bombadil exploration staging", () => {
+  it("retries a Chromium websocket startup timeout exactly once", async () => {
+    const runAttempt = vi.fn()
+      .mockResolvedValueOnce({ code: 1, stderr: 'Timeout while resolving websocket URL from browser process, stderr: BrowserStderr("")' })
+      .mockResolvedValueOnce({ code: 0, stderr: "" })
+    const resetOutput = vi.fn(async () => {})
+    const waitBeforeRetry = vi.fn(async () => {})
+    await expect(runWithBombadilStartupRetry({ runAttempt, resetOutput, waitBeforeRetry })).resolves.toBeUndefined()
+    expect(runAttempt).toHaveBeenCalledTimes(2)
+    expect(resetOutput).toHaveBeenCalledOnce()
+    expect(waitBeforeRetry).toHaveBeenCalledOnce()
+  })
+
+  it("does not retry arbitrary Bombadil failures", async () => {
+    for (const stderr of ["UI_REVIEW_EXPLORATION_STABLE_ACTION_STATE_MISSING:mobile", "property violation"]) {
+      const runAttempt = vi.fn(async () => ({ code: 1, stderr }))
+      const resetOutput = vi.fn(async () => {})
+      await expect(runWithBombadilStartupRetry({ runAttempt, resetOutput, waitBeforeRetry: async () => {} }))
+        .rejects.toThrow("UI_REVIEW_BOMBADIL_FAILED:1")
+      expect(runAttempt).toHaveBeenCalledOnce()
+      expect(resetOutput).not.toHaveBeenCalled()
+    }
+  })
+
+  it("fails after one retried startup timeout and propagates spawn errors", async () => {
+    const timeout = { code: 1, stderr: "Timeout while resolving websocket URL from browser process" }
+    const runAttempt = vi.fn(async () => timeout)
+    const resetOutput = vi.fn(async () => {})
+    await expect(runWithBombadilStartupRetry({ runAttempt, resetOutput, waitBeforeRetry: async () => {} }))
+      .rejects.toThrow("UI_REVIEW_BOMBADIL_FAILED:1")
+    expect(runAttempt).toHaveBeenCalledTimes(2)
+    expect(resetOutput).toHaveBeenCalledOnce()
+
+    const spawnError = new Error("spawn ENOENT")
+    await expect(runWithBombadilStartupRetry({
+      runAttempt: async () => { throw spawnError },
+      resetOutput: async () => { throw new Error("unexpected reset") },
+      waitBeforeRetry: async () => {},
+    })).rejects.toBe(spawnError)
+  })
+
+  it("recreates a clean Bombadil output directory before retry", async () => {
+    const root = await mkdtemp(join(tmpdir(), "ui-review-bombadil-reset-"))
+    try {
+      const outputPath = join(root, "raw")
+      await mkdir(outputPath)
+      const stale = join(outputPath, "partial-trace.jsonl")
+      await writeFile(stale, "partial")
+      await resetBombadilOutputDirectory(root, "raw")
+      await expect(readFile(stale)).rejects.toMatchObject({ code: "ENOENT" })
+      await expect(writeFile(join(outputPath, "retry-trace.jsonl"), "fresh")).resolves.toBeUndefined()
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it("recognizes only the Chromium websocket startup signature", () => {
+    expect(isRetryableBombadilStartupFailure("Timeout while resolving websocket URL from browser process")).toBe(true)
+    expect(isRetryableBombadilStartupFailure("Timeout while replaying browser actions")).toBe(false)
+  })
+
   it("reserves final files for candidate and paired baseline checkpoints", () => {
     const policy = createUiReviewStagingPolicy(testSpec)
     expect(policy.reservedFinalFiles).toBe(8 + (2 * testSpec.checkpoints.length * testSpec.viewports.length))

--- a/tools/ui-review/src/core/bombadilProcess.ts
+++ b/tools/ui-review/src/core/bombadilProcess.ts
@@ -1,0 +1,33 @@
+import { mkdir, rm } from "node:fs/promises"
+import { resolve } from "node:path"
+
+export type BombadilProcessResult = { code: number | null; stderr: string }
+
+export async function runWithBombadilStartupRetry(input: {
+  runAttempt: () => Promise<BombadilProcessResult>
+  resetOutput: () => Promise<void>
+  waitBeforeRetry: () => Promise<void>
+  onRetry?: () => void
+}): Promise<void> {
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const result = await input.runAttempt()
+    if (result.code === 0 || result.code === 2) return
+    if (attempt === 0 && isRetryableBombadilStartupFailure(result.stderr)) {
+      await input.resetOutput()
+      await input.waitBeforeRetry()
+      input.onRetry?.()
+      continue
+    }
+    throw new Error(`UI_REVIEW_BOMBADIL_FAILED:${result.code ?? "unknown"}`)
+  }
+}
+
+export function isRetryableBombadilStartupFailure(stderr: string): boolean {
+  return stderr.includes("Timeout while resolving websocket URL from browser process")
+}
+
+export async function resetBombadilOutputDirectory(cwd: string, outputPath: string): Promise<void> {
+  const target = resolve(cwd, outputPath)
+  await rm(target, { recursive: true, force: true })
+  await mkdir(target, { recursive: true })
+}


### PR DESCRIPTION
Closes #1291.

## What changed

- retries Bombadil exactly once only when stderr contains Chromium websocket startup timeout
- waits for child stdio closure before classifying failure
- honors stderr backpressure while preserving bounded diagnostic capture
- recreates the attempt output directory before retry
- leaves arbitrary scenario/property/replay failures non-retryable

## Verification

- UI Review tools: 76 passed
- UI Review tools typecheck passed
- behavioral tests cover success after retry, arbitrary failure, repeated timeout, spawn failure, and clean output reset
- fresh-context review: APPROVED

Local full UI Review could not be completed in the temporary symlinked worktree because package-relative workspace links resolve to the base checkout; PR CI is the authoritative full-process gate.
