### PR TITLE
[wt-391-forward-gb0o.2] Inline ask_user artifact list in chat

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -52,6 +52,10 @@
       "import": "./dist/front/index.js"
     },
     "./front/styles.css": "./dist/front/styles.css",
+    "./front/artifacts": {
+      "types": "./dist/front/artifacts.d.ts",
+      "import": "./dist/front/artifacts.js"
+    },
     "./eval": {
       "types": "./dist/eval/index.d.ts",
       "import": "./dist/eval/index.js"

--- a/packages/agent/scripts/assert-build-artifacts.mjs
+++ b/packages/agent/scripts/assert-build-artifacts.mjs
@@ -21,6 +21,8 @@ const requiredFiles = [
   'dist/server/worker/index.d.ts',
   'dist/front/index.js',
   'dist/front/index.d.ts',
+  'dist/front/artifacts.js',
+  'dist/front/artifacts.d.ts',
   'dist/front/styles.css',
   'dist/eval/index.js',
   'dist/eval/index.d.ts',
@@ -202,12 +204,14 @@ async function main() {
   assertNodeParsable(coreEntry.displayPath)
   assertNodeParsable(serverEntry.displayPath)
   assertNodeParsable('dist/front/index.js')
+  assertNodeParsable('dist/front/artifacts.js')
   assertNodeParsable('dist/eval/index.js')
 
   assertTsParsable('dist/shared/index.d.ts')
   assertTsParsable('dist/core/index.d.ts')
   assertTsParsable('dist/server/index.d.ts')
   assertTsParsable('dist/front/index.d.ts')
+  assertTsParsable('dist/front/artifacts.d.ts')
   assertTsParsable('dist/eval/index.d.ts')
   assertConsumerSafeCss('dist/front/styles.css')
   assertFastifyDetectorFixture()

--- a/packages/agent/src/front/__tests__/publicExports.test.ts
+++ b/packages/agent/src/front/__tests__/publicExports.test.ts
@@ -28,6 +28,7 @@ describe('@hachej/boring-agent/front public exports', () => {
       './core',
       './eval',
       './front',
+      './front/artifacts',
       './front/styles.css',
       './server',
       './server/agent-host/testing/compositionRouteProof',

--- a/packages/agent/src/front/artifacts.ts
+++ b/packages/agent/src/front/artifacts.ts
@@ -1,0 +1,13 @@
+export {
+  ArtifactOpenProvider,
+  useOpenArtifact,
+  type OpenArtifactHandler,
+} from "./ArtifactOpenContext"
+export {
+  Artifact,
+  ArtifactAction,
+  ArtifactActions,
+  ArtifactDescription,
+  ArtifactHeader,
+  ArtifactTitle,
+} from "./primitives/artifact"

--- a/packages/agent/src/front/index.ts
+++ b/packages/agent/src/front/index.ts
@@ -34,6 +34,14 @@ export {
   useOpenArtifact,
   type OpenArtifactHandler,
 } from './ArtifactOpenContext'
+export {
+  Artifact,
+  ArtifactAction,
+  ArtifactActions,
+  ArtifactDescription,
+  ArtifactHeader,
+  ArtifactTitle,
+} from './primitives/artifact'
 export { ChatEmptyState, defaultChatSuggestions } from './ChatEmptyState'
 export type { ChatEmptyStateProps, ChatSuggestion } from './ChatEmptyState'
 export { ModelSelect, ModelPickerMenu, ModelSelectTrigger, ThinkingSelect } from './chatPanelComposerControls'

--- a/packages/agent/tsup.config.ts
+++ b/packages/agent/tsup.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
     "server/agent-host/testing/compositionRouteProof": "src/server/agent-host/testing/compositionRouteProof.ts",
     "server/worker/index": "src/server/worker/index.ts",
     "front/index": "src/front/index.ts",
+    "front/artifacts": "src/front/artifacts.ts",
     "eval/index": "src/eval/index.ts",
   },
   format: ["esm"],

--- a/packages/cli/src/__tests__/folderModeRuntimePlugins.test.ts
+++ b/packages/cli/src/__tests__/folderModeRuntimePlugins.test.ts
@@ -317,7 +317,21 @@ describe("folder mode runtime plugin wiring", () => {
       // entry URL must use that path and the file must serve a 200.
       expect(askUser?.frontTarget?.entryUrl).toMatch(/\/dist\/front\/index\.[mc]?js$/)
       const runtime = await app.inject({ method: "GET", url: askUser!.frontTarget!.entryUrl! })
-      expect(runtime.statusCode).toBe(200)
+      expect(runtime.statusCode, runtime.body).toBe(200)
+      // The renderer imports the dependency-neutral Agent artifact adapter,
+      // not the full Agent front graph. Follow the transformed import so this
+      // integration test proves the published subpath is runtime-servable.
+      const artifactAdapterUrl = runtime.body.match(/from "([^"\n]*packages%2Fagent%2Fdist%2Ffront%2Fartifacts\.js[^"\n]*)"/)?.[1]
+      expect(artifactAdapterUrl).toBeDefined()
+      const artifactAdapter = await app.inject({ method: "GET", url: artifactAdapterUrl! })
+      expect(artifactAdapter.statusCode, artifactAdapter.body).toBe(200)
+      const artifactChunkUrls = [...artifactAdapter.body.matchAll(/from "([^"\n]*packages%2Fagent%2Fdist%2Fchunk-[^"\n]+\.js[^"\n]*)"/g)]
+        .map((match) => match[1]!)
+      expect(artifactChunkUrls.length).toBeGreaterThan(0)
+      for (const artifactChunkUrl of artifactChunkUrls) {
+        const artifactChunk = await app.inject({ method: "GET", url: artifactChunkUrl })
+        expect(artifactChunk.statusCode, artifactChunk.body).toBe(200)
+      }
       // ask-user is sourced as an `internal` package; the CLI should
       // not advertise it via the legacy `frontUrl` field.
       expect((askUser as Record<string, unknown>).frontUrl).toBeUndefined()

--- a/packages/cli/src/__tests__/workspacesModeRuntimePlugins.test.ts
+++ b/packages/cli/src/__tests__/workspacesModeRuntimePlugins.test.ts
@@ -274,7 +274,7 @@ describe("workspaces mode runtime plugin wiring", () => {
       for (const plugin of pluginsA) {
         expect(plugin.frontTarget?.entryUrl).toBeTruthy()
         const runtime = await app.inject({ method: "GET", url: plugin.frontTarget!.entryUrl! })
-        expect(runtime.statusCode).toBe(200)
+        expect(runtime.statusCode, runtime.body).toBe(200)
       }
 
       const listB = await app.inject({ method: "GET", url: `/api/v1/agent-plugins?workspaceId=${registeredB.id}` })

--- a/plugins/ask-user/package.json
+++ b/plugins/ask-user/package.json
@@ -53,7 +53,8 @@
     "@hachej/boring-workspace": "workspace:*",
     "fastify": "^5.11.2",
     "react": "^18.0.0 || ^19.0.0",
-    "react-dom": "^18.0.0 || ^19.0.0"
+    "react-dom": "^18.0.0 || ^19.0.0",
+    "@hachej/boring-agent": "workspace:*"
   },
   "dependencies": {
     "@hachej/boring-ui-kit": "workspace:*",
@@ -74,7 +75,8 @@
     "react-dom": "^19.2.8",
     "tsup": "^8.4.0",
     "typescript": "~6.0.3",
-    "vitest": "^4.1.9"
+    "vitest": "^4.1.9",
+    "@hachej/boring-agent": "workspace:*"
   },
   "peerDependenciesMeta": {
     "fastify": {

--- a/plugins/ask-user/src/front/__tests__/askUserPlugin.test.tsx
+++ b/plugins/ask-user/src/front/__tests__/askUserPlugin.test.tsx
@@ -1,7 +1,9 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest"
-import { UI_COMMAND_EVENT, WORKSPACE_ATTENTION_ACTION_EVENT, WORKSPACE_COMPOSER_STOP_EVENT, WORKSPACE_COMPOSER_STOP_REASONS, WorkspaceProvider, events, userMeta, useWorkspaceAttention, workspaceEvents } from "@hachej/boring-workspace"
+import { HumanArtifactListSchema, UI_COMMAND_EVENT, WORKSPACE_ATTENTION_ACTION_EVENT, WORKSPACE_COMPOSER_STOP_EVENT, WORKSPACE_COMPOSER_STOP_REASONS, WorkspaceProvider, events, userMeta, useWorkspaceAttention, workspaceEvents } from "@hachej/boring-workspace"
+import { ArtifactOpenProvider } from "@hachej/boring-agent/front"
 import { captureFrontPlugin } from "@hachej/boring-workspace/plugin"
+import { AskUserToolInputSchema } from "../../shared/schema"
 import type { AskUserQuestion } from "../../shared/types"
 import { askUserPlugin } from "../index"
 import { sharedQuestionsStore } from "../runtime"
@@ -593,6 +595,80 @@ describe("askUserPlugin front shell", () => {
 
     rerender(<Provider apiBaseUrl="" activeSessionId="other"><>{renderer.render({ toolCallId: "another-call" })}</></Provider>)
     expect(screen.queryByTestId("ask-user-inline-question")).not.toBeInTheDocument()
+  })
+
+  it("renders the authored artifact list while pending and after resolution, with host-specific routing", async () => {
+    const artifacts = [
+      { id: "review", surfaceKind: "workspace.open.path", target: "docs/review.html", title: "PR review", description: "Inspect the exact visual diff." },
+      { id: "catalog", surfaceKind: "catalog.open-row", target: "orders_daily", title: "Orders table", description: "Open the registered catalog surface." },
+    ]
+    const pendingQuestion = { ...question, artifacts }
+    vi.stubGlobal("fetch", vi.fn(async (url: string, init?: RequestInit) => {
+      if (String(url).endsWith("/api/v1/workspace-bridge/call") && String(init?.body).includes("ask-user.v1.pending")) return Response.json({ ok: true, output: { pending: pendingQuestion } })
+      if (String(url).endsWith("/api/v1/ui/state")) return Response.json(pendingStateFor(pendingQuestion))
+      return Response.json({})
+    }))
+    const Provider = getProvider()
+    const renderer = capturedPlugin.registrations.toolRenderers.find((registration) => registration.id === "ask_user")!
+    const onOpenArtifact = vi.fn()
+    const onCommand = vi.fn()
+    window.addEventListener(UI_COMMAND_EVENT, onCommand)
+    const input = { title: pendingQuestion.title, artifacts }
+    const view = render(
+      <ArtifactOpenProvider onOpenArtifact={onOpenArtifact}>
+        <Provider apiBaseUrl="" activeSessionId="default"><>{renderer.render({ toolCallId: pendingQuestion.toolCallId, state: "input-available", input })}</></Provider>
+      </ArtifactOpenProvider>,
+    )
+
+    expect(await screen.findByText("PR review")).toBeInTheDocument()
+    expect(screen.getByText("Inspect the exact visual diff.")).toBeInTheDocument()
+    expect(screen.getByText("Orders table")).toBeInTheDocument()
+    expect(screen.getByText("Open the registered catalog surface.")).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: "Open PR review" }))
+    expect(onOpenArtifact).toHaveBeenCalledWith("docs/review.html")
+    fireEvent.click(screen.getByRole("button", { name: "Open Orders table" }))
+    expect(onCommand).toHaveBeenCalledWith(expect.objectContaining({ detail: {
+      kind: "openSurface",
+      params: { kind: "catalog.open-row", target: "orders_daily" },
+    } }))
+
+    sharedQuestionsStore.setPending(null, pendingQuestion.sessionId)
+    view.rerender(
+      <ArtifactOpenProvider onOpenArtifact={onOpenArtifact}>
+        <Provider apiBaseUrl="" activeSessionId="default"><>{renderer.render({ toolCallId: "resolved-call", state: "output-available", input })}</></Provider>
+      </ArtifactOpenProvider>,
+    )
+    expect(screen.getByText("Answer submitted")).toBeInTheDocument()
+    expect(screen.getByText("PR review")).toBeInTheDocument()
+    expect(screen.getByText("Orders table")).toBeInTheDocument()
+    window.removeEventListener(UI_COMMAND_EVENT, onCommand)
+  })
+
+  it("keeps authored artifacts visible in cancelled output", () => {
+    const Provider = getProvider()
+    const renderer = capturedPlugin.registrations.toolRenderers.find((registration) => registration.id === "ask_user")!
+    render(<Provider apiBaseUrl=""><>{renderer.render({ state: "aborted", input: { title: "Review decision", artifacts: [{ id: "proof", surfaceKind: "workspace.open.path", target: "proof.md", title: "Proof bundle" }] } })}</></Provider>)
+    expect(screen.getByText("Question cancelled")).toBeInTheDocument()
+    expect(screen.getByText("Proof bundle")).toBeInTheDocument()
+  })
+
+  it("fails closed for an invalid artifact payload without crashing the resolved card", () => {
+    const Provider = getProvider()
+    const renderer = capturedPlugin.registrations.toolRenderers.find((registration) => registration.id === "ask_user")!
+    render(<Provider apiBaseUrl=""><>{renderer.render({ state: "output-available", input: { title: "Safe resolution", artifacts: [{ id: "duplicate", surfaceKind: "workspace.open.path", target: "one.md", title: "Must not render" }, { id: "duplicate", surfaceKind: "workspace.open.path", target: "two.md", title: "Also hidden" }] } })}</></Provider>)
+    expect(screen.getByText("Safe resolution")).toBeInTheDocument()
+    expect(screen.getByText("Answer submitted")).toBeInTheDocument()
+    expect(screen.queryByText("Must not render")).not.toBeInTheDocument()
+    expect(screen.queryByText("Also hidden")).not.toBeInTheDocument()
+  })
+
+  it("accepts the same authored artifact array in ask_user input and the shared Inbox schema", () => {
+    const artifacts = [{ id: "review", surfaceKind: "workspace.open.path", target: "review.html", title: "Review", description: "Owner-facing review" }]
+    const input = { title: "Approve?", schema: question.schema, artifacts }
+    const toolResult = AskUserToolInputSchema.parse(input)
+    const inboxResult = HumanArtifactListSchema.parse(input.artifacts)
+    expect(toolResult.artifacts).toEqual(inboxResult)
+    expect(toolResult.artifacts).toEqual(artifacts)
   })
 
   it("registers ask_user as an inline tool renderer", () => {

--- a/plugins/ask-user/src/front/__tests__/askUserPlugin.test.tsx
+++ b/plugins/ask-user/src/front/__tests__/askUserPlugin.test.tsx
@@ -613,7 +613,7 @@ describe("askUserPlugin front shell", () => {
     const onOpenArtifact = vi.fn()
     const onCommand = vi.fn()
     window.addEventListener(UI_COMMAND_EVENT, onCommand)
-    const input = { title: pendingQuestion.title, artifacts }
+    const input = { title: pendingQuestion.title, schema: pendingQuestion.schema, artifacts }
     const view = render(
       <ArtifactOpenProvider onOpenArtifact={onOpenArtifact}>
         <Provider apiBaseUrl="" activeSessionId="default"><>{renderer.render({ toolCallId: pendingQuestion.toolCallId, state: "input-available", input })}</></Provider>
@@ -626,6 +626,7 @@ describe("askUserPlugin front shell", () => {
     expect(screen.getByText("Open the registered catalog surface.")).toBeInTheDocument()
     fireEvent.click(screen.getByRole("button", { name: "Open PR review" }))
     expect(onOpenArtifact).toHaveBeenCalledWith("docs/review.html")
+    expect(onCommand).not.toHaveBeenCalled()
     fireEvent.click(screen.getByRole("button", { name: "Open Orders table" }))
     expect(onCommand).toHaveBeenCalledWith(expect.objectContaining({ detail: {
       kind: "openSurface",
@@ -647,19 +648,34 @@ describe("askUserPlugin front shell", () => {
   it("keeps authored artifacts visible in cancelled output", () => {
     const Provider = getProvider()
     const renderer = capturedPlugin.registrations.toolRenderers.find((registration) => registration.id === "ask_user")!
-    render(<Provider apiBaseUrl=""><>{renderer.render({ state: "aborted", input: { title: "Review decision", artifacts: [{ id: "proof", surfaceKind: "workspace.open.path", target: "proof.md", title: "Proof bundle" }] } })}</></Provider>)
+    const onCommand = vi.fn()
+    window.addEventListener(UI_COMMAND_EVENT, onCommand)
+    render(<Provider apiBaseUrl=""><>{renderer.render({ state: "aborted", input: { title: "Review decision", schema: question.schema, artifacts: [{ id: "proof", surfaceKind: "workspace.open.path", target: "proof.md", title: "Proof bundle" }] } })}</></Provider>)
     expect(screen.getByText("Question cancelled")).toBeInTheDocument()
     expect(screen.getByText("Proof bundle")).toBeInTheDocument()
+    const open = screen.getByRole("button", { name: "Open Proof bundle" })
+    expect(open).toBeDisabled()
+    fireEvent.click(open)
+    expect(onCommand).not.toHaveBeenCalled()
+    window.removeEventListener(UI_COMMAND_EVENT, onCommand)
   })
 
   it("fails closed for an invalid artifact payload without crashing the resolved card", () => {
     const Provider = getProvider()
     const renderer = capturedPlugin.registrations.toolRenderers.find((registration) => registration.id === "ask_user")!
-    render(<Provider apiBaseUrl=""><>{renderer.render({ state: "output-available", input: { title: "Safe resolution", artifacts: [{ id: "duplicate", surfaceKind: "workspace.open.path", target: "one.md", title: "Must not render" }, { id: "duplicate", surfaceKind: "workspace.open.path", target: "two.md", title: "Also hidden" }] } })}</></Provider>)
+    render(<Provider apiBaseUrl=""><>{renderer.render({ state: "output-available", input: { title: "Safe resolution", schema: question.schema, artifacts: [{ id: "duplicate", surfaceKind: "workspace.open.path", target: "one.md", title: "Must not render" }, { id: "duplicate", surfaceKind: "workspace.open.path", target: "two.md", title: "Also hidden" }] } })}</></Provider>)
     expect(screen.getByText("Safe resolution")).toBeInTheDocument()
     expect(screen.getByText("Answer submitted")).toBeInTheDocument()
     expect(screen.queryByText("Must not render")).not.toBeInTheDocument()
     expect(screen.queryByText("Also hidden")).not.toBeInTheDocument()
+  })
+
+  it("hides otherwise valid artifacts when the canonical ask_user input is malformed", () => {
+    const Provider = getProvider()
+    const renderer = capturedPlugin.registrations.toolRenderers.find((registration) => registration.id === "ask_user")!
+    render(<Provider apiBaseUrl=""><>{renderer.render({ state: "output-error", input: { title: "Missing required schema", artifacts: [{ id: "proof", surfaceKind: "catalog.open-row", target: "orders", title: "Must stay hidden" }] } })}</></Provider>)
+    expect(screen.getByText("Question cancelled")).toBeInTheDocument()
+    expect(screen.queryByText("Must stay hidden")).not.toBeInTheDocument()
   })
 
   it("accepts the same authored artifact array in ask_user input and the shared Inbox schema", () => {

--- a/plugins/ask-user/src/front/index.tsx
+++ b/plugins/ask-user/src/front/index.tsx
@@ -3,7 +3,6 @@
 import { Button, EmptyState, Notice, Pane, PaneBody, PaneHeader, PaneTitle } from "@hachej/boring-ui-kit"
 import { Artifact, ArtifactAction, ArtifactActions, ArtifactDescription, ArtifactHeader, ArtifactTitle, useOpenArtifact } from "@hachej/boring-agent/front"
 import {
-  HumanArtifactListSchema,
   WORKSPACE_COMPOSER_STOP_EVENT,
   postUiCommand,
   useWorkspaceAttention,
@@ -18,6 +17,7 @@ import { definePlugin, type BoringFrontAppLeftOverlayProps, type BoringFrontFact
 import { CheckCircle2, ExternalLink, FileText, HelpCircle, Inbox, SquareArrowOutUpRight, XCircle } from "lucide-react"
 import { useEffect, useMemo, useSyncExternalStore, useState } from "react"
 import { ASK_USER_PANEL_ID, ASK_USER_PANEL_TITLE, ASK_USER_PLUGIN_ID, ASK_USER_SURFACE_KIND } from "../shared/constants"
+import { AskUserToolInputSchema } from "../shared/schema"
 import type { AskUserAnswerValue, AskUserQuestion } from "../shared/types"
 import { createQuestionsClient, QuestionsClientError } from "./client"
 import { createQuestionsStore, pendingQuestionSnapshot, QuestionsRuntimeContext, isSessionOpen, useQuestionsRuntime, type QuestionsRuntime } from "./runtime"
@@ -159,9 +159,8 @@ function QuestionsPane({ api, params, className }: PaneProps<QuestionsPaneParams
 }
 
 function inlineArtifactsFromInput(input: unknown): HumanArtifact[] {
-  if (typeof input !== "object" || !input) return []
-  const result = HumanArtifactListSchema.safeParse((input as { artifacts?: unknown }).artifacts ?? [])
-  return result.success ? result.data : []
+  const result = AskUserToolInputSchema.safeParse(input)
+  return result.success ? result.data.artifacts ?? [] : []
 }
 
 function InlineArtifactList({ artifacts }: { artifacts: HumanArtifact[] }) {

--- a/plugins/ask-user/src/front/index.tsx
+++ b/plugins/ask-user/src/front/index.tsx
@@ -1,18 +1,21 @@
 "use client"
 
 import { Button, EmptyState, Notice, Pane, PaneBody, PaneHeader, PaneTitle } from "@hachej/boring-ui-kit"
+import { Artifact, ArtifactAction, ArtifactActions, ArtifactDescription, ArtifactHeader, ArtifactTitle, useOpenArtifact } from "@hachej/boring-agent/front"
 import {
+  HumanArtifactListSchema,
   WORKSPACE_COMPOSER_STOP_EVENT,
   postUiCommand,
   useWorkspaceAttention,
   useWorkspaceContext,
   useWorkspaceContextOptional,
   workspaceComposerStopAppliesToSession,
+  type HumanArtifact,
   type PaneProps,
   type PluginProviderProps,
 } from "@hachej/boring-workspace"
 import { definePlugin, type BoringFrontAppLeftOverlayProps, type BoringFrontFactoryWithId } from "@hachej/boring-workspace/plugin"
-import { CheckCircle2, HelpCircle, Inbox, SquareArrowOutUpRight, XCircle } from "lucide-react"
+import { CheckCircle2, ExternalLink, FileText, HelpCircle, Inbox, SquareArrowOutUpRight, XCircle } from "lucide-react"
 import { useEffect, useMemo, useSyncExternalStore, useState } from "react"
 import { ASK_USER_PANEL_ID, ASK_USER_PANEL_TITLE, ASK_USER_PLUGIN_ID, ASK_USER_SURFACE_KIND } from "../shared/constants"
 import type { AskUserAnswerValue, AskUserQuestion } from "../shared/types"
@@ -155,20 +158,65 @@ function QuestionsPane({ api, params, className }: PaneProps<QuestionsPaneParams
   </div>
 }
 
+function inlineArtifactsFromInput(input: unknown): HumanArtifact[] {
+  if (typeof input !== "object" || !input) return []
+  const result = HumanArtifactListSchema.safeParse((input as { artifacts?: unknown }).artifacts ?? [])
+  return result.success ? result.data : []
+}
+
+function InlineArtifactList({ artifacts }: { artifacts: HumanArtifact[] }) {
+  const openArtifact = useOpenArtifact()
+  if (artifacts.length === 0) return null
+  return <ul className="mt-3 space-y-2" aria-label="Artifacts">
+    {artifacts.map((artifact) => {
+      const opensWorkspacePath = artifact.surfaceKind === "workspace.open.path"
+      const open = () => {
+        if (opensWorkspacePath) openArtifact?.(artifact.target)
+        else postUiCommand({ kind: "openSurface", params: { kind: artifact.surfaceKind, target: artifact.target } })
+      }
+      const canOpen = !opensWorkspacePath || openArtifact !== null
+      return <li key={artifact.id}><Artifact className="shadow-none">
+        <ArtifactHeader className="gap-3 border-b-0 px-3 py-2">
+          <div className="min-w-0 flex-1">
+            <ArtifactTitle className="truncate">{artifact.title}</ArtifactTitle>
+            {artifact.description ? <ArtifactDescription className="mt-0.5 line-clamp-2 text-xs">{artifact.description}</ArtifactDescription> : null}
+          </div>
+          <ArtifactActions>
+            <ArtifactAction
+              icon={opensWorkspacePath ? FileText : ExternalLink}
+              label={`Open ${artifact.title}`}
+              tooltip={canOpen ? `Open ${artifact.title}` : "Workspace file opening is unavailable"}
+              disabled={!canOpen}
+              onClick={open}
+            />
+          </ArtifactActions>
+        </ArtifactHeader>
+      </Artifact></li>
+    })}
+  </ul>
+}
+
 function InlineQuestion({ part }: { part: unknown }) {
   const runtime = useQuestionsRuntime()
   useSyncExternalStore(runtime.subscribe, () => pendingQuestionSnapshot(runtime), () => "none")
   const toolPart = typeof part === "object" && part ? part as { toolCallId?: unknown; state?: unknown; input?: unknown } : null
   const toolCallId = typeof toolPart?.toolCallId === "string" ? toolPart.toolCallId : null
   const question = toolCallId ? runtime.getPendingByToolCallId(toolCallId) : null
-  if (question) return <section data-boring-ask-user-inline-question="true" data-testid="ask-user-inline-question" className="my-3 rounded-lg border border-border/70 bg-card p-4 text-sm shadow-sm"><PendingQuestionBody question={question} compact onOpen={() => postUiCommand({ kind: "openSurface", params: { kind: ASK_USER_SURFACE_KIND, target: question.questionId, meta: { sessionId: question.sessionId } } })} /></section>
+  const artifacts = inlineArtifactsFromInput(toolPart?.input)
+  if (question) return <section data-boring-ask-user-inline-question="true" data-testid="ask-user-inline-question" className="my-3 rounded-lg border border-border/70 bg-card p-4 text-sm shadow-sm">
+    <PendingQuestionBody question={question} compact onOpen={() => postUiCommand({ kind: "openSurface", params: { kind: ASK_USER_SURFACE_KIND, target: question.questionId, meta: { sessionId: question.sessionId } } })} />
+    <InlineArtifactList artifacts={artifacts} />
+  </section>
   if (toolPart?.state !== "output-available" && toolPart?.state !== "output-error" && toolPart?.state !== "aborted") return null
   const input = typeof toolPart.input === "object" && toolPart.input ? toolPart.input as { title?: unknown } : null
   const title = typeof input?.title === "string" ? input.title : "Agent question"
   const cancelled = toolPart.state !== "output-available"
-  return <section data-boring-ask-user-resolved-question="true" className="my-3 flex items-center gap-3 rounded-lg border border-border/60 bg-muted/25 px-4 py-3 text-sm">
-    {cancelled ? <XCircle className="h-4 w-4 text-muted-foreground" /> : <CheckCircle2 className="h-4 w-4 text-emerald-500" />}
-    <div className="min-w-0"><div className="truncate font-medium text-foreground">{title}</div><div className="text-xs text-muted-foreground">{cancelled ? "Question cancelled" : "Answer submitted"}</div></div>
+  return <section data-boring-ask-user-resolved-question="true" className="my-3 rounded-lg border border-border/60 bg-muted/25 px-4 py-3 text-sm">
+    <div className="flex items-center gap-3">
+      {cancelled ? <XCircle className="h-4 w-4 text-muted-foreground" /> : <CheckCircle2 className="h-4 w-4 text-emerald-500" />}
+      <div className="min-w-0"><div className="truncate font-medium text-foreground">{title}</div><div className="text-xs text-muted-foreground">{cancelled ? "Question cancelled" : "Answer submitted"}</div></div>
+    </div>
+    <InlineArtifactList artifacts={artifacts} />
   </section>
 }
 

--- a/plugins/ask-user/src/front/index.tsx
+++ b/plugins/ask-user/src/front/index.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Button, EmptyState, Notice, Pane, PaneBody, PaneHeader, PaneTitle } from "@hachej/boring-ui-kit"
-import { Artifact, ArtifactAction, ArtifactActions, ArtifactDescription, ArtifactHeader, ArtifactTitle, useOpenArtifact } from "@hachej/boring-agent/front"
+import { Artifact, ArtifactAction, ArtifactActions, ArtifactDescription, ArtifactHeader, ArtifactTitle, useOpenArtifact } from "@hachej/boring-agent/front/artifacts"
 import {
   WORKSPACE_COMPOSER_STOP_EVENT,
   postUiCommand,

--- a/plugins/ask-user/tsup.config.ts
+++ b/plugins/ask-user/tsup.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   clean: true,
   outDir: "dist",
   target: "es2022",
+  noExternal: ["@hachej/boring-workspace/shared"],
   external: [
     /^@hachej\/boring-/,
     "fastify",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1036,6 +1036,9 @@ importers:
         specifier: ^3.23.0
         version: 3.25.76
     devDependencies:
+      '@hachej/boring-agent':
+        specifier: workspace:*
+        version: link:../../packages/agent
       '@hachej/boring-workspace':
         specifier: workspace:*
         version: link:../../packages/workspace


### PR DESCRIPTION
## Summary
- Render the exact canonical `ask_user` input `artifacts[]` as an inline artifact list in pending, resolved, and cancelled chat cards while the same authored list continues to back Inbox.
- Validate the complete input through `AskUserToolInputSchema`, which nests `HumanArtifactListSchema`; malformed full payloads fail closed.
- Route `workspace.open.path` only through `ArtifactOpenContext` and other registered surface kinds through `openSurface`.
- Make runtime packaging safe by bundling the canonical Workspace shared schema into ask-user and importing Agent artifact behavior through the narrow published `@hachej/boring-agent/front/artifacts` adapter instead of the full Agent front graph.

## Proof
Exact head: `9ad21417901849d0ae7d6de05d5c0e2b2638fb99`

- `pnpm --filter @hachej/boring-ask-user exec vitest run src/front/__tests__/askUserPlugin.test.tsx --no-file-parallelism` — PASS, 28/28.
- With `ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY OPENROUTER_API_KEY GROQ_API_KEY XAI_API_KEY GOOGLE_API_KEY AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN` exported unset from command start: `pnpm --filter @hachej/boring-ask-user test` — PASS, 123/123; 1 credential-gated live eval skipped.
- `pnpm --filter @hachej/boring-agent exec vitest run src/front/__tests__/publicExports.test.ts --no-file-parallelism` — PASS, 3/3.
- `pnpm --filter @hachej/boring-ui-cli exec vitest run src/__tests__/folderModeRuntimePlugins.test.ts -t "folder mode ships ask-user as a default plugin package" --no-file-parallelism --reporter=verbose` — PASS, 1/1; follows and serves the built ask-user entry, Agent artifacts adapter, and implementation chunks that previously returned HTTP 400.
- `pnpm --filter @hachej/boring-agent typecheck` and `pnpm --filter @hachej/boring-ask-user typecheck` — PASS.
- `pnpm --filter @hachej/boring-agent build` and `pnpm --filter @hachej/boring-ask-user build` — PASS; Agent build asserts adapter JS/DTS existence and parsing.
- `pnpm --filter @hachej/boring-ui-review-tools ui:review -- review ask-user-inline --critic=fixture` — PASS, 1/1 Chromium registered review; desktop/mobile pending/selected/resolved hard gates green.
- `git diff --check` — PASS.
- GitHub Actions run `31896704608`, attempt 2 — PASS, 16/16 required checks at the exact SHA. Attempt 1's unrelated Agent property E2E failure passed on the single failed-job rerun.

## Review provenance
- Fresh-context exact-SHA reviewer explicitly requested `openai-codex/gpt-5.6-sol`; runtime did not expose resolved identity.
- `a277d07287eac390958b97ddaac98a126bf8966e` — REVISE: canonical full-input validation and route-exclusivity coverage; fixed in `09d87f5510bb562215917449e7a276424526712d`.
- `3bff45a4354ea6c2de5c67f2b7befef535741af1` — code/thermo clean; release verdict held only for pending CI. CI then found the missing public export-map expectation, fixed without product change.
- `9ad21417901849d0ae7d6de05d5c0e2b2638fb99` — CLEAN under adversarial dependency/runtime packaging, canonical single-source, routing/security, invalid/lifecycle/a11y, tests, and thermo mandate. Low accepted residual: credential-present Gemini live eval schema rejection is pre-existing and outside this diff.

## Artifacts
- Present-PR HTML: `.handoff/pr-1312-presentation.html`.
- Registered UI review: `.handoff/ask-user-inline-ui-review/report.html` (includes desktop/mobile screenshots and hard-gate evidence).
- CI: https://github.com/hachej/boring-ui/actions/runs/31896704608

## Risk & rollback
- Risk: the inline card now has one additional package-runtime boundary. The boundary is exact and dependency-neutral, with build/export assertions and a CLI integration test that serves the adapter and chunks. Invalid inputs render no artifacts; file targets remain disabled without a mounted file opener.
- Rollback: revert `9ad21417901849d0ae7d6de05d5c0e2b2638fb99`, `3bff45a4354ea6c2de5c67f2b7befef535741af1`, `09d87f5510bb562215917449e7a276424526712d`, and `a277d07287eac390958b97ddaac98a126bf8966e`.
- Residual: the credential-gated live Gemini eval is intentionally excluded from deterministic proof; no protocol, artifact model, surface kind, tab, or Inbox redesign was introduced.

## Refs
- Closes #1304
- Bead `wt-391-forward-gb0o.2`
- Head `9ad21417901849d0ae7d6de05d5c0e2b2638fb99`

