### PR TITLE
[wt-391-forward-xp3s.9] Reconcile persisted default Agents safely

### DIFF
--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
@@ -12,6 +12,12 @@ const mocks = vi.hoisted(() => {
   const hostRegisterDirectRoutes = vi.fn((_projection: any) => async () => {})
   const hostClose = vi.fn(async () => {})
   const acquireEnvironment = vi.fn()
+  const gatewayReadSessionState = vi.fn(async ({ ref }: { ref: unknown }) => ({
+    ref,
+    seq: 0,
+    summary: {},
+    state: { messages: [] },
+  }))
   return {
     createAgentHost: vi.fn(async (options: any) => {
       await options.fleetCompiler.compile({ agents: options.agents })
@@ -20,18 +26,22 @@ const mocks = vi.hoisted(() => {
         host: { close: hostClose, drain: vi.fn(async () => {}) },
         registerDirectRoutes: hostRegisterDirectRoutes,
         acquireEnvironment,
+        gateway: { readSessionState: gatewayReadSessionState },
         runWithWorkspaceAgent: vi.fn(),
       }
     }),
     hostRegisterDirectRoutes,
     hostClose,
     acquireEnvironment,
+    gatewayReadSessionState,
     provisionWorkspaceRuntime: vi.fn(async () => ({ changed: false, env: {}, pathEntries: [], skillPaths: [] })),
     collectWorkspaceAgentServerPlugins: vi.fn(),
     createWorkspaceUiTools: vi.fn(() => []),
     isMember: vi.fn(async (_workspaceId: string, _userId: string) => true),
-    getWorkspace: vi.fn(async (id: string) => ({ id, appId: 'test-app' })),
+    getWorkspace: vi.fn(async (id: string) => ({ id, appId: 'test-app', defaultAgentTypeId: 'default' })),
     getUser: vi.fn(async (id: string) => ({ id })),
+    inventoryDefaultAgentTypeIds: vi.fn(async (_appId: string): Promise<Array<{ defaultAgentTypeId: string | null; count: number }>> => []),
+    compareAndSetNullDefaultAgentTypeId: vi.fn(async (_appId: string, _value: string) => 0),
     actualCreateAgentHost: undefined as undefined | ((options: any) => Promise<any>),
     runtimeHost: {
       source: 'custom-adapter-host',
@@ -120,9 +130,12 @@ beforeEach(() => {
   vi.clearAllMocks()
   mocks.provisionWorkspaceRuntime.mockResolvedValue({ changed: false, env: {}, pathEntries: [], skillPaths: [] })
   mocks.acquireEnvironment.mockReset()
+  mocks.gatewayReadSessionState.mockClear()
   mocks.isMember.mockResolvedValue(true)
-  mocks.getWorkspace.mockImplementation(async (id: string) => ({ id, appId: 'test-app' }))
+  mocks.getWorkspace.mockImplementation(async (id: string) => ({ id, appId: 'test-app', defaultAgentTypeId: 'default' }))
   mocks.getUser.mockImplementation(async (id: string) => ({ id }))
+  mocks.inventoryDefaultAgentTypeIds.mockResolvedValue([])
+  mocks.compareAndSetNullDefaultAgentTypeId.mockResolvedValue(0)
 })
 
 vi.mock('../../../server/routes/index.js', () => ({
@@ -140,6 +153,10 @@ vi.mock('../../../server/db/index.js', () => ({
   PostgresWorkspaceStore: class {
     get(id: string) { return mocks.getWorkspace(id) }
     isMember(workspaceId: string, userId: string) { return mocks.isMember(workspaceId, userId) }
+    inventoryDefaultAgentTypeIds(appId: string) { return mocks.inventoryDefaultAgentTypeIds(appId) }
+    compareAndSetNullDefaultAgentTypeId(appId: string, value: string) {
+      return mocks.compareAndSetNullDefaultAgentTypeId(appId, value)
+    }
   },
 }))
 
@@ -180,6 +197,77 @@ test('core production mounts only the awaited CreatedAgentHost route projection'
   expect(orderedCompositionEdges.every((index) => index >= 0)).toBe(true)
   expect(orderedCompositionEdges).toEqual([...orderedCompositionEdges].sort((left, right) => left - right))
 })
+
+test('core backfills through explicit CAS after fleet validation and before routes', async () => {
+  mocks.collectWorkspaceAgentServerPlugins.mockReturnValue({
+    runtimePlugins: [], agentOptions: { extraTools: [], pi: {}, systemPromptAppend: undefined },
+    preservedUiStateKeys: [], routeContributions: [],
+  })
+  mocks.inventoryDefaultAgentTypeIds
+    .mockResolvedValueOnce([{ defaultAgentTypeId: null, count: 2 }])
+    .mockResolvedValueOnce([{ defaultAgentTypeId: 'default', count: 2 }])
+  mocks.compareAndSetNullDefaultAgentTypeId.mockResolvedValueOnce(2)
+  const { createCoreWorkspaceAgentServer } = await import('../createCoreWorkspaceAgentServer.js')
+  const app = await createCoreWorkspaceAgentServer({
+    config: createTestCoreConfig({ stores: 'postgres', databaseUrl: 'postgres://test' }),
+    workspaceRoot: '/tmp/full-app-workspaces', defaultAgentTypeId: 'default', serveFrontend: false,
+  })
+  try {
+    expect(mocks.inventoryDefaultAgentTypeIds).toHaveBeenNthCalledWith(1, 'boring-ui-v2-test')
+    expect(mocks.compareAndSetNullDefaultAgentTypeId).toHaveBeenCalledWith('boring-ui-v2-test', 'default')
+    expect(mocks.inventoryDefaultAgentTypeIds).toHaveBeenCalledTimes(2)
+    expect(mocks.createAgentHost.mock.invocationCallOrder[0])
+      .toBeLessThan(mocks.compareAndSetNullDefaultAgentTypeId.mock.invocationCallOrder[0]!)
+    expect(mocks.compareAndSetNullDefaultAgentTypeId.mock.invocationCallOrder[0])
+      .toBeLessThan(mocks.hostRegisterDirectRoutes.mock.invocationCallOrder[0]!)
+  } finally { await app.close() }
+}, 60_000)
+
+test('unknown persisted default denies execution but preserves session and history reads', async () => {
+  mocks.collectWorkspaceAgentServerPlugins.mockReturnValue({
+    runtimePlugins: [], agentOptions: { extraTools: [], pi: {}, systemPromptAppend: undefined },
+    preservedUiStateKeys: [], routeContributions: [],
+  })
+  mocks.getWorkspace.mockImplementation(async (id: string) => ({
+    id, appId: 'boring-ui-v2-test', defaultAgentTypeId: 'retired-seat',
+  }))
+  const { createCoreWorkspaceAgentServer } = await import('../createCoreWorkspaceAgentServer.js')
+  let dispatcher: import('@hachej/boring-agent/server').WorkspaceAgentDispatcherResolver | undefined
+  const app = await createCoreWorkspaceAgentServer({
+    config: createTestCoreConfig({ stores: 'postgres', databaseUrl: 'postgres://test' }),
+    workspaceRoot: '/tmp/full-app-workspaces', defaultAgentTypeId: 'default', serveFrontend: false,
+    onWorkspaceAgentDispatcher: (value) => { dispatcher = value },
+  })
+  try {
+    const hostOptions = (mocks.createAgentHost as any).mock.calls.at(-1)?.[0]
+    const projection = (mocks.hostRegisterDirectRoutes as any).mock.calls.at(-1)?.[0]
+    const authorizedScope = await projection.authorizeAgentRequest(fakeRequest('workspace-a', 'user-a'))
+    const verifiedClaim = await hostOptions.scopeVerifier.verify(authorizedScope)
+    const ref = { agentTypeId: 'default', sessionId: 'old-session' }
+    await expect(dispatcher!.authorizeSession!({ workspaceId: 'workspace-a', userId: 'user-a' }, ref)).resolves.toBeUndefined()
+    await expect(dispatcher!.readSessionRunDetails!(
+      { workspaceId: 'workspace-a', userId: 'user-a' }, ref, ['tool'],
+    )).resolves.toEqual([])
+    expect(mocks.gatewayReadSessionState).toHaveBeenCalledTimes(2)
+
+    const target = { kind: 'agent', agentTypeId: 'default' }
+    const execution = await hostOptions.effectAdmission.admit({
+      key: { workspaceScopeId: verifiedClaim.workspaceScopeId, authSubjectId: verifiedClaim.authSubjectId,
+        operation: 'session.create', target, requestId: 'unknown-default-create' },
+      digest: 'sha256:test', scope: verifiedClaim, operation: 'session.create', target,
+    })
+    expect(execution).toMatchObject({ type: 'rejected', error: {
+      code: 'AGENT_TYPE_UNKNOWN', details: { code: 'default_agent_type_unknown_seat' },
+    } })
+
+    const meta = await app.inject({ method: 'GET', url: '/api/v1/workspace/meta?workspaceId=workspace-a',
+      headers: { 'x-test-user-id': 'user-a' } })
+    expect(meta.statusCode).toBe(409)
+    expect(meta.json()).toEqual({ error: {
+      code: 'default_agent_type_unknown_seat', message: 'Workspace default Agent is unavailable',
+    } })
+  } finally { await app.close() }
+}, 60_000)
 
 test('core environment routes acquire one Host lease and release it after a finite response', async () => {
   mocks.collectWorkspaceAgentServerPlugins.mockReturnValue({
@@ -294,7 +382,8 @@ test('core/full-app gives strong admission only to the direct Host projection', 
 
   try {
     const hostOptions = (mocks.createAgentHost as any).mock.calls.at(-1)?.[0]
-    expect(hostOptions.effectAdmission).toBe(effectAdmission)
+    expect(hostOptions.effectAdmission).not.toBe(effectAdmission)
+    expect(hostOptions.effectAdmission).toMatchObject({ admit: expect.any(Function) })
     expect(hostOptions).not.toHaveProperty('admitEffect')
     expect(mocks.hostRegisterDirectRoutes).toHaveBeenCalledOnce()
   } finally {
@@ -424,7 +513,7 @@ test('core/full-app scope authority rejects forgeries and cross-workspace route 
     routeContributions: [],
   })
   const config = createTestCoreConfig({ stores: 'postgres', databaseUrl: 'postgres://test' })
-  mocks.getWorkspace.mockImplementation(async (id: string) => ({ id, appId: config.appId }))
+  mocks.getWorkspace.mockImplementation(async (id: string) => ({ id, appId: config.appId, defaultAgentTypeId: 'default' }))
   const { createCoreWorkspaceAgentServer } = await import('../createCoreWorkspaceAgentServer.js')
   const app = await createCoreWorkspaceAgentServer({
     config,

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
@@ -284,6 +284,26 @@ test.each(['before-inventory', 'cas', 'after-inventory', 'remaining-null'] as co
   30_000,
 )
 
+test('keeps the pre-schema reference health composition bootable without weakening other migration failures', async () => {
+  mocks.collectWorkspaceAgentServerPlugins.mockReturnValue({
+    runtimePlugins: [], agentOptions: { extraTools: [], pi: {}, systemPromptAppend: undefined },
+    preservedUiStateKeys: [], routeContributions: [],
+  })
+  mocks.inventoryDefaultAgentTypeIds.mockRejectedValueOnce(Object.assign(
+    new Error('inventory query failed'),
+    { cause: Object.assign(new Error('relation workspaces does not exist'), { code: '42P01' }) },
+  ))
+  const { createCoreWorkspaceAgentServer } = await import('../createCoreWorkspaceAgentServer.js')
+  const app = await createCoreWorkspaceAgentServer({
+    config: createTestCoreConfig({ stores: 'postgres', databaseUrl: 'postgres://test' }),
+    workspaceRoot: '/tmp/full-app-workspaces', defaultAgentTypeId: 'default', serveFrontend: false,
+  })
+  try {
+    expect(mocks.compareAndSetNullDefaultAgentTypeId).not.toHaveBeenCalled()
+    expect(mocks.hostRegisterDirectRoutes).toHaveBeenCalledOnce()
+  } finally { await app.close() }
+}, 30_000)
+
 test('unknown persisted default denies execution but preserves session and history reads', async () => {
   mocks.collectWorkspaceAgentServerPlugins.mockReturnValue({
     runtimePlugins: [], agentOptions: { extraTools: [], pi: {}, systemPromptAppend: undefined },

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
@@ -223,6 +223,33 @@ test('core backfills through explicit CAS after fleet validation and before rout
   } finally { await app.close() }
 }, 60_000)
 
+test('uses one validated config default for backfill and future workspace writers', async () => {
+  mocks.collectWorkspaceAgentServerPlugins.mockReturnValue({
+    runtimePlugins: [], agentOptions: { extraTools: [], pi: {}, systemPromptAppend: undefined },
+    preservedUiStateKeys: [], routeContributions: [],
+  })
+  const config = createTestCoreConfig({
+    stores: 'postgres',
+    databaseUrl: 'postgres://test',
+    defaultAgentTypeId: 'reviewer',
+  })
+  const { createCoreWorkspaceAgentServer } = await import('../createCoreWorkspaceAgentServer.js')
+  const app = await createCoreWorkspaceAgentServer({
+    config,
+    agents: [
+      { agentTypeId: 'default', legacyDefault: true },
+      { agentTypeId: 'reviewer', definition: { label: 'Reviewer', instructions: 'Review.' } },
+    ],
+    workspaceRoot: '/tmp/full-app-workspaces',
+    serveFrontend: false,
+  })
+  try {
+    expect(mocks.compareAndSetNullDefaultAgentTypeId)
+      .toHaveBeenCalledWith(config.appId, 'reviewer')
+    expect(app.config.defaultAgentTypeId).toBe('reviewer')
+  } finally { await app.close() }
+}, 30_000)
+
 test.each(['before-inventory', 'cas', 'after-inventory', 'remaining-null'] as const)(
   'closes AgentHost when default migration fails at %s',
   async (stage) => {
@@ -297,9 +324,11 @@ test('unknown persisted default denies execution but preserves session and histo
     const meta = await app.inject({ method: 'GET', url: '/api/v1/workspace/meta?workspaceId=workspace-a',
       headers: { 'x-test-user-id': 'user-a' } })
     expect(meta.statusCode).toBe(409)
-    expect(meta.json()).toEqual({ error: {
-      code: 'default_agent_type_unknown_seat', message: 'Workspace default Agent is unavailable',
-    } })
+    expect(meta.json()).toMatchObject({
+      code: 'default_agent_type_unknown_seat',
+      message: 'Workspace default Agent is unavailable',
+      requestId: expect.any(String),
+    })
   } finally { await app.close() }
 }, 60_000)
 

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
@@ -223,6 +223,40 @@ test('core backfills through explicit CAS after fleet validation and before rout
   } finally { await app.close() }
 }, 60_000)
 
+test.each(['before-inventory', 'cas', 'after-inventory', 'remaining-null'] as const)(
+  'closes AgentHost when default migration fails at %s',
+  async (stage) => {
+    mocks.collectWorkspaceAgentServerPlugins.mockReturnValue({
+      runtimePlugins: [], agentOptions: { extraTools: [], pi: {}, systemPromptAppend: undefined },
+      preservedUiStateKeys: [], routeContributions: [],
+    })
+    if (stage === 'before-inventory') {
+      mocks.inventoryDefaultAgentTypeIds.mockRejectedValueOnce(new Error('inventory unavailable'))
+    } else if (stage === 'cas') {
+      mocks.inventoryDefaultAgentTypeIds.mockResolvedValueOnce([])
+      mocks.compareAndSetNullDefaultAgentTypeId.mockRejectedValueOnce(new Error('CAS unavailable'))
+    } else if (stage === 'after-inventory') {
+      mocks.inventoryDefaultAgentTypeIds
+        .mockResolvedValueOnce([])
+        .mockRejectedValueOnce(new Error('post-inventory unavailable'))
+    } else {
+      mocks.inventoryDefaultAgentTypeIds
+        .mockResolvedValueOnce([{ defaultAgentTypeId: null, count: 1 }])
+        .mockResolvedValueOnce([{ defaultAgentTypeId: null, count: 1 }])
+    }
+    const { createCoreWorkspaceAgentServer } = await import('../createCoreWorkspaceAgentServer.js')
+    await expect(createCoreWorkspaceAgentServer({
+      config: createTestCoreConfig({ stores: 'postgres', databaseUrl: 'postgres://test' }),
+      workspaceRoot: '/tmp/full-app-workspaces', defaultAgentTypeId: 'default', serveFrontend: false,
+    })).rejects.toThrow(stage === 'remaining-null'
+      ? 'Workspace default Agent legacy reconciliation did not converge'
+      : /unavailable/)
+    expect(mocks.hostClose).toHaveBeenCalledOnce()
+    expect(mocks.hostRegisterDirectRoutes).not.toHaveBeenCalled()
+  },
+  30_000,
+)
+
 test('unknown persisted default denies execution but preserves session and history reads', async () => {
   mocks.collectWorkspaceAgentServerPlugins.mockReturnValue({
     runtimePlugins: [], agentOptions: { extraTools: [], pi: {}, systemPromptAppend: undefined },

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
@@ -250,7 +250,7 @@ test('uses one validated config default for backfill and future workspace writer
   } finally { await app.close() }
 }, 30_000)
 
-test.each(['before-inventory', 'cas', 'after-inventory', 'remaining-null'] as const)(
+test.each(['before-inventory', 'cas', 'cas-undefined-table', 'after-inventory', 'after-inventory-undefined-table', 'remaining-null'] as const)(
   'closes AgentHost when default migration fails at %s',
   async (stage) => {
     mocks.collectWorkspaceAgentServerPlugins.mockReturnValue({
@@ -259,13 +259,19 @@ test.each(['before-inventory', 'cas', 'after-inventory', 'remaining-null'] as co
     })
     if (stage === 'before-inventory') {
       mocks.inventoryDefaultAgentTypeIds.mockRejectedValueOnce(new Error('inventory unavailable'))
-    } else if (stage === 'cas') {
+    } else if (stage === 'cas' || stage === 'cas-undefined-table') {
       mocks.inventoryDefaultAgentTypeIds.mockResolvedValueOnce([])
-      mocks.compareAndSetNullDefaultAgentTypeId.mockRejectedValueOnce(new Error('CAS unavailable'))
-    } else if (stage === 'after-inventory') {
+      mocks.compareAndSetNullDefaultAgentTypeId.mockRejectedValueOnce(
+        stage === 'cas'
+          ? new Error('CAS unavailable')
+          : Object.assign(new Error('CAS relation failure'), { cause: { code: '42P01' } }),
+      )
+    } else if (stage === 'after-inventory' || stage === 'after-inventory-undefined-table') {
       mocks.inventoryDefaultAgentTypeIds
         .mockResolvedValueOnce([])
-        .mockRejectedValueOnce(new Error('post-inventory unavailable'))
+        .mockRejectedValueOnce(stage === 'after-inventory'
+          ? new Error('post-inventory unavailable')
+          : Object.assign(new Error('post-inventory relation failure'), { cause: { code: '42P01' } }))
     } else {
       mocks.inventoryDefaultAgentTypeIds
         .mockResolvedValueOnce([{ defaultAgentTypeId: null, count: 1 }])
@@ -277,7 +283,7 @@ test.each(['before-inventory', 'cas', 'after-inventory', 'remaining-null'] as co
       workspaceRoot: '/tmp/full-app-workspaces', defaultAgentTypeId: 'default', serveFrontend: false,
     })).rejects.toThrow(stage === 'remaining-null'
       ? 'Workspace default Agent legacy reconciliation did not converge'
-      : /unavailable/)
+      : stage.includes('undefined-table') ? /relation failure/ : /unavailable/)
     expect(mocks.hostClose).toHaveBeenCalledOnce()
     expect(mocks.hostRegisterDirectRoutes).not.toHaveBeenCalled()
   },

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.telemetry-smoke.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.telemetry-smoke.test.ts
@@ -205,7 +205,10 @@ vi.mock('../../../server/db/index.js', () => ({
     sql: { end: vi.fn() },
   }),
   PostgresUserStore: class PostgresUserStore {},
-  PostgresWorkspaceStore: class PostgresWorkspaceStore {},
+  PostgresWorkspaceStore: class PostgresWorkspaceStore {
+    async inventoryDefaultAgentTypeIds() { return [] }
+    async compareAndSetNullDefaultAgentTypeId() { return 0 }
+  },
 }))
 
 vi.mock('../../../server/config/index.js', () => ({

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.telemetry.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.telemetry.test.ts
@@ -132,7 +132,10 @@ vi.mock('../../../server/db/index.js', () => ({
     sql: { end: vi.fn() },
   }),
   PostgresUserStore: class PostgresUserStore {},
-  PostgresWorkspaceStore: class PostgresWorkspaceStore {},
+  PostgresWorkspaceStore: class PostgresWorkspaceStore {
+    async inventoryDefaultAgentTypeIds() { return [] }
+    async compareAndSetNullDefaultAgentTypeId() { return 0 }
+  },
 }))
 
 vi.mock('../../../server/config/index.js', () => ({

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.workspaceBridge.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.workspaceBridge.test.ts
@@ -295,6 +295,8 @@ vi.mock('../../../server/db/index.js', () => ({
       workspaceServerMock.memberChecks.push([workspaceId, userId])
       return true
     }
+    async inventoryDefaultAgentTypeIds() { return [] }
+    async compareAndSetNullDefaultAgentTypeId() { return 0 }
   },
 }))
 

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -1679,16 +1679,27 @@ export async function createCoreWorkspaceAgentServer(
   let hostMounted = false
   try {
     // Reference images intentionally prove the process can expose /health
-    // before schema deployment. With no workspaces relation there is no cohort
-    // or Agent execution to reconcile; every other migration error stays fatal.
+    // before schema deployment. Only an undefined workspaces relation on the
+    // initial inventory proves that state; after inventory succeeds, every CAS
+    // or convergence error remains fatal.
+    let inventoryBefore: Awaited<ReturnType<WorkspaceStore['inventoryDefaultAgentTypeIds']>> | undefined
     try {
+      inventoryBefore = await workspaceStore.inventoryDefaultAgentTypeIds(config.appId)
+    } catch (error) {
+      if (!hasErrorCode(error, '42P01')) throw error
+      app.log.warn({
+        event: 'workspace.default_agent_type_id.backfill.skipped',
+        appId: config.appId,
+        reason: 'workspaces_relation_absent',
+      }, 'workspace default Agent reconciliation skipped before schema deployment')
+    }
+    if (inventoryBefore) {
       // Decision 28 migration phase: createAgentHost has now compiled and
-      // validated the static fleet. Inventory every persisted cohort, then
-      // compare-and-set only legacy NULL rows before any route can serve.
-      // Re-running this startup phase is idempotent; concurrent non-NULL writers
-      // always win, and hostname never enters either store operation.
+      // validated the static fleet. Compare-and-set only legacy NULL rows
+      // before any route can serve. Re-running is idempotent; concurrent
+      // non-NULL writers always win, and hostname never enters either store.
       const cohortsBefore = classifyWorkspaceDefaultAgentTypeCohorts(
-        await workspaceStore.inventoryDefaultAgentTypeIds(config.appId),
+        inventoryBefore,
         availableAgentTypeIds,
       )
       const migratedDefaultAgentTypeIdCount = await workspaceStore.compareAndSetNullDefaultAgentTypeId(
@@ -1714,13 +1725,6 @@ export async function createCoreWorkspaceAgentServer(
         migratedCount: migratedDefaultAgentTypeIdCount,
         after: cohortsAfter,
       }, 'workspace default Agent legacy cohorts reconciled')
-    } catch (error) {
-      if (!hasErrorCode(error, '42P01')) throw error
-      app.log.warn({
-        event: 'workspace.default_agent_type_id.backfill.skipped',
-        appId: config.appId,
-        reason: 'workspaces_relation_absent',
-      }, 'workspace default Agent reconciliation skipped before schema deployment')
     }
 
     app.get('/api/v1/workspace/meta', async (request, reply) => {

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -117,6 +117,16 @@ import {
 import { WorkspaceRuntimeSandboxHandleStore } from '../../server/runtime/index.js'
 import { createDatabaseTelemetryFromEnv } from '../../server/telemetry/db.js'
 
+function hasErrorCode(error: unknown, code: string): boolean {
+  let current: unknown = error
+  for (let depth = 0; depth < 4; depth += 1) {
+    if (!current || typeof current !== 'object') return false
+    if ((current as { code?: unknown }).code === code) return true
+    current = (current as { cause?: unknown }).cause
+  }
+  return false
+}
+
 const DEFAULT_AGENT_EXECUTION_EFFECTS = new Set([
   'session.create',
   'session.prompt',
@@ -1668,38 +1678,50 @@ export async function createCoreWorkspaceAgentServer(
 
   let hostMounted = false
   try {
-    // Decision 28 migration phase: createAgentHost has now compiled and
-    // validated the static fleet. Inventory every persisted cohort, then
-    // compare-and-set only legacy NULL rows before any route can serve.
-    // Re-running this startup phase is idempotent; concurrent non-NULL writers
-    // always win, and hostname never enters either store operation.
-    const cohortsBefore = classifyWorkspaceDefaultAgentTypeCohorts(
-      await workspaceStore.inventoryDefaultAgentTypeIds(config.appId),
-      availableAgentTypeIds,
-    )
-    const migratedDefaultAgentTypeIdCount = await workspaceStore.compareAndSetNullDefaultAgentTypeId(
-      config.appId,
-      applicationDefaultAgentTypeId,
-    )
-    const cohortsAfter = classifyWorkspaceDefaultAgentTypeCohorts(
-      await workspaceStore.inventoryDefaultAgentTypeIds(config.appId),
-      availableAgentTypeIds,
-    )
-    if (cohortsAfter.nullCount > 0) {
-      throw new HttpError({
-        status: 500,
-        code: ERROR_CODES.DEFAULT_AGENT_TYPE_UNKNOWN_SEAT,
-        message: 'Workspace default Agent legacy reconciliation did not converge',
-      })
+    // Reference images intentionally prove the process can expose /health
+    // before schema deployment. With no workspaces relation there is no cohort
+    // or Agent execution to reconcile; every other migration error stays fatal.
+    try {
+      // Decision 28 migration phase: createAgentHost has now compiled and
+      // validated the static fleet. Inventory every persisted cohort, then
+      // compare-and-set only legacy NULL rows before any route can serve.
+      // Re-running this startup phase is idempotent; concurrent non-NULL writers
+      // always win, and hostname never enters either store operation.
+      const cohortsBefore = classifyWorkspaceDefaultAgentTypeCohorts(
+        await workspaceStore.inventoryDefaultAgentTypeIds(config.appId),
+        availableAgentTypeIds,
+      )
+      const migratedDefaultAgentTypeIdCount = await workspaceStore.compareAndSetNullDefaultAgentTypeId(
+        config.appId,
+        applicationDefaultAgentTypeId,
+      )
+      const cohortsAfter = classifyWorkspaceDefaultAgentTypeCohorts(
+        await workspaceStore.inventoryDefaultAgentTypeIds(config.appId),
+        availableAgentTypeIds,
+      )
+      if (cohortsAfter.nullCount > 0) {
+        throw new HttpError({
+          status: 500,
+          code: ERROR_CODES.DEFAULT_AGENT_TYPE_UNKNOWN_SEAT,
+          message: 'Workspace default Agent legacy reconciliation did not converge',
+        })
+      }
+      app.log.info({
+        event: 'workspace.default_agent_type_id.backfill',
+        appId: config.appId,
+        applicationDefaultAgentTypeId,
+        before: cohortsBefore,
+        migratedCount: migratedDefaultAgentTypeIdCount,
+        after: cohortsAfter,
+      }, 'workspace default Agent legacy cohorts reconciled')
+    } catch (error) {
+      if (!hasErrorCode(error, '42P01')) throw error
+      app.log.warn({
+        event: 'workspace.default_agent_type_id.backfill.skipped',
+        appId: config.appId,
+        reason: 'workspaces_relation_absent',
+      }, 'workspace default Agent reconciliation skipped before schema deployment')
     }
-    app.log.info({
-      event: 'workspace.default_agent_type_id.backfill',
-      appId: config.appId,
-      applicationDefaultAgentTypeId,
-      before: cohortsBefore,
-      migratedCount: migratedDefaultAgentTypeIdCount,
-      after: cohortsAfter,
-    }, 'workspace default Agent legacy cohorts reconciled')
 
     app.get('/api/v1/workspace/meta', async (request, reply) => {
       try {

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -1067,14 +1067,24 @@ export async function createCoreWorkspaceAgentServer(
     workspaceRoot: null,
     ...(discoveredPackages ? { discoveredPackages } : {}),
   })
+  const availableAgentTypeIds = agents.map((agent) => agent.agentTypeId)
+  const applicationDefaultAgentTypeId = resolveApplicationDefaultAgentTypeId({
+    bootDefaultAgentTypeId: options.defaultAgentTypeId ?? rawConfig.defaultAgentTypeId,
+    availableAgentTypeIds,
+  })
   const signupAgentDefaults = compileSignupAgentDefaults(
     rawConfig.signupAgentDefaults,
-    agents.map((agent) => agent.agentTypeId),
+    availableAgentTypeIds,
     rawConfig.security?.trustedProxy,
   )
-  // Decision 28 hook: validate all trusted signup config before allocating DB
-  // or HTTP resources. Unknown seats and malformed server options fail boot.
-  const config: CoreConfig = { ...rawConfig, signupAgentDefaults }
+  // Decision 28 hook: validate all trusted signup/default config before
+  // allocating DB or HTTP resources. Core creation writers receive this same
+  // resolved non-NULL application default used by the legacy backfill.
+  const config: CoreConfig = {
+    ...rawConfig,
+    defaultAgentTypeId: applicationDefaultAgentTypeId,
+    signupAgentDefaults,
+  }
   const { app, sql, db, userStore, workspaceStore, telemetry } = await createCoreRuntime(
     config,
     signupAgentDefaults,
@@ -1091,12 +1101,6 @@ export async function createCoreWorkspaceAgentServer(
     ?? normalizeOptionalPath(process.env.BORING_AGENT_SESSION_ROOT)
     ?? inferSessionRootForWorkspaceRoot(workspaceRoot, agentRuntimeMode)
   registerTelemetryHooks(app, telemetry)
-
-  const availableAgentTypeIds = agents.map((agent) => agent.agentTypeId)
-  const applicationDefaultAgentTypeId = resolveApplicationDefaultAgentTypeId({
-    bootDefaultAgentTypeId: options.defaultAgentTypeId,
-    availableAgentTypeIds,
-  })
 
   await registerCoreRoutes({ app, sql, db, userStore, workspaceStore })
 
@@ -1730,13 +1734,11 @@ export async function createCoreWorkspaceAgentServer(
         ) {
           throw error
         }
+        if (error instanceof HttpError) throw error
         const statusCode = typeof (error as { statusCode?: unknown })?.statusCode === 'number'
           ? (error as { statusCode: number }).statusCode
           : 500
         const message = error instanceof Error ? error.message : 'workspace meta failed'
-        if (error instanceof HttpError) {
-          return reply.code(statusCode).send({ error: { code: error.code, message } })
-        }
         return reply.code(statusCode).send({ error: message })
       }
     })

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -37,6 +37,7 @@ import {
   type VerifiedAgentScopeClaim,
   type WorkspaceAgentDispatcherResolver,
 } from '@hachej/boring-agent/server'
+import { AgentGatewayErrorCode } from '@hachej/boring-agent/shared'
 import type {
   AgentTool,
   SandboxHandleStore,
@@ -108,9 +109,20 @@ import {
   TRUSTED_SIGNUP_HOSTNAME_HEADER,
   type ValidatedSignupAgentDefaults,
 } from '../../server/signupAgentDefaults.js'
-import { resolveWorkspaceDefaultAgentTypeId } from '../../server/defaultAgentType.js'
+import {
+  classifyWorkspaceDefaultAgentTypeCohorts,
+  resolveApplicationDefaultAgentTypeId,
+  resolveWorkspaceDefaultAgentTypeId,
+} from '../../server/defaultAgentType.js'
 import { WorkspaceRuntimeSandboxHandleStore } from '../../server/runtime/index.js'
 import { createDatabaseTelemetryFromEnv } from '../../server/telemetry/db.js'
+
+const DEFAULT_AGENT_EXECUTION_EFFECTS = new Set([
+  'session.create',
+  'session.prompt',
+  'session.followup',
+  'session.command.execute',
+])
 
 const MIME_TYPES: Record<string, string> = {
   '.css': 'text/css; charset=utf-8',
@@ -332,6 +344,7 @@ function createCoreAgentScopeAuthority(input: {
   readonly userStore: UserStore
 }) {
   const records = new WeakMap<AuthorizedAgentScope, CoreAgentScopeRecord>()
+  const workspaceIdsByClaim = new WeakMap<VerifiedAgentScopeClaim, string>()
 
   const issueScope = ({
     claim,
@@ -353,6 +366,7 @@ function createCoreAgentScopeAuthority(input: {
       environment,
       agentRuntime,
     })
+    workspaceIdsByClaim.set(verifiedClaim, claim.workspaceScopeId)
     return scope
   }
 
@@ -367,6 +381,11 @@ function createCoreAgentScopeAuthority(input: {
       const record = records.get(scope)
       if (!record) throw new Error('agent scope was not issued by Core')
       return record.agentRuntime
+    },
+    resolveWorkspaceId(claim: VerifiedAgentScopeClaim): string {
+      const workspaceId = workspaceIdsByClaim.get(claim)
+      if (!workspaceId) throw new Error('agent scope claim was not issued by Core')
+      return workspaceId
     },
     verifier: {
       async verify(scope: AuthorizedAgentScope): Promise<VerifiedAgentScopeClaim> {
@@ -1073,6 +1092,12 @@ export async function createCoreWorkspaceAgentServer(
     ?? inferSessionRootForWorkspaceRoot(workspaceRoot, agentRuntimeMode)
   registerTelemetryHooks(app, telemetry)
 
+  const availableAgentTypeIds = agents.map((agent) => agent.agentTypeId)
+  const applicationDefaultAgentTypeId = resolveApplicationDefaultAgentTypeId({
+    bootDefaultAgentTypeId: options.defaultAgentTypeId,
+    availableAgentTypeIds,
+  })
+
   await registerCoreRoutes({ app, sql, db, userStore, workspaceStore })
 
   if (serveFrontend && appRoot) {
@@ -1567,6 +1592,48 @@ export async function createCoreWorkspaceAgentServer(
     })
   }
 
+  const assertWorkspaceDefaultAgentExecutionAvailable = async (workspaceId: string): Promise<void> => {
+    const workspace = await workspaceStore.get(workspaceId)
+    if (!workspace || workspace.appId !== config.appId) throw httpError('workspace access denied', 403)
+    resolveWorkspaceDefaultAgentTypeId({
+      persistedDefaultAgentTypeId: workspace.defaultAgentTypeId,
+      bootDefaultAgentTypeId: applicationDefaultAgentTypeId,
+      availableAgentTypeIds,
+      onUnknownPersistedSeat: (diagnostic) => {
+        app.log.warn(
+          { workspaceId, ...diagnostic },
+          'workspace default Agent is not in the validated fleet; execution denied',
+        )
+      },
+    })
+  }
+  const coreEffectAdmission: AgentEffectAdmission = {
+    async admit(input) {
+      if (DEFAULT_AGENT_EXECUTION_EFFECTS.has(input.operation)) {
+        const workspaceId = scopeAuthority.resolveWorkspaceId(input.scope)
+        try {
+          await assertWorkspaceDefaultAgentExecutionAvailable(workspaceId)
+        } catch (error) {
+          if (error instanceof HttpError && error.code === ERROR_CODES.DEFAULT_AGENT_TYPE_UNKNOWN_SEAT) {
+            return {
+              type: 'rejected',
+              error: {
+                code: AgentGatewayErrorCode.AGENT_TYPE_UNKNOWN,
+                message: 'Workspace default Agent is unavailable',
+                details: { code: ERROR_CODES.DEFAULT_AGENT_TYPE_UNKNOWN_SEAT },
+                target: input.target,
+                requestId: input.key.requestId,
+              },
+            }
+          }
+          throw error
+        }
+      }
+      if (options.effectAdmission) return await options.effectAdmission.admit(input)
+      return { type: 'accepted', admissionReceipt: `core-trusted-local:${input.key.requestId}` }
+    },
+  }
+
   const agentHost = await createAgentHost({
     agents,
     fleetCompiler: createValidatingAgentFleetCompiler({
@@ -1586,14 +1653,7 @@ export async function createCoreWorkspaceAgentServer(
     telemetry,
     metering: options.metering,
     harnessFactory: options.harnessFactory,
-    effectAdmission: options.effectAdmission ?? {
-      async admit({ key }) {
-        return {
-          type: 'accepted',
-          admissionReceipt: `core-trusted-local:${key.requestId}`,
-        }
-      },
-    },
+    effectAdmission: coreEffectAdmission,
     async resolveAuthorizedEnvironmentScope({ authorizedScope }) {
       return scopeAuthority.resolveEnvironment(authorizedScope)
     },
@@ -1601,6 +1661,32 @@ export async function createCoreWorkspaceAgentServer(
       return scopeAuthority.resolveAgentRuntime(authorizedScope)
     },
   })
+
+  // Decision 28 migration phase: createAgentHost has now compiled and
+  // validated the static fleet. Inventory every persisted cohort, then
+  // compare-and-set only legacy NULL rows before any route can serve.
+  // Re-running this startup phase is idempotent; concurrent non-NULL writers
+  // always win, and hostname never enters either store operation.
+  const cohortsBefore = classifyWorkspaceDefaultAgentTypeCohorts(
+    await workspaceStore.inventoryDefaultAgentTypeIds(config.appId),
+    availableAgentTypeIds,
+  )
+  const migratedDefaultAgentTypeIdCount = await workspaceStore.compareAndSetNullDefaultAgentTypeId(
+    config.appId,
+    applicationDefaultAgentTypeId,
+  )
+  const cohortsAfter = classifyWorkspaceDefaultAgentTypeCohorts(
+    await workspaceStore.inventoryDefaultAgentTypeIds(config.appId),
+    availableAgentTypeIds,
+  )
+  app.log.info({
+    event: 'workspace.default_agent_type_id.backfill',
+    appId: config.appId,
+    applicationDefaultAgentTypeId,
+    before: cohortsBefore,
+    migratedCount: migratedDefaultAgentTypeIdCount,
+    after: cohortsAfter,
+  }, 'workspace default Agent legacy cohorts reconciled')
 
   let hostMounted = false
   try {
@@ -1615,9 +1701,9 @@ export async function createCoreWorkspaceAgentServer(
           workspaceId,
           workspaceRoot: workspaceRootForRequest,
           projectName: workspace?.name ?? 'Workspace',
-          // Decision 28: prefer the workspace's persisted default seat when it
-          // names a validated fleet member; fail closed to the boot option,
-          // then the legacy default, with a stable diagnostic code.
+          // Decision 28: a configured persisted default is authoritative.
+          // Unknown values fail stably and are never reinterpreted as a boot
+          // or fleet default.
           defaultAgentTypeId: resolveWorkspaceDefaultAgentTypeId({
             persistedDefaultAgentTypeId: workspace?.defaultAgentTypeId,
             bootDefaultAgentTypeId: options.defaultAgentTypeId,
@@ -1625,7 +1711,7 @@ export async function createCoreWorkspaceAgentServer(
             onUnknownPersistedSeat: (diagnostic) => {
               request.log.warn(
                 { workspaceId, ...diagnostic },
-                'workspace default agent seat is not in the validated fleet; falling back',
+                'workspace default Agent is not in the validated fleet; meta resolution denied',
               )
             },
           }),
@@ -1641,6 +1727,9 @@ export async function createCoreWorkspaceAgentServer(
           ? (error as { statusCode: number }).statusCode
           : 500
         const message = error instanceof Error ? error.message : 'workspace meta failed'
+        if (error instanceof HttpError) {
+          return reply.code(statusCode).send({ error: { code: error.code, message } })
+        }
         return reply.code(statusCode).send({ error: message })
       }
     })
@@ -1661,6 +1750,7 @@ export async function createCoreWorkspaceAgentServer(
     const directDispatcherResolver: WorkspaceAgentDispatcherResolver = {
       async runWithWorkspaceAgent(input, run) {
         const authorizedScope = await authorizeAgentRequest(input.request, input.context)
+        await assertWorkspaceDefaultAgentExecutionAvailable(input.context.workspaceId)
         await agentHost.runWithWorkspaceAgent({ ...input, authorizedScope }, run)
       },
       async resolve() {

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -1662,34 +1662,41 @@ export async function createCoreWorkspaceAgentServer(
     },
   })
 
-  // Decision 28 migration phase: createAgentHost has now compiled and
-  // validated the static fleet. Inventory every persisted cohort, then
-  // compare-and-set only legacy NULL rows before any route can serve.
-  // Re-running this startup phase is idempotent; concurrent non-NULL writers
-  // always win, and hostname never enters either store operation.
-  const cohortsBefore = classifyWorkspaceDefaultAgentTypeCohorts(
-    await workspaceStore.inventoryDefaultAgentTypeIds(config.appId),
-    availableAgentTypeIds,
-  )
-  const migratedDefaultAgentTypeIdCount = await workspaceStore.compareAndSetNullDefaultAgentTypeId(
-    config.appId,
-    applicationDefaultAgentTypeId,
-  )
-  const cohortsAfter = classifyWorkspaceDefaultAgentTypeCohorts(
-    await workspaceStore.inventoryDefaultAgentTypeIds(config.appId),
-    availableAgentTypeIds,
-  )
-  app.log.info({
-    event: 'workspace.default_agent_type_id.backfill',
-    appId: config.appId,
-    applicationDefaultAgentTypeId,
-    before: cohortsBefore,
-    migratedCount: migratedDefaultAgentTypeIdCount,
-    after: cohortsAfter,
-  }, 'workspace default Agent legacy cohorts reconciled')
-
   let hostMounted = false
   try {
+    // Decision 28 migration phase: createAgentHost has now compiled and
+    // validated the static fleet. Inventory every persisted cohort, then
+    // compare-and-set only legacy NULL rows before any route can serve.
+    // Re-running this startup phase is idempotent; concurrent non-NULL writers
+    // always win, and hostname never enters either store operation.
+    const cohortsBefore = classifyWorkspaceDefaultAgentTypeCohorts(
+      await workspaceStore.inventoryDefaultAgentTypeIds(config.appId),
+      availableAgentTypeIds,
+    )
+    const migratedDefaultAgentTypeIdCount = await workspaceStore.compareAndSetNullDefaultAgentTypeId(
+      config.appId,
+      applicationDefaultAgentTypeId,
+    )
+    const cohortsAfter = classifyWorkspaceDefaultAgentTypeCohorts(
+      await workspaceStore.inventoryDefaultAgentTypeIds(config.appId),
+      availableAgentTypeIds,
+    )
+    if (cohortsAfter.nullCount > 0) {
+      throw new HttpError({
+        status: 500,
+        code: ERROR_CODES.DEFAULT_AGENT_TYPE_UNKNOWN_SEAT,
+        message: 'Workspace default Agent legacy reconciliation did not converge',
+      })
+    }
+    app.log.info({
+      event: 'workspace.default_agent_type_id.backfill',
+      appId: config.appId,
+      applicationDefaultAgentTypeId,
+      before: cohortsBefore,
+      migratedCount: migratedDefaultAgentTypeIdCount,
+      after: cohortsAfter,
+    }, 'workspace default Agent legacy cohorts reconciled')
+
     app.get('/api/v1/workspace/meta', async (request, reply) => {
       try {
         const workspaceId = await resolveWorkspaceId(request)
@@ -1788,8 +1795,8 @@ export async function createCoreWorkspaceAgentServer(
       await registerFrontendFallback(app, appRoot, telemetry, options.frontendRootHandler)
     }
   } catch (error) {
-    if (hostMounted) await app.close().catch(() => undefined)
-    else await agentHost.host.close().catch(() => undefined)
+    if (!hostMounted) await agentHost.host.close().catch(() => undefined)
+    await app.close().catch(() => undefined)
     throw error
   }
 

--- a/packages/core/src/server/__tests__/defaultAgentType.test.ts
+++ b/packages/core/src/server/__tests__/defaultAgentType.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it, vi } from 'vitest'
 import { ERROR_CODES } from '../../shared/errors.js'
 import {
   LEGACY_DEFAULT_AGENT_TYPE_ID,
+  classifyWorkspaceDefaultAgentTypeCohorts,
   isAgentTypeId,
   parseTrustedDefaultAgentTypeId,
+  resolveApplicationDefaultAgentTypeId,
   resolveWorkspaceDefaultAgentTypeId,
 } from '../defaultAgentType.js'
 
@@ -53,40 +55,66 @@ describe('resolveWorkspaceDefaultAgentTypeId', () => {
     })).toBe('boring-v2')
   })
 
-  it('falls back to the first fleet seat, then the legacy default', () => {
+  it('falls back to the first fleet seat and rejects an empty fleet', () => {
     expect(resolveWorkspaceDefaultAgentTypeId({
       persistedDefaultAgentTypeId: null,
       bootDefaultAgentTypeId: undefined,
       availableAgentTypeIds: fleet,
     })).toBe('default')
-    expect(resolveWorkspaceDefaultAgentTypeId({
+    expect(() => resolveWorkspaceDefaultAgentTypeId({
       persistedDefaultAgentTypeId: null,
       bootDefaultAgentTypeId: undefined,
       availableAgentTypeIds: [],
-    })).toBe(LEGACY_DEFAULT_AGENT_TYPE_ID)
+    })).toThrowError(expect.objectContaining({ code: ERROR_CODES.DEFAULT_AGENT_TYPE_UNKNOWN_SEAT }))
   })
 
-  it('fails closed to the fallback with a stable diagnostic when the persisted seat is unknown', () => {
+  it('fails stably without fallback when the persisted seat is unknown', () => {
     const onUnknownPersistedSeat = vi.fn()
-    expect(resolveWorkspaceDefaultAgentTypeId({
+    expect(() => resolveWorkspaceDefaultAgentTypeId({
       persistedDefaultAgentTypeId: 'retired-seat',
       bootDefaultAgentTypeId: 'boring-v2',
       availableAgentTypeIds: fleet,
       onUnknownPersistedSeat,
-    })).toBe('boring-v2')
-    expect(onUnknownPersistedSeat).toHaveBeenCalledTimes(1)
+    })).toThrowError(expect.objectContaining({
+      code: ERROR_CODES.DEFAULT_AGENT_TYPE_UNKNOWN_SEAT,
+      status: 409,
+    }))
     expect(onUnknownPersistedSeat).toHaveBeenCalledWith({
       code: ERROR_CODES.DEFAULT_AGENT_TYPE_UNKNOWN_SEAT,
       persistedDefaultAgentTypeId: 'retired-seat',
-      fallbackAgentTypeId: 'boring-v2',
     })
   })
 
-  it('never throws on an unknown persisted seat even without a diagnostic sink', () => {
-    expect(resolveWorkspaceDefaultAgentTypeId({
+  it('does not reinterpret an unknown persisted seat as the legacy default', () => {
+    expect(() => resolveWorkspaceDefaultAgentTypeId({
       persistedDefaultAgentTypeId: 'retired-seat',
       bootDefaultAgentTypeId: undefined,
-      availableAgentTypeIds: [],
-    })).toBe(LEGACY_DEFAULT_AGENT_TYPE_ID)
+      availableAgentTypeIds: [LEGACY_DEFAULT_AGENT_TYPE_ID],
+    })).toThrowError(expect.objectContaining({ code: ERROR_CODES.DEFAULT_AGENT_TYPE_UNKNOWN_SEAT }))
+  })
+})
+
+describe('legacy default-Agent cohorts', () => {
+  it('classifies NULL, known, and unknown persisted cohorts without repair', () => {
+    expect(classifyWorkspaceDefaultAgentTypeCohorts([
+      { defaultAgentTypeId: null, count: 3 },
+      { defaultAgentTypeId: 'default', count: 4 },
+      { defaultAgentTypeId: 'retired-seat', count: 2 },
+    ], ['default'])).toEqual({
+      nullCount: 3,
+      knownCount: 4,
+      unknown: [{ defaultAgentTypeId: 'retired-seat', count: 2 }],
+    })
+  })
+
+  it('requires the application default to be a current fleet member', () => {
+    expect(resolveApplicationDefaultAgentTypeId({
+      bootDefaultAgentTypeId: undefined,
+      availableAgentTypeIds: ['default'],
+    })).toBe('default')
+    expect(() => resolveApplicationDefaultAgentTypeId({
+      bootDefaultAgentTypeId: 'retired-seat',
+      availableAgentTypeIds: ['default'],
+    })).toThrowError(expect.objectContaining({ code: ERROR_CODES.DEFAULT_AGENT_TYPE_UNKNOWN_SEAT }))
   })
 })

--- a/packages/core/src/server/app/types.ts
+++ b/packages/core/src/server/app/types.ts
@@ -13,6 +13,9 @@ import type {
   MemberRole,
 } from '../../shared/types.js'
 import type { ERROR_CODES } from '../../shared/errors.js'
+import type { WorkspaceDefaultAgentTypeInventoryItem } from '../defaultAgentType.js'
+
+export type { WorkspaceDefaultAgentTypeInventoryItem } from '../defaultAgentType.js'
 import type { WorkspaceProvisioner } from '../provisioner/types.js'
 
 export interface UserStore {
@@ -48,11 +51,6 @@ export interface WorkspaceStoreCreateOptions {
    * initialization; an existing workspace's value is never rewritten.
    */
   readonly defaultAgentTypeId?: string
-}
-
-export interface WorkspaceDefaultAgentTypeInventoryItem {
-  readonly defaultAgentTypeId: string | null
-  readonly count: number
 }
 
 export interface WorkspaceStore {

--- a/packages/core/src/server/app/types.ts
+++ b/packages/core/src/server/app/types.ts
@@ -50,9 +50,18 @@ export interface WorkspaceStoreCreateOptions {
   readonly defaultAgentTypeId?: string
 }
 
+export interface WorkspaceDefaultAgentTypeInventoryItem {
+  readonly defaultAgentTypeId: string | null
+  readonly count: number
+}
+
 export interface WorkspaceStore {
   create(userId: string, name: string, appId: string, opts?: WorkspaceStoreCreateOptions): Promise<Workspace>
   list(userId: string, appId: string): Promise<Workspace[]>
+  /** Inventory persisted default-Agent cohorts without interpreting fleet membership. */
+  inventoryDefaultAgentTypeIds(appId: string): Promise<WorkspaceDefaultAgentTypeInventoryItem[]>
+  /** Idempotent compare-and-set backfill: only rows still NULL may change. */
+  compareAndSetNullDefaultAgentTypeId(appId: string, defaultAgentTypeId: string): Promise<number>
   get(id: string): Promise<Workspace | null>
   getIncludingDeleted(id: string): Promise<Workspace | null>
   restore(id: string): Promise<Workspace | null>

--- a/packages/core/src/server/db/__tests__/storeConformance.ts
+++ b/packages/core/src/server/db/__tests__/storeConformance.ts
@@ -354,6 +354,45 @@ export function describeWorkspaceStoreConformance(
     )
 
     it(
+      'inventories legacy cohorts and compare-and-sets NULL defaults idempotently',
+      withTaskId(TASK_ID, async ({ assertionPassed }) => {
+        const { workspaceStore, appId, otherAppId, users } = await setup()
+        const legacy = await workspaceStore.create(users.owner.id, 'Legacy NULL', appId)
+        const known = await workspaceStore.create(users.owner.id, 'Known', appId, { defaultAgentTypeId: 'default' })
+        const unknown = await workspaceStore.create(users.owner.id, 'Unknown', appId, { defaultAgentTypeId: 'retired-seat' })
+        const otherAppLegacy = await workspaceStore.create(users.owner.id, 'Other app NULL', otherAppId)
+
+        expect(await workspaceStore.inventoryDefaultAgentTypeIds(appId)).toEqual([
+          { defaultAgentTypeId: null, count: 1 },
+          { defaultAgentTypeId: 'default', count: 1 },
+          { defaultAgentTypeId: 'retired-seat', count: 1 },
+        ])
+        expect(await workspaceStore.compareAndSetNullDefaultAgentTypeId(appId, 'default')).toBe(1)
+        expect(await workspaceStore.compareAndSetNullDefaultAgentTypeId(appId, 'default')).toBe(0)
+        expect((await workspaceStore.get(legacy.id))?.defaultAgentTypeId).toBe('default')
+        expect((await workspaceStore.get(known.id))?.defaultAgentTypeId).toBe('default')
+        expect((await workspaceStore.get(unknown.id))?.defaultAgentTypeId).toBe('retired-seat')
+        expect((await workspaceStore.get(otherAppLegacy.id))?.defaultAgentTypeId ?? null).toBeNull()
+        assertionPassed('default-agent-null-cas-idempotent')
+      }),
+    )
+
+    it(
+      'allows exactly one concurrent NULL-default compare-and-set winner',
+      withTaskId(TASK_ID, async ({ assertionPassed }) => {
+        const { workspaceStore, appId, users } = await setup()
+        const legacy = await workspaceStore.create(users.owner.id, 'Concurrent legacy NULL', appId)
+        const results = await Promise.all([
+          workspaceStore.compareAndSetNullDefaultAgentTypeId(appId, 'default'),
+          workspaceStore.compareAndSetNullDefaultAgentTypeId(appId, 'alternate'),
+        ])
+        expect(results.reduce((sum, count) => sum + count, 0)).toBe(1)
+        expect(['default', 'alternate']).toContain((await workspaceStore.get(legacy.id))?.defaultAgentTypeId)
+        assertionPassed('default-agent-null-cas-concurrent-winner')
+      }),
+    )
+
+    it(
       'never rewrites an existing workspace defaultAgentTypeId implicitly (D28 write-once)',
       withTaskId(TASK_ID, async ({ assertionPassed }) => {
         const { workspaceStore, appId, users } = await setup()

--- a/packages/core/src/server/db/stores/LocalWorkspaceStore.ts
+++ b/packages/core/src/server/db/stores/LocalWorkspaceStore.ts
@@ -1,5 +1,9 @@
 import { randomUUID, createHash } from 'node:crypto'
-import type { WorkspaceStore, WorkspaceStoreCreateOptions } from '../../app/types.js'
+import type {
+  WorkspaceDefaultAgentTypeInventoryItem,
+  WorkspaceStore,
+  WorkspaceStoreCreateOptions,
+} from '../../app/types.js'
 import type {
   Workspace,
   WorkspaceMember,
@@ -102,6 +106,30 @@ export class LocalWorkspaceStore implements WorkspaceStore {
       return b.createdAt.localeCompare(a.createdAt)
     })
     return result
+  }
+
+  async inventoryDefaultAgentTypeIds(appId: string): Promise<WorkspaceDefaultAgentTypeInventoryItem[]> {
+    const counts = new Map<string | null, number>()
+    for (const workspace of this.workspaces.values()) {
+      if (workspace.appId !== appId) continue
+      const value = workspace.defaultAgentTypeId ?? null
+      counts.set(value, (counts.get(value) ?? 0) + 1)
+    }
+    return [...counts.entries()]
+      .map(([defaultAgentTypeId, count]) => ({ defaultAgentTypeId, count }))
+      .sort((left, right) => (left.defaultAgentTypeId ?? '').localeCompare(right.defaultAgentTypeId ?? ''))
+  }
+
+  async compareAndSetNullDefaultAgentTypeId(appId: string, value: string): Promise<number> {
+    const defaultAgentTypeId = parseTrustedDefaultAgentTypeId(value)
+    if (defaultAgentTypeId === null) return 0
+    let updated = 0
+    for (const [id, workspace] of this.workspaces) {
+      if (workspace.appId !== appId || workspace.defaultAgentTypeId != null) continue
+      this.workspaces.set(id, { ...workspace, defaultAgentTypeId })
+      updated += 1
+    }
+    return updated
   }
 
   async get(id: string): Promise<Workspace | null> {

--- a/packages/core/src/server/db/stores/PostgresWorkspaceStore.ts
+++ b/packages/core/src/server/db/stores/PostgresWorkspaceStore.ts
@@ -2,7 +2,11 @@ import { createHash, randomBytes } from 'node:crypto'
 import { and, eq, isNull, sql, desc } from 'drizzle-orm'
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js'
 
-import type { WorkspaceStore, WorkspaceStoreCreateOptions } from '../../app/types.js'
+import type {
+  WorkspaceDefaultAgentTypeInventoryItem,
+  WorkspaceStore,
+  WorkspaceStoreCreateOptions,
+} from '../../app/types.js'
 import type {
   MemberRole,
   User,
@@ -225,6 +229,35 @@ export class PostgresWorkspaceStore implements WorkspaceStore {
       .orderBy(desc(workspaces.isDefault), desc(workspaces.createdAt))
 
     return rows.map((r) => toWorkspace(r.ws))
+  }
+
+  async inventoryDefaultAgentTypeIds(appId: string): Promise<WorkspaceDefaultAgentTypeInventoryItem[]> {
+    const rows = await this.db
+      .select({
+        defaultAgentTypeId: workspaces.defaultAgentTypeId,
+        count: sql<number>`count(*)::integer`,
+      })
+      .from(workspaces)
+      .where(eq(workspaces.appId, appId))
+      .groupBy(workspaces.defaultAgentTypeId)
+
+    return rows
+      .map((row) => ({
+        defaultAgentTypeId: row.defaultAgentTypeId,
+        count: Number(row.count),
+      }))
+      .sort((left, right) => (left.defaultAgentTypeId ?? '').localeCompare(right.defaultAgentTypeId ?? ''))
+  }
+
+  async compareAndSetNullDefaultAgentTypeId(appId: string, value: string): Promise<number> {
+    const defaultAgentTypeId = parseTrustedDefaultAgentTypeId(value)
+    if (defaultAgentTypeId === null) return 0
+    const rows = await this.db
+      .update(workspaces)
+      .set({ defaultAgentTypeId })
+      .where(and(eq(workspaces.appId, appId), isNull(workspaces.defaultAgentTypeId)))
+      .returning({ id: workspaces.id })
+    return rows.length
   }
 
   async get(id: string): Promise<Workspace | null> {

--- a/packages/core/src/server/defaultAgentType.ts
+++ b/packages/core/src/server/defaultAgentType.ts
@@ -2,8 +2,8 @@ import { ERROR_CODES, HttpError } from '../shared/errors.js'
 
 /**
  * Decision 28: every initialized Workspace durably persists its
- * `defaultAgentTypeId`. This module owns the trusted write-path validation and
- * the read-path resolution preference order.
+ * `defaultAgentTypeId`. This module owns trusted write validation, legacy
+ * cohort classification, and fail-closed runtime resolution.
  *
  * Agent type ids share the workspace-type slug grammar (lowercase slug,
  * <= 63 chars), matching the `workspaces_default_agent_type_id_check`
@@ -15,64 +15,88 @@ export function isAgentTypeId(value: unknown): value is string {
   return typeof value === 'string' && AGENT_TYPE_ID_PATTERN.test(value)
 }
 
-/**
- * Validates a server-controlled default agent type id at workspace
- * initialization. `undefined` means "no persisted default" and maps to NULL.
- */
 export function parseTrustedDefaultAgentTypeId(value: unknown): string | null {
   if (value === undefined || value === null) return null
   if (!isAgentTypeId(value)) {
-    throw new HttpError({
-      status: 400,
-      code: ERROR_CODES.INVALID_DEFAULT_AGENT_TYPE_ID,
-      message: 'Invalid default agent type ID',
-    })
+    throw new HttpError({ status: 400, code: ERROR_CODES.INVALID_DEFAULT_AGENT_TYPE_ID, message: 'Invalid default agent type ID' })
   }
   return value
 }
 
-export interface ResolveWorkspaceDefaultAgentTypeIdInput {
-  /** Persisted per-workspace value (`workspaces.default_agent_type_id`). */
-  readonly persistedDefaultAgentTypeId: string | null | undefined
-  /** Boot-time host option (`defaultAgentTypeId`). */
-  readonly bootDefaultAgentTypeId: string | undefined
-  /** Validated fleet seats compiled at boot. */
-  readonly availableAgentTypeIds: readonly string[]
-  /** Diagnostic sink for the fail-closed fallback; stable error code attached. */
-  readonly onUnknownPersistedSeat?: (diagnostic: {
-    readonly code: typeof ERROR_CODES.DEFAULT_AGENT_TYPE_UNKNOWN_SEAT
-    readonly persistedDefaultAgentTypeId: string
-    readonly fallbackAgentTypeId: string
-  }) => void
+export interface WorkspaceDefaultAgentTypeInventoryItem {
+  readonly defaultAgentTypeId: string | null
+  readonly count: number
+}
+
+export interface WorkspaceDefaultAgentTypeCohorts {
+  readonly nullCount: number
+  readonly knownCount: number
+  readonly unknown: ReadonlyArray<{ readonly defaultAgentTypeId: string; readonly count: number }>
+}
+
+/** Classifies persisted cohorts without mutating or repairing any row. */
+export function classifyWorkspaceDefaultAgentTypeCohorts(
+  inventory: readonly WorkspaceDefaultAgentTypeInventoryItem[],
+  availableAgentTypeIds: readonly string[],
+): WorkspaceDefaultAgentTypeCohorts {
+  const available = new Set(availableAgentTypeIds)
+  let nullCount = 0
+  let knownCount = 0
+  const unknown: Array<{ defaultAgentTypeId: string; count: number }> = []
+  for (const item of inventory) {
+    if (item.defaultAgentTypeId === null) nullCount += item.count
+    else if (available.has(item.defaultAgentTypeId)) knownCount += item.count
+    else unknown.push({ defaultAgentTypeId: item.defaultAgentTypeId, count: item.count })
+  }
+  unknown.sort((left, right) => left.defaultAgentTypeId.localeCompare(right.defaultAgentTypeId))
+  return { nullCount, knownCount, unknown }
 }
 
 export const LEGACY_DEFAULT_AGENT_TYPE_ID = 'default'
 
+/** Resolves and validates the application default used by the NULL-only backfill. */
+export function resolveApplicationDefaultAgentTypeId(input: {
+  readonly bootDefaultAgentTypeId: string | undefined
+  readonly availableAgentTypeIds: readonly string[]
+}): string {
+  const candidate = input.bootDefaultAgentTypeId ?? input.availableAgentTypeIds[0] ?? LEGACY_DEFAULT_AGENT_TYPE_ID
+  if (!input.availableAgentTypeIds.includes(candidate)) {
+    throw new HttpError({
+      status: 500,
+      code: ERROR_CODES.DEFAULT_AGENT_TYPE_UNKNOWN_SEAT,
+      message: 'Configured application default Agent is unavailable',
+    })
+  }
+  return candidate
+}
+
+export interface ResolveWorkspaceDefaultAgentTypeIdInput {
+  readonly persistedDefaultAgentTypeId: string | null | undefined
+  readonly bootDefaultAgentTypeId: string | undefined
+  readonly availableAgentTypeIds: readonly string[]
+  readonly onUnknownPersistedSeat?: (diagnostic: {
+    readonly code: typeof ERROR_CODES.DEFAULT_AGENT_TYPE_UNKNOWN_SEAT
+    readonly persistedDefaultAgentTypeId: string
+  }) => void
+}
+
 /**
- * Read-path preference order (Decision 28):
- *   1. the workspace's persisted `defaultAgentTypeId`, iff it names a
- *      validated fleet seat;
- *   2. the boot-time host `defaultAgentTypeId` option;
- *   3. the first validated fleet seat;
- *   4. the legacy `'default'` agent.
- *
- * Fails closed to the fallback chain — never throws — when the persisted
- * value names an unknown seat; the caller receives a
- * `default_agent_type_unknown_seat` diagnostic instead.
+ * Resolves the persisted Workspace default after the explicit NULL backfill.
+ * Legacy NULL remains readable for rollback/pre-migration cohorts, but a
+ * configured non-NULL value is authoritative: an unavailable value fails
+ * stably and is never reinterpreted as a boot or fleet default.
  */
-export function resolveWorkspaceDefaultAgentTypeId(
-  input: ResolveWorkspaceDefaultAgentTypeIdInput,
-): string {
-  const fallback = input.bootDefaultAgentTypeId
-    ?? input.availableAgentTypeIds[0]
-    ?? LEGACY_DEFAULT_AGENT_TYPE_ID
+export function resolveWorkspaceDefaultAgentTypeId(input: ResolveWorkspaceDefaultAgentTypeIdInput): string {
   const persisted = input.persistedDefaultAgentTypeId ?? null
-  if (persisted === null) return fallback
+  if (persisted === null) return resolveApplicationDefaultAgentTypeId(input)
   if (input.availableAgentTypeIds.includes(persisted)) return persisted
   input.onUnknownPersistedSeat?.({
     code: ERROR_CODES.DEFAULT_AGENT_TYPE_UNKNOWN_SEAT,
     persistedDefaultAgentTypeId: persisted,
-    fallbackAgentTypeId: fallback,
   })
-  return fallback
+  throw new HttpError({
+    status: 409,
+    code: ERROR_CODES.DEFAULT_AGENT_TYPE_UNKNOWN_SEAT,
+    message: 'Workspace default Agent is unavailable',
+  })
 }


### PR DESCRIPTION
## Summary
- inventory persisted default-Agent cohorts and compare-and-set only legacy `NULL` rows to the one validated application default before routes serve
- preserve non-`NULL` values, fail startup when reconciliation does not converge, and close Core/AgentHost resources on every migration failure
- deny Agent execution stably when a persisted default is unavailable without blocking Workspace listing or session/history reads
- keep hostname out of repair/resolution and retain the existing single `createAgentHost()`/AgentGateway construction funnel


## Initial bug description

Migration `packages/core/drizzle/0024_workspace_default_agent_type_id.sql` deliberately introduced `default_agent_type_id` as nullable, leaving pre-existing Workspaces in the legacy `NULL` cohort. Before this PR, `packages/core/src/server/defaultAgentType.ts` also handled an unavailable persisted non-`NULL` Agent id by silently selecting the boot/first-fleet fallback. The result was an unreconciled legacy cohort plus a risk that a Workspace recorded for one Agent could execute a different Agent without an explicit migration or stable error.

This PR fixes that initial bug by inventorying cohorts at startup, compare-and-setting only app-scoped `NULL` rows to the validated application default before routes serve, preserving every non-`NULL` value, and denying Agent execution stably when that persisted Agent is unavailable while leaving Workspace list/session/history reads available.

**Owner request-changes addressed:** “can you just add to the handoff the init abug decirption ?” The same evidence-backed description is now the first prose section of `.handoff/pr-1311-handoff.html`.

## Proof
Exact head: `97e99d5651a2fb4261860b01deb401a368e990ad`

- `BORING_AGENT_FLEET=0 NODE_ENV=test pnpm --filter @hachej/boring-core exec vitest run src/server/__tests__/defaultAgentType.test.ts src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts src/server/db/stores/__tests__/LocalWorkspaceStore.test.ts src/server/db/stores/__tests__/PostgresWorkspaceStore.test.ts src/server/db/__tests__/defaultAgentTypeId.migration.test.ts --no-file-parallelism` — **5 files, 184 tests passed**
- `BORING_AGENT_FLEET=0 NODE_ENV=test pnpm --filter @hachej/boring-workspace exec vitest run src/app/server/__tests__/createWorkspaceAgentServer.test.ts src/app/front/__tests__/WorkspaceAgentFront.test.tsx --no-file-parallelism` — **2 files, 152 tests passed**
- `pnpm --filter @hachej/boring-core typecheck` — **passed**
- `pnpm check:agenthost-cutover-matrix` — **20 rows, 42 final routes, 23 deleted historical routes, zero forbidden compatibility references**
- `git diff --check origin/main...HEAD` — **passed**

Focused cases cover NULL CAS/idempotency, already-set preservation, competing CAS winner, app isolation, unknown cohort inventory, config/default unification, migration cleanup/convergence, stable unknown-default execution denial, meta 409, session/history readability, rollback-compatible NULL reads, and no silent switch.

CI: final-head run `31893499413` is green after one failed-job rerun. The first E2E attempt hit the unrelated Agent property-baseline running-tool flake on both Playwright retries; the rerun passed E2E and every required CI gate. Workflow Invariants run `31893499427` is green.

## Review provenance
- reviewer: `openai-codex/gpt-5.6-sol`
- mandate: fresh-context adversarial fresh-eyes + thermonuclear review; refute scope, CAS/race safety, execution/read split, rollback, hostname isolation, and AgentHost funnel
- target: `97e99d5651a2fb4261860b01deb401a368e990ad`
- verdict: **clean**; no material findings or residual risk
- earlier reviews at `3b0e8a8` / `4d65b58` found startup cleanup, NULL convergence, config-default split, and error-envelope issues; all were fixed and re-reviewed at the final SHA

## Artifacts
- r2 present-pr handoff: `.handoff/pr-1311-handoff.html` (regenerated with the initial bug description, live CI table, issue/bead header, and opened before the r2 owner gate)
- running surface: N/A — backend/store behavior, no UI surface changed

## Risk & rollback
- Risk: startup now intentionally fails if the configured application default is absent from the fleet or a post-CAS `NULL` cohort remains; this prevents serving ambiguous Agent behavior.
- Rollback: revert the five bead commits. The schema remains nullable, session/history reads are unchanged, and migrated values remain readable by the prior default-aware cohort. Unknown non-`NULL` rows are never rewritten.

## Refs
- Bead: `wt-391-forward-xp3s.9`
- Epic D revision 3
- Decisions 28 and 29
