### PR TITLE
[wt-391-forward-d5nj.1] Deflake insufficient-credit replay test

### DIFF
--- a/packages/agent/src/server/agent-host/__tests__/createAgentHost.test.ts
+++ b/packages/agent/src/server/agent-host/__tests__/createAgentHost.test.ts
@@ -1014,6 +1014,9 @@ describe('createAgentHost', () => {
     })
     const created = await createAgentHost({
       ...options(workspaceRoot),
+      // Metering rejects this request before harness execution. Keep the test on
+      // that causal seam instead of paying unrelated real-provider discovery.
+      harnessFactory: createScriptedPiHarness,
       metering: {
         isEnabled: () => true,
         reserveRun,


### PR DESCRIPTION
## Summary
- keep the insufficient-credit durable replay test on its actual metering/ledger seam by injecting the existing scripted harness
- remove unrelated real-provider discovery from the test without changing production code, assertions, or timeout bounds
- preserve the exact two-response 402 replay contract and single `reserveRun` assertion

## Proof
Causal evidence:
- Pre-fix isolated: `pnpm --dir packages/agent exec vitest run src/server/agent-host/__tests__/createAgentHost.test.ts -t 'durably replays insufficient-credit rejection' --reporter=verbose` — 1 passed / 12 skipped; target body **4.178s** against Vitest's 5s default.
- Pre-fix representative pressure: four concurrent copies of that exact focused command — **4/4 timed out at 5000ms**; an eight-way run was **0/8 green**.
- Post-fix isolated: the same focused command — 1 passed / 12 skipped; target body **224ms**.
- Post-fix representative pressure: eight concurrent copies of the same focused command — **8/8 green**.

Current green verification at `805f1e84ab70a2f8ea12c5d8d3008e116f2cba1e`:
- `env -u ANTHROPIC_API_KEY -u GEMINI_API_KEY -u OPENROUTER_API_KEY pnpm --dir packages/agent exec vitest run --reporter=dot --maxWorkers=4` — run 1: **222 files passed / 2 skipped; 2044 tests passed / 17 skipped (2061 total); 0 failures**.
- same full-package command — run 2: **222 files passed / 2 skipped; 2044 tests passed / 17 skipped (2061 total); 0 failures**.
- `env -u ANTHROPIC_API_KEY -u GEMINI_API_KEY -u OPENROUTER_API_KEY pnpm --dir packages/agent typecheck` — green.
- `git diff --check` — green.
- GitHub Actions runs `31888290490` (CI) and `31888290488` (Workflow Invariants) — success at exact head; changed unit tests, typecheck, lint, invariants, E2E, and reference-image/remote-worker smoke green.

The inherited non-OpenAI personal-key variables were explicitly unset so gated live-model evals skipped rather than billing prohibited providers. Four workers retain representative package parallelism while avoiding an unrelated pre-existing 5s timeout in `createStandaloneAgentHostApp.test.ts` seen under unbounded local saturation.

## Review provenance
- Fresh-eyes: `openai-codex/gpt-5.6-sol`; mandate: adversarially refute causal correctness, assertion preservation, scope, proof, and PR #1288 non-interference; target `805f1e84ab70a2f8ea12c5d8d3008e116f2cba1e`; verdict **SHIP**, no material findings.
- Thermo: `openai-codex/gpt-5.6-sol`; mandate: refute maintainability/test-seam quality and detect timing paper-over or hidden coupling; target `805f1e84ab70a2f8ea12c5d8d3008e116f2cba1e`; verdict **clean**, no material findings. The subagent acceptance wrapper reported a plumbing failure after emitting the clean review; the read-only review itself completed.

## Artifacts
- Present-PR review HTML: `.handoff/pr-1308-presentation.html` (generated from current PR metadata and green CI).
- Running surface: N/A — test-only change.

## Risk & rollback
- Risk is low and test-only. The replay test no longer exercises incidental real-provider initialization, which is outside its metering/ledger contract.
- Rollback: revert `805f1e84ab70a2f8ea12c5d8d3008e116f2cba1e`.

## Refs
- Fixes #1199
- Bead `wt-391-forward-d5nj.1`
- PR #1288 remains open and changes a distinct dispatcher-contract hunk in the same file; this PR does not alter that hunk.
