### PR TITLE
[br-wt-391-forward-rup1] Continue frozen chats through native pi forks

### DIFF
--- a/packages/agent/src/core/piChatSessionService.ts
+++ b/packages/agent/src/core/piChatSessionService.ts
@@ -31,6 +31,9 @@ export interface PiSessionRequestContext {
 export interface PiSessionCreateInit {
   title?: string
   modelDefault?: ChatModelSelection
+  /** Native transcript to copy into this newly current-scope session. */
+  forkSessionId?: string
+  forkPrompt?: PromptPayload
 }
 
 /** Server-only prompt admission selector; browser schemas never accept requireIdle. */

--- a/packages/agent/src/core/piChatSessionService.ts
+++ b/packages/agent/src/core/piChatSessionService.ts
@@ -33,7 +33,6 @@ export interface PiSessionCreateInit {
   modelDefault?: ChatModelSelection
   /** Native transcript to copy into this newly current-scope session. */
   forkSessionId?: string
-  forkPrompt?: PromptPayload
 }
 
 /** Server-only prompt admission selector; browser schemas never accept requireIdle. */

--- a/packages/agent/src/front/chat/PiChatPanel.tsx
+++ b/packages/agent/src/front/chat/PiChatPanel.tsx
@@ -180,6 +180,8 @@ export interface PiChatPanelProps<
   onSessionReset?: () => void | Promise<void>
   /** Creates and selects a session when the host controls sessionId. */
   onCreateSession?: () => void | Promise<void>
+  /** Natively forks a controlled frozen session and delivers its first prompt. */
+  onForkSession?: (sourceSessionId: string, prompt: Parameters<RemotePiSession['prompt']>[0]) => void | Promise<void>
   onBeforeSubmit?: (draft: string, context: ChatSubmitContext) => false | void | boolean | Promise<false | void | boolean>
   onReloadAgentPlugins?: () => Promise<AgentPluginReloadResult | string>
   onCommandResult?: (message: string) => void
@@ -247,6 +249,7 @@ export function PiChatPanel<
   workspaceWarmupStatus,
   onSessionReset,
   onCreateSession,
+  onForkSession,
   onBeforeSubmit,
   onReloadAgentPlugins,
   onCommandResult,
@@ -508,6 +511,7 @@ export function PiChatPanel<
       : []
     const combined = [...fromState, ...sessionNotice, ...largeStateNotice, ...localNotices]
       .filter((notice) => !dismissedNoticeIds.has(notice.id))
+      .filter((notice) => !('errorCode' in notice) || notice.errorCode !== AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH)
     // A terminal chat error (history failed to load, no messages present)
     // already explains why the agent looks unreachable. Showing
     // reconnect/retry chatter next to it reads as contradictory
@@ -779,6 +783,7 @@ export function PiChatPanel<
     insertSlashCommand(name)
   }, [dismissSlash, insertSlashCommand, openModelPicker, openThinkingPicker, setComposerDraft])
 
+  const lastPromptPayloadRef = useRef<Parameters<RemotePiSession['prompt']>[0] | null>(null)
   const policy = useMemo(() => {
     if (!selectedPiSession || !activeChatSessionId || !serverModelSelectionReady) return undefined
     const policySession = {
@@ -789,7 +794,10 @@ export function PiChatPanel<
         }
         return state
       },
-      prompt: selectedPiSession.prompt.bind(selectedPiSession),
+      prompt: (payload: Parameters<RemotePiSession['prompt']>[0]) => {
+        lastPromptPayloadRef.current = payload
+        return selectedPiSession.prompt(payload)
+      },
       followUp: selectedPiSession.followUp.bind(selectedPiSession),
       clearQueue: selectedPiSession.clearQueue.bind(selectedPiSession),
       interrupt: selectedPiSession.interrupt.bind(selectedPiSession),
@@ -901,6 +909,27 @@ export function PiChatPanel<
       return undefined
     } catch (error) {
       clearLocalSubmitted(activeChatSessionId)
+      if (
+        piChatErrorCode(error) === AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH
+        && activeChatSessionId
+      ) {
+        const forkPrompt = lastPromptPayloadRef.current
+        try {
+          if (!forkPrompt) throw new Error('The rejected prompt could not be recovered for the fork.')
+          if (externalSessionId) {
+            if (!onForkSession) throw new Error('The chat host cannot fork this frozen session.')
+            await onForkSession(activeChatSessionId, forkPrompt)
+          } else {
+            await sessions.create({ forkSessionId: activeChatSessionId, forkPrompt })
+          }
+          lastPromptPayloadRef.current = null
+          return undefined
+        } catch (forkError) {
+          restoreSubmittedDraft()
+          surfaceRunRejected(forkError)
+          return false
+        }
+      }
       restoreSubmittedDraft()
       // Single normalization point for rejected sends: surface as one stable
       // notice carrying the server error code so a host can attach a recovery
@@ -909,7 +938,7 @@ export function PiChatPanel<
       surfaceRunRejected(error)
       return false
     }
-  }, [activeChatSessionId, clearLocalSubmitted, dropLocalNotice, markLocalSubmitted, onPromptSubmitStarted, policy, selectedPiSession, setComposerDraft, surfaceRunRejected])
+  }, [activeChatSessionId, clearLocalSubmitted, dropLocalNotice, externalSessionId, markLocalSubmitted, onForkSession, onPromptSubmitStarted, policy, selectedPiSession, sessions.create, setComposerDraft, surfaceRunRejected])
 
   const availableAssistantSlashCommands = useMemo(
     () => policy ? actionableSlashCommands : actionableSlashCommands.filter((command) => command.clickBehavior === 'insert'),

--- a/packages/agent/src/front/chat/PiChatPanel.tsx
+++ b/packages/agent/src/front/chat/PiChatPanel.tsx
@@ -783,7 +783,6 @@ export function PiChatPanel<
     insertSlashCommand(name)
   }, [dismissSlash, insertSlashCommand, openModelPicker, openThinkingPicker, setComposerDraft])
 
-  const lastPromptPayloadRef = useRef<Parameters<RemotePiSession['prompt']>[0] | null>(null)
   const policy = useMemo(() => {
     if (!selectedPiSession || !activeChatSessionId || !serverModelSelectionReady) return undefined
     const policySession = {
@@ -794,10 +793,12 @@ export function PiChatPanel<
         }
         return state
       },
-      prompt: (payload: Parameters<RemotePiSession['prompt']>[0]) => {
-        lastPromptPayloadRef.current = payload
-        return selectedPiSession.prompt(payload)
-      },
+      prompt: (payload: Parameters<RemotePiSession['prompt']>[0]) => selectedPiSession.prompt(payload).catch((error) => {
+        throw Object.assign(new Error(errorMessage(error, 'Could not send your message.'), { cause: error }), {
+          errorCode: piChatErrorCode(error),
+          forkPrompt: payload,
+        })
+      }),
       followUp: selectedPiSession.followUp.bind(selectedPiSession),
       clearQueue: selectedPiSession.clearQueue.bind(selectedPiSession),
       interrupt: selectedPiSession.interrupt.bind(selectedPiSession),
@@ -913,7 +914,7 @@ export function PiChatPanel<
         piChatErrorCode(error) === AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH
         && activeChatSessionId
       ) {
-        const forkPrompt = lastPromptPayloadRef.current
+        const forkPrompt = (error as { forkPrompt?: Parameters<RemotePiSession['prompt']>[0] }).forkPrompt
         try {
           if (!forkPrompt) throw new Error('The rejected prompt could not be recovered for the fork.')
           if (externalSessionId) {
@@ -922,7 +923,6 @@ export function PiChatPanel<
           } else {
             await sessions.create({ forkSessionId: activeChatSessionId, forkPrompt })
           }
-          lastPromptPayloadRef.current = null
           return undefined
         } catch (forkError) {
           restoreSubmittedDraft()

--- a/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
+++ b/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
@@ -553,6 +553,7 @@ describe('PiChatPanel sandbox shell', () => {
     ))
     const forkCall = fetchMock.mock.calls.find((call) => String(call[0]).endsWith('/sessions') && call[1]?.method === 'POST')
     expect(JSON.parse(String(forkCall?.[1]?.body))).toMatchObject({
+      requestId: expect.stringMatching(/^fork:/),
       forkSessionId: 'pi-1',
       forkPrompt: { message: 'continue old chat' },
     })
@@ -560,6 +561,48 @@ describe('PiChatPanel sandbox shell', () => {
     expect(document.querySelector('[data-pi-chat-session-id="pi-current"]')).toBeTruthy()
     expect(document.querySelector('[data-runtime-notice-id="run-rejected"]')).toBeNull()
     expect(screen.queryByRole('button', { name: 'Start new chat' })).toBeNull()
+  })
+
+  test('binds a delayed mismatch to its original prompt across a session switch', async () => {
+    const remote = new FakeRemotePiSession(remoteState({ status: 'idle' }))
+    const firstPrompt = deferred<{ accepted: true; cursor: number; clientNonce: string }>()
+    remote.prompt.mockImplementationOnce(async () => firstPrompt.promise)
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      const method = init?.method ?? 'GET'
+      if (url.includes('/api/v1/agents/default/sessions?') && method === 'GET') {
+        return jsonResponse([session('pi-1', 'Frozen A'), session('pi-2', 'Live B')])
+      }
+      if (url.endsWith('/api/v1/agents/default/sessions') && method === 'POST') {
+        return jsonResponse(session('pi-fork', 'Forked A'), 201)
+      }
+      throw new Error(`unexpected fetch ${url}`)
+    })
+    render(<PiChatPanel showSessions serverResourcesEnabled={false} storageScope="scope-a" fetch={fetchMock as unknown as typeof fetch} createRemoteSession={remoteFactory(remote)} />)
+
+    const textarea = await screen.findByLabelText('Agent prompt')
+    fireEvent.change(textarea, { target: { value: 'message for A' } })
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+    await waitFor(() => expect(remote.prompt).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByText('Live B').closest('[data-boring-agent-part="session-row"]') as HTMLElement)
+    await waitFor(() => expect(document.querySelector('[data-pi-chat-session-id="pi-2"]')).toBeTruthy())
+    fireEvent.change(screen.getByLabelText('Agent prompt'), { target: { value: 'message for B' } })
+    fireEvent.keyDown(screen.getByLabelText('Agent prompt'), { key: 'Enter' })
+    await waitFor(() => expect(remote.prompt).toHaveBeenCalledTimes(2))
+
+    await act(async () => {
+      firstPrompt.reject(Object.assign(new Error('scope mismatch'), {
+        errorCode: AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH,
+      }))
+      await firstPrompt.promise.catch(() => undefined)
+    })
+    await waitFor(() => expect(fetchMock.mock.calls.some((call) => call[1]?.method === 'POST')).toBe(true))
+    const forkCall = fetchMock.mock.calls.find((call) => call[1]?.method === 'POST')
+    expect(JSON.parse(String(forkCall?.[1]?.body))).toMatchObject({
+      forkSessionId: 'pi-1',
+      forkPrompt: { message: 'message for A' },
+    })
   })
 
   test('uses the controlled host fork and hides the scope mismatch transport notice', async () => {

--- a/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
+++ b/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { act, createEvent, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { useState } from 'react'
 import { readFileSync } from 'node:fs'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import type { SessionSummary } from '../../../shared/session'
@@ -518,9 +519,9 @@ describe('PiChatPanel sandbox shell', () => {
     expect(onTurnComplete).not.toHaveBeenCalled()
   })
 
-  test('offers a new chat when a run is rejected by a stale runtime pin', async () => {
+  test('transparently forks a frozen transcript and retries the message in the live continuation', async () => {
     const remote = new FakeRemotePiSession(remoteState({ status: 'idle' }))
-    remote.prompt.mockRejectedValue(Object.assign(new Error('This chat belongs to a previous runtime configuration and can no longer be changed.'), {
+    remote.prompt.mockRejectedValueOnce(Object.assign(new Error('scope mismatch'), {
       errorCode: AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH,
     }))
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -543,42 +544,67 @@ describe('PiChatPanel sandbox shell', () => {
     fireEvent.change(textarea, { target: { value: 'continue old chat' } })
     fireEvent.keyDown(textarea, { key: 'Enter' })
 
-    const action = await screen.findByRole('button', { name: 'Start new chat' })
-    fireEvent.click(action)
-    fireEvent.click(action)
-
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
       '/api/v1/agents/default/sessions',
-      expect.objectContaining({ method: 'POST' }),
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.any(String),
+      }),
     ))
-    await waitFor(() => expect(document.querySelector('[data-pi-chat-session-id="pi-current"]')).toBeTruthy())
-    expect(fetchMock.mock.calls.filter((call) => String(call[0]).endsWith('/sessions') && call[1]?.method === 'POST')).toHaveLength(1)
+    const forkCall = fetchMock.mock.calls.find((call) => String(call[0]).endsWith('/sessions') && call[1]?.method === 'POST')
+    expect(JSON.parse(String(forkCall?.[1]?.body))).toMatchObject({
+      forkSessionId: 'pi-1',
+      forkPrompt: { message: 'continue old chat' },
+    })
+    expect(remote.prompt).toHaveBeenCalledTimes(1)
+    expect(document.querySelector('[data-pi-chat-session-id="pi-current"]')).toBeTruthy()
+    expect(document.querySelector('[data-runtime-notice-id="run-rejected"]')).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Start new chat' })).toBeNull()
   })
 
-  test('uses the host session creator for a runtime mismatch in controlled-session mode', async () => {
+  test('uses the controlled host fork and hides the scope mismatch transport notice', async () => {
     const remote = new FakeRemotePiSession(remoteState({
       status: 'error',
       notices: [{
         id: 'terminal-session-error',
         level: 'error',
-        text: 'This chat belongs to a previous runtime configuration and can no longer be changed.',
+        text: 'scope mismatch',
         errorCode: AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH,
       }],
     }))
-    const onCreateSession = vi.fn().mockResolvedValue(undefined)
-    render(
-      <PiChatPanel
-        sessionId="pi-1"
-        showSessions={false}
-        serverResourcesEnabled={false}
-        storageScope="scope-a"
-        createRemoteSession={remoteFactory(remote)}
-        onCreateSession={onCreateSession}
-      />,
-    )
+    remote.prompt.mockRejectedValueOnce(Object.assign(new Error('scope mismatch'), {
+      errorCode: AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH,
+    }))
+    const onForkSession = vi.fn()
+    function ControlledForkPanel() {
+      const [controlledSessionId, setControlledSessionId] = useState('pi-1')
+      return (
+        <PiChatPanel
+          sessionId={controlledSessionId}
+          showSessions={false}
+          serverResourcesEnabled={false}
+          storageScope="scope-a"
+          createRemoteSession={remoteFactory(remote)}
+          onForkSession={async (sourceSessionId, forkPrompt) => {
+            onForkSession(sourceSessionId, forkPrompt)
+            setControlledSessionId('pi-current')
+          }}
+        />
+      )
+    }
+    render(<ControlledForkPanel />)
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Start new chat' }))
-    await waitFor(() => expect(onCreateSession).toHaveBeenCalledTimes(1))
+    expect(document.querySelector('[data-runtime-notice-id="terminal-session-error"]')).toBeNull()
+    const textarea = screen.getByLabelText('Agent prompt')
+    fireEvent.change(textarea, { target: { value: 'continue controlled chat' } })
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+
+    await waitFor(() => expect(onForkSession).toHaveBeenCalledWith(
+      'pi-1',
+      expect.objectContaining({ message: 'continue controlled chat' }),
+    ))
+    expect(remote.prompt).toHaveBeenCalledTimes(1)
+    expect(document.querySelector('[data-pi-chat-session-id="pi-current"]')).toBeTruthy()
   })
 
   test('fires onTurnComplete per turn-settle event, including back-to-back queued turns', async () => {

--- a/packages/agent/src/front/chat/session/usePiSessions.ts
+++ b/packages/agent/src/front/chat/session/usePiSessions.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import type { PromptPayload } from '../../../shared/chat'
 import type { SessionSummary } from '../../../shared/session'
 import { createRequestId, withStorageScope } from '../../agentHttp'
 import { createRemotePiSession, type RemotePiSession, type RemotePiSessionOptions } from '../pi/remotePiSession'
@@ -24,6 +25,10 @@ export interface PiSessionCreateInit {
   title?: string
   /** Boot-only intent to resume this exact tab-owned empty session. */
   resumeSessionId?: string
+  /** Existing transcript to fork natively into the current runtime scope. */
+  forkSessionId?: string
+  /** First prompt delivered by the server to the newly created fork. */
+  forkPrompt?: PromptPayload
 }
 
 export interface PiSessionRefreshOptions {

--- a/packages/agent/src/front/chat/session/usePiSessions.ts
+++ b/packages/agent/src/front/chat/session/usePiSessions.ts
@@ -431,7 +431,9 @@ export function usePiSessions(options: UsePiSessionsOptions): UsePiSessionsResul
     const response = await fetchImpl(sessionsUrl(), {
       method: 'POST',
       headers: { ...requestHeaders(), 'Content-Type': 'application/json' },
-      body: JSON.stringify(init ?? {}),
+      body: JSON.stringify(init?.forkPrompt
+        ? { ...init, requestId: `fork:${init.forkPrompt.clientNonce}` }
+        : init ?? {}),
     })
     if (!response.ok) {
       const err = new Error(`Failed to create session: ${response.status}`)

--- a/packages/agent/src/server/agent-host/__tests__/httpProjection.test.ts
+++ b/packages/agent/src/server/agent-host/__tests__/httpProjection.test.ts
@@ -345,8 +345,9 @@ describe('addressed Agent Host HTTP projection', () => {
     expect(gateway.calls).toEqual(expect.arrayContaining([
       { method: 'listSessions', input: { scope, agentTypeId: 'alpha', cursor: undefined, limit: 25 } },
       { method: 'createSession', input: { scope, agentTypeId: 'alpha', requestId: 'create-1', title: 'Created', resumeSessionId: 'persisted-empty' } },
-      { method: 'createSession', input: { scope, agentTypeId: 'alpha', requestId: 'fork-1', title: undefined, forkSessionId: 'session-frozen', forkPrompt: { message: 'continue', clientNonce: 'fork-nonce' } } },
+      { method: 'createSession', input: { scope, agentTypeId: 'alpha', requestId: 'fork-1', title: undefined, forkSessionId: 'session-frozen' } },
       { method: 'send', input: expect.objectContaining({ kind: 'prompt', requestId: 'prompt-1', requireIdle: true, attachments: [expect.objectContaining({ path: 'uploads/chart.png' })] }) },
+      { method: 'send', input: { kind: 'prompt', requestId: 'fork-nonce', clientNonce: 'fork-nonce', content: 'continue', displayContent: undefined, model: undefined, thinkingLevel: undefined, attachments: undefined } },
       { method: 'send', input: { kind: 'followup', requestId: 'follow-1', clientNonce: 'nonce-f', content: 'next', displayContent: 'Next', clientSeq: 3 } },
       { method: 'interrupt', input: { requestId: 'interrupt-1' } },
       { method: 'stop', input: { requestId: 'stop-1' } },

--- a/packages/agent/src/server/agent-host/__tests__/httpProjection.test.ts
+++ b/packages/agent/src/server/agent-host/__tests__/httpProjection.test.ts
@@ -270,6 +270,17 @@ describe('addressed Agent Host HTTP projection', () => {
     })
     expect(created.statusCode).toBe(201)
     expect(created.json()).toEqual(ref)
+    const forked = await app.inject({
+      method: 'POST',
+      url: '/api/v1/agents/alpha/sessions',
+      payload: { requestId: 'fork-1', forkSessionId: 'session-frozen', forkPrompt: { message: 'continue', clientNonce: 'fork-nonce' } },
+    })
+    expect(forked.statusCode).toBe(201)
+    expect((await app.inject({
+      method: 'POST',
+      url: '/api/v1/agents/alpha/sessions',
+      payload: { resumeSessionId: 'empty', forkSessionId: 'frozen' },
+    })).statusCode).toBe(400)
     expect((await app.inject({ method: 'GET', url: '/api/v1/agents/alpha/sessions/session-1/state' })).json()).toEqual(snapshot)
     const attachment = await app.inject({
       method: 'GET',
@@ -334,6 +345,7 @@ describe('addressed Agent Host HTTP projection', () => {
     expect(gateway.calls).toEqual(expect.arrayContaining([
       { method: 'listSessions', input: { scope, agentTypeId: 'alpha', cursor: undefined, limit: 25 } },
       { method: 'createSession', input: { scope, agentTypeId: 'alpha', requestId: 'create-1', title: 'Created', resumeSessionId: 'persisted-empty' } },
+      { method: 'createSession', input: { scope, agentTypeId: 'alpha', requestId: 'fork-1', title: undefined, forkSessionId: 'session-frozen', forkPrompt: { message: 'continue', clientNonce: 'fork-nonce' } } },
       { method: 'send', input: expect.objectContaining({ kind: 'prompt', requestId: 'prompt-1', requireIdle: true, attachments: [expect.objectContaining({ path: 'uploads/chart.png' })] }) },
       { method: 'send', input: { kind: 'followup', requestId: 'follow-1', clientNonce: 'nonce-f', content: 'next', displayContent: 'Next', clientSeq: 3 } },
       { method: 'interrupt', input: { requestId: 'interrupt-1' } },

--- a/packages/agent/src/server/agent-host/__tests__/runtimeScopeIdentity.test.ts
+++ b/packages/agent/src/server/agent-host/__tests__/runtimeScopeIdentity.test.ts
@@ -1,4 +1,4 @@
-import { appendFile, mkdtemp, readFile, rename, rm } from 'node:fs/promises'
+import { appendFile, mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -200,11 +200,12 @@ describe('runtime scope identity', () => {
     })).rejects.toMatchObject({ code: AgentGatewayErrorCode.AGENT_COMMAND_INVALID_STATE })
     const namespace = sessionNamespaceForAgent(agent, 'workspace-a', 'sessions')!
     let transcriptPath = await sessionFilePath(join(sessionRoot, namespace), ref.sessionId)
-    await appendFile(transcriptPath, [
+    const originalHeader = JSON.parse((await readFile(transcriptPath, 'utf8')).split('\n')[0]!)
+    await writeFile(transcriptPath, [
+      { ...originalHeader, version: 1 },
       { type: 'message', id: 'user-1', parentId: null, timestamp: '2026-08-17T00:00:00.000Z', message: { role: 'user', content: 'inspect frozen chat', timestamp: 1 } },
       { type: 'message', id: 'assistant-1', parentId: 'user-1', timestamp: '2026-08-17T00:00:01.000Z', message: { role: 'assistant', content: [{ type: 'toolCall', id: 'call-1', name: 'read', arguments: { path: 'README.md' } }], timestamp: 2 } },
       { type: 'message', id: 'tool-1', parentId: 'assistant-1', timestamp: '2026-08-17T00:00:02.000Z', message: { role: 'toolResult', toolCallId: 'call-1', content: [{ type: 'text', text: 'frozen result' }], timestamp: 3 } },
-      { type: 'ui_snapshot', id: 'snapshot-1', timestamp: '2026-08-17T00:00:03.000Z', messages: [{ role: 'user', content: 'legacy duplicate' }] },
     ].map((entry) => JSON.stringify(entry)).join('\n') + '\n')
     await first.host.close()
     const legacyWrapperPath = join(sessionRoot, namespace, `${ref.sessionId}.jsonl`)
@@ -269,7 +270,21 @@ describe('runtime scope identity', () => {
     expect(await restarted.gateway.createSession(forkInput)).toEqual(fork)
     expect(fork).not.toEqual(ref)
     const continued = await restarted.gateway.readSessionState({ scope: other, ref: fork })
-    expect(continued.state.messages).toEqual(frozen.state.messages)
+    expect(continued.state.messages).toHaveLength(frozen.state.messages.length)
+    expect(continued.state.messages).toEqual([
+      expect.objectContaining({ role: 'user', parts: [expect.objectContaining({ text: 'inspect frozen chat' })] }),
+      expect.objectContaining({
+        role: 'assistant',
+        parts: [expect.objectContaining({
+          type: 'tool-call',
+          id: 'call-1',
+          toolName: 'read',
+          state: 'output-available',
+          output: [{ type: 'text', text: 'frozen result' }],
+        })],
+      }),
+    ])
+    expect(new Set(continued.state.messages.map((message) => message.id)).size).toBe(continued.state.messages.length)
     const forkPath = await sessionFilePath(join(sessionRoot, namespace), fork.sessionId)
     const forkHeader = JSON.parse((await readFile(forkPath, 'utf8')).split('\n')[0]!) as {
       id: string

--- a/packages/agent/src/server/agent-host/__tests__/runtimeScopeIdentity.test.ts
+++ b/packages/agent/src/server/agent-host/__tests__/runtimeScopeIdentity.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { appendFile, mkdtemp, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -186,7 +186,7 @@ describe('runtime scope identity', () => {
     await created.host.close()
   })
 
-  it('fails a restarted mismatching actor closed before a second runtime binding or transcript effect', async () => {
+  it('serves a mismatched transcript read-only while every write remains pin-rejected', async () => {
     const sessionRoot = await temporaryRoot()
     const creator = { workspaceScopeId: 'workspace-a', authSubjectId: 'creator' } as AuthorizedAgentScope
     const other = { workspaceScopeId: 'workspace-a', authSubjectId: 'other' } as AuthorizedAgentScope
@@ -194,6 +194,11 @@ describe('runtime scope identity', () => {
     const ref = await first.gateway.createSession({ scope: creator, agentTypeId: 'alpha', requestId: 'create' })
     const namespace = sessionNamespaceForAgent(agent, 'workspace-a', 'sessions')!
     const transcriptPath = await sessionFilePath(join(sessionRoot, namespace), ref.sessionId)
+    await appendFile(transcriptPath, [
+      { type: 'message', id: 'user-1', parentId: null, timestamp: '2026-08-17T00:00:00.000Z', message: { role: 'user', content: 'inspect frozen chat', timestamp: 1 } },
+      { type: 'message', id: 'assistant-1', parentId: 'user-1', timestamp: '2026-08-17T00:00:01.000Z', message: { role: 'assistant', content: [{ type: 'toolCall', id: 'call-1', name: 'read', arguments: { path: 'README.md' } }], timestamp: 2 } },
+      { type: 'message', id: 'tool-1', parentId: 'assistant-1', timestamp: '2026-08-17T00:00:02.000Z', message: { role: 'toolResult', toolCallId: 'call-1', content: [{ type: 'text', text: 'frozen result' }], timestamp: 3 } },
+    ].map((entry) => JSON.stringify(entry)).join('\n') + '\n')
     const before = await readFile(transcriptPath, 'utf8')
     await first.host.close()
 
@@ -205,15 +210,59 @@ describe('runtime scope identity', () => {
       createRuntime,
       effectAdmission: { admit },
     }))
+    const frozen = await restarted.gateway.readSessionState({ scope: other, ref })
+    expect(frozen.state.messages).toEqual([
+      expect.objectContaining({ role: 'user', parts: [expect.objectContaining({ text: 'inspect frozen chat' })] }),
+      expect.objectContaining({
+        role: 'assistant',
+        parts: [expect.objectContaining({
+          type: 'tool-call',
+          id: 'call-1',
+          toolName: 'read',
+          state: 'output-available',
+          output: [{ type: 'text', text: 'frozen result' }],
+        })],
+      }),
+    ])
     await expect(restarted.gateway.renameSession({
       scope: other,
       ref,
       requestId: 'must-not-mutate',
       title: 'Must not change',
     })).rejects.toMatchObject({ code: AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH })
+    await expect(restarted.gateway.connectSession({ scope: other, ref }))
+      .rejects.toMatchObject({ code: AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH })
+    await expect(restarted.gateway.readSessionState({
+      scope: { workspaceScopeId: 'workspace-b', authSubjectId: 'other' } as AuthorizedAgentScope,
+      ref,
+    })).rejects.toMatchObject({ code: AgentGatewayErrorCode.AGENT_SESSION_NOT_FOUND })
     expect(createRuntime).not.toHaveBeenCalled()
     expect(admit).not.toHaveBeenCalled()
     expect(await readFile(transcriptPath, 'utf8')).toBe(before)
+
+    const fork = await restarted.gateway.createSession({
+      scope: other,
+      agentTypeId: 'alpha',
+      requestId: 'fork-current-runtime',
+      forkSessionId: ref.sessionId,
+    })
+    expect(fork).not.toEqual(ref)
+    const continued = await restarted.gateway.readSessionState({ scope: other, ref: fork })
+    expect(continued.state.messages).toEqual(frozen.state.messages)
+    const forkPath = await sessionFilePath(join(sessionRoot, namespace), fork.sessionId)
+    const forkHeader = JSON.parse((await readFile(forkPath, 'utf8')).split('\n')[0]!) as {
+      id: string
+      parentSession?: string
+      boringSessionCtx?: { workspaceId?: string; runtimeScopeIdentity?: string }
+    }
+    expect(forkHeader).toMatchObject({
+      id: fork.sessionId,
+      parentSession: transcriptPath,
+      boringSessionCtx: { workspaceId: 'workspace-a', runtimeScopeIdentity: 'runtime-other' },
+    })
+    expect(await readFile(transcriptPath, 'utf8')).toBe(before)
+    expect(createRuntime).toHaveBeenCalledOnce()
+    expect(admit).toHaveBeenCalledOnce()
     await restarted.host.close()
   })
 
@@ -249,7 +298,7 @@ describe('runtime scope identity', () => {
     })
 
     await expect(restarted.gateway.readSessionState({ scope: laterReader, ref }))
-      .rejects.toMatchObject({ code: AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH })
+      .resolves.toMatchObject({ ref })
     expect(resolution).toHaveBeenCalledTimes(2)
     expect(runtimeIdentity).toHaveBeenCalled()
     expect(await readFile(transcriptPath, 'utf8')).toBe(before)

--- a/packages/agent/src/server/agent-host/__tests__/runtimeScopeIdentity.test.ts
+++ b/packages/agent/src/server/agent-host/__tests__/runtimeScopeIdentity.test.ts
@@ -1,4 +1,4 @@
-import { appendFile, mkdtemp, readFile, rm } from 'node:fs/promises'
+import { appendFile, mkdtemp, readFile, rename, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -192,15 +192,25 @@ describe('runtime scope identity', () => {
     const other = { workspaceScopeId: 'workspace-a', authSubjectId: 'other' } as AuthorizedAgentScope
     const first = await createAgentHost(hostOptions({ sessionRoot, runtimeIdentity: () => 'runtime-creator' }))
     const ref = await first.gateway.createSession({ scope: creator, agentTypeId: 'alpha', requestId: 'create' })
+    await expect(first.gateway.createSession({
+      scope: creator,
+      agentTypeId: 'alpha',
+      requestId: 'cannot-fork-current',
+      forkSessionId: ref.sessionId,
+    })).rejects.toMatchObject({ code: AgentGatewayErrorCode.AGENT_COMMAND_INVALID_STATE })
     const namespace = sessionNamespaceForAgent(agent, 'workspace-a', 'sessions')!
-    const transcriptPath = await sessionFilePath(join(sessionRoot, namespace), ref.sessionId)
+    let transcriptPath = await sessionFilePath(join(sessionRoot, namespace), ref.sessionId)
     await appendFile(transcriptPath, [
       { type: 'message', id: 'user-1', parentId: null, timestamp: '2026-08-17T00:00:00.000Z', message: { role: 'user', content: 'inspect frozen chat', timestamp: 1 } },
       { type: 'message', id: 'assistant-1', parentId: 'user-1', timestamp: '2026-08-17T00:00:01.000Z', message: { role: 'assistant', content: [{ type: 'toolCall', id: 'call-1', name: 'read', arguments: { path: 'README.md' } }], timestamp: 2 } },
       { type: 'message', id: 'tool-1', parentId: 'assistant-1', timestamp: '2026-08-17T00:00:02.000Z', message: { role: 'toolResult', toolCallId: 'call-1', content: [{ type: 'text', text: 'frozen result' }], timestamp: 3 } },
+      { type: 'ui_snapshot', id: 'snapshot-1', timestamp: '2026-08-17T00:00:03.000Z', messages: [{ role: 'user', content: 'legacy duplicate' }] },
     ].map((entry) => JSON.stringify(entry)).join('\n') + '\n')
-    const before = await readFile(transcriptPath, 'utf8')
     await first.host.close()
+    const legacyWrapperPath = join(sessionRoot, namespace, `${ref.sessionId}.jsonl`)
+    await rename(transcriptPath, legacyWrapperPath)
+    transcriptPath = legacyWrapperPath
+    const before = await readFile(transcriptPath, 'utf8')
 
     const createRuntime = vi.fn(createTestRuntimeModeAdapter('direct').create)
     const admit = vi.fn(async () => ({ type: 'accepted' as const, admissionReceipt: 'accepted' }))
@@ -240,12 +250,23 @@ describe('runtime scope identity', () => {
     expect(admit).not.toHaveBeenCalled()
     expect(await readFile(transcriptPath, 'utf8')).toBe(before)
 
-    const fork = await restarted.gateway.createSession({
+    ;(restarted.gateway as EmbeddedAgentGateway).setActivityForTesting('workspace-a', ref, 'running')
+    await expect(restarted.gateway.createSession({
+      scope: other,
+      agentTypeId: 'alpha',
+      requestId: 'cannot-fork-active',
+      forkSessionId: ref.sessionId,
+    })).rejects.toMatchObject({ code: AgentGatewayErrorCode.AGENT_COMMAND_INVALID_STATE })
+    ;(restarted.gateway as EmbeddedAgentGateway).setActivityForTesting('workspace-a', ref, 'idle')
+
+    const forkInput = {
       scope: other,
       agentTypeId: 'alpha',
       requestId: 'fork-current-runtime',
       forkSessionId: ref.sessionId,
-    })
+    }
+    const fork = await restarted.gateway.createSession(forkInput)
+    expect(await restarted.gateway.createSession(forkInput)).toEqual(fork)
     expect(fork).not.toEqual(ref)
     const continued = await restarted.gateway.readSessionState({ scope: other, ref: fork })
     expect(continued.state.messages).toEqual(frozen.state.messages)
@@ -262,7 +283,7 @@ describe('runtime scope identity', () => {
     })
     expect(await readFile(transcriptPath, 'utf8')).toBe(before)
     expect(createRuntime).toHaveBeenCalledOnce()
-    expect(admit).toHaveBeenCalledOnce()
+    expect(admit).toHaveBeenCalledTimes(2)
     await restarted.host.close()
   })
 

--- a/packages/agent/src/server/agent-host/createAgentHost.ts
+++ b/packages/agent/src/server/agent-host/createAgentHost.ts
@@ -65,6 +65,12 @@ export interface AgentHostRuntime {
     scope: AuthorizedAgentScope,
     claim: VerifiedAgentScopeClaim,
   ): Promise<readonly import('../../shared/session').SessionSummary[]>
+  readPersistedSession(
+    agentTypeId: string,
+    scope: AuthorizedAgentScope,
+    claim: VerifiedAgentScopeClaim,
+    sessionId: string,
+  ): ReturnType<AgentSessionInventory['readPersistedSession']>
   isDraining(): boolean
   assertOpen(): void
   verify(scope: AuthorizedAgentScope): Promise<VerifiedAgentScopeClaim>
@@ -332,6 +338,10 @@ function createRuntime(
     listSessionSummaries(agentTypeId, scope, claim) {
       runtime.assertOpen()
       return inventory.list(agentTypeId, scope, claim)
+    },
+    readPersistedSession(agentTypeId, scope, claim, sessionId) {
+      runtime.assertOpen()
+      return inventory.readPersistedSession(agentTypeId, scope, claim, sessionId)
     },
     isDraining: () => draining,
     assertOpen() {

--- a/packages/agent/src/server/agent-host/embeddedGateway.ts
+++ b/packages/agent/src/server/agent-host/embeddedGateway.ts
@@ -306,11 +306,33 @@ export class EmbeddedAgentGateway implements AgentGateway {
         agentTypeId: input.agentTypeId,
         title: input.title ?? null,
         resumeSessionId: input.resumeSessionId ?? null,
+        forkSessionId: input.forkSessionId ?? null,
+        forkPrompt: input.forkPrompt ? input.forkPrompt as unknown as JsonValue : null,
       },
       async () => {
         const preparedBinding = binding
         if (!preparedBinding) throw new TypeError('session creation executed before binding preflight')
         return await this.runtime.runBindingOperation(preparedBinding.key, async () => {
+          if (input.forkSessionId) {
+            const forked = await preparedBinding.composition.service.createSession!(
+              context(claim, input.requestId, preparedBinding.scope.identity),
+              { title: input.title, forkSessionId: input.forkSessionId },
+            )
+            const ref = { agentTypeId: input.agentTypeId, sessionId: forked.id }
+            this.pins.set(agentSessionKey(claim.workspaceScopeId, ref), preparedBinding.scope.identity)
+            if (input.forkPrompt) {
+              await preparedBinding.composition.service.prompt(
+                context(claim, input.requestId, preparedBinding.scope.identity),
+                ref.sessionId,
+                input.forkPrompt,
+              )
+              this.runtime.activity.set(claim.workspaceScopeId, ref, 'running')
+            } else {
+              this.runtime.activity.set(claim.workspaceScopeId, ref, 'idle')
+            }
+            return ref
+          }
+
           if (input.resumeSessionId) {
             const candidateRef = { agentTypeId: input.agentTypeId, sessionId: input.resumeSessionId }
             const authority = await this.runtime.resolveSessionRuntime(
@@ -353,7 +375,27 @@ export class EmbeddedAgentGateway implements AgentGateway {
 
   async readSessionState(input: Parameters<AgentGateway['readSessionState']>[0]): Promise<AgentSessionStateSnapshot> {
     const claim = await this.verify(input.scope)
-    const binding = await this.bindingForSession(input.scope, claim, input.ref)
+    let binding: Awaited<ReturnType<EmbeddedAgentGateway['bindingForSession']>>
+    try {
+      binding = await this.bindingForSession(input.scope, claim, input.ref)
+    } catch (error) {
+      if ((error as { code?: unknown })?.code !== AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH) throw error
+      const persisted = await this.runtime.readPersistedSession(
+        input.ref.agentTypeId,
+        input.scope,
+        claim,
+        input.ref.sessionId,
+      )
+      if (!persisted) {
+        throw new AgentGatewayError(AgentGatewayErrorCode.AGENT_SESSION_NOT_FOUND, 'session was not found')
+      }
+      return {
+        ref: input.ref,
+        seq: persisted.state.seq,
+        summary: summaryFromLegacy(input.ref, persisted.summary, 'idle'),
+        state: persisted.state as unknown as AgentSessionStateSnapshot['state'],
+      }
+    }
     let state: PiChatSnapshot
     try {
       state = await binding.composition.service.readState(

--- a/packages/agent/src/server/agent-host/embeddedGateway.ts
+++ b/packages/agent/src/server/agent-host/embeddedGateway.ts
@@ -292,6 +292,12 @@ export class EmbeddedAgentGateway implements AgentGateway {
 
   async createSession(input: Parameters<AgentGateway['createSession']>[0]) {
     const claim = await this.verify(input.scope)
+    if (input.resumeSessionId && input.forkSessionId) {
+      throw new AgentGatewayError(
+        AgentGatewayErrorCode.AGENT_COMMAND_INVALID_STATE,
+        'resumeSessionId and forkSessionId are mutually exclusive',
+      )
+    }
     if (!this.runtime.compiledById.has(input.agentTypeId)) {
       throw new AgentGatewayError(AgentGatewayErrorCode.AGENT_TYPE_UNKNOWN, 'agent type is not available')
     }
@@ -307,7 +313,6 @@ export class EmbeddedAgentGateway implements AgentGateway {
         title: input.title ?? null,
         resumeSessionId: input.resumeSessionId ?? null,
         forkSessionId: input.forkSessionId ?? null,
-        forkPrompt: input.forkPrompt ? input.forkPrompt as unknown as JsonValue : null,
       },
       async () => {
         const preparedBinding = binding
@@ -320,16 +325,7 @@ export class EmbeddedAgentGateway implements AgentGateway {
             )
             const ref = { agentTypeId: input.agentTypeId, sessionId: forked.id }
             this.pins.set(agentSessionKey(claim.workspaceScopeId, ref), preparedBinding.scope.identity)
-            if (input.forkPrompt) {
-              await preparedBinding.composition.service.prompt(
-                context(claim, input.requestId, preparedBinding.scope.identity),
-                ref.sessionId,
-                input.forkPrompt,
-              )
-              this.runtime.activity.set(claim.workspaceScopeId, ref, 'running')
-            } else {
-              this.runtime.activity.set(claim.workspaceScopeId, ref, 'idle')
-            }
+            this.runtime.activity.set(claim.workspaceScopeId, ref, 'idle')
             return ref
           }
 
@@ -368,6 +364,32 @@ export class EmbeddedAgentGateway implements AgentGateway {
       {
         preflight: async () => {
           binding = await this.runtime.resolveBinding(input.agentTypeId, input.scope, claim)
+          if (!input.forkSessionId) return
+          const sourceRef = { agentTypeId: input.agentTypeId, sessionId: input.forkSessionId }
+          const sourceAuthority = await this.runtime.resolveSessionRuntime(
+            input.agentTypeId,
+            input.scope,
+            claim,
+            input.forkSessionId,
+          )
+          if (!sourceAuthority) {
+            throw new AgentGatewayError(AgentGatewayErrorCode.AGENT_SESSION_NOT_FOUND, 'session was not found')
+          }
+          if (
+            !sourceAuthority.runtimeScopeIdentity
+            || sourceAuthority.runtimeScopeIdentity === binding.scope.identity
+          ) {
+            throw new AgentGatewayError(
+              AgentGatewayErrorCode.AGENT_COMMAND_INVALID_STATE,
+              'only a session pinned to a previous runtime scope can be forked',
+            )
+          }
+          if (this.runtime.activity.get(claim.workspaceScopeId, sourceRef) !== 'idle') {
+            throw new AgentGatewayError(
+              AgentGatewayErrorCode.AGENT_COMMAND_INVALID_STATE,
+              'an active session cannot be forked',
+            )
+          }
         },
       },
     ) as AgentSessionRef

--- a/packages/agent/src/server/agent-host/httpProjection.ts
+++ b/packages/agent/src/server/agent-host/httpProjection.ts
@@ -5,6 +5,7 @@ import { z } from 'zod'
 import {
   AgentGatewayError,
   AgentGatewayErrorCode,
+  PromptPayloadSchema,
   type AgentGateway,
   type AgentSessionConnection,
   type AgentSessionRef,
@@ -100,7 +101,15 @@ const CreateSessionBodySchema = z.preprocess((value) => value === undefined ? {}
   requestId: RequestIdSchema.optional(),
   title: NonEmptyString.max(200).optional(),
   resumeSessionId: SessionIdSchema.optional(),
-}).strict())
+  forkSessionId: SessionIdSchema.optional(),
+  forkPrompt: PromptPayloadSchema.optional(),
+}).strict()
+  .refine((body) => !(body.resumeSessionId && body.forkSessionId), {
+    message: 'resumeSessionId and forkSessionId are mutually exclusive',
+  })
+  .refine((body) => !body.forkPrompt || Boolean(body.forkSessionId), {
+    message: 'forkPrompt requires forkSessionId',
+  }))
 const RenameSessionBodySchema = z.object({
   requestId: RequestIdSchema,
   title: NonEmptyString.max(200),
@@ -330,6 +339,8 @@ function registerAddressedRoutes(app: Parameters<FastifyPluginAsync>[0], input: 
         requestId: body.requestId ?? randomUUID(),
         title: body.title,
         ...(body.resumeSessionId ? { resumeSessionId: body.resumeSessionId } : {}),
+        ...(body.forkSessionId ? { forkSessionId: body.forkSessionId } : {}),
+        ...(body.forkPrompt ? { forkPrompt: body.forkPrompt } : {}),
       })
       return reply.code(201).send(ref)
     } catch (error) {

--- a/packages/agent/src/server/agent-host/httpProjection.ts
+++ b/packages/agent/src/server/agent-host/httpProjection.ts
@@ -333,15 +333,28 @@ function registerAddressedRoutes(app: Parameters<FastifyPluginAsync>[0], input: 
     const body = parseWithSchema(CreateSessionBodySchema, request.body, reply, 'body')
     if (!body) return
     try {
+      const scope = await input.options.authorizeAgentRequest(request)
       const ref = await input.gateway.createSession({
-        scope: await input.options.authorizeAgentRequest(request),
+        scope,
         agentTypeId: params.agentTypeId,
         requestId: body.requestId ?? randomUUID(),
         title: body.title,
         ...(body.resumeSessionId ? { resumeSessionId: body.resumeSessionId } : {}),
         ...(body.forkSessionId ? { forkSessionId: body.forkSessionId } : {}),
-        ...(body.forkPrompt ? { forkPrompt: body.forkPrompt } : {}),
       })
+      if (body.forkPrompt) {
+        const command: IdempotentAgentSend = {
+          kind: 'prompt',
+          requestId: body.forkPrompt.clientNonce,
+          clientNonce: body.forkPrompt.clientNonce,
+          content: body.forkPrompt.message,
+          displayContent: body.forkPrompt.displayMessage,
+          model: body.forkPrompt.model,
+          thinkingLevel: body.forkPrompt.thinkingLevel,
+          attachments: body.forkPrompt.attachments,
+        }
+        await withConnection(input, request, ref, (connection) => connection.send(command))
+      }
       return reply.code(201).send(ref)
     } catch (error) {
       return sendError(reply, error)

--- a/packages/agent/src/server/agent-host/sessionInventory.ts
+++ b/packages/agent/src/server/agent-host/sessionInventory.ts
@@ -94,18 +94,15 @@ export class AgentSessionInventory {
     if (!resolved) return undefined
     try {
       const ctx = { workspaceId: claim.workspaceScopeId }
-      const [summary, entries] = await Promise.all([
-        resolved.store.load(ctx, sessionId),
-        resolved.store.loadEntries(ctx, sessionId),
-      ])
+      const persisted = await resolved.store.readPersisted(ctx, sessionId)
       return {
-        summary,
+        summary: persisted.summary,
         state: {
           protocolVersion: 1,
-          sessionId: entries.id,
+          sessionId: persisted.entries.id,
           seq: 0,
           status: 'idle',
-          messages: buildPiChatHistory(entries.messages, { sessionId: entries.id }),
+          messages: buildPiChatHistory(persisted.entries.messages, { sessionId: persisted.entries.id }),
           queue: { followUps: [] },
           followUpMode: 'one-at-a-time',
         },

--- a/packages/agent/src/server/agent-host/sessionInventory.ts
+++ b/packages/agent/src/server/agent-host/sessionInventory.ts
@@ -1,8 +1,9 @@
 import { createHash } from 'node:crypto'
-import type { PiChatEvent } from '../../shared/chat'
+import type { PiChatEvent, PiChatSnapshot } from '../../shared/chat'
 import type { AgentSessionActivity, AgentSessionRef, AuthorizedAgentScope, VerifiedAgentScopeClaim } from '../../shared/index'
 import type { SessionSummary } from '../../shared/session'
 import { PiSessionStore } from '../harness/pi-coding-agent/sessions'
+import { buildPiChatHistory } from '../pi-chat/piChatHistory'
 import { agentSessionKey } from './agentSessionKey'
 import type { CompiledAgentHostAgentSpec, ResolvedAgentRuntimeScope } from './types'
 
@@ -70,6 +71,44 @@ export class AgentSessionInventory {
           { workspaceId: claim.workspaceScopeId },
           sessionId,
         ),
+      }
+    } catch (error) {
+      if (error instanceof Error && error.message === `Session not found: ${sessionId}`) return undefined
+      throw error
+    }
+  }
+
+  /**
+   * Reads a persisted transcript without constructing an executable runtime
+   * binding. The store still enforces the workspace/user header before any
+   * content is returned; the omitted runtime pin is deliberate because this
+   * path can never expose a command-capable service.
+   */
+  async readPersistedSession(
+    agentTypeId: string,
+    scope: AuthorizedAgentScope,
+    claim: VerifiedAgentScopeClaim,
+    sessionId: string,
+  ): Promise<{ summary: SessionSummary; state: PiChatSnapshot } | undefined> {
+    const resolved = await this.resolveStore(agentTypeId, scope, claim)
+    if (!resolved) return undefined
+    try {
+      const ctx = { workspaceId: claim.workspaceScopeId }
+      const [summary, entries] = await Promise.all([
+        resolved.store.load(ctx, sessionId),
+        resolved.store.loadEntries(ctx, sessionId),
+      ])
+      return {
+        summary,
+        state: {
+          protocolVersion: 1,
+          sessionId: entries.id,
+          seq: 0,
+          status: 'idle',
+          messages: buildPiChatHistory(entries.messages, { sessionId: entries.id }),
+          queue: { followUps: [] },
+          followUpMode: 'one-at-a-time',
+        },
       }
     } catch (error) {
       if (error instanceof Error && error.message === `Session not found: ${sessionId}`) return undefined

--- a/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
@@ -16,6 +16,7 @@ import { homedir } from "node:os";
 import { getEnv } from "../../config/env.js";
 import {
   parseSessionEntries,
+  SessionManager,
   type SessionEntry,
   type SessionHeader,
   type SessionMessageEntry,
@@ -270,6 +271,43 @@ export class PiSessionStore implements SessionStore {
       nativeSessionId: id,
       hasAssistantReply: false,
     };
+  }
+
+  /**
+   * Uses pi's native branch copier to create a new transcript at the source
+   * leaf, then replaces only the new header's Boring authority with the
+   * current runtime scope. The source file is never opened for append.
+   */
+  async fork(
+    ctx: RuntimePinnedSessionCtx,
+    sessionId: string,
+    _init?: { title?: string },
+  ): Promise<SessionSummary> {
+    const sourceCtx: RuntimePinnedSessionCtx = {
+      ...(ctx.workspaceId ? { workspaceId: ctx.workspaceId } : {}),
+      ...(ctx.userId ? { userId: ctx.userId } : {}),
+    };
+    const source = await this.resolveSessionTranscript(sourceCtx, sessionId);
+    const sourceFile = source.linkedFilepath ?? source.filepath;
+    const manager = SessionManager.open(sourceFile, this.sessionDir, this.cwd);
+    const leafId = manager.getLeafId();
+    if (!leafId) return await this.create(ctx, _init);
+    const forkedPath = manager.createBranchedSession(leafId);
+    if (!forkedPath) throw new Error(`Failed to fork session: ${sessionId}`);
+    const header = manager.getHeader();
+    if (!header) throw new Error(`Forked session header is unavailable: ${sessionId}`);
+    const pinnedHeader: SessionHeader & { boringSessionCtx: RuntimePinnedSessionCtx } = {
+      ...header,
+      boringSessionCtx: normalizeSessionCtx(ctx) ?? {},
+    };
+    const content = [pinnedHeader, ...manager.getEntries()]
+      .map((entry) => JSON.stringify(entry))
+      .join("\n") + "\n";
+    const tmp = `${forkedPath}.pin-${randomUUID()}`;
+    await writeFile(tmp, content, "utf-8");
+    await rename(tmp, forkedPath);
+    this.prefixCache.delete(forkedPath);
+    return await this.load(ctx, manager.getSessionId());
   }
 
   async load(ctx: SessionCtx, sessionId: string): Promise<SessionDetail> {

--- a/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
@@ -5,6 +5,7 @@ import {
   stat as fsStat,
   rm,
   mkdir,
+  mkdtemp,
   writeFile,
   appendFile,
   rename,
@@ -296,44 +297,44 @@ export class PiSessionStore implements SessionStore {
     const nativeEntries = sourceFile === sourcePath
       ? sourceEntries
       : safeParseEntries(await readFile(sourceFile, "utf-8"));
-    const hasLegacySnapshots = nativeEntries.some((entry) => (entry as { type?: string }).type === "ui_snapshot");
-    const temporarySource = hasLegacySnapshots ? `${sourceFile}.fork-read-${randomUUID()}` : undefined;
-    if (temporarySource) {
+    // SessionManager.open() may migrate and rewrite older transcripts. Always
+    // branch from an isolated copy so even legacy sources remain byte-for-byte
+    // immutable. The SDK's initially unpinned branch also stays hidden in the
+    // staging directory until its current-scope header is ready to publish.
+    const stagingDir = await mkdtemp(join(this.sessionDir, ".fork-stage-"));
+    try {
+      const stagingSource = join(stagingDir, "source.jsonl");
       await writeFile(
-        temporarySource,
+        stagingSource,
         nativeEntries
           .filter((entry) => (entry as { type?: string }).type !== "ui_snapshot")
           .map((entry) => JSON.stringify(entry))
           .join("\n") + "\n",
         "utf-8",
       );
-    }
-    let manager: SessionManager | undefined;
-    let forkedPath: string | undefined;
-    try {
-      manager = SessionManager.open(temporarySource ?? sourceFile, this.sessionDir, this.cwd);
+      const manager = SessionManager.open(stagingSource, stagingDir, this.cwd);
       const leafId = manager.getLeafId();
       if (!leafId) return await this.create(ctx, _init);
-      forkedPath = manager.createBranchedSession(leafId);
+      const stagedForkPath = manager.createBranchedSession(leafId);
+      if (!stagedForkPath) throw new Error(`Failed to fork session: ${sessionId}`);
+      const header = manager.getHeader();
+      if (!header) throw new Error(`Forked session header is unavailable: ${sessionId}`);
+      const pinnedHeader: SessionHeader & { boringSessionCtx: RuntimePinnedSessionCtx } = {
+        ...header,
+        parentSession: sourceFile,
+        boringSessionCtx: normalizeSessionCtx(ctx) ?? {},
+      };
+      const content = [pinnedHeader, ...manager.getEntries()]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n";
+      await writeFile(stagedForkPath, content, "utf-8");
+      const publishedPath = join(this.sessionDir, basename(stagedForkPath));
+      await rename(stagedForkPath, publishedPath);
+      this.prefixCache.delete(publishedPath);
+      return await this.load(ctx, manager.getSessionId());
     } finally {
-      if (temporarySource) await rm(temporarySource, { force: true });
+      await rm(stagingDir, { recursive: true, force: true });
     }
-    if (!manager || !forkedPath) throw new Error(`Failed to fork session: ${sessionId}`);
-    const header = manager.getHeader();
-    if (!header) throw new Error(`Forked session header is unavailable: ${sessionId}`);
-    const pinnedHeader: SessionHeader & { boringSessionCtx: RuntimePinnedSessionCtx } = {
-      ...header,
-      parentSession: sourceFile,
-      boringSessionCtx: normalizeSessionCtx(ctx) ?? {},
-    };
-    const content = [pinnedHeader, ...manager.getEntries()]
-      .map((entry) => JSON.stringify(entry))
-      .join("\n") + "\n";
-    const tmp = `${forkedPath}.pin-${randomUUID()}`;
-    await writeFile(tmp, content, "utf-8");
-    await rename(tmp, forkedPath);
-    this.prefixCache.delete(forkedPath);
-    return await this.load(ctx, manager.getSessionId());
   }
 
   async load(ctx: SessionCtx, sessionId: string): Promise<SessionDetail> {

--- a/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
@@ -287,17 +287,43 @@ export class PiSessionStore implements SessionStore {
       ...(ctx.workspaceId ? { workspaceId: ctx.workspaceId } : {}),
       ...(ctx.userId ? { userId: ctx.userId } : {}),
     };
-    const source = await this.resolveSessionTranscript(sourceCtx, sessionId);
-    const sourceFile = source.linkedFilepath ?? source.filepath;
-    const manager = SessionManager.open(sourceFile, this.sessionDir, this.cwd);
-    const leafId = manager.getLeafId();
-    if (!leafId) return await this.create(ctx, _init);
-    const forkedPath = manager.createBranchedSession(leafId);
-    if (!forkedPath) throw new Error(`Failed to fork session: ${sessionId}`);
+    const sourcePath = await this.resolveSessionFile(sessionId, sourceCtx);
+    const sourceEntries = safeParseEntries(await readFile(sourcePath, "utf-8"));
+    const linkedPiFile = extractPiSessionFilePath(sourceEntries);
+    const sourceFile = linkedPiFile && resolve(linkedPiFile) !== resolve(sourcePath)
+      ? linkedPiFile
+      : sourcePath;
+    const nativeEntries = sourceFile === sourcePath
+      ? sourceEntries
+      : safeParseEntries(await readFile(sourceFile, "utf-8"));
+    const hasLegacySnapshots = nativeEntries.some((entry) => (entry as { type?: string }).type === "ui_snapshot");
+    const temporarySource = hasLegacySnapshots ? `${sourceFile}.fork-read-${randomUUID()}` : undefined;
+    if (temporarySource) {
+      await writeFile(
+        temporarySource,
+        nativeEntries
+          .filter((entry) => (entry as { type?: string }).type !== "ui_snapshot")
+          .map((entry) => JSON.stringify(entry))
+          .join("\n") + "\n",
+        "utf-8",
+      );
+    }
+    let manager: SessionManager | undefined;
+    let forkedPath: string | undefined;
+    try {
+      manager = SessionManager.open(temporarySource ?? sourceFile, this.sessionDir, this.cwd);
+      const leafId = manager.getLeafId();
+      if (!leafId) return await this.create(ctx, _init);
+      forkedPath = manager.createBranchedSession(leafId);
+    } finally {
+      if (temporarySource) await rm(temporarySource, { force: true });
+    }
+    if (!manager || !forkedPath) throw new Error(`Failed to fork session: ${sessionId}`);
     const header = manager.getHeader();
     if (!header) throw new Error(`Forked session header is unavailable: ${sessionId}`);
     const pinnedHeader: SessionHeader & { boringSessionCtx: RuntimePinnedSessionCtx } = {
       ...header,
+      parentSession: sourceFile,
       boringSessionCtx: normalizeSessionCtx(ctx) ?? {},
     };
     const content = [pinnedHeader, ...manager.getEntries()]
@@ -336,6 +362,58 @@ export class PiSessionStore implements SessionStore {
           }
         : {}),
     };
+  }
+
+  /**
+   * Non-mutating storage snapshot for frozen-session reads. Unlike the normal
+   * cold-load path, this never compacts legacy wrappers while reading them.
+   */
+  async readPersisted(ctx: SessionCtx, sessionId: string): Promise<{
+    summary: SessionSummary;
+    entries: PiSessionEntries;
+  }> {
+    const filepath = await this.resolveSessionFile(sessionId, ctx);
+    const [content, fileStat] = await Promise.all([
+      readFile(filepath, "utf-8"),
+      fsStat(filepath),
+    ]);
+    const fileEntries = safeParseEntries(content);
+    const header = fileEntries.find((entry): entry is SessionHeader => entry.type === "session");
+    const timestampNamedNative = isTimestampNamedPiSessionFile(filepath, header?.id ?? sessionId);
+    if (!this.headerBelongsToCtx(header, ctx, timestampNamedNative)) {
+      throw new Error(`Session not found: ${sessionId}`);
+    }
+    const sessionEntries = fileEntries.filter(
+      (entry): entry is SessionEntry => entry.type !== "session" && (entry as { type?: string }).type !== "ui_snapshot",
+    );
+    const linkedPiFile = extractPiSessionFilePath(fileEntries);
+    const linked = linkedPiFile && resolve(linkedPiFile) !== resolve(filepath)
+      ? await this.readLinkedPiSession(linkedPiFile)
+      : null;
+    const linkedEntries = linked?.entries.filter(
+      (entry): entry is SessionEntry => entry.type !== "session",
+    ) ?? [];
+    const transcriptEntries = linkedEntries.length > 0 ? linkedEntries : sessionEntries;
+    const id = header?.id ?? sessionId;
+    const directNative = timestampNamedNative && !linkedPiFile;
+    const updatedAtMs = Math.max(fileStat.mtime.getTime(), linked?.mtime.getTime() ?? 0);
+    const summary: SessionSummary = {
+      id,
+      title: newestDurableTitle(sessionEntries, linkedEntries)
+        ?? firstUserMessage(transcriptEntries)
+        ?? "New session",
+      createdAt: header?.timestamp ?? fileStat.birthtime.toISOString(),
+      updatedAt: new Date(updatedAtMs).toISOString(),
+      turnCount: countUserTurns(transcriptEntries),
+      ...(directNative ? {
+        nativeSessionId: id,
+        hasAssistantReply: hasAssistantReply(transcriptEntries),
+      } : {}),
+    };
+    const messages = transcriptEntries
+      .filter((entry): entry is SessionMessageEntry => entry.type === "message")
+      .map((entry) => withStableMessageId(entry.message, entry.id));
+    return { summary, entries: { id, messages } };
   }
 
   /**

--- a/packages/agent/src/server/pi-chat/harnessPiChatService.ts
+++ b/packages/agent/src/server/pi-chat/harnessPiChatService.ts
@@ -1,5 +1,5 @@
 import type { AgentHarness, RunContext, AgentSendInput } from '../../shared/harness'
-import type { SessionCtx, SessionListOptions, SessionStore } from '../../shared/session'
+import type { SessionCtx, SessionListOptions, SessionStore, SessionSummary } from '../../shared/session'
 import type { Workspace } from '../../shared/workspace'
 import type { BoringChatMessage, BoringChatPart, ChatError, FollowUpPayload, FollowUpReceipt, InterruptPayload, PiChatEvent, PiChatSnapshot, PromptPayload, PromptReceipt, QueuedUserMessage, QueueClearPayload, QueueClearReceipt, StopPayload, StopReceipt } from '../../shared/chat'
 import { sessionStreamPath, type AgentEvent } from '../../shared/events'
@@ -36,6 +36,7 @@ const PROMPT_IMAGE_EXTENSIONS = new Set(['.avif', '.gif', '.jpg', '.jpeg', '.png
 type PiSessionStoreLike = SessionStore & {
   loadEntries?: (ctx: { workspaceId?: string; userId?: string }, sessionId: string) => Promise<{ id: string; messages: unknown[] }>
   loadAttachment?: (ctx: { workspaceId?: string; userId?: string }, sessionId: string, messageId: string, index: number) => Promise<{ data: Uint8Array; mediaType: string; filename?: string }>
+  fork?: (ctx: SessionCtx, sessionId: string, init?: { title?: string }) => Promise<SessionSummary>
 }
 
 interface LiveSessionChannel {
@@ -199,7 +200,17 @@ export class HarnessPiChatService implements PiChatSessionService {
   }
 
   async createSession(ctx: PiSessionRequestContext, init?: PiSessionCreateInit) {
-    return this.lifecycle.run(() => this.sessionStore.create(toSessionCtx(ctx), init))
+    return this.lifecycle.run(() => {
+      const sessionCtx = toSessionCtx(ctx)
+      if (!init?.forkSessionId) return this.sessionStore.create(sessionCtx, init)
+      if (!this.sessionStore.fork) {
+        throw Object.assign(new Error('session store does not support native forks'), {
+          code: ErrorCode.enum.CONFIG_INVALID,
+          statusCode: 400,
+        })
+      }
+      return this.sessionStore.fork(sessionCtx, init.forkSessionId, init)
+    })
   }
 
   async deleteSession(ctx: PiSessionRequestContext, sessionId: string): Promise<void> {

--- a/packages/agent/src/shared/gateway/types.ts
+++ b/packages/agent/src/shared/gateway/types.ts
@@ -4,6 +4,7 @@ import type {
   PiChatSnapshot,
   QueuedUserMessage,
   ThinkingLevel,
+  PromptPayload,
 } from '../chat'
 import type { AgentSessionEvent } from './events'
 
@@ -106,6 +107,10 @@ export interface CreateAgentSessionInput {
   readonly title?: string
   /** Boot-only intent to resume this exact tab-owned empty session. */
   readonly resumeSessionId?: string
+  /** Existing transcript to fork into a new session in the current runtime scope. */
+  readonly forkSessionId?: string
+  /** First prompt delivered to the new fork before it is returned to the client. */
+  readonly forkPrompt?: PromptPayload
 }
 
 export interface ConnectAgentSessionInput {

--- a/packages/agent/src/shared/gateway/types.ts
+++ b/packages/agent/src/shared/gateway/types.ts
@@ -4,7 +4,6 @@ import type {
   PiChatSnapshot,
   QueuedUserMessage,
   ThinkingLevel,
-  PromptPayload,
 } from '../chat'
 import type { AgentSessionEvent } from './events'
 
@@ -109,8 +108,6 @@ export interface CreateAgentSessionInput {
   readonly resumeSessionId?: string
   /** Existing transcript to fork into a new session in the current runtime scope. */
   readonly forkSessionId?: string
-  /** First prompt delivered to the new fork before it is returned to the client. */
-  readonly forkPrompt?: PromptPayload
 }
 
 export interface ConnectAgentSessionInput {

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -1999,13 +1999,17 @@ export function WorkspaceAgentFront<
     sourceSessionId: string,
     ownerAgentTypeId: string,
     forkPrompt: Parameters<NonNullable<WorkspaceChatPanelProps['onForkSession']>>[1],
-  ) => createChatPaneTransaction(
-    paneId,
-    "replace",
-    undefined,
-    ownerAgentTypeId,
-    { forkSessionId: sourceSessionId, forkPrompt },
-  ), [createChatPaneTransaction])
+  ) => {
+    if (!sessionApi) return Promise.reject(new Error("This chat provider cannot create native forks."))
+    if (pendingCreatePaneRef.current) return Promise.reject(new Error("Another chat is still being created."))
+    return createChatPaneTransaction(
+      paneId,
+      "replace",
+      undefined,
+      ownerAgentTypeId,
+      { forkSessionId: sourceSessionId, forkPrompt },
+    )
+  }, [createChatPaneTransaction, sessionApi])
 
   const closeChatPane = useCallback((sessionKey: string) => {
     if (pendingCreatePaneRef.current) return

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -133,7 +133,7 @@ export interface WorkspaceAgentSessionsApi<
   workspaceId?: string | null
   switch: (id: string, agentTypeId?: string) => void
   /** Returns the canonical created row; void providers are a protocol violation. */
-  create: (input?: { title?: string; resumeSessionId?: string; agentTypeId?: string }) => TSession | Promise<TSession>
+  create: (input?: { title?: string; resumeSessionId?: string; forkSessionId?: string; forkPrompt?: Parameters<NonNullable<WorkspaceChatPanelProps['onForkSession']>>[1]; agentTypeId?: string }) => TSession | Promise<TSession>
   rename?: (id: string, title: string, agentTypeId?: string) => void | Promise<unknown>
   delete: (id: string, agentTypeId?: string) => void | Promise<unknown>
   loadMore?: () => void | Promise<unknown>
@@ -1083,7 +1083,7 @@ export function WorkspaceAgentFront<
   })
   const coordinateRemoteCreate = useCallback((
     dedupeKey: string,
-    input?: { title?: string; resumeSessionId?: string; agentTypeId?: string },
+    input?: { title?: string; resumeSessionId?: string; forkSessionId?: string; forkPrompt?: Parameters<NonNullable<WorkspaceChatPanelProps['onForkSession']>>[1]; agentTypeId?: string },
   ): Promise<TSession | undefined> => {
     if (!sessionSourceIsCurrent() || !remoteSessionsAvailable) return Promise.resolve(undefined)
     const create = remoteSessionApi.create
@@ -1262,7 +1262,11 @@ export function WorkspaceAgentFront<
       ? rawSwitch(nextSessionId, nextAgentTypeId)
       : rawSwitch(nextSessionId)
   }, [effectiveActiveSessionId, rawSwitch, sessionSourceIsCurrent])
-  const resolvedCreate = useCallback((dedupeKey = "manual", ownerAgentTypeId?: string): Promise<TSession | undefined> => {
+  const resolvedCreate = useCallback((
+    dedupeKey = "manual",
+    ownerAgentTypeId?: string,
+    createInput?: { title?: string; resumeSessionId?: string; forkSessionId?: string; forkPrompt?: Parameters<NonNullable<WorkspaceChatPanelProps['onForkSession']>>[1] },
+  ): Promise<TSession | undefined> => {
     if (remoteSessionsPending) return Promise.resolve(undefined)
     if (sessionApi) {
       // A user create owns the empty-list transition. Cancel only a queued boot
@@ -1272,7 +1276,9 @@ export function WorkspaceAgentFront<
       sessionCreation.cancel((task) => task.phase === "queued" && task.dedupeKey === "initial-auto")
       return coordinateRemoteCreate(
         dedupeKey,
-        fleetModeEnabled && ownerAgentTypeId ? { agentTypeId: ownerAgentTypeId } : undefined,
+        createInput || (fleetModeEnabled && ownerAgentTypeId)
+          ? { ...createInput, ...(fleetModeEnabled && ownerAgentTypeId ? { agentTypeId: ownerAgentTypeId } : {}) }
+          : undefined,
       ).catch((error) => {
         // A canceled queued boot create resolves without running its own error
         // path. Re-arm boot creation if the user-owned request failed.
@@ -1897,6 +1903,7 @@ export function WorkspaceAgentFront<
     mode: "insert" | "replace",
     placementDirection?: ChatPaneSplitDirection,
     ownerAgentTypeId?: string,
+    createInput?: { title?: string; resumeSessionId?: string; forkSessionId?: string; forkPrompt?: Parameters<NonNullable<WorkspaceChatPanelProps['onForkSession']>>[1] },
   ) => {
     if (pendingCreatePaneRef.current) return
     const pendingCreatePane: PendingCreatePane = {
@@ -1921,7 +1928,7 @@ export function WorkspaceAgentFront<
       : "manual"
     let created: ReturnType<typeof resolvedCreate>
     try {
-      created = resolvedCreate(createReason, ownerAgentTypeId)
+      created = resolvedCreate(createReason, ownerAgentTypeId, createInput)
     } catch (error) {
       settleIfOwner()
       throw error
@@ -1986,6 +1993,19 @@ export function WorkspaceAgentFront<
   const createChatSession = useCallback((ownerAgentTypeId = fleetModeEnabled ? newChatAgentTypeId : undefined) => (
     createChatPaneTransaction(activeChatPaneId, "replace", undefined, ownerAgentTypeId)
   ), [activeChatPaneId, newChatAgentTypeId, createChatPaneTransaction, fleetModeEnabled])
+
+  const forkFrozenChatSession = useCallback((
+    paneId: string,
+    sourceSessionId: string,
+    ownerAgentTypeId: string,
+    forkPrompt: Parameters<NonNullable<WorkspaceChatPanelProps['onForkSession']>>[1],
+  ) => createChatPaneTransaction(
+    paneId,
+    "replace",
+    undefined,
+    ownerAgentTypeId,
+    { forkSessionId: sourceSessionId, forkPrompt },
+  ), [createChatPaneTransaction])
 
   const closeChatPane = useCallback((sessionKey: string) => {
     if (pendingCreatePaneRef.current) return
@@ -2179,6 +2199,15 @@ export function WorkspaceAgentFront<
       remoteSessionOptions: chatRemoteSessionOptions,
       showSessions: false,
       onCreateSession: () => createChatSession(sessionRef.agentTypeId ?? selectedAgentTypeId),
+      onForkSession: (
+        sourceSessionId: string,
+        forkPrompt: Parameters<NonNullable<WorkspaceChatPanelProps['onForkSession']>>[1],
+      ) => forkFrozenChatSession(
+        sessionKey,
+        sourceSessionId,
+        sessionRef.agentTypeId ?? selectedAgentTypeId,
+        forkPrompt,
+      ),
       onReloadAgentPlugins: chatParams?.onReloadAgentPlugins ?? (() => reloadAgentPluginsForSession({ agentTypeId: sessionRef.agentTypeId ?? selectedAgentTypeId, sessionId })),
       toolRenderers: { ...pluginToolRenderers, ...(chatToolRenderers ?? {}) },
       bridgeEndpoint: null,
@@ -2219,7 +2248,7 @@ export function WorkspaceAgentFront<
       ...(resolvedHotReloadEnabled !== undefined ? { hotReloadEnabled: resolvedHotReloadEnabled } : {}),
     }
     },
-    [apiBaseUrl, chatParams, chatRemoteSessionOptions, createChatSession, delayAutoSubmitDraft, resolvedRequestHeaders, surfaceDispatch, extraCommands, workspaceWarmupStatus, hydrateMessages, emptySessionIds, resolvedHotReloadEnabled, pluginToolRenderers, reloadAgentPluginsForSession, selectedAgentTypeId, sessionSourceIsCurrent, workspaceId],
+    [apiBaseUrl, chatParams, chatRemoteSessionOptions, createChatSession, delayAutoSubmitDraft, forkFrozenChatSession, resolvedRequestHeaders, surfaceDispatch, extraCommands, workspaceWarmupStatus, hydrateMessages, emptySessionIds, resolvedHotReloadEnabled, pluginToolRenderers, reloadAgentPluginsForSession, selectedAgentTypeId, sessionSourceIsCurrent, workspaceId],
   )
   const centerParams = useMemo(
     () => makeCenterParams(chatSessionKey),

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -1853,6 +1853,82 @@ describe("WorkspaceAgentFront", () => {
     }))
   })
 
+  it("rejects a frozen fork while another pane creation is pending", async () => {
+    const user = userEvent.setup()
+    const create = vi.fn(() => new Promise<{ id: string; agentTypeId: string; title: string }>(() => {}))
+    const BusyForkChat = (props: WorkspaceChatPanelProps) => {
+      const [error, setError] = useState("")
+      return (
+        <>
+          <button type="button" onClick={() => void props.onCreateSession?.()}>Start another chat</button>
+          <button
+            type="button"
+            onClick={() => void Promise.resolve(props.onForkSession?.("stale", { message: "continue", clientNonce: "nonce" })).catch((reason: unknown) => setError(String(reason)))}
+          >
+            Send frozen message
+          </button>
+          <output>{error}</output>
+        </>
+      )
+    }
+    render(
+      <WorkspaceAgentFront
+        workspaceId="busy-frozen-fork"
+        chatPanel={BusyForkChat}
+        useSessions={(options) => ({
+          sourceIdentity: options.sourceIdentity,
+          sessions: [{ id: "stale", agentTypeId: "default", title: "Frozen" }],
+          activeSessionId: "stale",
+          activeSession: { id: "stale", agentTypeId: "default", title: "Frozen" },
+          loading: false,
+          workspaceId: options.workspaceId,
+          switch: vi.fn(),
+          delete: vi.fn(),
+          create,
+        })}
+        persistenceEnabled={false}
+      />,
+    )
+
+    await user.click(screen.getByRole("button", { name: "Start another chat" }))
+    await user.click(screen.getByRole("button", { name: "Send frozen message" }))
+    await waitFor(() => expect(screen.getByText(/Another chat is still being created/)).toBeTruthy())
+    expect(create).toHaveBeenCalledOnce()
+  })
+
+  it("refuses frozen recovery when a controlled provider cannot carry fork input", async () => {
+    const user = userEvent.setup()
+    const onCreateSession = vi.fn()
+    const UnsupportedForkChat = (props: WorkspaceChatPanelProps) => {
+      const [error, setError] = useState("")
+      return (
+        <>
+          <button
+            type="button"
+            onClick={() => void Promise.resolve(props.onForkSession?.("stale", { message: "continue", clientNonce: "nonce" })).catch((reason: unknown) => setError(String(reason)))}
+          >
+            Send frozen message
+          </button>
+          <output>{error}</output>
+        </>
+      )
+    }
+    render(
+      <WorkspaceAgentFront
+        workspaceId="unsupported-frozen-fork"
+        chatPanel={UnsupportedForkChat}
+        sessions={[{ id: "stale", title: "Frozen" }]}
+        activeSessionId="stale"
+        onCreateSession={onCreateSession}
+        persistenceEnabled={false}
+      />,
+    )
+
+    await user.click(screen.getByRole("button", { name: "Send frozen message" }))
+    await waitFor(() => expect(screen.getByText(/cannot create native forks/)).toBeTruthy())
+    expect(onCreateSession).not.toHaveBeenCalled()
+  })
+
   it("keeps an async returned created pane while controlled sessions catch up", async () => {
     const user = userEvent.setup()
 

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -1808,6 +1808,51 @@ describe("WorkspaceAgentFront", () => {
     expect(create).toHaveBeenCalledWith()
   })
 
+  it("replaces a frozen pane with the current-scope native fork", async () => {
+    const user = userEvent.setup()
+    const create = vi.fn(async (input?: { forkSessionId?: string }) => ({
+      id: "forked",
+      agentTypeId: "default",
+      title: "Continued session",
+      ...(input ?? {}),
+    }))
+    const FrozenChat = (props: WorkspaceChatPanelProps) => (
+      <button
+        type="button"
+        data-session-id={props.sessionId}
+        onClick={() => void props.onForkSession?.("stale", { message: "continue", clientNonce: "nonce" })}
+      >
+        Send frozen message
+      </button>
+    )
+
+    render(
+      <WorkspaceAgentFront
+        workspaceId="transparent-frozen-fork"
+        chatPanel={FrozenChat}
+        useSessions={(options) => ({
+          sourceIdentity: options.sourceIdentity,
+          sessions: [{ id: "stale", agentTypeId: "default", title: "Frozen session" }],
+          activeSessionId: "stale",
+          activeSessionAgentTypeId: "default",
+          activeSession: { id: "stale", agentTypeId: "default", title: "Frozen session" },
+          loading: false,
+          workspaceId: options.workspaceId,
+          switch: vi.fn(),
+          delete: vi.fn(),
+          create,
+        })}
+        persistenceEnabled={false}
+      />,
+    )
+
+    await user.click(screen.getByRole("button", { name: "Send frozen message" }))
+    await waitFor(() => expect(create).toHaveBeenCalledWith({
+      forkSessionId: "stale",
+      forkPrompt: { message: "continue", clientNonce: "nonce" },
+    }))
+  })
+
   it("keeps an async returned created pane while controlled sessions catch up", async () => {
     const user = userEvent.setup()
 


### PR DESCRIPTION
Closes #1238

A runtime-scope-mismatched chat remains readable. On the first send, the client transparently asks the current AgentHost to create a native pi branch at the frozen transcript leaf and deliver the typed prompt to the new current-scope session. The original transcript and its write pin remain untouched.

Proof and owner presentation will be added after independent review and the :5301 anchor-hub demo.