### PR TITLE
[wt-391-forward-9jxj] Composer shows the session's actual model

### DIFF
--- a/packages/agent/e2e/pi-native-baseline-composer-controls.spec.ts
+++ b/packages/agent/e2e/pi-native-baseline-composer-controls.spec.ts
@@ -199,7 +199,8 @@ test.describe('Pi-native baseline composer controls', () => {
     expect(await readModelLabels(page)).toEqual([...MODEL_LABEL_ORDER])
 
     await page.getByText('Claude Opus').click()
-    await expect(modelSelect).toContainText('Claude Opus')
+    await expect(modelSelect).toContainText('Claude Sonnet')
+    await expect(modelSelect).toContainText('Next override: Claude Opus')
     await expect(messages).toHaveCount(0)
 
     await modelSelect.click()
@@ -214,7 +215,8 @@ test.describe('Pi-native baseline composer controls', () => {
 
     await page.reload({ waitUntil: 'domcontentloaded' })
     await expect(chat).toHaveAttribute('data-pi-chat-connection', /connected|connecting/, { timeout: 10_000 })
-    await expect(modelSelect).toContainText('Claude Opus', { timeout: 10_000 })
+    await expect(modelSelect).toContainText('Claude Sonnet', { timeout: 10_000 })
+    await expect(modelSelect).toContainText('Next override: Claude Opus', { timeout: 10_000 })
     await expect(thinkingSelect).toHaveAttribute('aria-label', 'Thinking level: Med')
     await expect(messages).toHaveCount(0)
 
@@ -287,7 +289,8 @@ test.describe('Pi-native baseline composer controls', () => {
     await composer.press('ArrowDown')
     await composer.press('Enter')
     await expect(modelMenu).toHaveCount(0)
-    await expect(modelSelect).toContainText('Claude Opus')
+    await expect(modelSelect).toContainText('Claude Sonnet')
+    await expect(modelSelect).toContainText('Next override: Claude Opus')
 
     await composer.fill('/thinking')
     await slashMenu.getByText('/thinking', { exact: true }).click()
@@ -441,7 +444,7 @@ test.describe('Pi-native baseline composer controls', () => {
 
     await expect(chat).toHaveAttribute('data-pi-chat-session-id', 'pi-e2e', { timeout: 10_000 })
     await expect(conversation.getByText('ACTIVE_CONTROL_STREAM')).toBeVisible({ timeout: 10_000 })
-    await expect(modelSelect).toContainText('Claude Opus', { timeout: 10_000 })
+    await expect(modelSelect).toContainText('Claude Sonnet', { timeout: 10_000 })
     await expect(modelSelect).toBeDisabled()
     await expect(modelSelect).toHaveAttribute('data-boring-state', 'disabled')
     await expect(thinkingSelect).toHaveAttribute('aria-label', 'Thinking level: Med')
@@ -454,7 +457,7 @@ test.describe('Pi-native baseline composer controls', () => {
     await expect(chat).toHaveAttribute('data-pi-chat-session-id', 'controls-idle', { timeout: 10_000 })
     await expect(conversation.getByText('IDLE_CONTROL_SESSION')).toBeVisible({ timeout: 10_000 })
     await expect(conversation.getByText('ACTIVE_CONTROL_STREAM')).toHaveCount(0)
-    await expect(modelSelect).toContainText('Claude Opus')
+    await expect(modelSelect).toContainText('Claude Sonnet')
     await expect(modelSelect).not.toBeDisabled()
     await expect(modelSelect).not.toHaveAttribute('data-boring-state', 'disabled')
     await expect(thinkingSelect).toHaveAttribute('aria-label', 'Thinking level: Med')
@@ -467,7 +470,7 @@ test.describe('Pi-native baseline composer controls', () => {
     await expect(chat).toHaveAttribute('data-pi-chat-session-id', 'pi-e2e', { timeout: 10_000 })
     await expect(conversation.getByText('ACTIVE_CONTROL_STREAM')).toBeVisible({ timeout: 10_000 })
     await expect(conversation.getByText('IDLE_CONTROL_SESSION')).toHaveCount(0)
-    await expect(modelSelect).toContainText('Claude Opus')
+    await expect(modelSelect).toContainText('Claude Sonnet')
     await expect(modelSelect).toBeDisabled()
     await expect(modelSelect).toHaveAttribute('data-boring-state', 'disabled')
     await expect(thinkingSelect).toHaveAttribute('aria-label', 'Thinking level: Med')

--- a/packages/agent/e2e/pi-native-mock.ts
+++ b/packages/agent/e2e/pi-native-mock.ts
@@ -28,6 +28,7 @@ export async function installPiNativeMock(page: Page): Promise<void> {
     type MockSessionState = {
       seq: number
       status: 'idle' | 'streaming'
+      currentModel: { provider: string; id: string }
       messages: Array<{ id: string; role: 'user' | 'assistant'; status?: string; clientSeq?: number; clientNonce?: string; parts: unknown[] }>
       queue: { followUps: Array<{ id: string; kind: 'followup'; displayText: string; clientSeq?: number; clientNonce?: string }> }
       prompts: Array<Record<string, unknown>>
@@ -64,6 +65,7 @@ export async function installPiNativeMock(page: Page): Promise<void> {
     const initial = (): MockState => ({
       seq: 0,
       status: 'idle',
+      currentModel: { provider: 'anthropic', id: 'claude-sonnet' },
       messages: [],
       queue: { followUps: [] },
       prompts: [],
@@ -136,6 +138,7 @@ export async function installPiNativeMock(page: Page): Promise<void> {
         sessionId,
         seq: state.seq,
         status: state.status,
+        currentModel: state.currentModel,
         messages: state.messages,
         queue: state.queue,
         followUpMode: 'one-at-a-time',
@@ -272,6 +275,14 @@ export async function installPiNativeMock(page: Page): Promise<void> {
         const toolId = `tool-${turnIndex}`
         const textId = `t${turnIndex}`
         state.status = 'streaming'
+        if (payload.model && typeof payload.model === 'object') {
+          const model = payload.model as { provider?: unknown; id?: unknown }
+          if (typeof model.provider === 'string' && typeof model.id === 'string'
+            && (state.currentModel.provider !== model.provider || state.currentModel.id !== model.id)) {
+            state.currentModel = { provider: model.provider, id: model.id }
+            nextSeq(state); emitPiE2E({ type: 'model-changed', seq: state.seq, currentModel: state.currentModel })
+          }
+        }
         nextSeq(state); emitPiE2E({ type: 'agent-start', seq: state.seq, turnId: `turn-${turnIndex}` })
         nextSeq(state); emitPiE2E({ type: 'message-start', seq: state.seq, messageId: userId, role: 'user', clientNonce: payload.clientNonce, text: payload.content })
         nextSeq(state); emitPiE2E({ type: 'message-start', seq: state.seq, messageId: assistantId, role: 'assistant' })

--- a/packages/agent/src/front/chat/PiChatPanel.tsx
+++ b/packages/agent/src/front/chat/PiChatPanel.tsx
@@ -344,6 +344,8 @@ export function PiChatPanel<
       selectedChatState?.hydrated
       && selectedChatState.history.messageCount === 0
       && selectedChatState.committedMessages.length === 0
+      && selectedChatState.queue.followUps.length === 0
+      && Object.keys(selectedChatState.optimisticOutbox).length === 0
       && !selectedChatState.streamingMessage
     ),
     sessionModel: selectedChatState?.currentModel,

--- a/packages/agent/src/front/chat/PiChatPanel.tsx
+++ b/packages/agent/src/front/chat/PiChatPanel.tsx
@@ -338,13 +338,21 @@ export function PiChatPanel<
     agentTypeId,
     apiBaseUrl,
     defaultModel,
+    sessionId: activeSessionId,
+    sessionHydrated: selectedChatState?.hydrated ?? false,
+    sessionIsNew: Boolean(selectedChatState?.hydrated && selectedChatState.history.messageCount === 0),
+    sessionModel: selectedChatState?.currentModel,
     fetch,
     requestHeaders: normalizedRequestHeaders,
     storage,
     storageScope,
     enabled: modelDiscoveryEnabled,
   })
+  const sessionModel = selectedChatState?.currentModel
   const selectedModel = model === undefined ? modelDiscovery.model : model
+  const modelOverride = model === undefined
+    ? modelDiscovery.isOverride
+    : Boolean(model && sessionModel && (model.provider !== sessionModel.provider || model.id !== sessionModel.id))
   const modelOptions = useMemo(
     () => modelOptionsForSelection(availableModels ?? modelDiscovery.availableModels, selectedModel),
     [availableModels, modelDiscovery.availableModels, selectedModel],
@@ -1198,6 +1206,8 @@ export function PiChatPanel<
               onDismissSlash={dismissSlash}
               modelPickerOpen={modelPickerOpen}
               selectedModel={selectedModel}
+              sessionModel={sessionModel}
+              modelOverride={modelOverride}
               modelOptions={modelOptions}
               modelControlled={model !== undefined}
               hideDefaultModelOption={hideDefaultModelOption}

--- a/packages/agent/src/front/chat/PiChatPanel.tsx
+++ b/packages/agent/src/front/chat/PiChatPanel.tsx
@@ -340,7 +340,12 @@ export function PiChatPanel<
     defaultModel,
     sessionId: activeSessionId,
     sessionHydrated: selectedChatState?.hydrated ?? false,
-    sessionIsNew: Boolean(selectedChatState?.hydrated && selectedChatState.history.messageCount === 0),
+    sessionIsNew: Boolean(
+      selectedChatState?.hydrated
+      && selectedChatState.history.messageCount === 0
+      && selectedChatState.committedMessages.length === 0
+      && !selectedChatState.streamingMessage
+    ),
     sessionModel: selectedChatState?.currentModel,
     fetch,
     requestHeaders: normalizedRequestHeaders,

--- a/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
+++ b/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
@@ -1173,7 +1173,7 @@ describe('PiChatPanel sandbox shell', () => {
       [scopedComposerStorageKey('workspace-a', 'thinking')]: 'high',
       [scopedComposerStorageKey('workspace-a', 'show-thoughts')]: '1',
     })
-    const remote = new FakeRemotePiSession(remoteState())
+    const remote = new FakeRemotePiSession(remoteState({ committedMessages: [], history: { mode: 'full', messageCount: 0 } }))
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse([session('pi-1')]))
 
     render(
@@ -1248,7 +1248,7 @@ describe('PiChatPanel sandbox shell', () => {
   })
 
   test('opens model and thinking pickers from slash commands', async () => {
-    const remote = new FakeRemotePiSession(remoteState())
+    const remote = new FakeRemotePiSession(remoteState({ committedMessages: [], history: { mode: 'full', messageCount: 0 } }))
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse([session('pi-1')]))
     render(
       <PiChatPanel

--- a/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
+++ b/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
@@ -1200,6 +1200,40 @@ describe('PiChatPanel sandbox shell', () => {
     })))
   })
 
+  test('does not treat a queued addressed session as genuinely new', async () => {
+    const sessionModel = { provider: 'openai-codex', id: 'gpt-5.6-sol' } as const
+    const staleLocalModel = { provider: 'infomaniak', id: 'Kimi-K2.6' } as const
+    const persisted = storage({
+      [scopedComposerStorageKey('workspace-a', 'model')]: JSON.stringify(staleLocalModel),
+      [scopedComposerStorageKey('workspace-a', 'model:user-selected')]: '1',
+    })
+    const remote = new FakeRemotePiSession(remoteState({
+      currentModel: sessionModel,
+      committedMessages: [],
+      history: { mode: 'full', messageCount: 0 },
+      queue: { followUps: [{ id: 'queued', kind: 'followup', displayText: 'already queued' }] },
+    }))
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse([session('pi-1')]))
+
+    render(
+      <PiChatPanel
+        serverResourcesEnabled={false}
+        storageScope="workspace-a"
+        storage={persisted}
+        availableModels={[
+          { ...sessionModel, label: 'GPT 5.6 Sol', available: true },
+          { ...staleLocalModel, label: 'Kimi K2.6', available: true },
+        ]}
+        fetch={fetchMock as unknown as typeof fetch}
+        createRemoteSession={remoteFactory(remote)}
+      />,
+    )
+
+    const control = await screen.findByRole('button', { name: /Current model: GPT 5.6 Sol/ })
+    expect(control.textContent).not.toContain('Next override')
+    expect(control.textContent).not.toContain('Kimi K2.6')
+  })
+
   test('shows the addressed session model and labels an explicit next-message override', async () => {
     const sessionModel = { provider: 'openai-codex', id: 'gpt-5.6-sol' } as const
     const staleLocalModel = { provider: 'infomaniak', id: 'Kimi-K2.6' } as const

--- a/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
+++ b/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
@@ -1200,6 +1200,53 @@ describe('PiChatPanel sandbox shell', () => {
     })))
   })
 
+  test('shows the addressed session model and labels an explicit next-message override', async () => {
+    const sessionModel = { provider: 'openai-codex', id: 'gpt-5.6-sol' } as const
+    const staleLocalModel = { provider: 'infomaniak', id: 'Kimi-K2.6' } as const
+    const nextModel = { provider: 'openai', id: 'gpt-5.7' } as const
+    const persisted = storage({
+      [scopedComposerStorageKey('workspace-a', 'model')]: JSON.stringify(staleLocalModel),
+      [scopedComposerStorageKey('workspace-a', 'model:user-selected')]: '1',
+    })
+    const remote = new FakeRemotePiSession(remoteState({ currentModel: sessionModel }))
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse([session('pi-1')]))
+
+    render(
+      <PiChatPanel
+        serverResourcesEnabled={false}
+        storageScope="workspace-a"
+        storage={persisted}
+        availableModels={[
+          { ...sessionModel, label: 'GPT 5.6 Sol', available: true },
+          { ...nextModel, label: 'GPT 5.7', available: true },
+          { ...staleLocalModel, label: 'Kimi K2.6', available: true },
+        ]}
+        fetch={fetchMock as unknown as typeof fetch}
+        createRemoteSession={remoteFactory(remote)}
+      />,
+    )
+
+    const modelControl = await screen.findByRole('button', { name: /Current model: GPT 5.6 Sol/ })
+    expect(modelControl.textContent).toContain('GPT 5.6 Sol')
+    expect(modelControl.textContent).not.toContain('Kimi K2.6')
+
+    fireEvent.click(modelControl)
+    fireEvent.click(await screen.findByText('GPT 5.7'))
+
+    const overrideControl = screen.getByRole('button', { name: /Next-message override: GPT 5.7/ })
+    expect(overrideControl.textContent).toContain('GPT 5.6 Sol')
+    expect(overrideControl.textContent).toContain('Next override: GPT 5.7')
+    expect(overrideControl.getAttribute('data-boring-model-override')).toBe('true')
+
+    const textarea = screen.getByLabelText('Agent prompt')
+    fireEvent.change(textarea, { target: { value: 'use override once' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+    await waitFor(() => expect(remote.prompt).toHaveBeenCalledWith(expect.objectContaining({
+      message: 'use override once',
+      model: nextModel,
+    })))
+  })
+
   test('opens model and thinking pickers from slash commands', async () => {
     const remote = new FakeRemotePiSession(remoteState())
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse([session('pi-1')]))

--- a/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
+++ b/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
@@ -1200,6 +1200,48 @@ describe('PiChatPanel sandbox shell', () => {
     })))
   })
 
+  test('does not treat an optimistic addressed session as genuinely new', async () => {
+    const sessionModel = { provider: 'openai-codex', id: 'gpt-5.6-sol' } as const
+    const staleLocalModel = { provider: 'infomaniak', id: 'Kimi-K2.6' } as const
+    const persisted = storage({
+      [scopedComposerStorageKey('workspace-a', 'model')]: JSON.stringify(staleLocalModel),
+      [scopedComposerStorageKey('workspace-a', 'model:user-selected')]: '1',
+    })
+    const remote = new FakeRemotePiSession(remoteState({
+      currentModel: sessionModel,
+      committedMessages: [],
+      history: { mode: 'full', messageCount: 0 },
+      optimisticOutbox: {
+        pending: {
+          id: 'optimistic:pending',
+          role: 'user',
+          status: 'pending',
+          clientNonce: 'pending',
+          parts: [{ type: 'text', id: 'optimistic:pending:text', text: 'pending prompt' }],
+        },
+      },
+    }))
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse([session('pi-1')]))
+
+    render(
+      <PiChatPanel
+        serverResourcesEnabled={false}
+        storageScope="workspace-a"
+        storage={persisted}
+        availableModels={[
+          { ...sessionModel, label: 'GPT 5.6 Sol', available: true },
+          { ...staleLocalModel, label: 'Kimi K2.6', available: true },
+        ]}
+        fetch={fetchMock as unknown as typeof fetch}
+        createRemoteSession={remoteFactory(remote)}
+      />,
+    )
+
+    const control = await screen.findByRole('button', { name: /Current model: GPT 5.6 Sol/ })
+    expect(control.textContent).not.toContain('Next override')
+    expect(control.textContent).not.toContain('Kimi K2.6')
+  })
+
   test('does not treat a queued addressed session as genuinely new', async () => {
     const sessionModel = { provider: 'openai-codex', id: 'gpt-5.6-sol' } as const
     const staleLocalModel = { provider: 'infomaniak', id: 'Kimi-K2.6' } as const

--- a/packages/agent/src/front/chat/components/PiChatComposerSurface.tsx
+++ b/packages/agent/src/front/chat/components/PiChatComposerSurface.tsx
@@ -103,6 +103,8 @@ export interface PiChatComposerSurfaceProps<
   onDismissSlash: () => void
   modelPickerOpen: boolean
   selectedModel: ModelSelection | null
+  sessionModel?: ModelSelection
+  modelOverride: boolean
   modelOptions: AvailableModel[]
   modelControlled: boolean
   hideDefaultModelOption?: boolean
@@ -166,6 +168,8 @@ export function PiChatComposerSurface<
   onDismissSlash,
   modelPickerOpen,
   selectedModel,
+  sessionModel,
+  modelOverride,
   modelOptions,
   modelControlled,
   hideDefaultModelOption = false,
@@ -467,6 +471,8 @@ export function PiChatComposerSurface<
         <div className="flex min-w-0 items-center justify-center gap-1">
         <ModelSelectTrigger
           value={selectedModel}
+          sessionModel={sessionModel}
+          isOverride={modelOverride}
           options={modelOptions}
           disabled={isStreaming || modelControlled}
           trigger="slash"

--- a/packages/agent/src/front/chat/pi/__tests__/piChatReducer.test.ts
+++ b/packages/agent/src/front/chat/pi/__tests__/piChatReducer.test.ts
@@ -80,6 +80,20 @@ describe('piChatReducer', () => {
     expect(state.notices).toContainEqual(expect.objectContaining({ id: 'stale-outbox-cleared', level: 'warning' }))
   })
 
+  it('refreshes the authoritative current model from each addressed state snapshot', () => {
+    const first = piChatReducer(initial(), {
+      type: 'hydrate',
+      snapshot: snapshot({ currentModel: { provider: 'openai-codex', id: 'gpt-5.6-sol' } }),
+    })
+    expect(first.currentModel).toEqual({ provider: 'openai-codex', id: 'gpt-5.6-sol' })
+
+    const refreshed = piChatReducer(first, {
+      type: 'hydrate',
+      snapshot: snapshot({ seq: 11, currentModel: { provider: 'openai', id: 'gpt-5.7' } }),
+    })
+    expect(refreshed.currentModel).toEqual({ provider: 'openai', id: 'gpt-5.7' })
+  })
+
   it('preserves a first prompt submitted while the empty session snapshot is hydrating', () => {
     let state = initial()
     state = piChatReducer(state, { type: 'optimistic-user-message', message: optimistic('nonce-first', 'first message') })

--- a/packages/agent/src/front/chat/pi/__tests__/remotePiSession.test.ts
+++ b/packages/agent/src/front/chat/pi/__tests__/remotePiSession.test.ts
@@ -726,6 +726,32 @@ describe('RemotePiSession', () => {
     session.dispose()
   })
 
+  it('updates an already-connected viewer from an external model-change event', async () => {
+    const events = openNdjsonStream()
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith('/state')) return jsonResponse(snapshot({
+        seq: 5,
+        status: 'idle',
+        activeTurnId: undefined,
+        currentModel: { provider: 'openai', id: 'gpt-old' },
+      }))
+      if (url.endsWith('/events?cursor=5')) return new Response(events.stream)
+      throw new Error(`unexpected URL ${url}`)
+    }) as unknown as MockFetch
+    const session = createSession(fetchMock)
+    await waitUntil(() => session.getState().connection.state === 'connected')
+
+    events.write({
+      type: 'model-changed',
+      seq: 6,
+      currentModel: { provider: 'openai-codex', id: 'gpt-5.6-sol' },
+    } satisfies PiChatEvent)
+
+    await waitUntil(() => session.getState().currentModel?.id === 'gpt-5.6-sol')
+    expect(session.getState().currentModel).toEqual({ provider: 'openai-codex', id: 'gpt-5.6-sol' })
+    session.dispose()
+  })
+
   it('confirms an accepted next-message override as the session current model', async () => {
     const events = openNdjsonStream()
     const model = { provider: 'openai', id: 'gpt-5.7' }

--- a/packages/agent/src/front/chat/pi/__tests__/remotePiSession.test.ts
+++ b/packages/agent/src/front/chat/pi/__tests__/remotePiSession.test.ts
@@ -726,6 +726,22 @@ describe('RemotePiSession', () => {
     session.dispose()
   })
 
+  it('confirms an accepted next-message override as the session current model', async () => {
+    const events = openNdjsonStream()
+    const model = { provider: 'openai', id: 'gpt-5.7' }
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith('/events?cursor=0')) return new Response(events.stream)
+      if (url.endsWith('/prompt')) return jsonResponse({ accepted: true, cursor: 0, clientNonce: 'nonce-model' })
+      throw new Error(`unexpected URL ${url}`)
+    }) as unknown as MockFetch
+    const session = createSession(fetchMock, { autoStart: false })
+
+    await session.prompt({ message: 'switch model', clientNonce: 'nonce-model', model })
+
+    expect(session.getState().currentModel).toEqual(model)
+    session.dispose()
+  })
+
   it('opens events from the current cursor before the first command when autoStart is false', async () => {
     const events = openNdjsonStream()
     const promptResponse = deferred<Response>()

--- a/packages/agent/src/front/chat/pi/piChatReducer.ts
+++ b/packages/agent/src/front/chat/pi/piChatReducer.ts
@@ -69,6 +69,7 @@ export interface PiChatState {
   workspaceId?: string
   storageScope: string
   status: PiChatStatus
+  currentModel?: PiChatSnapshot['currentModel']
   turnId?: string
   lastSeq: number
   committedMessages: BoringChatMessage[]
@@ -92,6 +93,7 @@ export interface PiChatState {
 export type PiChatReducerAction =
   | { type: 'hydrate'; snapshot: PiChatSnapshot; allowSeqRewind?: boolean }
   | { type: 'cursor-sync'; cursor: number }
+  | { type: 'model-confirmed'; model: NonNullable<PiChatSnapshot['currentModel']> }
   | { type: 'event'; event: PiChatEvent }
   | { type: 'optimistic-user-message'; message: OptimisticUserMessage }
   | { type: 'remove-optimistic-user-message'; clientNonce: string }
@@ -134,6 +136,8 @@ export function piChatReducer(state: PiChatState, action: PiChatReducerAction): 
       return hydrateFromSnapshot(state, action.snapshot, { allowSeqRewind: action.allowSeqRewind })
     case 'cursor-sync':
       return syncCursor(state, action.cursor)
+    case 'model-confirmed':
+      return { ...state, currentModel: action.model }
     case 'event':
       return applySequencedEvent(state, action.event)
     case 'optimistic-user-message':
@@ -274,6 +278,7 @@ function hydrateFromSnapshot(
     ...state,
     sessionId: snapshot.sessionId,
     status: snapshot.status,
+    currentModel: snapshot.currentModel,
     turnId: snapshot.activeTurnId,
     lastSeq: snapshot.seq,
     committedMessages,

--- a/packages/agent/src/front/chat/pi/piChatReducer.ts
+++ b/packages/agent/src/front/chat/pi/piChatReducer.ts
@@ -350,6 +350,8 @@ function applySequencedEvent(state: PiChatState, event: PiChatEvent): PiChatStat
 
 function reduceEvent(state: PiChatState, event: PiChatEvent): PiChatState {
   switch (event.type) {
+    case 'model-changed':
+      return { ...state, currentModel: event.currentModel }
     case 'agent-start':
       return { ...state, status: 'streaming', turnId: event.turnId, error: undefined, streamingPreservedTextPartKeys: undefined }
     case 'agent-end':

--- a/packages/agent/src/front/chat/pi/remotePiSession.ts
+++ b/packages/agent/src/front/chat/pi/remotePiSession.ts
@@ -240,6 +240,9 @@ export class RemotePiSession {
     else if (!this.suspended) this.ensureReconnectScheduled()
     try {
       const receipt = await this.postCommand('/prompt', payload, PromptReceiptSchema)
+      if (!this.disposed && payload.model) {
+        this.store.dispatch({ type: 'model-confirmed', model: payload.model }, { flush: true })
+      }
       return receipt
     } catch (error) {
       this.rollbackOptimisticMessage(payload.clientNonce)

--- a/packages/agent/src/front/chatPanelComposerControls.tsx
+++ b/packages/agent/src/front/chatPanelComposerControls.tsx
@@ -164,6 +164,8 @@ function groupModelOptions(options: AvailableModel[]): Map<string, AvailableMode
 type ModelSelectTriggerProps = Omit<ComponentPropsWithoutRef<'button'>, 'value'> & {
   value: ModelSelection | null
   options: AvailableModel[]
+  sessionModel?: ModelSelection
+  isOverride?: boolean
   disabled?: boolean
   trigger?: SelectorTrigger
   open?: boolean
@@ -173,6 +175,8 @@ type ModelSelectTriggerProps = Omit<ComponentPropsWithoutRef<'button'>, 'value'>
 export const ModelSelectTrigger = forwardRef<HTMLButtonElement, ModelSelectTriggerProps>(function ModelSelectTrigger({
   value,
   options,
+  sessionModel,
+  isOverride = false,
   disabled,
   trigger = 'button',
   open = false,
@@ -182,19 +186,27 @@ export const ModelSelectTrigger = forwardRef<HTMLButtonElement, ModelSelectTrigg
   ...props
 }, ref) {
   const triggerLabel = modelTriggerLabel(value, options, emptyLabel)
+  const sessionTriggerLabel = sessionModel ? modelTriggerLabel(sessionModel, options) : undefined
   // Show the provider alongside the model so the same model name across
   // providers stays unambiguous. The default automatic selection has no
   // provider to show.
   const triggerDisplay = value ? `${triggerLabel} (${displayProviderLabel(value.provider)})` : triggerLabel
+  const sessionDisplay = sessionModel && sessionTriggerLabel
+    ? `${sessionTriggerLabel} (${displayProviderLabel(sessionModel.provider)})`
+    : triggerDisplay
+  const accessibleDisplay = isOverride && value
+    ? `Current model: ${sessionDisplay}. Next-message override: ${triggerDisplay}`
+    : `Current model: ${sessionDisplay}`
   return (
     <button
       ref={ref}
       type="button"
       data-boring-agent-part="model-select"
       data-boring-state={disabled ? "disabled" : undefined}
+      data-boring-model-override={isOverride ? "true" : undefined}
       disabled={disabled}
-      aria-label={trigger === 'slash' ? `Open model picker. Current model: ${triggerDisplay}` : 'Model'}
-      title={trigger === 'slash' ? `Open model picker. Current model: ${triggerDisplay}` : undefined}
+      aria-label={trigger === 'slash' ? `Open model picker. ${accessibleDisplay}` : 'Model'}
+      title={trigger === 'slash' ? accessibleDisplay : undefined}
       onClick={onClick}
       className={cn(
         trigger === 'slash'
@@ -209,8 +221,15 @@ export const ModelSelectTrigger = forwardRef<HTMLButtonElement, ModelSelectTrigg
       {trigger === 'slash' ? (
         <>
           <span className="text-muted-foreground">Model · </span>
-          <span className="min-w-0 truncate text-foreground">{triggerLabel}</span>
-          {value ? <span className="shrink-0 text-muted-foreground"> · {displayProviderLabel(value.provider)}</span> : null}
+          <span className="min-w-0 truncate text-foreground">{sessionTriggerLabel ?? triggerLabel}</span>
+          {sessionModel ? (
+            <span className="shrink-0 text-muted-foreground"> · {displayProviderLabel(sessionModel.provider)}</span>
+          ) : value ? (
+            <span className="shrink-0 text-muted-foreground"> · {displayProviderLabel(value.provider)}</span>
+          ) : null}
+          {isOverride && value ? (
+            <span className="shrink-0 text-amber-600 dark:text-amber-400"> · Next override: {triggerLabel} · {displayProviderLabel(value.provider)}</span>
+          ) : null}
         </>
       ) : (
         <>

--- a/packages/agent/src/front/hooks/__tests__/useChatModelSelection.test.tsx
+++ b/packages/agent/src/front/hooks/__tests__/useChatModelSelection.test.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
-import { readPiComposerSettings, type ActiveSessionStorageLike } from '../../chat/session'
+import { readPiComposerSettings, scopedComposerStorageKey, type ActiveSessionStorageLike } from '../../chat/session'
+import type { ModelSelection } from '../../chatPanelSettings'
 import { useChatModelSelection as useAddressedChatModelSelection } from '../useChatModelSelection'
 
 function useChatModelSelection(options: Omit<Parameters<typeof useAddressedChatModelSelection>[0], 'agentTypeId'> & { agentTypeId?: string }) {
@@ -37,6 +38,91 @@ describe('useChatModelSelection', () => {
 
     await waitFor(() => expect(result.current.model).toBeNull())
     expect(readPiComposerSettings({ storageScope: 'scope-b', storage: store }).model).toBeNull()
+  })
+
+  it('uses addressed session model instead of conflicting browser storage for an existing session', async () => {
+    const stale = { provider: 'infomaniak', id: 'Kimi-K2.6' } as const
+    const currentModel = { provider: 'openai-codex', id: 'gpt-5.6-sol' } as const
+    const store = storage({
+      [scopedComposerStorageKey('scope-a', 'model')]: JSON.stringify(stale),
+      [scopedComposerStorageKey('scope-a', 'model:user-selected')]: '1',
+    })
+
+    const { result } = renderHook(() => useChatModelSelection({
+      sessionId: 'api-created',
+      sessionHydrated: true,
+      sessionModel: currentModel,
+      storageScope: 'scope-a',
+      storage: store,
+      enabled: false,
+    }))
+
+    await waitFor(() => expect(result.current.model).toEqual(currentModel))
+    expect(result.current.sessionModel).toEqual(currentModel)
+    expect(result.current.isOverride).toBe(false)
+  })
+
+  it('uses local storage only as the default for a genuinely new session', async () => {
+    const localDefault = { provider: 'openai', id: 'gpt-new-default' } as const
+    const store = storage({
+      [scopedComposerStorageKey('scope-a', 'model')]: JSON.stringify(localDefault),
+      [scopedComposerStorageKey('scope-a', 'model:user-selected')]: '1',
+    })
+
+    const { result } = renderHook(() => useChatModelSelection({
+      sessionId: 'new-session',
+      sessionHydrated: true,
+      sessionIsNew: true,
+      storageScope: 'scope-a',
+      storage: store,
+      enabled: false,
+    }))
+
+    await waitFor(() => expect(result.current.model).toEqual(localDefault))
+    expect(result.current.sessionModel).toBeUndefined()
+    expect(result.current.isOverride).toBe(false)
+  })
+
+  it('represents an explicit next-message model difference as an override and clears it on refresh', async () => {
+    const currentModel: ModelSelection = { provider: 'openai-codex', id: 'gpt-5.6-sol' } as const
+    const override = { provider: 'openai', id: 'gpt-5.7' } as const
+    const store = storage()
+    const { result, rerender } = renderHook(
+      ({ sessionModel }) => useChatModelSelection({
+        sessionId: 'existing',
+        sessionHydrated: true,
+        sessionModel,
+        storageScope: 'scope-a',
+        storage: store,
+        enabled: false,
+      }),
+      { initialProps: { sessionModel: currentModel } },
+    )
+
+    act(() => result.current.setModel(override))
+    expect(result.current.model).toEqual(override)
+    expect(result.current.sessionModel).toEqual(currentModel)
+    expect(result.current.isOverride).toBe(true)
+
+    rerender({ sessionModel: override })
+    await waitFor(() => expect(result.current.isOverride).toBe(false))
+    expect(result.current.model).toEqual(override)
+  })
+
+  it('does not fall back to local storage for a non-new session whose model authority is unavailable', async () => {
+    const store = storage({
+      [scopedComposerStorageKey('scope-a', 'model')]: JSON.stringify({ provider: 'infomaniak', id: 'stale' }),
+    })
+    const { result } = renderHook(() => useChatModelSelection({
+      sessionId: 'existing-with-history',
+      sessionHydrated: true,
+      sessionIsNew: false,
+      storageScope: 'scope-a',
+      storage: store,
+      enabled: false,
+    }))
+
+    expect(result.current.model).toBeNull()
   })
 
   it('normalizes discovered model metadata before storing a prompt selection', async () => {

--- a/packages/agent/src/front/hooks/__tests__/useChatModelSelection.test.tsx
+++ b/packages/agent/src/front/hooks/__tests__/useChatModelSelection.test.tsx
@@ -83,6 +83,28 @@ describe('useChatModelSelection', () => {
     expect(result.current.isOverride).toBe(false)
   })
 
+  it('restores a local default as an honest override for a still-empty new session', async () => {
+    const sessionModel = { provider: 'anthropic', id: 'claude-sonnet' } as const
+    const localDefault = { provider: 'anthropic', id: 'claude-opus' } as const
+    const store = storage({
+      [scopedComposerStorageKey('scope-a', 'model')]: JSON.stringify(localDefault),
+      [scopedComposerStorageKey('scope-a', 'model:user-selected')]: '1',
+    })
+    const { result } = renderHook(() => useChatModelSelection({
+      sessionId: 'empty-new',
+      sessionHydrated: true,
+      sessionIsNew: true,
+      sessionModel,
+      storageScope: 'scope-a',
+      storage: store,
+      enabled: false,
+    }))
+
+    await waitFor(() => expect(result.current.isOverride).toBe(true))
+    expect(result.current.sessionModel).toEqual(sessionModel)
+    expect(result.current.model).toEqual(localDefault)
+  })
+
   it('represents an explicit next-message model difference as an override and clears it on refresh', async () => {
     const currentModel: ModelSelection = { provider: 'openai-codex', id: 'gpt-5.6-sol' } as const
     const override = { provider: 'openai', id: 'gpt-5.7' } as const

--- a/packages/agent/src/front/hooks/useChatModelSelection.ts
+++ b/packages/agent/src/front/hooks/useChatModelSelection.ts
@@ -15,6 +15,10 @@ export function useChatModelSelection({
   agentTypeId,
   apiBaseUrl,
   defaultModel,
+  sessionId,
+  sessionHydrated = sessionId === undefined,
+  sessionIsNew = sessionId === undefined,
+  sessionModel,
   fetch: fetchImpl,
   requestHeaders,
   storage,
@@ -24,6 +28,10 @@ export function useChatModelSelection({
   agentTypeId: string
   apiBaseUrl?: string
   defaultModel?: ModelSelection
+  sessionId?: string
+  sessionHydrated?: boolean
+  sessionIsNew?: boolean
+  sessionModel?: ModelSelection
   fetch?: typeof globalThis.fetch
   requestHeaders?: Record<string, string>
   storage?: ActiveSessionStorageLike
@@ -31,11 +39,13 @@ export function useChatModelSelection({
   enabled?: boolean
 }) {
   const initialModelState = useMemo(() => readPiComposerSettings({ storageScope, storage }), [])
-  const [model, setModelState] = useState<ModelSelection | null>(
-    () => initialModelState.model ?? defaultModel ?? null,
-  )
+  const [model, setModelState] = useState<ModelSelection | null>(() => {
+    if (sessionId && (!sessionHydrated || (!sessionModel && !sessionIsNew))) return null
+    return sessionModel ?? initialModelState.model ?? defaultModel ?? null
+  })
+  const [selectionSessionId, setSelectionSessionId] = useState(sessionId)
   const [userSelectedModel, setUserSelectedModel] = useState<boolean>(
-    () => initialModelState.userSelectedModel,
+    () => sessionId === undefined && initialModelState.userSelectedModel,
   )
   const userSelectedModelRef = useRef(userSelectedModel)
   const loadedSettingsSourceRef = useRef({ storage, storageScope })
@@ -45,11 +55,15 @@ export function useChatModelSelection({
 
   const setModel = useCallback((next: ModelSelection | null) => {
     const normalized = next === null ? null : parseModelSelection(next)
-    userSelectedModelRef.current = normalized !== null
-    setUserSelectedModel(normalized !== null)
-    setModelState(normalized)
+    const differsFromSession = normalized !== null && sessionModel !== undefined
+      && (normalized.provider !== sessionModel.provider || normalized.id !== sessionModel.id)
+    const userSelected = sessionModel ? differsFromSession : normalized !== null && (!sessionId || sessionIsNew)
+    userSelectedModelRef.current = userSelected
+    setUserSelectedModel(userSelected)
+    setSelectionSessionId(sessionId)
+    setModelState(normalized ?? sessionModel ?? null)
     writePiComposerModelSelection(normalized, { storageScope, storage })
-  }, [storage, storageScope])
+  }, [sessionId, sessionIsNew, sessionModel, storage, storageScope])
 
   const discoveryKey = useMemo(
     () => JSON.stringify({
@@ -73,15 +87,34 @@ export function useChatModelSelection({
   useEffect(() => {
     const settings = readPiComposerSettings({ storageScope, storage })
     loadedSettingsSourceRef.current = { storage, storageScope }
-    userSelectedModelRef.current = settings.userSelectedModel
-    setUserSelectedModel(settings.userSelectedModel)
+    setSelectionSessionId(sessionId)
+    if (sessionId && (!sessionHydrated || (!sessionModel && !sessionIsNew))) {
+      userSelectedModelRef.current = false
+      setUserSelectedModel(false)
+      setModelState(null)
+      return
+    }
+    if (sessionModel) {
+      const currentIsOverride = userSelectedModelRef.current
+        && selectionSessionId === sessionId
+        && model !== null
+        && (model.provider !== sessionModel.provider || model.id !== sessionModel.id)
+      if (currentIsOverride) return
+      userSelectedModelRef.current = false
+      setUserSelectedModel(false)
+      setModelState(sessionModel)
+      return
+    }
+    const userSelected = sessionId === undefined && settings.userSelectedModel
+    userSelectedModelRef.current = userSelected
+    setUserSelectedModel(userSelected)
     setModelState(settings.model ?? defaultModel ?? null)
-  }, [storage, storageScope])
+  }, [defaultModel, sessionHydrated, sessionId, sessionIsNew, sessionModel?.id, sessionModel?.provider, storage, storageScope])
 
   useEffect(() => {
-    if (userSelectedModelRef.current || !defaultModel) return
+    if (sessionModel || (sessionId && (!sessionHydrated || !sessionIsNew)) || userSelectedModelRef.current || !defaultModel) return
     setModelState(defaultModel)
-  }, [defaultModel])
+  }, [defaultModel, sessionHydrated, sessionId, sessionIsNew, sessionModel])
 
   // Fetch the live list from pi's ModelRegistry so the dropdown reflects
   // what the server actually has auth for, not a hardcoded alias set.
@@ -104,8 +137,8 @@ export function useChatModelSelection({
           userSelectedModelRef.current = false
           setUserSelectedModel(false)
           setAvailableModels([])
-          setModelState(null)
-          writePiComposerModelSelection(null, { storageScope, storage })
+          setModelState(sessionModel ?? null)
+          if (!sessionModel) writePiComposerModelSelection(null, { storageScope, storage })
           setLoadedDiscoveryKey(discoveryKey)
           setLoaded(true)
           return
@@ -124,6 +157,8 @@ export function useChatModelSelection({
           setUserSelectedModel(false)
           writePiComposerModelSelection(null, { storageScope, storage })
 
+          if (sessionModel) return sessionModel
+          if (sessionId && !sessionIsNew) return null
           if (payload.defaultModel) return { provider: payload.defaultModel.provider, id: payload.defaultModel.id }
           const firstAvailable = available[0]
           return firstAvailable ? { provider: firstAvailable.provider, id: firstAvailable.id } : null
@@ -134,13 +169,13 @@ export function useChatModelSelection({
         userSelectedModelRef.current = false
         setUserSelectedModel(false)
         setAvailableModels([])
-        setModelState(null)
-        writePiComposerModelSelection(null, { storageScope, storage })
+        setModelState(sessionModel ?? null)
+        if (!sessionModel) writePiComposerModelSelection(null, { storageScope, storage })
         setLoadedDiscoveryKey(discoveryKey)
         setLoaded(true)
       })
     return () => { aborted = true }
-  }, [agentTypeId, apiBaseUrl, discoveryKey, enabled, fetchImpl, requestHeaders, storage, storageScope])
+  }, [agentTypeId, apiBaseUrl, discoveryKey, enabled, fetchImpl, requestHeaders, sessionId, sessionIsNew, sessionModel, storage, storageScope])
 
   // Optional integration hook for host slash commands. Accepts explicit
   // provider-qualified selections only ({ provider, id } or "provider:id");
@@ -157,7 +192,23 @@ export function useChatModelSelection({
 
   const currentDiscoveryLoaded = !enabled || (loaded && loadedDiscoveryKey === discoveryKey)
   const currentAvailableModels = currentDiscoveryLoaded ? availableModels : []
-  const currentModel = currentDiscoveryLoaded ? model : null
+  const selectionBelongsToSession = selectionSessionId === sessionId
+  const isOverride = Boolean(
+    selectionBelongsToSession
+      && sessionModel
+      && model
+      && (model.provider !== sessionModel.provider || model.id !== sessionModel.id),
+  )
+  const currentModel = currentDiscoveryLoaded && (!sessionId || (sessionHydrated && (sessionModel !== undefined || sessionIsNew)))
+    ? isOverride ? model : sessionModel ?? model
+    : null
 
-  return { availableModels: currentAvailableModels, loaded: currentDiscoveryLoaded, model: currentModel, setModel }
+  return {
+    availableModels: currentAvailableModels,
+    loaded: currentDiscoveryLoaded,
+    model: currentModel,
+    sessionModel,
+    isOverride,
+    setModel,
+  }
 }

--- a/packages/agent/src/front/hooks/useChatModelSelection.ts
+++ b/packages/agent/src/front/hooks/useChatModelSelection.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { agentResourceUrl, withStorageScope } from '../agentHttp'
 import {
   parseModelSelection,
@@ -10,6 +10,24 @@ import {
   readPiComposerSettings,
   writePiComposerModelSelection,
 } from '../chat/session/composerPolicy'
+
+interface SessionModelSelection {
+  sessionId?: string
+  storage?: ActiveSessionStorageLike
+  storageScope?: string
+  localDefault: ModelSelection | null
+  pendingOverride?: ModelSelection
+}
+
+function sameModel(left: ModelSelection | null | undefined, right: ModelSelection | null | undefined): boolean {
+  return left?.provider === right?.provider && left?.id === right?.id
+}
+
+function availableModel(models: AvailableModel[], model: ModelSelection | null | undefined): boolean {
+  return Boolean(model && models.some((candidate) => (
+    candidate.available && candidate.provider === model.provider && candidate.id === model.id
+  )))
+}
 
 export function useChatModelSelection({
   agentTypeId,
@@ -38,30 +56,44 @@ export function useChatModelSelection({
   storageScope?: string
   enabled?: boolean
 }) {
-  const initialModelState = useMemo(() => readPiComposerSettings({ storageScope, storage }), [])
-  const [model, setModelState] = useState<ModelSelection | null>(() => {
-    if (sessionId && (!sessionHydrated || (!sessionModel && !sessionIsNew))) return null
-    return sessionModel ?? initialModelState.model ?? defaultModel ?? null
-  })
-  const [selectionSessionId, setSelectionSessionId] = useState(sessionId)
-  const [userSelectedModel, setUserSelectedModel] = useState<boolean>(
-    () => sessionId === undefined && initialModelState.userSelectedModel,
-  )
-  const userSelectedModelRef = useRef(userSelectedModel)
-  const loadedSettingsSourceRef = useRef({ storage, storageScope })
+  const initialSettings = useMemo(() => readPiComposerSettings({ storageScope, storage }), [])
+  const [selection, setSelection] = useState<SessionModelSelection>(() => ({
+    sessionId,
+    storage,
+    storageScope,
+    localDefault: initialSettings.model ?? defaultModel ?? null,
+  }))
+
   useEffect(() => {
-    userSelectedModelRef.current = userSelectedModel
-  }, [userSelectedModel])
+    const settings = readPiComposerSettings({ storageScope, storage })
+    setSelection((current) => {
+      const sameSession = current.sessionId === sessionId
+      const pendingOverride = sameSession
+        && current.pendingOverride
+        && sessionModel
+        && !sameModel(current.pendingOverride, sessionModel)
+        ? current.pendingOverride
+        : undefined
+      return {
+        sessionId,
+        storage,
+        storageScope,
+        localDefault: settings.model ?? defaultModel ?? null,
+        ...(pendingOverride ? { pendingOverride } : {}),
+      }
+    })
+  }, [defaultModel, sessionId, sessionModel?.id, sessionModel?.provider, storage, storageScope])
 
   const setModel = useCallback((next: ModelSelection | null) => {
     const normalized = next === null ? null : parseModelSelection(next)
-    const differsFromSession = normalized !== null && sessionModel !== undefined
-      && (normalized.provider !== sessionModel.provider || normalized.id !== sessionModel.id)
-    const userSelected = sessionModel ? differsFromSession : normalized !== null && (!sessionId || sessionIsNew)
-    userSelectedModelRef.current = userSelected
-    setUserSelectedModel(userSelected)
-    setSelectionSessionId(sessionId)
-    setModelState(normalized ?? sessionModel ?? null)
+    setSelection((current) => {
+      if (sessionModel) {
+        const pendingOverride = normalized && !sameModel(normalized, sessionModel) ? normalized : undefined
+        return { ...current, sessionId, ...(pendingOverride ? { pendingOverride } : { pendingOverride: undefined }) }
+      }
+      if (sessionId && !sessionIsNew) return current
+      return { ...current, sessionId, localDefault: normalized, pendingOverride: undefined }
+    })
     writePiComposerModelSelection(normalized, { storageScope, storage })
   }, [sessionId, sessionIsNew, sessionModel, storage, storageScope])
 
@@ -79,46 +111,6 @@ export function useChatModelSelection({
   const [loadedDiscoveryKey, setLoadedDiscoveryKey] = useState<string | null>(enabled ? null : discoveryKey)
 
   useEffect(() => {
-    if (loadedSettingsSourceRef.current.storage !== storage || loadedSettingsSourceRef.current.storageScope !== storageScope) return
-    if (!userSelectedModel || !model) return
-    writePiComposerModelSelection(model, { storageScope, storage })
-  }, [model, storage, storageScope, userSelectedModel])
-
-  useEffect(() => {
-    const settings = readPiComposerSettings({ storageScope, storage })
-    loadedSettingsSourceRef.current = { storage, storageScope }
-    setSelectionSessionId(sessionId)
-    if (sessionId && (!sessionHydrated || (!sessionModel && !sessionIsNew))) {
-      userSelectedModelRef.current = false
-      setUserSelectedModel(false)
-      setModelState(null)
-      return
-    }
-    if (sessionModel) {
-      const currentIsOverride = userSelectedModelRef.current
-        && selectionSessionId === sessionId
-        && model !== null
-        && (model.provider !== sessionModel.provider || model.id !== sessionModel.id)
-      if (currentIsOverride) return
-      userSelectedModelRef.current = false
-      setUserSelectedModel(false)
-      setModelState(sessionModel)
-      return
-    }
-    const userSelected = sessionId === undefined && settings.userSelectedModel
-    userSelectedModelRef.current = userSelected
-    setUserSelectedModel(userSelected)
-    setModelState(settings.model ?? defaultModel ?? null)
-  }, [defaultModel, sessionHydrated, sessionId, sessionIsNew, sessionModel?.id, sessionModel?.provider, storage, storageScope])
-
-  useEffect(() => {
-    if (sessionModel || (sessionId && (!sessionHydrated || !sessionIsNew)) || userSelectedModelRef.current || !defaultModel) return
-    setModelState(defaultModel)
-  }, [defaultModel, sessionHydrated, sessionId, sessionIsNew, sessionModel])
-
-  // Fetch the live list from pi's ModelRegistry so the dropdown reflects
-  // what the server actually has auth for, not a hardcoded alias set.
-  useEffect(() => {
     if (!enabled) {
       setLoaded(true)
       setLoadedDiscoveryKey(discoveryKey)
@@ -130,46 +122,40 @@ export function useChatModelSelection({
     nextFetch(agentResourceUrl(apiBaseUrl, `/api/v1/agents/${encodeURIComponent(agentTypeId)}/models`), {
       headers: withStorageScope(requestHeaders, storageScope),
     })
-      .then((res) => (res.ok ? res.json() : null))
+      .then((response) => (response.ok ? response.json() : null))
       .then((payload: { models?: AvailableModel[]; defaultModel?: ModelSelection } | null) => {
         if (aborted) return
-        if (!payload?.models) {
-          userSelectedModelRef.current = false
-          setUserSelectedModel(false)
+        const models = payload?.models
+        if (!models) {
           setAvailableModels([])
-          setModelState(sessionModel ?? null)
+          setSelection((current) => ({ ...current, pendingOverride: undefined, localDefault: sessionModel ?? null }))
           if (!sessionModel) writePiComposerModelSelection(null, { storageScope, storage })
           setLoadedDiscoveryKey(discoveryKey)
           setLoaded(true)
           return
         }
-        setAvailableModels(payload.models)
+
+        setAvailableModels(models)
+        setSelection((current) => {
+          const selected = current.pendingOverride ?? sessionModel ?? current.localDefault
+          if (availableModel(models, selected)) return current
+          if (sessionModel) return { ...current, pendingOverride: undefined }
+          if (sessionId && !sessionIsNew) return { ...current, pendingOverride: undefined, localDefault: null }
+          const firstAvailable = models.find((candidate) => candidate.available)
+          return {
+            ...current,
+            pendingOverride: undefined,
+            localDefault: payload.defaultModel
+              ?? (firstAvailable ? { provider: firstAvailable.provider, id: firstAvailable.id } : null),
+          }
+        })
         setLoadedDiscoveryKey(discoveryKey)
         setLoaded(true)
-        const available = payload.models.filter((m) => m.available)
-        setModelState((current) => {
-          const currentAvailable = current
-            ? available.some((m) => m.provider === current.provider && m.id === current.id)
-            : false
-          if (currentAvailable) return current
-
-          userSelectedModelRef.current = false
-          setUserSelectedModel(false)
-          writePiComposerModelSelection(null, { storageScope, storage })
-
-          if (sessionModel) return sessionModel
-          if (sessionId && !sessionIsNew) return null
-          if (payload.defaultModel) return { provider: payload.defaultModel.provider, id: payload.defaultModel.id }
-          const firstAvailable = available[0]
-          return firstAvailable ? { provider: firstAvailable.provider, id: firstAvailable.id } : null
-        })
       })
       .catch(() => {
         if (aborted) return
-        userSelectedModelRef.current = false
-        setUserSelectedModel(false)
         setAvailableModels([])
-        setModelState(sessionModel ?? null)
+        setSelection((current) => ({ ...current, pendingOverride: undefined, localDefault: sessionModel ?? null }))
         if (!sessionModel) writePiComposerModelSelection(null, { storageScope, storage })
         setLoadedDiscoveryKey(discoveryKey)
         setLoaded(true)
@@ -177,10 +163,6 @@ export function useChatModelSelection({
     return () => { aborted = true }
   }, [agentTypeId, apiBaseUrl, discoveryKey, enabled, fetchImpl, requestHeaders, sessionId, sessionIsNew, sessionModel, storage, storageScope])
 
-  // Optional integration hook for host slash commands. Accepts explicit
-  // provider-qualified selections only ({ provider, id } or "provider:id");
-  // unqualified legacy aliases are intentionally ignored so Boring never
-  // guesses a model provider on Pi's behalf.
   useEffect(() => {
     const onChange = (event: Event) => {
       const next = parseModelSelection((event as CustomEvent).detail)
@@ -191,22 +173,20 @@ export function useChatModelSelection({
   }, [setModel])
 
   const currentDiscoveryLoaded = !enabled || (loaded && loadedDiscoveryKey === discoveryKey)
-  const currentAvailableModels = currentDiscoveryLoaded ? availableModels : []
-  const selectionBelongsToSession = selectionSessionId === sessionId
-  const isOverride = Boolean(
-    selectionBelongsToSession
-      && sessionModel
-      && model
-      && (model.provider !== sessionModel.provider || model.id !== sessionModel.id),
-  )
-  const currentModel = currentDiscoveryLoaded && (!sessionId || (sessionHydrated && (sessionModel !== undefined || sessionIsNew)))
-    ? isOverride ? model : sessionModel ?? model
+  const selectionBelongsToSession = selection.sessionId === sessionId
+    && selection.storage === storage
+    && selection.storageScope === storageScope
+  const pendingOverride = selectionBelongsToSession ? selection.pendingOverride : undefined
+  const isOverride = Boolean(pendingOverride && sessionModel && !sameModel(pendingOverride, sessionModel))
+  const sessionAuthorityReady = !sessionId || (sessionHydrated && (sessionModel !== undefined || sessionIsNew))
+  const model = currentDiscoveryLoaded && sessionAuthorityReady
+    ? pendingOverride ?? sessionModel ?? selection.localDefault
     : null
 
   return {
-    availableModels: currentAvailableModels,
+    availableModels: currentDiscoveryLoaded ? availableModels : [],
     loaded: currentDiscoveryLoaded,
-    model: currentModel,
+    model,
     sessionModel,
     isOverride,
     setModel,

--- a/packages/agent/src/front/hooks/useChatModelSelection.ts
+++ b/packages/agent/src/front/hooks/useChatModelSelection.ts
@@ -73,7 +73,9 @@ export function useChatModelSelection({
         && sessionModel
         && !sameModel(current.pendingOverride, sessionModel)
         ? current.pendingOverride
-        : undefined
+        : sessionIsNew && sessionModel && settings.model && !sameModel(settings.model, sessionModel)
+          ? settings.model
+          : undefined
       return {
         sessionId,
         storage,
@@ -82,7 +84,7 @@ export function useChatModelSelection({
         ...(pendingOverride ? { pendingOverride } : {}),
       }
     })
-  }, [defaultModel, sessionId, sessionModel?.id, sessionModel?.provider, storage, storageScope])
+  }, [defaultModel, sessionId, sessionIsNew, sessionModel?.id, sessionModel?.provider, storage, storageScope])
 
   const setModel = useCallback((next: ModelSelection | null) => {
     const normalized = next === null ? null : parseModelSelection(next)

--- a/packages/agent/src/server/harness/pi-coding-agent/__tests__/sessions.load.test.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/__tests__/sessions.load.test.ts
@@ -116,6 +116,36 @@ describe("PiSessionStore.loadEntries transcript reconstruction", () => {
     await expect(store.list(ctx)).resolves.toEqual([]);
   });
 
+  it("returns the latest persisted model change even when no later assistant message exists", async () => {
+    const sessionId = "sess-model-change";
+    const filepath = join(tmpDir, `${sessionId}.jsonl`);
+    const lines = [
+      { type: "session", version: 1, id: sessionId, timestamp: "2026-05-01T00:00:00.000Z", cwd: "/workspace" },
+      {
+        type: "message",
+        id: "a1",
+        parentId: null,
+        timestamp: "2026-05-01T00:00:01.000Z",
+        message: { role: "assistant", provider: "openai", model: "gpt-old", content: [{ type: "text", text: "old" }] },
+      },
+      {
+        type: "model_change",
+        id: "model-2",
+        parentId: "a1",
+        timestamp: "2026-05-01T00:00:02.000Z",
+        provider: "openai-codex",
+        modelId: "gpt-5.6-sol",
+      },
+    ];
+    await writeFile(filepath, `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`, "utf-8");
+
+    const store = new PiSessionStore("/workspace", tmpDir);
+    const entries = await store.loadEntries(ctx, sessionId);
+
+    expect(entries.currentModel).toEqual({ provider: "openai-codex", id: "gpt-5.6-sol" });
+    expect(entries.messages).toHaveLength(1);
+  });
+
   it("serves historical image attachment bytes from the raw transcript without requiring /state to inline them", async () => {
     const sessionId = "sess-image-history";
     const filepath = join(tmpDir, `${sessionId}.jsonl`);

--- a/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
@@ -23,6 +23,7 @@ import {
   CURRENT_SESSION_VERSION,
 } from "@mariozechner/pi-coding-agent";
 import { ErrorCode } from "../../../shared/error-codes.js";
+import type { ChatModelSelection } from "../../../shared/chat/chatSubmitPayload.js";
 import {
   SAFE_NATIVE_SESSION_ID,
   type SessionStore,
@@ -48,33 +49,33 @@ export {
 export interface PiSessionEntries {
   id: string;
   messages: unknown[];
-  currentModel?: { provider: string; id: string };
+  currentModel?: ChatModelSelection;
 }
 
-function currentModelFromTranscript(entries: readonly SessionEntry[]): { provider: string; id: string } | undefined {
+function legacyAssistantModel(entry: SessionMessageEntry): ChatModelSelection | undefined {
+  const message = entry.message as unknown as Record<string, unknown>;
+  if (message.role !== "assistant") return undefined;
+  if (typeof message.provider === "string" && typeof message.model === "string") {
+    return { provider: message.provider, id: message.model };
+  }
+  if (typeof message.model !== "object" || message.model === null) return undefined;
+  const model = message.model as Record<string, unknown>;
+  return typeof model.provider === "string" && typeof model.id === "string"
+    ? { provider: model.provider, id: model.id }
+    : undefined;
+}
+
+function currentModelFromTranscript(entries: readonly SessionEntry[]): ChatModelSelection | undefined {
   for (let index = entries.length - 1; index >= 0; index -= 1) {
-    const raw = entries[index] as unknown
-    if (typeof raw !== "object" || raw === null) continue
-    const entry = raw as Record<string, unknown>
-    if (entry.type === "model_change") {
-      const provider = entry.provider
-      const id = entry.modelId ?? entry.model
-      if (typeof provider === "string" && typeof id === "string") return { provider, id }
-    }
-    if (entry.type !== "message" || typeof entry.message !== "object" || entry.message === null) continue
-    const message = entry.message as Record<string, unknown>
-    if (message.role !== "assistant") continue
-    if (typeof message.provider === "string" && typeof message.model === "string") {
-      return { provider: message.provider, id: message.model }
-    }
-    if (typeof message.model === "object" && message.model !== null) {
-      const model = message.model as Record<string, unknown>
-      if (typeof model.provider === "string" && typeof model.id === "string") {
-        return { provider: model.provider, id: model.id }
-      }
+    const entry = entries[index];
+    if (!entry) continue;
+    if (entry.type === "model_change") return { provider: entry.provider, id: entry.modelId };
+    if (entry.type === "message") {
+      const model = legacyAssistantModel(entry);
+      if (model) return model;
     }
   }
-  return undefined
+  return undefined;
 }
 
 export interface PiSessionAttachment {

--- a/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
@@ -48,6 +48,33 @@ export {
 export interface PiSessionEntries {
   id: string;
   messages: unknown[];
+  currentModel?: { provider: string; id: string };
+}
+
+function currentModelFromTranscript(entries: readonly SessionEntry[]): { provider: string; id: string } | undefined {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const raw = entries[index] as unknown
+    if (typeof raw !== "object" || raw === null) continue
+    const entry = raw as Record<string, unknown>
+    if (entry.type === "model_change") {
+      const provider = entry.provider
+      const id = entry.modelId ?? entry.model
+      if (typeof provider === "string" && typeof id === "string") return { provider, id }
+    }
+    if (entry.type !== "message" || typeof entry.message !== "object" || entry.message === null) continue
+    const message = entry.message as Record<string, unknown>
+    if (message.role !== "assistant") continue
+    if (typeof message.provider === "string" && typeof message.model === "string") {
+      return { provider: message.provider, id: message.model }
+    }
+    if (typeof message.model === "object" && message.model !== null) {
+      const model = message.model as Record<string, unknown>
+      if (typeof model.provider === "string" && typeof model.id === "string") {
+        return { provider: model.provider, id: model.id }
+      }
+    }
+  }
+  return undefined
 }
 
 export interface PiSessionAttachment {
@@ -310,7 +337,11 @@ export class PiSessionStore implements SessionStore {
     const messages = resolved.transcriptEntries
       .filter((entry): entry is SessionMessageEntry => entry.type === "message")
       .map((entry) => withStableMessageId(entry.message, entry.id));
-    return { id: resolved.resolvedSessionId, messages };
+    return {
+      id: resolved.resolvedSessionId,
+      messages,
+      currentModel: currentModelFromTranscript(resolved.transcriptEntries),
+    };
   }
 
   async loadAttachment(ctx: SessionCtx, sessionId: string, messageId: string, index: number): Promise<PiSessionAttachment> {

--- a/packages/agent/src/server/pi-chat/__tests__/harnessPiChatService.test.ts
+++ b/packages/agent/src/server/pi-chat/__tests__/harnessPiChatService.test.ts
@@ -1087,6 +1087,8 @@ describe('HarnessPiChatService', () => {
           {
             id: 'a1',
             role: 'assistant',
+            provider: 'openai-codex',
+            model: 'gpt-5.6-sol',
             content: [
               { type: 'thinking', thinking: 'thought' },
               {
@@ -1122,6 +1124,7 @@ describe('HarnessPiChatService', () => {
     expect(state).toMatchObject({
       sessionId: 's-history',
       status: 'idle',
+      currentModel: { provider: 'openai-codex', id: 'gpt-5.6-sol' },
       messages: [
         expect.objectContaining({
           id: 'u1',

--- a/packages/agent/src/server/pi-chat/__tests__/harnessPiChatService.test.ts
+++ b/packages/agent/src/server/pi-chat/__tests__/harnessPiChatService.test.ts
@@ -167,24 +167,33 @@ describe('HarnessPiChatService', () => {
     await service.dispose()
   })
 
-  it('publishes an addressed model change before an externally submitted turn', async () => {
+  it('publishes only real addressed model transitions for externally submitted turns', async () => {
     const adapter = createAdapter()
-    const currentModel = { provider: 'openai-codex', id: 'gpt-5.6-sol' }
+    let currentModel = { provider: 'openai', id: 'gpt-old' }
     adapter.currentModel = () => currentModel
-    const { service } = createService(adapter)
+    const harness = createHarness(adapter)
+    vi.mocked(harness.getPiSessionAdapter).mockImplementation(async (input: AgentSendInput) => {
+      if (input.model) currentModel = input.model
+      return adapter
+    })
+    const service = new HarnessPiChatService({ harness, sessionStore, workdir: '/workspace' })
     const events: PiChatEvent[] = []
     const subscription = await service.subscribe(ctx, 's1', 0, (event) => events.push(event))
     if (subscription.type !== 'ok') throw new Error('expected live subscription')
 
+    const nextModel = { provider: 'openai-codex', id: 'gpt-5.6-sol' }
     await service.prompt(ctx, 's1', {
       message: 'automation prompt',
       clientNonce: 'automation-model',
-      model: currentModel,
+      model: nextModel,
     })
-    await vi.waitFor(() => expect(events).toContainEqual(expect.objectContaining({
-      type: 'model-changed',
-      currentModel,
-    })))
+    await service.prompt(ctx, 's1', {
+      message: 'same model again',
+      clientNonce: 'automation-model-2',
+    })
+    await vi.waitFor(() => expect(events.filter((event) => event.type === 'model-changed')).toEqual([
+      expect.objectContaining({ type: 'model-changed', currentModel: nextModel }),
+    ]))
 
     subscription.unsubscribe()
     await service.dispose()

--- a/packages/agent/src/server/pi-chat/__tests__/harnessPiChatService.test.ts
+++ b/packages/agent/src/server/pi-chat/__tests__/harnessPiChatService.test.ts
@@ -19,7 +19,7 @@ const ctx: PiSessionRequestContext = {
 }
 
 type PersistedSessionStore = SessionStore & {
-  loadEntries?: (ctx: { workspaceId?: string; userId?: string }, sessionId: string) => Promise<{ id: string; messages: unknown[] }>
+  loadEntries?: (ctx: { workspaceId?: string; userId?: string }, sessionId: string) => Promise<{ id: string; messages: unknown[]; currentModel?: { provider: string; id: string } }>
 }
 
 const sessionStore: SessionStore = {
@@ -164,6 +164,29 @@ describe('HarnessPiChatService', () => {
       filename: 'live.png',
     })
     subscription.type === 'ok' && subscription.unsubscribe()
+    await service.dispose()
+  })
+
+  it('publishes an addressed model change before an externally submitted turn', async () => {
+    const adapter = createAdapter()
+    const currentModel = { provider: 'openai-codex', id: 'gpt-5.6-sol' }
+    adapter.currentModel = () => currentModel
+    const { service } = createService(adapter)
+    const events: PiChatEvent[] = []
+    const subscription = await service.subscribe(ctx, 's1', 0, (event) => events.push(event))
+    if (subscription.type !== 'ok') throw new Error('expected live subscription')
+
+    await service.prompt(ctx, 's1', {
+      message: 'automation prompt',
+      clientNonce: 'automation-model',
+      model: currentModel,
+    })
+    await vi.waitFor(() => expect(events).toContainEqual(expect.objectContaining({
+      type: 'model-changed',
+      currentModel,
+    })))
+
+    subscription.unsubscribe()
     await service.dispose()
   })
 
@@ -1078,6 +1101,7 @@ describe('HarnessPiChatService', () => {
       ...sessionStore,
       loadEntries: vi.fn(async () => ({
         id: 's-history',
+        currentModel: { provider: 'openai-codex', id: 'gpt-5.6-sol' },
         messages: [
           {
             id: 'u1',

--- a/packages/agent/src/server/pi-chat/__tests__/piChatEvents.test.ts
+++ b/packages/agent/src/server/pi-chat/__tests__/piChatEvents.test.ts
@@ -417,6 +417,22 @@ describe('PiChatEventMapper', () => {
     expect(PiChatEventSchema.parse(end[0])).toEqual(end[0])
   })
 
+  it('maps native model changes into addressed model authority events', () => {
+    const mapper = new PiChatEventMapper({ sessionId: 'sess-1' })
+    const [event] = mapper.map({
+      type: 'model_change',
+      provider: 'openai-codex',
+      modelId: 'gpt-5.6-sol',
+    } as unknown as AgentSessionEvent)
+
+    expect(event).toEqual({
+      type: 'model-changed',
+      seq: 1,
+      currentModel: { provider: 'openai-codex', id: 'gpt-5.6-sol' },
+    })
+    expect(PiChatEventSchema.parse(event)).toEqual(event)
+  })
+
   it('maps queue updates, auto retry notices, UI commands, and assistant errors', () => {
     const mapper = new PiChatEventMapper({ sessionId: 'sess-1' })
 

--- a/packages/agent/src/server/pi-chat/__tests__/piChatEvents.test.ts
+++ b/packages/agent/src/server/pi-chat/__tests__/piChatEvents.test.ts
@@ -417,22 +417,6 @@ describe('PiChatEventMapper', () => {
     expect(PiChatEventSchema.parse(end[0])).toEqual(end[0])
   })
 
-  it('maps native model changes into addressed model authority events', () => {
-    const mapper = new PiChatEventMapper({ sessionId: 'sess-1' })
-    const [event] = mapper.map({
-      type: 'model_change',
-      provider: 'openai-codex',
-      modelId: 'gpt-5.6-sol',
-    } as unknown as AgentSessionEvent)
-
-    expect(event).toEqual({
-      type: 'model-changed',
-      seq: 1,
-      currentModel: { provider: 'openai-codex', id: 'gpt-5.6-sol' },
-    })
-    expect(PiChatEventSchema.parse(event)).toEqual(event)
-  })
-
   it('maps queue updates, auto retry notices, UI commands, and assistant errors', () => {
     const mapper = new PiChatEventMapper({ sessionId: 'sess-1' })
 

--- a/packages/agent/src/server/pi-chat/__tests__/piChatSnapshot.test.ts
+++ b/packages/agent/src/server/pi-chat/__tests__/piChatSnapshot.test.ts
@@ -101,6 +101,16 @@ describe('buildPiChatSnapshot', () => {
     ])
   })
 
+  it('projects the adapter current model into addressed session state', () => {
+    const adapter = createAdapter({ sessionId: 'pi-model' })
+    adapter.currentModel = () => ({ provider: 'openai-codex', id: 'gpt-5.6-sol' })
+
+    expect(buildPiChatSnapshot(adapter, { seq: 8 })).toMatchObject({
+      sessionId: 'pi-model',
+      currentModel: { provider: 'openai-codex', id: 'gpt-5.6-sol' },
+    })
+  })
+
   it('pins followUpMode to one-at-a-time and derives stable queue preview ids', () => {
     const snapshot = buildPiChatSnapshot(
       createAdapter({

--- a/packages/agent/src/server/pi-chat/harnessPiChatService.ts
+++ b/packages/agent/src/server/pi-chat/harnessPiChatService.ts
@@ -1,7 +1,7 @@
 import type { AgentHarness, RunContext, AgentSendInput } from '../../shared/harness'
 import type { SessionCtx, SessionListOptions, SessionStore } from '../../shared/session'
 import type { Workspace } from '../../shared/workspace'
-import type { BoringChatMessage, BoringChatPart, ChatError, FollowUpPayload, FollowUpReceipt, InterruptPayload, PiChatEvent, PiChatSnapshot, PromptPayload, PromptReceipt, QueuedUserMessage, QueueClearPayload, QueueClearReceipt, StopPayload, StopReceipt } from '../../shared/chat'
+import type { BoringChatMessage, BoringChatPart, ChatError, ChatModelSelection, FollowUpPayload, FollowUpReceipt, InterruptPayload, PiChatEvent, PiChatSnapshot, PromptPayload, PromptReceipt, QueuedUserMessage, QueueClearPayload, QueueClearReceipt, StopPayload, StopReceipt } from '../../shared/chat'
 import { sessionStreamPath, type AgentEvent } from '../../shared/events'
 import { ErrorCode } from '../../shared/error-codes'
 import { formatOffset, parseOffset, MAX_READ_LIMIT, type EventStreamStore } from '../events/eventStreamStore'
@@ -30,12 +30,16 @@ type PiNativeHarness = AgentHarness & {
 const MAX_PROMPT_IMAGE_BYTES = 10 * 1024 * 1024
 const PROMPT_IMAGE_EXTENSIONS = new Set(['.avif', '.gif', '.jpg', '.jpeg', '.png', '.webp'])
 
+function sameModelSelection(left: ChatModelSelection | undefined, right: ChatModelSelection): boolean {
+  return left?.provider === right.provider && left.id === right.id
+}
+
 
 /** Pi session stores additionally expose the raw persisted message entries so
  * the cold-load path can run them through the same buildPiChatHistory mapping
  * as the live event path. */
 type PiSessionStoreLike = SessionStore & {
-  loadEntries?: (ctx: { workspaceId?: string; userId?: string }, sessionId: string) => Promise<{ id: string; messages: unknown[]; currentModel?: { provider: string; id: string } }>
+  loadEntries?: (ctx: { workspaceId?: string; userId?: string }, sessionId: string) => Promise<{ id: string; messages: unknown[]; currentModel?: ChatModelSelection }>
   loadAttachment?: (ctx: { workspaceId?: string; userId?: string }, sessionId: string, messageId: string, index: number) => Promise<{ data: Uint8Array; mediaType: string; filename?: string }>
 }
 
@@ -52,6 +56,7 @@ interface LiveSessionChannel {
   rejectClosed: (error: unknown) => void
   activeTurnId?: string
   messageTurnIds: Map<string, string>
+  advertisedModel?: ChatModelSelection
 }
 
 interface SyntheticPromptFailure {
@@ -433,7 +438,8 @@ export class HarnessPiChatService implements PiChatSessionService {
     }
     if (outcome === 'cancelled') throw promptCancelledError()
     const currentModel = adapter.currentModel?.()
-    if (currentModel) {
+    if (currentModel && !sameModelSelection(channel.advertisedModel, currentModel)) {
+      channel.advertisedModel = currentModel
       this.publishChannelEvents(sessionId, channel, [
         channel.mapper.mapSynthetic({ type: 'model-changed', currentModel }),
       ])
@@ -985,6 +991,7 @@ export class HarnessPiChatService implements PiChatSessionService {
       resolveClosed: () => closed.resolve(),
       rejectClosed: closed.reject,
       messageTurnIds: new Map(),
+      advertisedModel: adapter.currentModel?.(),
     }
     const unsubscribe = adapter.subscribe((event) => {
       const mappedEvents = mapper.map(event)

--- a/packages/agent/src/server/pi-chat/harnessPiChatService.ts
+++ b/packages/agent/src/server/pi-chat/harnessPiChatService.ts
@@ -30,6 +30,29 @@ type PiNativeHarness = AgentHarness & {
 const MAX_PROMPT_IMAGE_BYTES = 10 * 1024 * 1024
 const PROMPT_IMAGE_EXTENSIONS = new Set(['.avif', '.gif', '.jpg', '.jpeg', '.png', '.webp'])
 
+
+function currentModelFromPiMessages(entries: readonly unknown[]): { provider: string; id: string } | undefined {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const raw = entries[index]
+    if (typeof raw !== 'object' || raw === null) continue
+    const record = raw as Record<string, unknown>
+    const message = typeof record.message === 'object' && record.message !== null
+      ? record.message as Record<string, unknown>
+      : record
+    if (message.role !== 'assistant') continue
+    if (typeof message.provider === 'string' && typeof message.model === 'string') {
+      return { provider: message.provider, id: message.model }
+    }
+    if (typeof message.model === 'object' && message.model !== null) {
+      const model = message.model as Record<string, unknown>
+      if (typeof model.provider === 'string' && typeof model.id === 'string') {
+        return { provider: model.provider, id: model.id }
+      }
+    }
+  }
+  return undefined
+}
+
 /** Pi session stores additionally expose the raw persisted message entries so
  * the cold-load path can run them through the same buildPiChatHistory mapping
  * as the live event path. */
@@ -377,6 +400,7 @@ export class HarnessPiChatService implements PiChatSessionService {
         sessionId: id,
         seq: await this.readDurableLatestPiChatSeq(sessionStreamPath(this.sessionKey(ctx, id))),
         status: 'idle',
+        currentModel: currentModelFromPiMessages(messages),
         messages: buildPiChatHistory(messages, {
           sessionId: id,
           attachmentUrl: this.attachmentUrlFor(id),

--- a/packages/agent/src/server/pi-chat/harnessPiChatService.ts
+++ b/packages/agent/src/server/pi-chat/harnessPiChatService.ts
@@ -31,33 +31,11 @@ const MAX_PROMPT_IMAGE_BYTES = 10 * 1024 * 1024
 const PROMPT_IMAGE_EXTENSIONS = new Set(['.avif', '.gif', '.jpg', '.jpeg', '.png', '.webp'])
 
 
-function currentModelFromPiMessages(entries: readonly unknown[]): { provider: string; id: string } | undefined {
-  for (let index = entries.length - 1; index >= 0; index -= 1) {
-    const raw = entries[index]
-    if (typeof raw !== 'object' || raw === null) continue
-    const record = raw as Record<string, unknown>
-    const message = typeof record.message === 'object' && record.message !== null
-      ? record.message as Record<string, unknown>
-      : record
-    if (message.role !== 'assistant') continue
-    if (typeof message.provider === 'string' && typeof message.model === 'string') {
-      return { provider: message.provider, id: message.model }
-    }
-    if (typeof message.model === 'object' && message.model !== null) {
-      const model = message.model as Record<string, unknown>
-      if (typeof model.provider === 'string' && typeof model.id === 'string') {
-        return { provider: model.provider, id: model.id }
-      }
-    }
-  }
-  return undefined
-}
-
 /** Pi session stores additionally expose the raw persisted message entries so
  * the cold-load path can run them through the same buildPiChatHistory mapping
  * as the live event path. */
 type PiSessionStoreLike = SessionStore & {
-  loadEntries?: (ctx: { workspaceId?: string; userId?: string }, sessionId: string) => Promise<{ id: string; messages: unknown[] }>
+  loadEntries?: (ctx: { workspaceId?: string; userId?: string }, sessionId: string) => Promise<{ id: string; messages: unknown[]; currentModel?: { provider: string; id: string } }>
   loadAttachment?: (ctx: { workspaceId?: string; userId?: string }, sessionId: string, messageId: string, index: number) => Promise<{ data: Uint8Array; mediaType: string; filename?: string }>
 }
 
@@ -394,13 +372,13 @@ export class HarnessPiChatService implements PiChatSessionService {
   private async readPersistedState(ctx: PiSessionRequestContext, sessionId: string): Promise<PiChatSnapshot | null> {
     if (!this.sessionStore.loadEntries) return null
     try {
-      const { id, messages } = await this.sessionStore.loadEntries(toSessionCtx(ctx), sessionId)
+      const { id, messages, currentModel } = await this.sessionStore.loadEntries(toSessionCtx(ctx), sessionId)
       return {
         protocolVersion: 1,
         sessionId: id,
         seq: await this.readDurableLatestPiChatSeq(sessionStreamPath(this.sessionKey(ctx, id))),
         status: 'idle',
-        currentModel: currentModelFromPiMessages(messages),
+        currentModel,
         messages: buildPiChatHistory(messages, {
           sessionId: id,
           attachmentUrl: this.attachmentUrlFor(id),
@@ -454,6 +432,12 @@ export class HarnessPiChatService implements PiChatSessionService {
       }
     }
     if (outcome === 'cancelled') throw promptCancelledError()
+    const currentModel = adapter.currentModel?.()
+    if (currentModel) {
+      this.publishChannelEvents(sessionId, channel, [
+        channel.mapper.mapSynthetic({ type: 'model-changed', currentModel }),
+      ])
+    }
     this.messageMetadata.recordPrompt(sessionKey, payload)
     const receiptCursor = nextPromptReceiptCursor(channel)
     try {

--- a/packages/agent/src/server/pi-chat/piChatEvents.ts
+++ b/packages/agent/src/server/pi-chat/piChatEvents.ts
@@ -69,6 +69,14 @@ export class PiChatEventMapper {
         return [this.event({ type: 'agent-start', turnId })]
       }
 
+      case 'model_change': {
+        const provider = optionalString(event.provider)
+        const id = optionalString(event.modelId) ?? optionalString(event.model)
+        return provider && id
+          ? [this.event({ type: 'model-changed', currentModel: { provider, id } })]
+          : []
+      }
+
       case 'agent_end': {
         const turnId = this.activeTurnId ?? this.createTurnId()
         const status = agentEndStatus(event)

--- a/packages/agent/src/server/pi-chat/piChatEvents.ts
+++ b/packages/agent/src/server/pi-chat/piChatEvents.ts
@@ -69,14 +69,6 @@ export class PiChatEventMapper {
         return [this.event({ type: 'agent-start', turnId })]
       }
 
-      case 'model_change': {
-        const provider = optionalString(event.provider)
-        const id = optionalString(event.modelId) ?? optionalString(event.model)
-        return provider && id
-          ? [this.event({ type: 'model-changed', currentModel: { provider, id } })]
-          : []
-      }
-
       case 'agent_end': {
         const turnId = this.activeTurnId ?? this.createTurnId()
         const status = agentEndStatus(event)

--- a/packages/agent/src/server/pi-chat/piChatSnapshot.ts
+++ b/packages/agent/src/server/pi-chat/piChatSnapshot.ts
@@ -67,6 +67,7 @@ export function buildPiChatSnapshot(adapter: PiAgentSessionAdapter, options: Bui
     seq: options.seq,
     status,
     activeTurnId: options.activeTurnId,
+    currentModel: adapter.currentModel?.(),
     messages: buildPiChatHistory(piSnapshot.messages, {
       sessionId,
       messageTurnIds: options.messageTurnIds,

--- a/packages/agent/src/server/testing/__tests__/scriptedPiHarness.test.ts
+++ b/packages/agent/src/server/testing/__tests__/scriptedPiHarness.test.ts
@@ -5,6 +5,17 @@ import { PiChatEventMapper } from '../../pi-chat/piChatEvents'
 import { createScriptedPiHarness } from '../scriptedPiHarness'
 
 describe('createScriptedPiHarness', () => {
+  it('tracks the requested model as addressed session authority', async () => {
+    const harness = createScriptedPiHarness({ tools: [], cwd: '/workspace' })
+    const model = { provider: 'openai-codex', id: 'gpt-5.6-sol' }
+    const adapter = await harness.getPiSessionAdapter({ sessionId: 's1', content: '', model }, {
+      abortSignal: new AbortController().signal,
+      workdir: '/workspace',
+    })
+
+    expect(adapter.currentModel?.()).toEqual(model)
+  })
+
   it('clears the selected queued follow-up by client selector', async () => {
     const harness = createScriptedPiHarness({ tools: [], cwd: '/workspace' })
     const adapter = await harness.getPiSessionAdapter({ sessionId: 's1', content: '' }, {

--- a/packages/agent/src/server/testing/scriptedPiHarness.ts
+++ b/packages/agent/src/server/testing/scriptedPiHarness.ts
@@ -61,10 +61,12 @@ export function createScriptedPiHarness(input: AgentHarnessFactoryInput): AgentH
     id: 'scripted-pi-e2e',
     placement: 'server',
     sessions,
-    async getPiSessionAdapter({ sessionId }: AgentSendInput) {
+    async getPiSessionAdapter({ sessionId, model }: AgentSendInput) {
       if (!sessionId) throw new Error('sessionId is required')
       await sessions.ensure(sessionId)
-      return getAdapter(sessionId)
+      const adapter = getAdapter(sessionId)
+      if (model) adapter.setCurrentModel(model)
+      return adapter
     },
     async reloadSession() {
       return true
@@ -131,6 +133,7 @@ class ScriptedPiSessionAdapter implements PiAgentSessionAdapter {
   private streaming = false
   private turn = 0
   private activeRun: ScriptedRun | undefined
+  private model: { provider: string; id: string } | undefined
 
   constructor(
     private readonly sessionId: string,
@@ -138,6 +141,14 @@ class ScriptedPiSessionAdapter implements PiAgentSessionAdapter {
     private readonly toolDelayTicks: number,
     private readonly reasoningPartCount: number,
   ) {}
+
+  setCurrentModel(model: { provider: string; id: string }): void {
+    this.model = model
+  }
+
+  currentModel(): { provider: string; id: string } | undefined {
+    return this.model
+  }
 
   readSnapshot(): PiAgentSessionSnapshot {
     return {

--- a/packages/agent/src/shared/chat/__tests__/piChatSchemas.test.ts
+++ b/packages/agent/src/shared/chat/__tests__/piChatSchemas.test.ts
@@ -23,6 +23,7 @@ describe('Pi chat shared schemas', () => {
       seq: 42,
       status: 'streaming',
       activeTurnId: 'turn-1',
+      currentModel: { provider: 'openai-codex', id: 'gpt-5.6-sol' },
       messages: [
         {
           id: 'entry-user-1',
@@ -55,6 +56,7 @@ describe('Pi chat shared schemas', () => {
       seq: 42,
       status: 'streaming',
       activeTurnId: 'turn-1',
+      currentModel: { provider: 'openai-codex', id: 'gpt-5.6-sol' },
       queue: { followUps: [{ displayText: 'next question' }] },
     })
   })

--- a/packages/agent/src/shared/chat/piChatEvent.ts
+++ b/packages/agent/src/shared/chat/piChatEvent.ts
@@ -1,10 +1,11 @@
 import type { BoringChatMessage, BoringChatPart } from './boringChatMessage'
-import type { QueuedUserMessage } from './piChatSnapshot'
+import type { PiChatSnapshot, QueuedUserMessage } from './piChatSnapshot'
 import type { ChatError } from './chatError'
 import type { ToolUiMetadata } from '../tool-ui'
 
 export type PiChatEvent =
   | { type: 'agent-start'; seq: number; turnId: string }
+  | { type: 'model-changed'; seq: number; currentModel: NonNullable<PiChatSnapshot['currentModel']> }
   // willRetry=true marks a NON-terminal end (pi will auto-retry this turn). Consumers
   // that act once-per-settle (e.g. a host's onTurnComplete) must ignore those.
   | { type: 'agent-end'; seq: number; turnId: string; status: 'ok' | 'aborted' | 'error'; willRetry?: boolean }

--- a/packages/agent/src/shared/chat/piChatSchemas.ts
+++ b/packages/agent/src/shared/chat/piChatSchemas.ts
@@ -139,6 +139,7 @@ const baseEvent = z.object({ seq: seqNumber })
 
 export const PiChatEventSchema = z.discriminatedUnion('type', [
   baseEvent.extend({ type: z.literal('agent-start'), turnId: nonEmptyString }),
+  baseEvent.extend({ type: z.literal('model-changed'), currentModel: ChatModelSelectionSchema }),
   baseEvent.extend({ type: z.literal('agent-end'), turnId: nonEmptyString, status: z.enum(['ok', 'aborted', 'error']), willRetry: z.boolean().optional() }),
   baseEvent.extend({
     type: z.literal('message-start'),

--- a/packages/agent/src/shared/chat/piChatSchemas.ts
+++ b/packages/agent/src/shared/chat/piChatSchemas.ts
@@ -117,12 +117,18 @@ export const QueuedUserMessageSchema = z.object({
 
 export const PiChatStatusSchema = z.enum(['idle', 'hydrating', 'submitted', 'streaming', 'aborting', 'error'])
 
+export const ChatModelSelectionSchema = z.object({
+  provider: nonEmptyString,
+  id: nonEmptyString,
+}) satisfies z.ZodType<ChatModelSelection>
+
 export const PiChatSnapshotSchema = z.object({
   protocolVersion: z.literal(1),
   sessionId: nonEmptyString,
   seq: seqNumber,
   status: PiChatStatusSchema,
   activeTurnId: z.string().optional(),
+  currentModel: ChatModelSelectionSchema.optional(),
   messages: z.array(BoringChatMessageSchema),
   queue: z.object({ followUps: z.array(QueuedUserMessageSchema) }),
   followUpMode: z.literal('one-at-a-time'),
@@ -205,11 +211,6 @@ export const PiChatEventSchema = z.discriminatedUnion('type', [
 export const PiChatHeartbeatFrameSchema = z.object({ type: z.literal('heartbeat'), now: z.string() })
 
 export const PiChatStreamFrameSchema = z.union([PiChatEventSchema, PiChatHeartbeatFrameSchema]) satisfies z.ZodType<PiChatStreamFrame, z.ZodTypeDef, unknown>
-
-export const ChatModelSelectionSchema = z.object({
-  provider: nonEmptyString,
-  id: nonEmptyString,
-}) satisfies z.ZodType<ChatModelSelection>
 
 export const ThinkingLevelSchema = z.enum(['off', 'low', 'medium', 'high'])
 

--- a/packages/agent/src/shared/chat/piChatSnapshot.ts
+++ b/packages/agent/src/shared/chat/piChatSnapshot.ts
@@ -1,5 +1,6 @@
 import type { BoringChatMessage } from './boringChatMessage'
 import type { ChatError } from './chatError'
+import type { ChatModelSelection } from './chatSubmitPayload'
 
 export type PiChatStatus = 'idle' | 'hydrating' | 'submitted' | 'streaming' | 'aborting' | 'error'
 
@@ -18,6 +19,7 @@ export interface PiChatSnapshot {
   seq: number
   status: PiChatStatus
   activeTurnId?: string
+  currentModel?: ChatModelSelection
   messages: BoringChatMessage[]
   queue: { followUps: QueuedUserMessage[] }
   followUpMode: 'one-at-a-time'


### PR DESCRIPTION
## Summary
- Add addressed `currentModel` authority to session state, sourced from live Pi state or the latest persisted `model_change`/assistant model.
- Existing sessions ignore conflicting browser-local model history; local storage remains only a genuinely empty new-session default.
- Keep the current session model visible while labeling a differing viewer choice as a next-message override.
- Deduplicate and durably replay real addressed model transitions to connected viewers; preserve session authorization/isolation and leave provider/credential policy unchanged.

## Proof
- `node …/vitest.mjs run --exclude 'src/eval/**' --testTimeout 15000` ✅ **219 files passed; 2028 tests passed; 12 skipped; 0 failed; type errors: none** at `4dafa07e1dbe0fc9fc1edf271479826f6cc1bb1b`.
- `node …/typescript/bin/tsc -p packages/agent/tsconfig.json --noEmit` ✅ **0 errors**.
- Focused final `PiChatPanel` regression run ✅ **72/72** (including queued and optimistic non-new session isolation).
- GitHub Actions run `32022709726` ✅ **success**: E2E, changed unit tests, typecheck, lint, invariants, and reference/remote-worker smoke green at the exact SHA.
- Surface policy: two local browser attempts maximum were used while diagnosing CI; no origin cycling. The final authoritative E2E proof is the green GitHub run above.

## Review provenance
- Fresh-eyes — `openai-codex/gpt-5.6-sol`, adversarial acceptance/isolation review, SHA `a7d3adf020097ea96470d34dc66aa05a3eda9d87`: **revise**; connected viewers stale and persisted `model_change` omitted. Fixed.
- Thermo — `openai-codex/gpt-5.6-sol`, maintainability review, SHA `97ff572c2958dcedf5727e30b5491239aaf061d9`: **revise**; impossible event seam, duplicate events, implicit state machine, weak typing. Fixed.
- Fresh-eyes + thermo second passes — same required model, SHA `de6998acd6c5ff73025646b4a09b60ac39adebba`: **clean**.
- Final harness review — same model, SHA `e41709ff9878552bfcb0b90127151500a81cc896`: **clean**.
- New-session edge review — same model, SHA `2d7e0224df0d129e7382d9b8e99881202888640c`: **revise**; queued/optimistic emptiness coverage incomplete. Fixed.
- Final fresh-eyes + thermo — same model, exact SHA `4dafa07e1dbe0fc9fc1edf271479826f6cc1bb1b`: **clean**, no material findings.

## Artifacts
- Present-PR r2 workspace pane: `.handoff/pr-1319-handoff.html` — SHA-256 `83c40af0d03664d8fc7d2138ce00abfa92c12e9c893087d79af1c03f90fec398`.
- Live exact-branch playground: `http://vps-15cf2c41.tail6ddfe5.ts.net:5183/` (kept running for owner review).
- Browser evidence: `.handoff/pr-1319-authoritative-model.png` and `.handoff/pr-1319-next-override.png`.
- PR: https://github.com/hachej/boring-ui/pull/1319
- Running demo: `http://vps-15cf2c41.tail6ddfe5.ts.net:5183/` — exact-branch Agent playground, `/ready` HTTP 200.
- Manual validation: open an API/automation-created session while browser storage names another model; verify the composer shows the session model. Pick another model and verify “Next override” while current remains visible. Submit/reconnect another viewer and verify both show the accepted model.

## Risk & rollback
- Risk: narrow protocol addition (`currentModel` snapshot + `model-changed` addressed event), persisted authority extraction, and composer selection-state refactor.
- Authorization paths, provider policy, credentials, and model availability policy are unchanged. Foreign-session isolation remains under the existing addressed gateway boundary.
- Rollback: revert this PR's commits; no migration or data deletion is involved.

## Refs
- Bead: `wt-391-forward-9jxj`
- GitHub issue: #1290
- PR: #1319
- Head: `4dafa07e1dbe0fc9fc1edf271479826f6cc1bb1b`
- Base: `origin/main@ee2017188b4cad1c7adfcc0564429cbfcf98ddea`
## Owner request-changes r2 — running Tailscale playground

> “I need a runnig playgorund url tailscale url to poerply ltest”

Addressed with a real, running exact-branch playground: **http://vps-15cf2c41.tail6ddfe5.ts.net:5183/**

Evidence:
- Exact head: `4dafa07e1dbe0fc9fc1edf271479826f6cc1bb1b`; runtime cwd is this PR worktree and `@hachej/boring-agent/server` resolves to this worktree's `packages/agent/dist/server/index.js`.
- Tailscale-origin `GET /ready` returns HTTP 200 with `{"status":"ready"}`.
- Seeded non-empty session `2514d372-aaae-4200-b5ef-56878d4d3ea2` is authoritative on `openai-codex/gpt-5.6-sol`.
- Playwright opened that same Tailscale URL with conflicting browser-local history set to `anthropic/claude-sonnet-4-6`: the composer still showed **GPT 5.6 sol · OpenAI Codex**.
- After explicitly picking Sonnet, the composer kept GPT visible as current and showed **Next override: Claude Sonnet 4.6 · Anthropic**.
- Evidence: `.handoff/pr-1319-playground-proof.md`, `.handoff/pr-1319-authoritative-model.png`, `.handoff/pr-1319-next-override.png`, and canonical `.handoff/pr-1319-handoff.html` (SHA-256 `83c40af0d03664d8fc7d2138ce00abfa92c12e9c893087d79af1c03f90fec398`).
- Final fresh-eyes: **clean** — `openai-codex/gpt-5.6-sol`, run `fefb77d8`, exact SHA `4dafa07e1dbe0fc9fc1edf271479826f6cc1bb1b`.

Test path:
1. Open the Tailscale URL above.
2. Confirm the seeded `demo ready` conversation shows **GPT 5.6 sol · OpenAI Codex**.
3. Pick **claude-sonnet-4-6** and confirm GPT remains current while Sonnet appears as **Next override**.
4. Leave the prompt unsent unless you intentionally want to exercise the next-message transition.

