### PR TITLE
[wt-391-forward-d5nj.2] Enable ambient context in local CLI modes

### DIFF
--- a/packages/agent/src/server/createStandaloneAgentHostApp.ts
+++ b/packages/agent/src/server/createStandaloneAgentHostApp.ts
@@ -217,6 +217,7 @@ export async function createStandaloneAgentHostApp(
           return createPiResourceDigestInput({
             piCwd: workspaceRoot,
             noSkills: pi.noSkills,
+            noContextFiles: pi.noContextFiles,
             resourceSets: [{
               promptParts: [
                 options.systemPromptAppend,

--- a/packages/agent/src/server/harness/pi-coding-agent/__tests__/createHarness.test.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/__tests__/createHarness.test.ts
@@ -9,6 +9,7 @@ import {
   createPiCodingAgentHarness,
   mergePiPackageSources,
   projectSkillResourceLocations,
+  withPiHarnessDefaults,
 } from "../createHarness.js";
 import { adaptToolsForPi } from "../tool-adapter.js";
 import {
@@ -19,6 +20,7 @@ import {
 import { sessionFilePath } from "./fixtures/sessionFiles.js";
 import { ErrorCode } from "../../../../shared/error-codes.js";
 import type { AgentTool } from "../../../../shared/tool.js";
+import { createPiResourceDigestInput, digestPiResourceInputs } from "../../../piResourceDigest.js";
 
 const fsHooks = vi.hoisted(() => ({
   onRename: undefined as (() => Promise<void>) | undefined,
@@ -95,6 +97,71 @@ describe("createPiCodingAgentHarness", () => {
     expect(harness.sessions).toBeInstanceOf(PiSessionStore);
     expect(typeof harness.getPiSessionAdapter).toBe("function");
     expect(typeof harness.reloadSession).toBe("function");
+  });
+
+  it("keeps ambient context files sealed by default and loads them only after explicit local opt-in", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "pi-ambient-context-cwd-"));
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-ambient-context-agent-"));
+    const marker = "AMBIENT_CONTEXT_FIXTURE_FROM_AGENTS_MD";
+    await writeFile(join(cwd, "AGENTS.md"), `${marker}\n`, "utf8");
+
+    const loadResolvedContext = async (noContextFiles: boolean) => {
+      const loader = new DefaultResourceLoader({
+        cwd,
+        agentDir,
+        noContextFiles,
+        noSkills: true,
+        noExtensions: true,
+        noPromptTemplates: true,
+        noThemes: true,
+      });
+      await loader.reload();
+      return loader.getAgentsFiles().agentsFiles;
+    };
+
+    try {
+      const hosted = withPiHarnessDefaults();
+      expect(hosted.noContextFiles).toBe(true);
+      expect(await loadResolvedContext(hosted.noContextFiles)).toEqual([]);
+
+      const local = withPiHarnessDefaults({ noContextFiles: false });
+      expect(local.noContextFiles).toBe(false);
+      expect(await loadResolvedContext(local.noContextFiles)).toEqual([
+        expect.objectContaining({ path: join(cwd, "AGENTS.md"), content: `${marker}\n` }),
+      ]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+      await rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("includes ambient context content in reload identity while sealed hosts ignore it", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "pi-context-digest-cwd-"));
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-context-digest-agent-"));
+    const contextPath = join(cwd, "AGENTS.md");
+    const input = (noContextFiles: boolean) => createPiResourceDigestInput({
+      piCwd: cwd,
+      piAgentDir: agentDir,
+      noSkills: true,
+      noContextFiles,
+      resourceSets: [],
+      authorizedRoots: [cwd, agentDir],
+    });
+
+    try {
+      await writeFile(contextPath, "context-before\n", "utf8");
+      const ambientBefore = await digestPiResourceInputs(input(false));
+      const sealedBefore = await digestPiResourceInputs(input(true));
+      await writeFile(contextPath, "context-after\n", "utf8");
+      const ambientAfter = await digestPiResourceInputs(input(false));
+      const sealedAfter = await digestPiResourceInputs(input(true));
+
+      expect(ambientAfter).not.toBe(ambientBefore);
+      expect(sealedAfter).toBe(sealedBefore);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+      await rm(agentDir, { recursive: true, force: true });
+    }
   });
 
   it("rejects unavailable requested models when strict model resolution is enabled", async () => {

--- a/packages/agent/src/server/harness/pi-coding-agent/createHarness.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/createHarness.ts
@@ -142,11 +142,14 @@ export type ResolvedPiHarnessOptions = PiHarnessOptions & {
  * flag literals; hosts override per-field through their `pi` config.
  *
  * - `noContextFiles: true` — boring composes its own workspace context
- *   prompt; pi's ambient AGENTS.md/CLAUDE.md discovery stays off.
+ *   prompt; pi's ambient AGENTS.md/CLAUDE.md discovery stays off. The
+ *   standalone local CLI opts back in, while hosted/embedded hosts and the
+ *   workspace-server/playground library default remain sealed.
  * - `noSkills: true` — ambient skill discovery (workspace + user-global
  *   ~/.pi skills) stays off so user-global skills don't leak into hosted
  *   agents. Hosts that run on the user's own machine (the standalone CLI)
- *   opt in with `pi: { noSkills: false }`.
+ *   opt in with `pi: { noSkills: false }`. Local context discovery follows
+ *   the same explicit opt-in with `pi: { noContextFiles: false }`.
  */
 export function withPiHarnessDefaults(pi?: PiHarnessOptions): ResolvedPiHarnessOptions {
   const { noContextFiles = true, noSkills = true, ...rest } = pi ?? {};

--- a/packages/agent/src/server/piResourceDigest.ts
+++ b/packages/agent/src/server/piResourceDigest.ts
@@ -4,7 +4,7 @@ import { lstat, open, opendir, realpath, stat as statPath } from 'node:fs/promis
 import { homedir } from 'node:os'
 import { dirname, isAbsolute, join, parse, relative, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { DefaultPackageManager, getAgentDir, type ResolvedPaths } from '@mariozechner/pi-coding-agent'
+import { DefaultPackageManager, getAgentDir, loadProjectContextFiles, type ResolvedPaths } from '@mariozechner/pi-coding-agent'
 import { ErrorCode } from '../shared/error-codes'
 import { AgentGatewayError, AgentGatewayErrorCode } from '../shared/gateway/errors'
 import { compactPiPackages, type PiPackageSource } from './piPackages'
@@ -33,6 +33,8 @@ export interface PiResourceDigestInput {
   readonly piUserHome: string
   /** Mirrors Pi's noSkills resource-loader option. */
   readonly noSkills: boolean
+  /** Mirrors Pi's noContextFiles resource-loader option; omitted stays sealed. */
+  readonly noContextFiles?: boolean
   readonly promptParts?: readonly (string | undefined)[]
   readonly additionalSkillPaths?: readonly string[]
   readonly packages?: readonly PiPackageSource[]
@@ -55,6 +57,7 @@ export function createPiResourceDigestInput(input: {
   readonly piAgentDir?: string
   readonly piUserHome?: string
   readonly noSkills?: boolean
+  readonly noContextFiles?: boolean
   readonly resourceSets: readonly PiResourceSet[]
   readonly authorizedRoots: readonly string[]
   readonly limits?: Partial<PiResourceDigestLimits>
@@ -63,11 +66,13 @@ export function createPiResourceDigestInput(input: {
   const piAgentDir = resolvePiPath(input.piAgentDir ?? getAgentDir(), process.cwd())
   const piUserHome = resolvePiPath(input.piUserHome ?? homedir(), process.cwd())
   const noSkills = input.noSkills ?? true
+  const noContextFiles = input.noContextFiles ?? true
   return {
     piCwd,
     piAgentDir,
     piUserHome,
     noSkills,
+    noContextFiles,
     promptParts: input.resourceSets.flatMap((set) => set.promptParts ?? []),
     additionalSkillPaths: uniqueStrings(input.resourceSets.flatMap((set) => set.additionalSkillPaths ?? [])),
     packages: compactPiPackages(input.resourceSets.flatMap((set) => set.packages ?? [])),
@@ -92,7 +97,7 @@ interface WalkState {
   bytes: number
 }
 
-const FORMAT_VERSION = 'boring-pi-resource-digest-v4'
+const FORMAT_VERSION = 'boring-pi-resource-digest-v5'
 const EXCLUDED_DIRECTORIES = new Set(['.git', 'node_modules'])
 // Host-written observation metadata is not a Pi input. Including it makes the
 // act of loading a newly discovered Boring plugin invalidate its own reload.
@@ -105,6 +110,7 @@ export async function digestPiResourceInputs(input: PiResourceDigestInput): Prom
   const piAgentDir = resolvePiPath(input.piAgentDir, process.cwd())
   const piUserHome = resolvePiPath(input.piUserHome, process.cwd())
   const projectSettingsDir = join(piCwd, '.pi')
+  const noContextFiles = input.noContextFiles ?? true
   const authorizedRoots = [...new Set(input.authorizedRoots.map((path) => resolvePiPath(path, piCwd)))]
   if (authorizedRoots.length === 0) {
     throw stableError(ErrorCode.enum.CONFIG_INVALID, 400, 'Pi resource digest requires at least one independently authorized root')
@@ -116,11 +122,31 @@ export async function digestPiResourceInputs(input: PiResourceDigestInput): Prom
   frameString(hash, 'project-settings-dir', projectSettingsDir)
   frameString(hash, 'user-agent-dir', piAgentDir)
   frameString(hash, 'user-home', piUserHome)
+  frameString(hash, 'context-policy', noContextFiles ? 'sealed' : 'ambient')
   const promptText = (input.promptParts ?? [])
     .map((part) => part?.trim())
     .filter((part): part is string => Boolean(part))
     .join('\n\n')
   frameString(hash, 'prompt', promptText)
+  if (!noContextFiles) {
+    const contextFiles = loadProjectContextFiles({ cwd: piCwd, agentDir: piAgentDir })
+    for (const contextFile of contextFiles) {
+      const bytes = Buffer.byteLength(contextFile.content)
+      state.nodes += 1
+      if (state.nodes > state.limits.maxFiles) {
+        throw limitError(`Pi resource tree exceeds maximum node count ${state.limits.maxFiles}`)
+      }
+      if (bytes > state.limits.maxFileBytes) {
+        throw limitError(`Pi context file exceeds maximum bytes ${state.limits.maxFileBytes}: ${contextFile.path}`)
+      }
+      if (state.bytes + bytes > state.limits.maxTotalBytes) {
+        throw limitError(`Pi resource tree exceeds maximum total bytes ${state.limits.maxTotalBytes}`)
+      }
+      frameString(hash, 'context-path', contextFile.path)
+      frameString(hash, 'context-content', contextFile.content)
+      state.bytes += bytes
+    }
+  }
   await hashResourceCollection(state, piCwd, 'settings', [
     join(projectSettingsDir, 'settings.json'),
     join(piAgentDir, 'settings.json'),

--- a/packages/cli/src/server/__tests__/modeApps.agentHost.test.ts
+++ b/packages/cli/src/server/__tests__/modeApps.agentHost.test.ts
@@ -82,6 +82,34 @@ afterEach(async () => {
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
 })
 
+async function resolvedSystemPrompt(
+  app: FastifyInstance,
+  requestId: string,
+  headers?: Record<string, string>,
+): Promise<string> {
+  const created = await app.inject({
+    method: "POST",
+    url: "/api/v1/agents/default/sessions",
+    payload: { requestId },
+    ...(headers ? { headers } : {}),
+  })
+  expect(created.statusCode, created.body).toBe(201)
+  const sessionId = (created.json() as { sessionId: string }).sessionId
+  const commands = await app.inject({
+    method: "GET",
+    url: `/api/v1/agents/default/commands?sessionId=${encodeURIComponent(sessionId)}`,
+    ...(headers ? { headers } : {}),
+  })
+  expect(commands.statusCode, commands.body).toBe(200)
+  const response = await app.inject({
+    method: "GET",
+    url: `/api/v1/agents/default/sessions/${encodeURIComponent(sessionId)}/system-prompt`,
+    ...(headers ? { headers } : {}),
+  })
+  expect(response.statusCode, response.body).toBe(200)
+  return (response.json() as { systemPrompt: string }).systemPrompt
+}
+
 async function fixtureApp(useConfiguredSessionRoot: boolean) {
   const home = await temporaryRoot("boring-cli-agent-host-home-")
   const workspaceRoot = await temporaryRoot("boring-cli-agent-host-workspace-")
@@ -142,11 +170,98 @@ async function fixtureApp(useConfiguredSessionRoot: boolean) {
     mode: "direct",
     registryPath,
     provisionWorkspace: false,
+    // This fixture proves transcript routing, not ambient skill admission. Keep
+    // it hermetic from whatever ~/.pi skills exist on the test machine.
+    loadAmbientSkills: false,
   })
   return { app, workspace, sessionId, compatibleSessionIds, transcript, transcriptPath, skillPath, createAgentHost, rollbackReader }
 }
 
 describe.sequential("CLI Agent Host composition", () => {
+  it("folder mode resolves workspace AGENTS.md into Pi context by default", async () => {
+    const home = await temporaryRoot("boring-cli-folder-context-home-")
+    const workspaceRoot = await temporaryRoot("boring-cli-folder-context-workspace-")
+    const marker = "FOLDER_MODE_AMBIENT_CONTEXT_FIXTURE"
+    process.env.HOME = home
+    await writeFile(join(workspaceRoot, "AGENTS.md"), `${marker}\n`, "utf8")
+
+    const app = await createFolderModeApp({
+      workspaceRoot,
+      mode: "direct",
+      provisionWorkspace: false,
+      loadAmbientSkills: false,
+    })
+    try {
+      expect(await resolvedSystemPrompt(app, "folder-ambient-context")).toContain(marker)
+    } finally {
+      await app.close()
+    }
+  }, 30_000)
+
+  it("workspaces mode resolves each workspace AGENTS.md into Pi context by default", async () => {
+    const home = await temporaryRoot("boring-cli-workspaces-context-home-")
+    const workspaceRoot = await temporaryRoot("boring-cli-workspaces-context-workspace-")
+    const registryRoot = await temporaryRoot("boring-cli-workspaces-context-registry-")
+    const marker = "WORKSPACES_MODE_AMBIENT_CONTEXT_FIXTURE"
+    const registryPath = join(registryRoot, "workspaces.yaml")
+    process.env.HOME = home
+    await writeFile(join(workspaceRoot, "AGENTS.md"), `${marker}\n`, "utf8")
+    const workspace = await createLocalWorkspaceRegistry(registryPath).add(workspaceRoot)
+
+    const app = await createWorkspacesModeApp({
+      mode: "direct",
+      registryPath,
+      provisionWorkspace: false,
+      loadAmbientSkills: false,
+    })
+    try {
+      const headers = { "x-boring-workspace-id": workspace.id }
+      expect(await resolvedSystemPrompt(app, "workspaces-ambient-context", headers)).toContain(marker)
+    } finally {
+      await app.close()
+    }
+  }, 30_000)
+
+  it("both local CLI modes honor an explicit ambient-context opt-out", async () => {
+    const home = await temporaryRoot("boring-cli-context-off-home-")
+    const folderRoot = await temporaryRoot("boring-cli-folder-context-off-")
+    const workspaceRoot = await temporaryRoot("boring-cli-workspaces-context-off-")
+    const registryRoot = await temporaryRoot("boring-cli-context-off-registry-")
+    const marker = "AMBIENT_CONTEXT_MUST_STAY_ABSENT"
+    const registryPath = join(registryRoot, "workspaces.yaml")
+    process.env.HOME = home
+    await writeFile(join(folderRoot, "AGENTS.md"), `${marker}\n`, "utf8")
+    await writeFile(join(workspaceRoot, "AGENTS.md"), `${marker}\n`, "utf8")
+    const workspace = await createLocalWorkspaceRegistry(registryPath).add(workspaceRoot)
+
+    const folderApp = await createFolderModeApp({
+      workspaceRoot: folderRoot,
+      mode: "direct",
+      provisionWorkspace: false,
+      loadAmbientSkills: false,
+      loadAmbientContext: false,
+    })
+    try {
+      expect(await resolvedSystemPrompt(folderApp, "folder-context-off")).not.toContain(marker)
+    } finally {
+      await folderApp.close()
+    }
+
+    const workspacesApp = await createWorkspacesModeApp({
+      mode: "direct",
+      registryPath,
+      provisionWorkspace: false,
+      loadAmbientSkills: false,
+      loadAmbientContext: false,
+    })
+    try {
+      const headers = { "x-boring-workspace-id": workspace.id }
+      expect(await resolvedSystemPrompt(workspacesApp, "workspaces-context-off", headers)).not.toContain(marker)
+    } finally {
+      await workspacesApp.close()
+    }
+  }, 45_000)
+
   it("folder-mode fleet seats receive workspace plugin agent tools", async () => {
     const fleetRoot = await temporaryRoot("boring-cli-seat-tools-fleet-")
     const workspaceRoot = await temporaryRoot("boring-cli-seat-tools-workspace-")

--- a/packages/cli/src/server/modeApps.ts
+++ b/packages/cli/src/server/modeApps.ts
@@ -424,6 +424,7 @@ export async function createFolderModeApp(opts: {
   provisionWorkspace?: boolean
   allowInsecureLocalBridgeAuth?: boolean
   loadAmbientSkills?: boolean
+  loadAmbientContext?: boolean
   liveTranscripts?: {
     enabled: boolean
     listenerHost: string
@@ -510,10 +511,14 @@ export async function createFolderModeApp(opts: {
       // by them. Stated explicitly here so the CLI does not silently inherit a
       // future change to the library default.
       readonlyWorkspacePaths: ['.agents'],
-      // The standalone CLI runs on the user's own machine, so ambient skill
-      // discovery (workspace + user-global ~/.pi skills) is on. The library
-      // default is off (withPiHarnessDefaults) to keep hosted agents isolated.
-      pi: { noSkills: opts.loadAmbientSkills === false },
+      // The standalone CLI runs on the user's own machine, so Pi's ambient
+      // skills and AGENTS.md/CLAUDE.md discovery are on. The workspace-server
+      // library (and therefore the playground unless it explicitly opts in)
+      // keeps both defaults sealed for hosted/embedded trust boundaries.
+      pi: {
+        noSkills: opts.loadAmbientSkills === false,
+        noContextFiles: opts.loadAmbientContext === false,
+      },
       // CLI-bundled internal plugins, resolved to absolute package dirs. This
       // drives the server-side install array (boot-time routes/agentTools);
       // additionalBoringPluginDirs only feeds the asset-manager scan.
@@ -613,6 +618,7 @@ export async function createWorkspacesModeApp(opts: {
   registryPath?: string
   provisionWorkspace?: boolean
   loadAmbientSkills?: boolean
+  loadAmbientContext?: boolean
 }): Promise<FastifyInstance> {
   if (process.env.BORING_LIVE_TRANSCRIPTS_ENABLED === "1") {
     throw new Error("live_transcript_local_only: live transcripts are supported only by boring-ui [folder]")
@@ -1058,6 +1064,7 @@ export async function createWorkspacesModeApp(opts: {
           return agentServer.createPiResourceDigestInput({
             piCwd: workspace.path,
             noSkills: opts.loadAmbientSkills === false,
+            noContextFiles: opts.loadAmbientContext === false,
             resourceSets: [{
               promptParts: [workspaceAppServer.buildWorkspaceContextPrompt(), hotResources.systemPromptAppend],
               additionalSkillPaths,
@@ -1132,8 +1139,12 @@ export async function createWorkspacesModeApp(opts: {
           ],
         }),
       ]
+      // This hub is still a trusted local CLI host even though it serves many
+      // folders. Match folder mode: ambient context is on unless explicitly
+      // disabled. Hosted/embedded composition never passes this local switch.
       const pi = {
         noSkills: opts.loadAmbientSkills === false,
+        noContextFiles: opts.loadAmbientContext === false,
         additionalSkillPaths: [join(workspace.path, ".agents", "skills")],
         packages: [],
         extensionPaths: [],
@@ -1146,6 +1157,7 @@ export async function createWorkspacesModeApp(opts: {
           agentServer.createPiResourceDigestInput({
             piCwd: workspace.path,
             noSkills: opts.loadAmbientSkills === false,
+            noContextFiles: opts.loadAmbientContext === false,
             resourceSets: [{
               promptParts: [workspaceAppServer.buildWorkspaceContextPrompt(), hotResources.systemPromptAppend],
               additionalSkillPaths: [

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -1456,6 +1456,7 @@ export async function createCoreWorkspaceAgentServer(
       return createPiResourceDigestInput({
         piCwd: root,
         noSkills: pi.noSkills,
+        noContextFiles: pi.noContextFiles,
         resourceSets: [{
           promptParts: [
             pluginCollection.agentOptions.systemPromptAppend,

--- a/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
+++ b/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
@@ -1921,6 +1921,7 @@ export async function createWorkspaceAgentServer(
         return createPiResourceDigestInput({
           piCwd: workspaceRoot,
           noSkills: selectedPi?.noSkills ?? resolvedBasePi.noSkills,
+          noContextFiles: selectedPi?.noContextFiles ?? resolvedBasePi.noContextFiles,
           resourceSets: [{
             promptParts: [staticSystemPromptAppend, dynamicSystemPromptAppend],
             additionalSkillPaths,


### PR DESCRIPTION
## Summary

- Add a `loadAmbientContext` local-host switch parallel to `loadAmbientSkills`.
- Enable Pi ambient `AGENTS.md` / `CLAUDE.md` discovery by default in both CLI folder and workspaces modes.
- Keep hosted, embedded, workspace-server, and playground defaults sealed with `noContextFiles: true` unless their host explicitly opts in.
- Include the resolved context policy and exact Pi-discovered context content in reload resource digests.

## Proof

- `env -u BORING_AGENT_FLEET node node_modules/vitest/vitest.mjs run packages/agent/src/server/harness/pi-coding-agent/__tests__/createHarness.test.ts packages/cli/src/server/__tests__/modeApps.agentHost.test.ts` — **2 files passed; 71 tests passed**.
- `node node_modules/vitest/vitest.mjs run packages/workspace/src/app/server/__tests__/createWorkspaceAgentServer.test.ts -t "resource input digest|resource digest"` — **1 file passed; 3 tests passed, 57 skipped**.
- `pnpm --filter @hachej/boring-agent run typecheck` — **pass, 0 errors**.
- `pnpm --filter @hachej/boring-ui-cli run typecheck` — **pass, 0 errors**.
- `pnpm --filter @hachej/boring-core run typecheck` — **pass, 0 errors**.
- `pnpm --filter @hachej/boring-workspace run typecheck` — **pass, 0 errors**.
- `git diff --check origin/main...HEAD` — **pass, no output**.
- GitHub Actions runs `31882091153` (CI) and `31882091171` (Workflow Invariants) at exact head `d32d914d` — **green; all required jobs passed**.

## Review provenance

- `openai-codex/gpt-5.6-sol` · fresh-eyes adversarial mandate · target `b5a04ae3062c9bf45756ff3d164b644c1d585230` · **clean with a reload-digest gap noted by thermo**.
- `openai-codex/gpt-5.6-sol` · thermonuclear maintainability mandate · target `b5a04ae3062c9bf45756ff3d164b644c1d585230` · **revise**: context content was absent from reload identity; fixed in `d32d914dc7d2c310224e61d07771de39d7f41e50`.
- `openai-codex/gpt-5.6-sol` · second-pass fresh-eyes mandate · target `d32d914dc7d2c310224e61d07771de39d7f41e50` · **clean**.
- `openai-codex/gpt-5.6-sol` · second-pass thermo + contested-risk disposition · target `d32d914dc7d2c310224e61d07771de39d7f41e50` · **clean**; Pi's local symlink/ancestor discovery semantics accepted as required local parity, while hosted trust remains sealed.

## Artifacts

- Present-PR HTML: `.handoff/pr-1305-presentation.html` (self-contained review page).
- Running surface: N/A — server policy and harness behavior only; no UI change.

## Risk & rollback

- Local CLI prompts can grow by discovered context files and inherit Pi's ancestor/symlink discovery semantics. This is an accepted trusted-local parity risk; hosted and embedded defaults remain sealed.
- Reload digests now include context content, so local context edits correctly change reload identity.
- Roll back by reverting `d32d914dc7d2c310224e61d07771de39d7f41e50`.

## Refs

- Closes #1191
- Bead `wt-391-forward-d5nj.2`
- Avoids PR #1288's factory dispatch/session-control hunks and does not touch package-resource enumeration reserved for #1196.
