### PR TITLE
fix(ui-review): admit first settled replay wait

### DIFF
--- a/tools/ui-review/package.json
+++ b/tools/ui-review/package.json
@@ -9,7 +9,7 @@
     "ui:review": "tsx scripts/run-ui-review.mjs",
     "ui:improve:validate": "tsx scripts/validate-ui-improvement-packet.ts",
     "test:explore": "tsx scripts/run-ui-review.mjs --explore-only",
-    "ui:review:ci": "BOMBADIL_TIME_LIMIT=30s UI_REVIEW_OUTPUT_DIR=e2e-artifacts/ui-review UI_REVIEW_RUN_ID=ci UI_REVIEW_CRITIC=fixture UI_REVIEW_VITE_PORT=5480 UI_REVIEW_AGENT_API_PORT=5490 pnpm run ui:review -- review workspace-command-palette",
+    "ui:review:ci": "BOMBADIL_TIME_LIMIT=60s UI_REVIEW_OUTPUT_DIR=e2e-artifacts/ui-review UI_REVIEW_RUN_ID=ci UI_REVIEW_CRITIC=fixture UI_REVIEW_VITE_PORT=5480 UI_REVIEW_AGENT_API_PORT=5490 pnpm run ui:review -- review workspace-command-palette",
     "ui:review:components:ci": "UI_REVIEW_OUTPUT_DIR=e2e-artifacts/ui-review-components UI_REVIEW_RUN_ID=components-ci UI_REVIEW_CRITIC=fixture UI_REVIEW_VITE_PORT=5580 pnpm run ui:review -- review workspace-component-baselines",
     "ui:review:components:update": "UI_REVIEW_UPDATE_SNAPSHOTS=1 UI_REVIEW_RUN_ID=components-update UI_REVIEW_CRITIC=fixture UI_REVIEW_VITE_PORT=5580 pnpm run ui:review -- review workspace-component-baselines",
     "ui:review:automation:update": "UI_REVIEW_UPDATE_SNAPSHOTS=1 UI_REVIEW_RUN_ID=automation-update UI_REVIEW_CRITIC=fixture UI_REVIEW_VITE_PORT=5680 pnpm run ui:review -- review automation-pane-popover"

--- a/tools/ui-review/src/__tests__/registry.test.ts
+++ b/tools/ui-review/src/__tests__/registry.test.ts
@@ -70,6 +70,14 @@ describe("UI review spec registry", () => {
     expect(select(states)).toBe(states[0])
     expect(select(states.slice(1))).toBeUndefined()
 
+    const firstSettledWaitPath = [
+      { ordinal: 1, viewport: { name: "desktop" }, action: null, screenshotDigest: "initial", screenshotBytes: 80, screenshotPHash: "0000000000000000", normalizedState: { palette: { dialogVisible: false, mode: "none" } } },
+      { ordinal: 2, viewport: { name: "desktop" }, action: "Wait", screenshotDigest: "settled", screenshotBytes: 100, screenshotPHash: "0000000000000000", normalizedState: { palette: { dialogVisible: false, mode: "none" } } },
+      { ordinal: 3, viewport: { name: "desktop" }, action: { Click: {} }, screenshotDigest: "opening", screenshotBytes: 100, screenshotPHash: "0000000000000001", normalizedState: { palette: { dialogVisible: true, mode: "Commands" } } },
+      { ordinal: 4, viewport: { name: "desktop" }, action: "Wait", screenshotDigest: "painted", screenshotBytes: 120, screenshotPHash: "ffffffffffffffff", normalizedState: { palette: { dialogVisible: true, mode: "Commands" } } },
+    ] as unknown as UiReviewExplorationState[]
+    expect(select(firstSettledWaitPath)).toBe(firstSettledWaitPath[3])
+
     const mobileStates = [
       { ordinal: 17, viewport: { name: "mobile" }, action: "Wait", screenshotDigest: "painted", screenshotBytes: 80, screenshotPHash: "ffffffffffffffff", normalizedState: { palette: { dialogVisible: true, mode: null } } },
       { ordinal: 14, viewport: { name: "mobile" }, action: "Wait", screenshotDigest: "closed", screenshotBytes: 100, screenshotPHash: "0000000000000000", normalizedState: { palette: { dialogVisible: false, mode: null } } },

--- a/tools/ui-review/src/review-specs/workspace-command-palette/spec.ts
+++ b/tools/ui-review/src/review-specs/workspace-command-palette/spec.ts
@@ -129,7 +129,7 @@ export const workspaceCommandPaletteSpec: UiReviewSpec = {
       const painted = [...waits].reverse().find((state) => {
         const closed = ordered.filter((candidate) => {
           const palette = candidate.normalizedState.palette as Record<string, unknown> | undefined
-          return candidate.ordinal > 2
+          return (candidate.ordinal > 2 || candidate.action === "Wait")
             && candidate.ordinal < state.ordinal
             && palette?.dialogVisible === false
         }).at(-1)


### PR DESCRIPTION
Closes #1293.

The command-palette scenario mandates an initial `Wait`. Treat that closed Wait as a settled replay predecessor even at ordinal 2, while continuing to exclude the raw initial state and require perceptual paint distance. Final replay verification remains unchanged.

Verification: UI Review tools 76 passed; typecheck passed; fresh-context review APPROVED.
