### PR TITLE
[wt-391-forward-d5nj.5] Add safe scratch aging preflight

### DIFF
--- a/docs/factory/scratch-guard.md
+++ b/docs/factory/scratch-guard.md
@@ -34,6 +34,7 @@ store is tmpfs/ramfs. Invalid or unavailable inputs exit `3`.
 ```bash
 export TMPDIR=/var/tmp/boring-ui-tmp
 export PNPM_STORE_DIR=/var/cache/boring-ui/pnpm-store
+install -d -m 0700 "$TMPDIR" "$PNPM_STORE_DIR"
 scratch-guard check --path "$PWD" --path "$TMPDIR" --path "$PNPM_STORE_DIR" \
   --inode-threshold 85 --tmpdir "$TMPDIR" --pnpm-store "$PNPM_STORE_DIR"
 ```
@@ -46,8 +47,11 @@ safe. Supply `--pnpm-store` (or `PNPM_STORE_DIR`) to make that check meaningful.
 ## Create a dedicated marked root
 
 `init-root` refuses an existing path and creates a private mode-0700 directory.
-The cleaner later refuses roots that are symlinks, non-canonical, owned by a
-different uid, group/world writable, or missing the exact root marker.
+Initialization stages protocol files privately and exposes the final path with one
+rename; a failed setup removes only its own private staging directory so the exact
+command can be retried. The cleaner later refuses roots that are symlinks,
+non-canonical, owned by a different uid, group/world writable, or missing the
+exact root marker.
 
 ```bash
 scratch-guard init-root /var/tmp/boring-ui-owned-scratch
@@ -61,14 +65,15 @@ A producer using an entry must:
 - refresh `.boring-heartbeat` while active.
 
 A producer that cannot honor both rules must not use this aging protocol. The
-cleaner treats missing, malformed, replaced, live, locked, symlinked, cross-filesystem,
-or otherwise ambiguous entries as retained. It examines direct children only
+cleaner treats missing, malformed, replaced, live, locked, symlinked, mounted (including same-device
+bind mounts), cross-filesystem, or otherwise ambiguous entries as retained. It examines direct children only
 and requires the entry marker to match the root id and child name exactly.
 
 Example producer lock (the heartbeat update happens while the lock is held):
 
 ```bash
 entry=/var/tmp/boring-ui-owned-scratch/run-2026-08-17-a
+mkdir -m 0700 "$entry/tmp"
 (
   flock -s 9
   touch "$entry/.boring-heartbeat"

--- a/docs/factory/scratch-guard.md
+++ b/docs/factory/scratch-guard.md
@@ -1,0 +1,111 @@
+# Opt-in factory scratch guard
+
+`ops/factory-scratch/scratch_guard.py` is a Linux operator utility for two
+bounded jobs:
+
+1. fail before a long run when a selected filesystem reaches a configured inode
+   percentage or when `TMPDIR` / the pnpm store resolves to `tmpfs` or `ramfs`;
+2. dry-run or age direct children of a **new, private, explicitly marked**
+   boring-ui scratch root.
+
+It is not a generic `/tmp` cleaner. It does not discover roots, install a timer,
+or change the host unless an operator explicitly runs an init or `clean --apply`
+command. Never point it at an existing directory. Existing build, workspace,
+session, plugin, and PR #1288 stores are outside this protocol.
+
+## Optional installation
+
+Review the checked-in file, then install a copy only if this host should opt in:
+
+```bash
+sudo install -m 0755 ops/factory-scratch/scratch_guard.py /usr/local/bin/scratch-guard
+scratch-guard --help
+```
+
+Rollback is removal of that copied executable and any operator-created scratch
+root. This repository installs no cron job, systemd unit, or host policy.
+
+## Preflight before a long run
+
+Choose disk-backed locations explicitly. The command exits `2` when inode usage
+is at or above the limit, when `TMPDIR` is tmpfs/ramfs, or when the supplied pnpm
+store is tmpfs/ramfs. Invalid or unavailable inputs exit `3`.
+
+```bash
+export TMPDIR=/var/tmp/boring-ui-tmp
+export PNPM_STORE_DIR=/var/cache/boring-ui/pnpm-store
+scratch-guard check --path "$PWD" --path "$TMPDIR" --path "$PNPM_STORE_DIR" \
+  --inode-threshold 85 --tmpdir "$TMPDIR" --pnpm-store "$PNPM_STORE_DIR"
+```
+
+The filesystem match comes from `/proc/self/mountinfo` and uses the longest
+matching mountpoint. If the pnpm store is omitted or a filesystem cannot be
+identified, the command prints a warning rather than pretending the location is
+safe. Supply `--pnpm-store` (or `PNPM_STORE_DIR`) to make that check meaningful.
+
+## Create a dedicated marked root
+
+`init-root` refuses an existing path and creates a private mode-0700 directory.
+The cleaner later refuses roots that are symlinks, non-canonical, owned by a
+different uid, group/world writable, or missing the exact root marker.
+
+```bash
+scratch-guard init-root /var/tmp/boring-ui-owned-scratch
+scratch-guard init-entry /var/tmp/boring-ui-owned-scratch run-2026-08-17-a
+```
+
+A producer using an entry must:
+
+- hold a shared or exclusive `flock` on `.boring-active.lock` for its entire
+  active lifetime; and
+- refresh `.boring-heartbeat` while active.
+
+A producer that cannot honor both rules must not use this aging protocol. The
+cleaner treats missing, malformed, replaced, live, locked, symlinked, cross-filesystem,
+or otherwise ambiguous entries as retained. It examines direct children only
+and requires the entry marker to match the root id and child name exactly.
+
+Example producer lock (the heartbeat update happens while the lock is held):
+
+```bash
+entry=/var/tmp/boring-ui-owned-scratch/run-2026-08-17-a
+(
+  flock -s 9
+  touch "$entry/.boring-heartbeat"
+  exec env TMPDIR="$entry/tmp" your-long-running-command
+) 9<>"$entry/.boring-active.lock"
+```
+
+## Inspect first, then apply deliberately
+
+The default is dry-run; eligible entries print `WOULD-DELETE` and nothing is
+renamed or removed:
+
+```bash
+scratch-guard clean --root /var/tmp/boring-ui-owned-scratch --stale-seconds 86400
+```
+
+After inspecting that output, the explicit mutation command is:
+
+```bash
+scratch-guard clean --root /var/tmp/boring-ui-owned-scratch \
+  --stale-seconds 86400 --apply
+```
+
+For an eligible entry, the utility holds the exclusive lease lock, rechecks the
+lease and heartbeat, rejects symlinks/filesystem boundaries, atomically renames
+the direct child to a unique quarantine name within the same private root, then
+removes that quarantine. A failed removal is retained and reported; ambiguous
+quarantines are never retried automatically. This is cooperative safety, not a
+way to clean paths written by producers that ignore the lock protocol.
+
+## Repository proof (fixtures only)
+
+The test creates and deletes only its own temporary fixture root:
+
+```bash
+python3 -m unittest -v ops/factory-scratch/test_scratch_guard.py
+python3 -m py_compile ops/factory-scratch/scratch_guard.py \
+  ops/factory-scratch/test_scratch_guard.py
+git diff --check
+```

--- a/docs/factory/scratch-guard.md
+++ b/docs/factory/scratch-guard.md
@@ -50,8 +50,10 @@ safe. Supply `--pnpm-store` (or `PNPM_STORE_DIR`) to make that check meaningful.
 `init-root` refuses an existing path and creates a private mode-0700 directory.
 Initialization stages protocol files privately and exposes the final path with one
 Linux `renameat2(RENAME_NOREPLACE)` operation, so a concurrently created path is
-never overwritten. On failure it removes staging only while the created inode still
-matches; a replaced or ambiguous staging path is retained rather than touched. The cleaner later refuses roots that are symlinks,
+never overwritten. On failure it clears staging only while the created inode still
+matches, but deliberately leaves that empty top-level staging directory to avoid a
+final pathname-removal race. Replaced or ambiguous staging paths are retained
+untouched; retries remain possible because the requested final path was never exposed. The cleaner later refuses roots that are symlinks,
 non-canonical, owned by a different uid, group/world writable, or missing the
 exact root marker.
 

--- a/docs/factory/scratch-guard.md
+++ b/docs/factory/scratch-guard.md
@@ -50,8 +50,8 @@ safe. Supply `--pnpm-store` (or `PNPM_STORE_DIR`) to make that check meaningful.
 `init-root` refuses an existing path and creates a private mode-0700 directory.
 Initialization stages protocol files privately and exposes the final path with one
 Linux `renameat2(RENAME_NOREPLACE)` operation, so a concurrently created path is
-never overwritten; a failed setup removes only its own private staging directory so the exact
-command can be retried. The cleaner later refuses roots that are symlinks,
+never overwritten. On failure it removes staging only while the created inode still
+matches; a replaced or ambiguous staging path is retained rather than touched. The cleaner later refuses roots that are symlinks,
 non-canonical, owned by a different uid, group/world writable, or missing the
 exact root marker.
 

--- a/docs/factory/scratch-guard.md
+++ b/docs/factory/scratch-guard.md
@@ -1,6 +1,7 @@
 # Opt-in factory scratch guard
 
-`ops/factory-scratch/scratch_guard.py` is a Linux operator utility for two
+`ops/factory-scratch/scratch_guard.py` is a Linux operator utility (it requires
+`/proc/self/mountinfo`, `/proc/self/fdinfo`, and `renameat2`) for two
 bounded jobs:
 
 1. fail before a long run when a selected filesystem reaches a configured inode
@@ -48,7 +49,8 @@ safe. Supply `--pnpm-store` (or `PNPM_STORE_DIR`) to make that check meaningful.
 
 `init-root` refuses an existing path and creates a private mode-0700 directory.
 Initialization stages protocol files privately and exposes the final path with one
-rename; a failed setup removes only its own private staging directory so the exact
+Linux `renameat2(RENAME_NOREPLACE)` operation, so a concurrently created path is
+never overwritten; a failed setup removes only its own private staging directory so the exact
 command can be retried. The cleaner later refuses roots that are symlinks,
 non-canonical, owned by a different uid, group/world writable, or missing the
 exact root marker.
@@ -100,7 +102,9 @@ scratch-guard clean --root /var/tmp/boring-ui-owned-scratch \
 For an eligible entry, the utility holds the exclusive lease lock, rechecks the
 lease and heartbeat, rejects symlinks/filesystem boundaries, atomically renames
 the direct child to a unique quarantine name within the same private root, then
-removes that quarantine. A failed removal is retained and reported; ambiguous
+removes that quarantine through directory descriptors. Every opened node must
+retain the root mount id from `/proc/self/fdinfo`, so a late same-device bind mount
+is refused rather than traversed. A failed removal is retained and reported; ambiguous
 quarantines are never retried automatically. This is cooperative safety, not a
 way to clean paths written by producers that ignore the lock protocol.
 

--- a/ops/factory-scratch/scratch_guard.py
+++ b/ops/factory-scratch/scratch_guard.py
@@ -129,6 +129,7 @@ def _remove_tree_at(
     name: str,
     expected_mount_id: int,
     expected_identity: tuple[int, int] | None = None,
+    remove_root: bool = True,
 ) -> None:
     directory_fd = os.open(
         name, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=parent_fd
@@ -155,7 +156,8 @@ def _remove_tree_at(
             os.unlink(child, dir_fd=directory_fd)
     finally:
         os.close(directory_fd)
-    os.rmdir(name, dir_fd=parent_fd)
+    if remove_root:
+        os.rmdir(name, dir_fd=parent_fd)
 
 
 def _discard_private_staging(staging: Path, identity: tuple[int, int]) -> None:
@@ -168,7 +170,11 @@ def _discard_private_staging(staging: Path, identity: tuple[int, int]) -> None:
         if (current_st.st_dev, current_st.st_ino) != identity:
             return
         _remove_tree_at(
-            parent_fd, staging.name, _fd_mount_id(parent_fd), expected_identity=identity
+            parent_fd,
+            staging.name,
+            _fd_mount_id(parent_fd),
+            expected_identity=identity,
+            remove_root=False,
         )
     finally:
         os.close(parent_fd)

--- a/ops/factory-scratch/scratch_guard.py
+++ b/ops/factory-scratch/scratch_guard.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import shutil
 import stat
 import sys
+import tempfile
 import time
 import uuid
 from dataclasses import dataclass
@@ -41,6 +42,14 @@ class Decision:
     path: Path
     action: str
     reason: str
+
+
+@dataclass
+class LeaseEvidence:
+    lock: TextIO
+    entry_identity: tuple[int, int]
+    heartbeat_identity: tuple[int, int]
+    heartbeat_mtime_ns: int
 
 
 def _strict_json(path: Path, expected_keys: set[str]) -> dict[str, object]:
@@ -84,16 +93,29 @@ def _validate_root(root: Path) -> tuple[Path, str]:
     return resolved, root_id
 
 
+def _discard_private_staging(staging: Path) -> None:
+    if staging.exists() and not staging.is_symlink():
+        shutil.rmtree(staging)
+
+
 def initialize_root(root: Path) -> None:
     if not root.is_absolute():
         raise SafetyError("scratch root must be absolute")
     if root.exists() or root.is_symlink():
         raise SafetyError("init refuses an existing path")
-    root.mkdir(mode=0o700, parents=False)
-    marker = {"owner": OWNER, "protocol": PROTOCOL_VERSION, "root_id": str(uuid.uuid4())}
-    marker_path = root / ROOT_MARKER
-    marker_path.write_text(json.dumps(marker, sort_keys=True) + "\n", encoding="utf-8")
-    marker_path.chmod(0o600)
+    if not root.parent.is_dir():
+        raise SafetyError("scratch root parent must already exist")
+    staging = Path(tempfile.mkdtemp(prefix=f".{root.name}.boring-init-", dir=root.parent))
+    try:
+        staging.chmod(0o700)
+        marker = {"owner": OWNER, "protocol": PROTOCOL_VERSION, "root_id": str(uuid.uuid4())}
+        marker_path = staging / ROOT_MARKER
+        marker_path.write_text(json.dumps(marker, sort_keys=True) + "\n", encoding="utf-8")
+        marker_path.chmod(0o600)
+        staging.rename(root)
+    except BaseException:
+        _discard_private_staging(staging)
+        raise
 
 
 def initialize_entry(root: Path, name: str, *, now: float | None = None) -> Path:
@@ -101,7 +123,7 @@ def initialize_entry(root: Path, name: str, *, now: float | None = None) -> Path
     if (
         not name
         or name in {".", "..", ROOT_MARKER}
-        or name.startswith(".boring-trash-")
+        or name.startswith((".boring-trash-", ".boring-init-"))
         or "/" in name
         or os.sep in name
     ):
@@ -109,19 +131,27 @@ def initialize_entry(root: Path, name: str, *, now: float | None = None) -> Path
     entry = canonical_root / name
     if entry.exists() or entry.is_symlink():
         raise SafetyError("entry path already exists")
-    entry.mkdir(mode=0o700)
-    marker = {
-        "entry": name,
-        "owner": OWNER,
-        "protocol": PROTOCOL_VERSION,
-        "root_id": root_id,
-    }
-    (entry / ENTRY_MARKER).write_text(json.dumps(marker, sort_keys=True) + "\n", encoding="utf-8")
-    (entry / LOCK_FILE).touch(mode=0o600)
-    heartbeat = entry / HEARTBEAT_FILE
-    heartbeat.touch(mode=0o600)
-    timestamp = time.time() if now is None else now
-    os.utime(heartbeat, (timestamp, timestamp), follow_symlinks=False)
+    staging = Path(tempfile.mkdtemp(prefix=".boring-init-", dir=canonical_root))
+    try:
+        staging.chmod(0o700)
+        marker = {
+            "entry": name,
+            "owner": OWNER,
+            "protocol": PROTOCOL_VERSION,
+            "root_id": root_id,
+        }
+        marker_path = staging / ENTRY_MARKER
+        marker_path.write_text(json.dumps(marker, sort_keys=True) + "\n", encoding="utf-8")
+        marker_path.chmod(0o600)
+        (staging / LOCK_FILE).touch(mode=0o600)
+        heartbeat = staging / HEARTBEAT_FILE
+        heartbeat.touch(mode=0o600)
+        timestamp = time.time() if now is None else now
+        os.utime(heartbeat, (timestamp, timestamp), follow_symlinks=False)
+        staging.rename(entry)
+    except BaseException:
+        _discard_private_staging(staging)
+        raise
     return entry
 
 
@@ -149,7 +179,8 @@ def _entry_decision(
     *,
     stale_before: float,
     now: float,
-) -> tuple[Decision, TextIO | None]:
+    mounts: list[Mount],
+) -> tuple[Decision, LeaseEvidence | None]:
     try:
         entry_st = entry.lstat()
     except OSError as exc:
@@ -158,6 +189,11 @@ def _entry_decision(
         return Decision(entry, "retain", "not a real directory"), None
     if entry_st.st_dev != root.lstat().st_dev:
         return Decision(entry, "retain", "entry is a filesystem boundary"), None
+    for mount in mounts:
+        if mount.point == entry or entry in mount.point.parents:
+            return Decision(entry, "retain", f"mounted path boundary at {mount.point}"), None
+    if not getattr(shutil.rmtree, "avoids_symlink_attacks", False):
+        return Decision(entry, "retain", "platform lacks symlink-safe tree removal"), None
     try:
         marker = _strict_json(entry / ENTRY_MARKER, {"entry", "owner", "protocol", "root_id"})
     except SafetyError as exc:
@@ -219,7 +255,27 @@ def _entry_decision(
     if not confined:
         lock_handle.close()
         return Decision(entry, "retain", reason), None
-    return Decision(entry, "delete", f"stale heartbeat ({int(age)}s old), unlocked, confined"), lock_handle
+    evidence = LeaseEvidence(
+        lock=lock_handle,
+        entry_identity=(entry_st.st_dev, entry_st.st_ino),
+        heartbeat_identity=(heartbeat_st.st_dev, heartbeat_st.st_ino),
+        heartbeat_mtime_ns=heartbeat_st.st_mtime_ns,
+    )
+    return (
+        Decision(entry, "delete", f"stale heartbeat ({int(age)}s old), unlocked, confined"),
+        evidence,
+    )
+
+
+def _read_mounts() -> list[Mount]:
+    try:
+        with Path("/proc/self/mountinfo").open(encoding="utf-8") as mountinfo:
+            mounts = parse_mountinfo(mountinfo)
+    except OSError as exc:
+        raise SafetyError(f"cannot read mount boundaries: {exc}") from exc
+    if not mounts:
+        raise SafetyError("mount boundary data is empty or malformed")
+    return mounts
 
 
 def clean_root(
@@ -228,67 +284,93 @@ def clean_root(
     stale_seconds: int,
     apply: bool,
     now: float | None = None,
+    mounts: list[Mount] | None = None,
 ) -> list[Decision]:
     if stale_seconds <= 0:
         raise SafetyError("stale-seconds must be greater than zero")
     canonical_root, root_id = _validate_root(root)
+    root_st = canonical_root.lstat()
+    root_identity = (root_st.st_dev, root_st.st_ino)
+    active_mounts = _read_mounts() if mounts is None else mounts
     current_time = time.time() if now is None else now
     stale_before = current_time - stale_seconds
     decisions: list[Decision] = []
-    for entry in sorted(canonical_root.iterdir(), key=lambda item: item.name):
-        if entry.name == ROOT_MARKER:
-            continue
-        if entry.name.startswith(".boring-trash-"):
-            decisions.append(Decision(entry, "retain", "ambiguous prior quarantine"))
-            continue
-        decision, lock_handle = _entry_decision(
-            canonical_root, root_id, entry, stale_before=stale_before, now=current_time
-        )
-        if decision.action != "delete" or not apply:
-            if lock_handle is not None:
-                lock_handle.close()
-            decisions.append(
-                Decision(entry, "would-delete", decision.reason) if decision.action == "delete" else decision
+    root_fd = os.open(canonical_root, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        if (os.fstat(root_fd).st_dev, os.fstat(root_fd).st_ino) != root_identity:
+            raise SafetyError("scratch root changed while opening")
+        for entry in sorted(canonical_root.iterdir(), key=lambda item: item.name):
+            if entry.name == ROOT_MARKER:
+                continue
+            if entry.name.startswith((".boring-trash-", ".boring-init-")):
+                decisions.append(Decision(entry, "retain", "ambiguous prior quarantine/staging"))
+                continue
+            decision, evidence = _entry_decision(
+                canonical_root,
+                root_id,
+                entry,
+                stale_before=stale_before,
+                now=current_time,
+                mounts=active_mounts,
             )
-            continue
+            if decision.action != "delete" or not apply:
+                if evidence is not None:
+                    evidence.lock.close()
+                decisions.append(
+                    Decision(entry, "would-delete", decision.reason)
+                    if decision.action == "delete"
+                    else decision
+                )
+                continue
 
-        if not getattr(shutil.rmtree, "avoids_symlink_attacks", False):
-            lock_handle.close()
-            decisions.append(Decision(entry, "retain", "platform lacks symlink-safe tree removal"))
-            continue
-        quarantine_name = f".boring-trash-{uuid.uuid4().hex}"
-        quarantine = canonical_root / quarantine_name
-        root_fd = os.open(canonical_root, os.O_RDONLY | os.O_DIRECTORY)
-        renamed = False
-        try:
-            # Revalidate the locked inode immediately before the mutation boundary.
-            held_lock_st = os.fstat(lock_handle.fileno())
-            path_lock_st = (entry / LOCK_FILE).lstat()
-            if (held_lock_st.st_dev, held_lock_st.st_ino) != (
-                path_lock_st.st_dev,
-                path_lock_st.st_ino,
-            ):
-                raise SafetyError("lock file changed before quarantine")
-            # Same-directory rename is atomic. The exclusive lease lock remains held.
-            os.rename(
-                entry.name,
-                quarantine_name,
-                src_dir_fd=root_fd,
-                dst_dir_fd=root_fd,
-            )
-            renamed = True
-            quarantined_st = os.stat(quarantine_name, dir_fd=root_fd, follow_symlinks=False)
-            if not stat.S_ISDIR(quarantined_st.st_mode):
-                raise SafetyError("quarantine changed type")
-            shutil.rmtree(quarantine_name, dir_fd=root_fd)
-            decisions.append(Decision(entry, "deleted", decision.reason))
-        except (OSError, SafetyError) as exc:
-            retained_path = quarantine if renamed else entry
-            reason = "quarantined but deletion failed" if renamed else "atomic quarantine failed"
-            decisions.append(Decision(retained_path, "retain", f"{reason}: {exc}"))
-        finally:
-            os.close(root_fd)
-            lock_handle.close()
+            if evidence is None:
+                raise SafetyError("eligible entry is missing lease evidence")
+            quarantine_name = f".boring-trash-{uuid.uuid4().hex}"
+            quarantine = canonical_root / quarantine_name
+            renamed = False
+            try:
+                current_root_st = canonical_root.lstat()
+                if (current_root_st.st_dev, current_root_st.st_ino) != root_identity:
+                    raise SafetyError("scratch root changed before quarantine")
+                held_lock_st = os.fstat(evidence.lock.fileno())
+                path_lock_st = (entry / LOCK_FILE).lstat()
+                if (held_lock_st.st_dev, held_lock_st.st_ino) != (
+                    path_lock_st.st_dev,
+                    path_lock_st.st_ino,
+                ):
+                    raise SafetyError("lock file changed before quarantine")
+                current_heartbeat_st = (entry / HEARTBEAT_FILE).lstat()
+                if (
+                    (current_heartbeat_st.st_dev, current_heartbeat_st.st_ino)
+                    != evidence.heartbeat_identity
+                    or current_heartbeat_st.st_mtime_ns != evidence.heartbeat_mtime_ns
+                ):
+                    raise SafetyError("heartbeat changed before quarantine")
+                current_entry_st = os.stat(entry.name, dir_fd=root_fd, follow_symlinks=False)
+                if (current_entry_st.st_dev, current_entry_st.st_ino) != evidence.entry_identity:
+                    raise SafetyError("entry directory changed before quarantine")
+                os.rename(
+                    entry.name,
+                    quarantine_name,
+                    src_dir_fd=root_fd,
+                    dst_dir_fd=root_fd,
+                )
+                renamed = True
+                quarantined_st = os.stat(
+                    quarantine_name, dir_fd=root_fd, follow_symlinks=False
+                )
+                if (quarantined_st.st_dev, quarantined_st.st_ino) != evidence.entry_identity:
+                    raise SafetyError("quarantine identity mismatch")
+                shutil.rmtree(quarantine_name, dir_fd=root_fd)
+                decisions.append(Decision(entry, "deleted", decision.reason))
+            except (OSError, SafetyError) as exc:
+                retained_path = quarantine if renamed else entry
+                reason = "quarantined but deletion failed" if renamed else "atomic quarantine failed"
+                decisions.append(Decision(retained_path, "retain", f"{reason}: {exc}"))
+            finally:
+                evidence.lock.close()
+    finally:
+        os.close(root_fd)
     return decisions
 
 
@@ -420,8 +502,7 @@ def main(argv: list[str] | None = None) -> int:
                 )
             return 0
         if args.command == "check":
-            with Path("/proc/self/mountinfo").open(encoding="utf-8") as mountinfo:
-                mounts = parse_mountinfo(mountinfo)
+            mounts = _read_mounts()
             pnpm_store = args.pnpm_store
             if pnpm_store is None and os.environ.get("PNPM_STORE_DIR"):
                 pnpm_store = Path(os.environ["PNPM_STORE_DIR"])

--- a/ops/factory-scratch/scratch_guard.py
+++ b/ops/factory-scratch/scratch_guard.py
@@ -9,8 +9,8 @@ import errno
 import fcntl
 import json
 import os
+import re
 from pathlib import Path
-import shutil
 import stat
 import sys
 import tempfile
@@ -124,11 +124,19 @@ def _fd_mount_id(fd: int) -> int:
     raise SafetyError("mount identity is unavailable")
 
 
-def _remove_tree_at(parent_fd: int, name: str, expected_mount_id: int) -> None:
+def _remove_tree_at(
+    parent_fd: int,
+    name: str,
+    expected_mount_id: int,
+    expected_identity: tuple[int, int] | None = None,
+) -> None:
     directory_fd = os.open(
         name, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=parent_fd
     )
     try:
+        opened_st = os.fstat(directory_fd)
+        if expected_identity is not None and (opened_st.st_dev, opened_st.st_ino) != expected_identity:
+            raise SafetyError(f"directory identity changed at {name}")
         if _fd_mount_id(directory_fd) != expected_mount_id:
             raise SafetyError(f"mounted directory appeared at {name}")
         for child in os.listdir(directory_fd):
@@ -150,9 +158,20 @@ def _remove_tree_at(parent_fd: int, name: str, expected_mount_id: int) -> None:
     os.rmdir(name, dir_fd=parent_fd)
 
 
-def _discard_private_staging(staging: Path) -> None:
-    if staging.exists() and not staging.is_symlink():
-        shutil.rmtree(staging)
+def _discard_private_staging(staging: Path, identity: tuple[int, int]) -> None:
+    parent_fd = os.open(staging.parent, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        try:
+            current_st = os.stat(staging.name, dir_fd=parent_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            return
+        if (current_st.st_dev, current_st.st_ino) != identity:
+            return
+        _remove_tree_at(
+            parent_fd, staging.name, _fd_mount_id(parent_fd), expected_identity=identity
+        )
+    finally:
+        os.close(parent_fd)
 
 
 def initialize_root(root: Path) -> None:
@@ -163,6 +182,8 @@ def initialize_root(root: Path) -> None:
     if not root.parent.is_dir():
         raise SafetyError("scratch root parent must already exist")
     staging = Path(tempfile.mkdtemp(prefix=f".{root.name}.boring-init-", dir=root.parent))
+    staging_st = staging.lstat()
+    staging_identity = (staging_st.st_dev, staging_st.st_ino)
     try:
         staging.chmod(0o700)
         marker = {"owner": OWNER, "protocol": PROTOCOL_VERSION, "root_id": str(uuid.uuid4())}
@@ -171,7 +192,7 @@ def initialize_root(root: Path) -> None:
         marker_path.chmod(0o600)
         _rename_noreplace(staging, root)
     except BaseException:
-        _discard_private_staging(staging)
+        _discard_private_staging(staging, staging_identity)
         raise
 
 
@@ -189,6 +210,8 @@ def initialize_entry(root: Path, name: str, *, now: float | None = None) -> Path
     if entry.exists() or entry.is_symlink():
         raise SafetyError("entry path already exists")
     staging = Path(tempfile.mkdtemp(prefix=".boring-init-", dir=canonical_root))
+    staging_st = staging.lstat()
+    staging_identity = (staging_st.st_dev, staging_st.st_ino)
     try:
         staging.chmod(0o700)
         marker = {
@@ -207,7 +230,7 @@ def initialize_entry(root: Path, name: str, *, now: float | None = None) -> Path
         os.utime(heartbeat, (timestamp, timestamp), follow_symlinks=False)
         _rename_noreplace(staging, entry)
     except BaseException:
-        _discard_private_staging(staging)
+        _discard_private_staging(staging, staging_identity)
         raise
     return entry
 
@@ -418,7 +441,12 @@ def clean_root(
                 )
                 if (quarantined_st.st_dev, quarantined_st.st_ino) != evidence.entry_identity:
                     raise SafetyError("quarantine identity mismatch")
-                _remove_tree_at(root_fd, quarantine_name, root_mount_id)
+                _remove_tree_at(
+                    root_fd,
+                    quarantine_name,
+                    root_mount_id,
+                    expected_identity=evidence.entry_identity,
+                )
                 decisions.append(Decision(entry, "deleted", decision.reason))
             except (OSError, SafetyError) as exc:
                 retained_path = quarantine if renamed else entry
@@ -441,7 +469,9 @@ def parse_mountinfo(lines: Iterable[str]) -> list[Mount]:
             fs_type = fields[separator + 1]
         except (ValueError, IndexError):
             continue
-        decoded = point.replace("\\040", " ").replace("\\011", "\t").replace("\\134", "\\")
+        decoded = re.sub(
+            r"\\([0-7]{3})", lambda match: chr(int(match.group(1), 8)), point
+        )
         mounts.append(Mount(Path(decoded), fs_type))
     return mounts
 

--- a/ops/factory-scratch/scratch_guard.py
+++ b/ops/factory-scratch/scratch_guard.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import ctypes
 import errno
 import fcntl
 import json
@@ -25,6 +26,8 @@ ENTRY_MARKER = ".boring-scratch.json"
 LOCK_FILE = ".boring-active.lock"
 HEARTBEAT_FILE = ".boring-heartbeat"
 TMPFS_TYPES = frozenset({"tmpfs", "ramfs"})
+AT_FDCWD = -100
+RENAME_NOREPLACE = 1
 
 
 class SafetyError(RuntimeError):
@@ -93,6 +96,60 @@ def _validate_root(root: Path) -> tuple[Path, str]:
     return resolved, root_id
 
 
+def _rename_noreplace(source: Path, target: Path) -> None:
+    try:
+        renameat2 = ctypes.CDLL(None, use_errno=True).renameat2
+    except AttributeError as exc:
+        raise SafetyError("platform lacks atomic no-clobber renameat2") from exc
+    renameat2.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p, ctypes.c_uint]
+    renameat2.restype = ctypes.c_int
+    if renameat2(
+        AT_FDCWD, os.fsencode(source), AT_FDCWD, os.fsencode(target), RENAME_NOREPLACE
+    ) != 0:
+        error = ctypes.get_errno()
+        raise OSError(error, os.strerror(error), target)
+
+
+def _fd_mount_id(fd: int) -> int:
+    try:
+        lines = Path(f"/proc/self/fdinfo/{fd}").read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise SafetyError(f"cannot inspect mount identity: {exc}") from exc
+    for line in lines:
+        if line.startswith("mnt_id:"):
+            try:
+                return int(line.split(":", 1)[1].strip())
+            except ValueError as exc:
+                raise SafetyError("mount identity is malformed") from exc
+    raise SafetyError("mount identity is unavailable")
+
+
+def _remove_tree_at(parent_fd: int, name: str, expected_mount_id: int) -> None:
+    directory_fd = os.open(
+        name, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=parent_fd
+    )
+    try:
+        if _fd_mount_id(directory_fd) != expected_mount_id:
+            raise SafetyError(f"mounted directory appeared at {name}")
+        for child in os.listdir(directory_fd):
+            child_st = os.stat(child, dir_fd=directory_fd, follow_symlinks=False)
+            if stat.S_ISLNK(child_st.st_mode):
+                raise SafetyError(f"symlink appeared during removal at {child}")
+            if stat.S_ISDIR(child_st.st_mode):
+                _remove_tree_at(directory_fd, child, expected_mount_id)
+                continue
+            path_fd = os.open(child, os.O_PATH | os.O_NOFOLLOW, dir_fd=directory_fd)
+            try:
+                if _fd_mount_id(path_fd) != expected_mount_id:
+                    raise SafetyError(f"mounted file appeared at {child}")
+            finally:
+                os.close(path_fd)
+            os.unlink(child, dir_fd=directory_fd)
+    finally:
+        os.close(directory_fd)
+    os.rmdir(name, dir_fd=parent_fd)
+
+
 def _discard_private_staging(staging: Path) -> None:
     if staging.exists() and not staging.is_symlink():
         shutil.rmtree(staging)
@@ -112,7 +169,7 @@ def initialize_root(root: Path) -> None:
         marker_path = staging / ROOT_MARKER
         marker_path.write_text(json.dumps(marker, sort_keys=True) + "\n", encoding="utf-8")
         marker_path.chmod(0o600)
-        staging.rename(root)
+        _rename_noreplace(staging, root)
     except BaseException:
         _discard_private_staging(staging)
         raise
@@ -148,7 +205,7 @@ def initialize_entry(root: Path, name: str, *, now: float | None = None) -> Path
         heartbeat.touch(mode=0o600)
         timestamp = time.time() if now is None else now
         os.utime(heartbeat, (timestamp, timestamp), follow_symlinks=False)
-        staging.rename(entry)
+        _rename_noreplace(staging, entry)
     except BaseException:
         _discard_private_staging(staging)
         raise
@@ -192,8 +249,6 @@ def _entry_decision(
     for mount in mounts:
         if mount.point == entry or entry in mount.point.parents:
             return Decision(entry, "retain", f"mounted path boundary at {mount.point}"), None
-    if not getattr(shutil.rmtree, "avoids_symlink_attacks", False):
-        return Decision(entry, "retain", "platform lacks symlink-safe tree removal"), None
     try:
         marker = _strict_json(entry / ENTRY_MARKER, {"entry", "owner", "protocol", "root_id"})
     except SafetyError as exc:
@@ -297,8 +352,10 @@ def clean_root(
     decisions: list[Decision] = []
     root_fd = os.open(canonical_root, os.O_RDONLY | os.O_DIRECTORY)
     try:
-        if (os.fstat(root_fd).st_dev, os.fstat(root_fd).st_ino) != root_identity:
+        opened_root_st = os.fstat(root_fd)
+        if (opened_root_st.st_dev, opened_root_st.st_ino) != root_identity:
             raise SafetyError("scratch root changed while opening")
+        root_mount_id = _fd_mount_id(root_fd)
         for entry in sorted(canonical_root.iterdir(), key=lambda item: item.name):
             if entry.name == ROOT_MARKER:
                 continue
@@ -361,7 +418,7 @@ def clean_root(
                 )
                 if (quarantined_st.st_dev, quarantined_st.st_ino) != evidence.entry_identity:
                     raise SafetyError("quarantine identity mismatch")
-                shutil.rmtree(quarantine_name, dir_fd=root_fd)
+                _remove_tree_at(root_fd, quarantine_name, root_mount_id)
                 decisions.append(Decision(entry, "deleted", decision.reason))
             except (OSError, SafetyError) as exc:
                 retained_path = quarantine if renamed else entry

--- a/ops/factory-scratch/scratch_guard.py
+++ b/ops/factory-scratch/scratch_guard.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+"""Opt-in inode preflight and conservative cleanup for repo-owned scratch roots."""
+
+from __future__ import annotations
+
+import argparse
+import errno
+import fcntl
+import json
+import os
+from pathlib import Path
+import shutil
+import stat
+import sys
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Callable, Iterable, TextIO
+
+OWNER = "boring-ui"
+PROTOCOL_VERSION = 1
+ROOT_MARKER = ".boring-scratch-root.json"
+ENTRY_MARKER = ".boring-scratch.json"
+LOCK_FILE = ".boring-active.lock"
+HEARTBEAT_FILE = ".boring-heartbeat"
+TMPFS_TYPES = frozenset({"tmpfs", "ramfs"})
+
+
+class SafetyError(RuntimeError):
+    """A condition that makes mutation unsafe."""
+
+
+@dataclass(frozen=True)
+class Mount:
+    point: Path
+    fs_type: str
+
+
+@dataclass(frozen=True)
+class Decision:
+    path: Path
+    action: str
+    reason: str
+
+
+def _strict_json(path: Path, expected_keys: set[str]) -> dict[str, object]:
+    try:
+        st = path.lstat()
+    except OSError as exc:
+        raise SafetyError(f"cannot stat marker: {exc.strerror}") from exc
+    if not stat.S_ISREG(st.st_mode) or path.is_symlink():
+        raise SafetyError("marker is not a regular non-symlink file")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise SafetyError(f"marker is unreadable or malformed: {exc}") from exc
+    if not isinstance(value, dict) or set(value) != expected_keys:
+        raise SafetyError("marker schema is ambiguous")
+    return value
+
+
+def _validate_root(root: Path) -> tuple[Path, str]:
+    if not root.is_absolute():
+        raise SafetyError("scratch root must be absolute")
+    try:
+        st = root.lstat()
+    except OSError as exc:
+        raise SafetyError(f"scratch root is unavailable: {exc.strerror}") from exc
+    if not stat.S_ISDIR(st.st_mode) or root.is_symlink():
+        raise SafetyError("scratch root must be a real directory, not a symlink")
+    if st.st_uid != os.getuid():
+        raise SafetyError("scratch root must be owned by the current uid")
+    if stat.S_IMODE(st.st_mode) & 0o022:
+        raise SafetyError("scratch root must not be group/world writable")
+    resolved = root.resolve(strict=True)
+    if resolved != root:
+        raise SafetyError("scratch root path must already be canonical")
+    marker = _strict_json(root / ROOT_MARKER, {"owner", "protocol", "root_id"})
+    if marker["owner"] != OWNER or marker["protocol"] != PROTOCOL_VERSION:
+        raise SafetyError("scratch root marker has the wrong owner or protocol")
+    root_id = marker["root_id"]
+    if not isinstance(root_id, str) or not root_id or len(root_id) > 128:
+        raise SafetyError("scratch root marker has an invalid root_id")
+    return resolved, root_id
+
+
+def initialize_root(root: Path) -> None:
+    if not root.is_absolute():
+        raise SafetyError("scratch root must be absolute")
+    if root.exists() or root.is_symlink():
+        raise SafetyError("init refuses an existing path")
+    root.mkdir(mode=0o700, parents=False)
+    marker = {"owner": OWNER, "protocol": PROTOCOL_VERSION, "root_id": str(uuid.uuid4())}
+    marker_path = root / ROOT_MARKER
+    marker_path.write_text(json.dumps(marker, sort_keys=True) + "\n", encoding="utf-8")
+    marker_path.chmod(0o600)
+
+
+def initialize_entry(root: Path, name: str, *, now: float | None = None) -> Path:
+    canonical_root, root_id = _validate_root(root)
+    if (
+        not name
+        or name in {".", "..", ROOT_MARKER}
+        or name.startswith(".boring-trash-")
+        or "/" in name
+        or os.sep in name
+    ):
+        raise SafetyError("entry name must be one non-reserved direct child name")
+    entry = canonical_root / name
+    if entry.exists() or entry.is_symlink():
+        raise SafetyError("entry path already exists")
+    entry.mkdir(mode=0o700)
+    marker = {
+        "entry": name,
+        "owner": OWNER,
+        "protocol": PROTOCOL_VERSION,
+        "root_id": root_id,
+    }
+    (entry / ENTRY_MARKER).write_text(json.dumps(marker, sort_keys=True) + "\n", encoding="utf-8")
+    (entry / LOCK_FILE).touch(mode=0o600)
+    heartbeat = entry / HEARTBEAT_FILE
+    heartbeat.touch(mode=0o600)
+    timestamp = time.time() if now is None else now
+    os.utime(heartbeat, (timestamp, timestamp), follow_symlinks=False)
+    return entry
+
+
+def _tree_is_confined(entry: Path, root_device: int) -> tuple[bool, str]:
+    for current, dirs, files in os.walk(entry, topdown=True, followlinks=False):
+        current_path = Path(current)
+        names = [*dirs, *files]
+        for name in names:
+            candidate = current_path / name
+            try:
+                st = candidate.lstat()
+            except OSError as exc:
+                return False, f"tree changed during validation: {exc.strerror}"
+            if stat.S_ISLNK(st.st_mode):
+                return False, f"symlink present at {candidate.relative_to(entry)}"
+            if st.st_dev != root_device:
+                return False, f"filesystem boundary at {candidate.relative_to(entry)}"
+    return True, "confined"
+
+
+def _entry_decision(
+    root: Path,
+    root_id: str,
+    entry: Path,
+    *,
+    stale_before: float,
+    now: float,
+) -> tuple[Decision, TextIO | None]:
+    try:
+        entry_st = entry.lstat()
+    except OSError as exc:
+        return Decision(entry, "retain", f"cannot stat entry: {exc.strerror}"), None
+    if not stat.S_ISDIR(entry_st.st_mode) or entry.is_symlink():
+        return Decision(entry, "retain", "not a real directory"), None
+    if entry_st.st_dev != root.lstat().st_dev:
+        return Decision(entry, "retain", "entry is a filesystem boundary"), None
+    try:
+        marker = _strict_json(entry / ENTRY_MARKER, {"entry", "owner", "protocol", "root_id"})
+    except SafetyError as exc:
+        return Decision(entry, "retain", str(exc)), None
+    expected = {
+        "entry": entry.name,
+        "owner": OWNER,
+        "protocol": PROTOCOL_VERSION,
+        "root_id": root_id,
+    }
+    if marker != expected:
+        return Decision(entry, "retain", "entry marker does not exactly match path/root"), None
+
+    lock_path = entry / LOCK_FILE
+    heartbeat_path = entry / HEARTBEAT_FILE
+    try:
+        lock_st = lock_path.lstat()
+        heartbeat_st = heartbeat_path.lstat()
+    except OSError as exc:
+        return Decision(entry, "retain", f"lease files unavailable: {exc.strerror}"), None
+    if (
+        not stat.S_ISREG(lock_st.st_mode)
+        or lock_path.is_symlink()
+        or not stat.S_ISREG(heartbeat_st.st_mode)
+        or heartbeat_path.is_symlink()
+    ):
+        return Decision(entry, "retain", "lease files must be regular non-symlink files"), None
+
+    lock_handle: TextIO | None = None
+    try:
+        lock_handle = lock_path.open("r+")
+        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError as exc:
+        if lock_handle is not None:
+            lock_handle.close()
+        if exc.errno in {errno.EACCES, errno.EAGAIN}:
+            return Decision(entry, "retain", "active lock held"), None
+        return Decision(entry, "retain", f"lock state ambiguous: {exc.strerror}"), None
+
+    # Re-stat after taking the lock so lease replacement and heartbeat updates are observed.
+    try:
+        locked_st = lock_path.lstat()
+        heartbeat_st = heartbeat_path.lstat()
+    except OSError as exc:
+        lock_handle.close()
+        return Decision(entry, "retain", f"lease changed after lock: {exc.strerror}"), None
+    if (locked_st.st_dev, locked_st.st_ino) != (lock_st.st_dev, lock_st.st_ino):
+        lock_handle.close()
+        return Decision(entry, "retain", "lock file changed during validation"), None
+    age = now - heartbeat_st.st_mtime
+    if age < 0:
+        lock_handle.close()
+        return Decision(entry, "retain", "heartbeat timestamp is in the future"), None
+    if heartbeat_st.st_mtime >= stale_before:
+        lock_handle.close()
+        return Decision(entry, "retain", f"heartbeat live ({int(age)}s old)"), None
+
+    confined, reason = _tree_is_confined(entry, root.lstat().st_dev)
+    if not confined:
+        lock_handle.close()
+        return Decision(entry, "retain", reason), None
+    return Decision(entry, "delete", f"stale heartbeat ({int(age)}s old), unlocked, confined"), lock_handle
+
+
+def clean_root(
+    root: Path,
+    *,
+    stale_seconds: int,
+    apply: bool,
+    now: float | None = None,
+) -> list[Decision]:
+    if stale_seconds <= 0:
+        raise SafetyError("stale-seconds must be greater than zero")
+    canonical_root, root_id = _validate_root(root)
+    current_time = time.time() if now is None else now
+    stale_before = current_time - stale_seconds
+    decisions: list[Decision] = []
+    for entry in sorted(canonical_root.iterdir(), key=lambda item: item.name):
+        if entry.name == ROOT_MARKER:
+            continue
+        if entry.name.startswith(".boring-trash-"):
+            decisions.append(Decision(entry, "retain", "ambiguous prior quarantine"))
+            continue
+        decision, lock_handle = _entry_decision(
+            canonical_root, root_id, entry, stale_before=stale_before, now=current_time
+        )
+        if decision.action != "delete" or not apply:
+            if lock_handle is not None:
+                lock_handle.close()
+            decisions.append(
+                Decision(entry, "would-delete", decision.reason) if decision.action == "delete" else decision
+            )
+            continue
+
+        if not getattr(shutil.rmtree, "avoids_symlink_attacks", False):
+            lock_handle.close()
+            decisions.append(Decision(entry, "retain", "platform lacks symlink-safe tree removal"))
+            continue
+        quarantine_name = f".boring-trash-{uuid.uuid4().hex}"
+        quarantine = canonical_root / quarantine_name
+        root_fd = os.open(canonical_root, os.O_RDONLY | os.O_DIRECTORY)
+        renamed = False
+        try:
+            # Revalidate the locked inode immediately before the mutation boundary.
+            held_lock_st = os.fstat(lock_handle.fileno())
+            path_lock_st = (entry / LOCK_FILE).lstat()
+            if (held_lock_st.st_dev, held_lock_st.st_ino) != (
+                path_lock_st.st_dev,
+                path_lock_st.st_ino,
+            ):
+                raise SafetyError("lock file changed before quarantine")
+            # Same-directory rename is atomic. The exclusive lease lock remains held.
+            os.rename(
+                entry.name,
+                quarantine_name,
+                src_dir_fd=root_fd,
+                dst_dir_fd=root_fd,
+            )
+            renamed = True
+            quarantined_st = os.stat(quarantine_name, dir_fd=root_fd, follow_symlinks=False)
+            if not stat.S_ISDIR(quarantined_st.st_mode):
+                raise SafetyError("quarantine changed type")
+            shutil.rmtree(quarantine_name, dir_fd=root_fd)
+            decisions.append(Decision(entry, "deleted", decision.reason))
+        except (OSError, SafetyError) as exc:
+            retained_path = quarantine if renamed else entry
+            reason = "quarantined but deletion failed" if renamed else "atomic quarantine failed"
+            decisions.append(Decision(retained_path, "retain", f"{reason}: {exc}"))
+        finally:
+            os.close(root_fd)
+            lock_handle.close()
+    return decisions
+
+
+def parse_mountinfo(lines: Iterable[str]) -> list[Mount]:
+    mounts: list[Mount] = []
+    for raw in lines:
+        fields = raw.rstrip("\n").split(" ")
+        try:
+            separator = fields.index("-")
+            point = fields[4]
+            fs_type = fields[separator + 1]
+        except (ValueError, IndexError):
+            continue
+        decoded = point.replace("\\040", " ").replace("\\011", "\t").replace("\\134", "\\")
+        mounts.append(Mount(Path(decoded), fs_type))
+    return mounts
+
+
+def filesystem_type(path: Path, mounts: Iterable[Mount]) -> str | None:
+    resolved = path.resolve(strict=True)
+    matches: list[Mount] = []
+    for mount in mounts:
+        try:
+            resolved.relative_to(mount.point)
+        except ValueError:
+            continue
+        matches.append(mount)
+    if not matches:
+        return None
+    return max(matches, key=lambda mount: len(mount.point.parts)).fs_type
+
+
+def inode_used_percent(path: Path, statvfs: Callable[[Path], os.statvfs_result] = os.statvfs) -> float:
+    values = statvfs(path)
+    if values.f_files <= 0:
+        raise SafetyError(f"filesystem for {path} does not report inode capacity")
+    return 100.0 * (values.f_files - values.f_ffree) / values.f_files
+
+
+def preflight(
+    *,
+    paths: list[Path],
+    threshold: float,
+    tmpdir: Path,
+    pnpm_store: Path | None,
+    mounts: list[Mount],
+    statvfs: Callable[[Path], os.statvfs_result] = os.statvfs,
+) -> tuple[list[str], list[str]]:
+    if not 0 < threshold <= 100:
+        raise SafetyError("inode threshold must be in (0, 100]")
+    failures: list[str] = []
+    warnings: list[str] = []
+    checked: set[tuple[int, int]] = set()
+    for path in paths:
+        resolved = path.resolve(strict=True)
+        st = resolved.stat()
+        device = (os.major(st.st_dev), os.minor(st.st_dev))
+        if device in checked:
+            continue
+        checked.add(device)
+        used = inode_used_percent(resolved, statvfs)
+        line = f"inode usage {used:.2f}% at {resolved} (limit {threshold:.2f}%)"
+        (failures if used >= threshold else warnings).append(("FAIL " if used >= threshold else "OK ") + line)
+
+    tmp_type = filesystem_type(tmpdir, mounts)
+    if tmp_type in TMPFS_TYPES:
+        failures.append(f"FAIL TMPDIR {tmpdir.resolve(strict=True)} is on {tmp_type}")
+    elif tmp_type is None:
+        warnings.append(f"WARN TMPDIR filesystem is unknown for {tmpdir.resolve(strict=True)}")
+    else:
+        warnings.append(f"OK TMPDIR {tmpdir.resolve(strict=True)} is on {tmp_type}")
+
+    if pnpm_store is None:
+        warnings.append("WARN pnpm store path not supplied; pass --pnpm-store or PNPM_STORE_DIR")
+    else:
+        pnpm_type = filesystem_type(pnpm_store, mounts)
+        if pnpm_type in TMPFS_TYPES:
+            failures.append(f"FAIL pnpm store {pnpm_store.resolve(strict=True)} is on {pnpm_type}")
+        elif pnpm_type is None:
+            warnings.append(f"WARN pnpm store filesystem is unknown for {pnpm_store.resolve(strict=True)}")
+        else:
+            warnings.append(f"OK pnpm store {pnpm_store.resolve(strict=True)} is on {pnpm_type}")
+    return failures, warnings
+
+
+def _print_decisions(decisions: Iterable[Decision]) -> None:
+    for decision in decisions:
+        print(f"{decision.action.upper()} {decision.path}: {decision.reason}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_root_parser = subparsers.add_parser("init-root", help="create a new private marked root")
+    init_root_parser.add_argument("root", type=Path)
+
+    init_entry_parser = subparsers.add_parser("init-entry", help="create one marked scratch entry")
+    init_entry_parser.add_argument("root", type=Path)
+    init_entry_parser.add_argument("name")
+
+    clean_parser = subparsers.add_parser("clean", help="inspect or age marked entries")
+    clean_parser.add_argument("--root", action="append", required=True, type=Path)
+    clean_parser.add_argument("--stale-seconds", required=True, type=int)
+    clean_parser.add_argument("--apply", action="store_true", help="delete eligible entries; default is dry-run")
+
+    check_parser = subparsers.add_parser("check", help="fail fast on inode or tmpfs pressure")
+    check_parser.add_argument("--path", action="append", required=True, type=Path)
+    check_parser.add_argument("--inode-threshold", required=True, type=float)
+    check_parser.add_argument("--tmpdir", type=Path, default=Path(os.environ.get("TMPDIR", "/tmp")))
+    check_parser.add_argument("--pnpm-store", type=Path, default=None)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.command == "init-root":
+            initialize_root(args.root)
+            print(f"INITIALIZED {args.root}")
+            return 0
+        if args.command == "init-entry":
+            print(f"INITIALIZED {initialize_entry(args.root, args.name)}")
+            return 0
+        if args.command == "clean":
+            for root in args.root:
+                _print_decisions(
+                    clean_root(root, stale_seconds=args.stale_seconds, apply=args.apply)
+                )
+            return 0
+        if args.command == "check":
+            with Path("/proc/self/mountinfo").open(encoding="utf-8") as mountinfo:
+                mounts = parse_mountinfo(mountinfo)
+            pnpm_store = args.pnpm_store
+            if pnpm_store is None and os.environ.get("PNPM_STORE_DIR"):
+                pnpm_store = Path(os.environ["PNPM_STORE_DIR"])
+            failures, messages = preflight(
+                paths=args.path,
+                threshold=args.inode_threshold,
+                tmpdir=args.tmpdir,
+                pnpm_store=pnpm_store,
+                mounts=mounts,
+            )
+            for message in [*messages, *failures]:
+                print(message)
+            return 2 if failures else 0
+    except (OSError, SafetyError) as exc:
+        print(f"REFUSED: {exc}", file=sys.stderr)
+        return 3
+    return 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/factory-scratch/test_scratch_guard.py
+++ b/ops/factory-scratch/test_scratch_guard.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 import fcntl
 import importlib.util
 import json
+import os
 from pathlib import Path
 import stat
 import subprocess
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 MODULE_PATH = Path(__file__).with_name("scratch_guard.py")
 spec = importlib.util.spec_from_file_location("scratch_guard", MODULE_PATH)
@@ -134,6 +136,78 @@ class ScratchGuardTest(unittest.TestCase):
         self.assertTrue(outside.exists())
         self.assertTrue(nested.exists())
 
+
+    def test_same_device_nested_mount_boundary_is_retained(self) -> None:
+        entry = self.entry("mounted")
+        mounted_path = entry / "bind-target"
+        result = scratch_guard.clean_root(
+            self.root, stale_seconds=100, apply=True, now=10_000,
+            mounts=[scratch_guard.Mount(mounted_path, "ext4")],
+        )[0]
+        self.assertEqual("retain", result.action)
+        self.assertIn("mounted path boundary", result.reason)
+        self.assertTrue(entry.exists())
+
+    def test_dry_run_refuses_when_safe_removal_is_unavailable(self) -> None:
+        entry = self.entry("portable")
+        with mock.patch.object(scratch_guard.shutil.rmtree, "avoids_symlink_attacks", False):
+            result = self.decisions(apply=False)[0]
+        self.assertEqual("retain", result.action)
+        self.assertIn("lacks symlink-safe", result.reason)
+        self.assertTrue(entry.exists())
+
+
+    def test_heartbeat_change_at_mutation_boundary_is_retained(self) -> None:
+        entry = self.entry("heartbeat-race")
+        real_decision = scratch_guard._entry_decision
+
+        def change_heartbeat(*args, **kwargs):
+            decision, evidence = real_decision(*args, **kwargs)
+            if evidence is not None:
+                os.utime(entry / scratch_guard.HEARTBEAT_FILE, (9_950, 9_950))
+            return decision, evidence
+
+        with mock.patch.object(scratch_guard, "_entry_decision", side_effect=change_heartbeat):
+            result = self.decisions(apply=True)[0]
+        self.assertEqual("retain", result.action)
+        self.assertIn("heartbeat changed", result.reason)
+        self.assertTrue(entry.exists())
+
+    def test_entry_inode_swap_at_mutation_boundary_is_retained(self) -> None:
+        entry = self.entry("swap")
+        real_stat = scratch_guard.os.stat
+
+        def changed_stat(path, *args, **kwargs):
+            result = real_stat(path, *args, **kwargs)
+            if path == "swap" and kwargs.get("dir_fd") is not None:
+                values = list(result)
+                values[1] += 1
+                return os.stat_result(values)
+            return result
+
+        with mock.patch.object(scratch_guard.os, "stat", side_effect=changed_stat):
+            result = self.decisions(apply=True)[0]
+        self.assertEqual("retain", result.action)
+        self.assertIn("entry directory changed", result.reason)
+        self.assertTrue(entry.exists())
+
+    def test_failed_initialization_removes_private_staging_and_allows_retry(self) -> None:
+        target = self.base / "atomic-root"
+        original = Path.write_text
+
+        def fail_marker(path, *args, **kwargs):
+            if path.name == scratch_guard.ROOT_MARKER:
+                raise OSError("fixture write failure")
+            return original(path, *args, **kwargs)
+
+        with mock.patch.object(Path, "write_text", autospec=True, side_effect=fail_marker):
+            with self.assertRaisesRegex(OSError, "fixture write failure"):
+                scratch_guard.initialize_root(target)
+        self.assertFalse(target.exists())
+        self.assertEqual([], list(self.base.glob(".atomic-root.boring-init-*")))
+        scratch_guard.initialize_root(target)
+        self.assertTrue(target.is_dir())
+
     def test_unrelated_paths_are_preserved(self) -> None:
         unrelated = self.root / "notes.txt"
         unrelated.write_text("operator data")
@@ -179,6 +253,27 @@ class ScratchGuardTest(unittest.TestCase):
         )
         self.assertEqual(0, check_run.returncode, check_run.stdout)
         self.assertIn("inode usage", check_run.stdout)
+        cli_root = self.base / "cli-root"
+        init_root_run = subprocess.run(
+            [str(installed), "init-root", str(cli_root)], check=False, text=True,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        )
+        self.assertEqual(0, init_root_run.returncode, init_root_run.stdout)
+        init_entry_run = subprocess.run(
+            [str(installed), "init-entry", str(cli_root), "documented-run"],
+            check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        )
+        self.assertEqual(0, init_entry_run.returncode, init_entry_run.stdout)
+        cli_entry = cli_root / "documented-run"
+        (cli_entry / "tmp").mkdir()
+        os.utime(cli_entry / scratch_guard.HEARTBEAT_FILE, (1, 1))
+        dry_run = subprocess.run(
+            [str(installed), "clean", "--root", str(cli_root), "--stale-seconds", "1"],
+            check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        )
+        self.assertEqual(0, dry_run.returncode, dry_run.stdout)
+        self.assertIn("WOULD-DELETE", dry_run.stdout)
+        self.assertTrue(cli_entry.exists())
         help_run = subprocess.run(
             [str(installed), "check", "--help"], cwd=repo,
             check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,

--- a/ops/factory-scratch/test_scratch_guard.py
+++ b/ops/factory-scratch/test_scratch_guard.py
@@ -194,6 +194,18 @@ class ScratchGuardTest(unittest.TestCase):
 
 
 
+
+    def test_staging_cleanup_keeps_validated_empty_top_level_directory(self) -> None:
+        staging = self.base / ".empty-staging"
+        staging.mkdir()
+        (staging / "partial").write_text("partial")
+        staging_st = staging.lstat()
+        scratch_guard._discard_private_staging(
+            staging, (staging_st.st_dev, staging_st.st_ino)
+        )
+        self.assertTrue(staging.is_dir())
+        self.assertEqual([], list(staging.iterdir()))
+
     def test_staging_cleanup_retains_replacement_directory(self) -> None:
         staging = self.base / ".staging"
         staging.mkdir()
@@ -242,9 +254,11 @@ class ScratchGuardTest(unittest.TestCase):
             with self.assertRaises(FileExistsError):
                 scratch_guard.initialize_root(target)
         self.assertEqual("competitor", (target / "sentinel").read_text())
-        self.assertEqual([], list(self.base.glob(".raced-root.boring-init-*")))
+        retained = list(self.base.glob(".raced-root.boring-init-*"))
+        self.assertEqual(1, len(retained))
+        self.assertEqual([], list(retained[0].iterdir()))
 
-    def test_failed_initialization_removes_private_staging_and_allows_retry(self) -> None:
+    def test_failed_initialization_clears_private_staging_and_allows_retry(self) -> None:
         target = self.base / "atomic-root"
         original = Path.write_text
 
@@ -257,7 +271,9 @@ class ScratchGuardTest(unittest.TestCase):
             with self.assertRaisesRegex(OSError, "fixture write failure"):
                 scratch_guard.initialize_root(target)
         self.assertFalse(target.exists())
-        self.assertEqual([], list(self.base.glob(".atomic-root.boring-init-*")))
+        retained = list(self.base.glob(".atomic-root.boring-init-*"))
+        self.assertEqual(1, len(retained))
+        self.assertEqual([], list(retained[0].iterdir()))
         scratch_guard.initialize_root(target)
         self.assertTrue(target.is_dir())
 

--- a/ops/factory-scratch/test_scratch_guard.py
+++ b/ops/factory-scratch/test_scratch_guard.py
@@ -193,6 +193,29 @@ class ScratchGuardTest(unittest.TestCase):
         self.assertTrue(entry.exists())
 
 
+
+    def test_staging_cleanup_retains_replacement_directory(self) -> None:
+        staging = self.base / ".staging"
+        staging.mkdir()
+        staging_st = staging.lstat()
+        identity = (staging_st.st_dev, staging_st.st_ino)
+        original = self.base / "original-staging"
+        staging.rename(original)
+        staging.mkdir()
+        sentinel = staging / "sentinel"
+        sentinel.write_text("replacement")
+        scratch_guard._discard_private_staging(staging, identity)
+        self.assertEqual("replacement", sentinel.read_text())
+        self.assertTrue(original.exists())
+
+    def test_mountinfo_decodes_all_octal_escapes(self) -> None:
+        mounts = scratch_guard.parse_mountinfo(
+            ["1 0 0:1 / /mnt/space\\040tab\\011newline\\012slash\\134 rw - tmpfs tmpfs rw\n"]
+        )
+        self.assertEqual(
+            Path("/mnt/space tab\tnewline\nslash\\"), mounts[0].point
+        )
+
     def test_atomic_publication_never_clobbers_existing_directory(self) -> None:
         source = self.base / "publication-source"
         target = self.base / "publication-target"

--- a/ops/factory-scratch/test_scratch_guard.py
+++ b/ops/factory-scratch/test_scratch_guard.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import fcntl
+import importlib.util
+import json
+from pathlib import Path
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+
+MODULE_PATH = Path(__file__).with_name("scratch_guard.py")
+spec = importlib.util.spec_from_file_location("scratch_guard", MODULE_PATH)
+assert spec and spec.loader
+scratch_guard = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = scratch_guard
+spec.loader.exec_module(scratch_guard)
+
+
+class FakeStatvfs:
+    def __init__(self, files: int, free: int) -> None:
+        self.f_files = files
+        self.f_ffree = free
+
+
+class ScratchGuardTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory(prefix="scratch-guard-fixture-")
+        self.base = Path(self.temp.name)
+        self.root = self.base / "owned-root"
+        scratch_guard.initialize_root(self.root)
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def entry(self, name: str, heartbeat_age: int = 1_000) -> Path:
+        return scratch_guard.initialize_entry(self.root, name, now=10_000 - heartbeat_age)
+
+    def decisions(self, *, apply: bool = False, stale_seconds: int = 100):
+        return scratch_guard.clean_root(
+            self.root, stale_seconds=stale_seconds, apply=apply, now=10_000
+        )
+
+    def test_inode_threshold_above_and_below_configured_percentage(self) -> None:
+        mounts = [scratch_guard.Mount(Path("/"), "ext4")]
+        below, messages = scratch_guard.preflight(
+            paths=[self.base], threshold=80, tmpdir=self.base, pnpm_store=self.base,
+            mounts=mounts, statvfs=lambda _: FakeStatvfs(100, 21),
+        )
+        self.assertEqual([], below)
+        self.assertTrue(any("79.00%" in line and line.startswith("OK") for line in messages))
+        above, _ = scratch_guard.preflight(
+            paths=[self.base], threshold=80, tmpdir=self.base, pnpm_store=self.base,
+            mounts=mounts, statvfs=lambda _: FakeStatvfs(100, 20),
+        )
+        self.assertTrue(any("80.00%" in line and line.startswith("FAIL") for line in above))
+
+    def test_tmpdir_mount_selection_uses_longest_mount_and_warns_on_tmpfs(self) -> None:
+        tmpdir = self.base / "nested"
+        tmpdir.mkdir()
+        mounts = [
+            scratch_guard.Mount(Path("/"), "ext4"),
+            scratch_guard.Mount(self.base, "tmpfs"),
+        ]
+        failures, _ = scratch_guard.preflight(
+            paths=[tmpdir], threshold=90, tmpdir=tmpdir, pnpm_store=None,
+            mounts=mounts, statvfs=lambda _: FakeStatvfs(100, 90),
+        )
+        self.assertIn(f"FAIL TMPDIR {tmpdir} is on tmpfs", failures)
+
+    def test_pnpm_store_on_tmpfs_is_a_failure(self) -> None:
+        store = self.base / "pnpm"
+        store.mkdir()
+        failures, _ = scratch_guard.preflight(
+            paths=[self.base], threshold=90, tmpdir=Path("/"), pnpm_store=store,
+            mounts=[scratch_guard.Mount(Path("/"), "ext4"), scratch_guard.Mount(self.base, "tmpfs")],
+            statvfs=lambda _: FakeStatvfs(100, 90),
+        )
+        self.assertTrue(any("pnpm store" in line and "tmpfs" in line for line in failures))
+
+    def test_dry_run_reports_but_does_not_delete(self) -> None:
+        entry = self.entry("stale")
+        result = self.decisions()
+        self.assertEqual("would-delete", result[0].action)
+        self.assertTrue(entry.exists())
+
+    def test_stale_marked_unlocked_entry_is_deleted_on_apply(self) -> None:
+        entry = self.entry("stale")
+        result = self.decisions(apply=True)
+        self.assertEqual("deleted", result[0].action)
+        self.assertFalse(entry.exists())
+
+    def test_active_lock_is_retained(self) -> None:
+        entry = self.entry("active-lock")
+        with (entry / scratch_guard.LOCK_FILE).open("r+") as lock:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_SH | fcntl.LOCK_NB)
+            result = self.decisions(apply=True)
+        self.assertEqual("retain", result[0].action)
+        self.assertIn("active lock", result[0].reason)
+        self.assertTrue(entry.exists())
+
+    def test_live_heartbeat_is_retained(self) -> None:
+        entry = self.entry("live", heartbeat_age=99)
+        result = self.decisions(apply=True, stale_seconds=100)
+        self.assertEqual("retain", result[0].action)
+        self.assertIn("heartbeat live", result[0].reason)
+        self.assertTrue(entry.exists())
+
+    def test_malformed_and_ambiguous_markers_are_retained(self) -> None:
+        malformed = self.root / "malformed"
+        malformed.mkdir()
+        (malformed / scratch_guard.ENTRY_MARKER).write_text("not json")
+        ambiguous = self.entry("ambiguous")
+        marker = json.loads((ambiguous / scratch_guard.ENTRY_MARKER).read_text())
+        marker["extra"] = "not allowed"
+        (ambiguous / scratch_guard.ENTRY_MARKER).write_text(json.dumps(marker))
+        results = self.decisions(apply=True)
+        self.assertEqual(["retain", "retain"], [result.action for result in results])
+        self.assertTrue(malformed.exists())
+        self.assertTrue(ambiguous.exists())
+
+    def test_symlink_entry_and_nested_path_escape_are_retained(self) -> None:
+        outside = self.base / "outside"
+        outside.mkdir()
+        symlink_entry = self.root / "entry-link"
+        symlink_entry.symlink_to(outside, target_is_directory=True)
+        nested = self.entry("nested-link")
+        (nested / "escape").symlink_to(outside, target_is_directory=True)
+        results = {result.path.name: result for result in self.decisions(apply=True)}
+        self.assertEqual("retain", results["entry-link"].action)
+        self.assertEqual("retain", results["nested-link"].action)
+        self.assertTrue(outside.exists())
+        self.assertTrue(nested.exists())
+
+    def test_unrelated_paths_are_preserved(self) -> None:
+        unrelated = self.root / "notes.txt"
+        unrelated.write_text("operator data")
+        result = self.decisions(apply=True)[0]
+        self.assertEqual("retain", result.action)
+        self.assertEqual("operator data", unrelated.read_text())
+
+    def test_apply_is_idempotent(self) -> None:
+        self.entry("once")
+        first = self.decisions(apply=True)
+        second = self.decisions(apply=True)
+        self.assertEqual("deleted", first[0].action)
+        self.assertEqual([], second)
+
+    def test_root_must_be_private_canonical_and_marked(self) -> None:
+        unmarked = self.base / "unmarked"
+        unmarked.mkdir(mode=0o700)
+        with self.assertRaisesRegex(scratch_guard.SafetyError, "marker"):
+            scratch_guard.clean_root(unmarked, stale_seconds=100, apply=False)
+        linked = self.base / "linked"
+        linked.symlink_to(self.root, target_is_directory=True)
+        with self.assertRaisesRegex(scratch_guard.SafetyError, "symlink"):
+            scratch_guard.clean_root(linked, stale_seconds=100, apply=False)
+
+    def test_exact_documented_install_and_check_commands_validate(self) -> None:
+        repo = MODULE_PATH.parents[2]
+        doc = (repo / "docs/factory/scratch-guard.md").read_text()
+        self.assertIn("install -m 0755 ops/factory-scratch/scratch_guard.py", doc)
+        self.assertIn("scratch-guard check --path", doc)
+        installed = self.base / "bin" / "scratch-guard"
+        installed.parent.mkdir()
+        install_run = subprocess.run(
+            ["install", "-m", "0755", str(MODULE_PATH), str(installed)],
+            cwd=repo, check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        )
+        self.assertEqual(0, install_run.returncode, install_run.stdout)
+        self.assertEqual(0o755, stat.S_IMODE(installed.stat().st_mode))
+        check_run = subprocess.run(
+            [str(installed), "check", "--path", str(self.base),
+             "--inode-threshold", "100", "--tmpdir", str(self.base),
+             "--pnpm-store", str(self.base)],
+            cwd=repo, check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        )
+        self.assertEqual(0, check_run.returncode, check_run.stdout)
+        self.assertIn("inode usage", check_run.stdout)
+        help_run = subprocess.run(
+            [str(installed), "check", "--help"], cwd=repo,
+            check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        )
+        self.assertEqual(0, help_run.returncode, help_run.stdout)
+        self.assertIn("--inode-threshold", help_run.stdout)
+        self.assertIn("--pnpm-store", help_run.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/ops/factory-scratch/test_scratch_guard.py
+++ b/ops/factory-scratch/test_scratch_guard.py
@@ -148,12 +148,13 @@ class ScratchGuardTest(unittest.TestCase):
         self.assertIn("mounted path boundary", result.reason)
         self.assertTrue(entry.exists())
 
-    def test_dry_run_refuses_when_safe_removal_is_unavailable(self) -> None:
+    def test_dry_run_refuses_when_mount_identity_is_unavailable(self) -> None:
         entry = self.entry("portable")
-        with mock.patch.object(scratch_guard.shutil.rmtree, "avoids_symlink_attacks", False):
-            result = self.decisions(apply=False)[0]
-        self.assertEqual("retain", result.action)
-        self.assertIn("lacks symlink-safe", result.reason)
+        with mock.patch.object(
+            scratch_guard, "_fd_mount_id", side_effect=scratch_guard.SafetyError("unavailable")
+        ):
+            with self.assertRaisesRegex(scratch_guard.SafetyError, "unavailable"):
+                self.decisions(apply=False)
         self.assertTrue(entry.exists())
 
 
@@ -190,6 +191,35 @@ class ScratchGuardTest(unittest.TestCase):
         self.assertEqual("retain", result.action)
         self.assertIn("entry directory changed", result.reason)
         self.assertTrue(entry.exists())
+
+
+    def test_atomic_publication_never_clobbers_existing_directory(self) -> None:
+        source = self.base / "publication-source"
+        target = self.base / "publication-target"
+        source.mkdir()
+        target.mkdir()
+        sentinel = target / "sentinel"
+        sentinel.write_text("preserve")
+        with self.assertRaises(FileExistsError):
+            scratch_guard._rename_noreplace(source, target)
+        self.assertTrue(source.exists())
+        self.assertEqual("preserve", sentinel.read_text())
+
+
+    def test_init_root_loses_race_without_clobbering_competitor(self) -> None:
+        target = self.base / "raced-root"
+        real_rename = scratch_guard._rename_noreplace
+
+        def competitor_wins(source, destination):
+            destination.mkdir()
+            (destination / "sentinel").write_text("competitor")
+            real_rename(source, destination)
+
+        with mock.patch.object(scratch_guard, "_rename_noreplace", side_effect=competitor_wins):
+            with self.assertRaises(FileExistsError):
+                scratch_guard.initialize_root(target)
+        self.assertEqual("competitor", (target / "sentinel").read_text())
+        self.assertEqual([], list(self.base.glob(".raced-root.boring-init-*")))
 
     def test_failed_initialization_removes_private_staging_and_allows_retry(self) -> None:
         target = self.base / "atomic-root"


### PR DESCRIPTION
## Summary

- add a Linux-only, repo-owned opt-in inode/tmpfs preflight and marked scratch-root aging utility
- retain live locks/heartbeats, malformed or ambiguous markers, symlinks, mount boundaries, path/inode races, and unrelated paths
- document explicit install/check/init/dry-run/apply commands; install no host policy, timer, service, or cleanup rule
- scope is limited to new `ops/factory-scratch/**` and `docs/factory/scratch-guard.md`; no PR #1288/plugin/runtime surface is touched

## Proof

Exact head: `5f2311ced9ad0e206d6be82f03e360de40431c38`

- `python3 -m unittest -v ops/factory-scratch/test_scratch_guard.py` — **23 passed** (fixture roots only)
- `ruff check ops/factory-scratch` — **All checks passed**
- `python3 -m py_compile ops/factory-scratch/scratch_guard.py ops/factory-scratch/test_scratch_guard.py` — **passed**
- `python3 ops/factory-scratch/scratch_guard.py check --path "$PWD" --inode-threshold 100 --tmpdir "$PWD" --pnpm-store "$PWD"` — **passed**, 39.47% inode use, TMPDIR/pnpm store both ext4
- `git diff --check origin/main...HEAD` — **passed**
- Fixture assertions cover threshold above/below, TMPDIR mount selection, pnpm warning/failure, dry-run, stale unlocked apply, live lock/heartbeat retention, malformed/ambiguous retention, symlink and same-device bind rejection, entry/heartbeat/publication/staging races, unrelated preservation, idempotence, mountinfo escaping, and exact install/check lifecycle.

## Review provenance

All reviewers ran fresh/read-only on `openai-codex/gpt-5.6-sol` with a mandate to refute active-path safety, marker/lease races, confinement, dry-run truthfulness, portability, rollback, usability, and/or thermo maintainability.

- `bf37c3a6913493fe64e9335cdbaed9314eed2be8` — fresh-eyes **revise**: stable bind mount, entry inode, dry-run, docs lifecycle, and partial-init gaps; fixed by `40748264f`.
- `40748264f06a47d954eede91c440b9d53356c710` — fresh-eyes **revise**: late mount insertion and init no-clobber races; fixed by `356b4dac3`.
- `356b4dac33783ce7c3133ca75b40fc9094f067b5` — fresh-eyes **revise**: staging replacement cleanup and mountinfo octal gaps; fixed by `32f368382`.
- `32f368382493e6001111d55350414cfd875ad8ae` — thermo **revise**: final staging `rmdir` replacement race; fixed by final `5f2311ced` by deliberately retaining the validated empty top-level failed-init staging directory.

**Gate status:** review-round cap is exhausted and final SHA has no green exact-SHA re-review. This PR is intentionally **not ready for owner approval/merge**; no owner intention was raised.

## Artifacts

- `.handoff/wt-391-forward-d5nj.5-proof.txt` — exact-SHA command transcript (workspace-local)
- `.handoff/pr-1320-presentation.html` — present-pr review artifact (generated after PR creation)
- `docs/factory/scratch-guard.md` — operator install/check/init/dry-run/apply and rollback guide

## Risk & rollback

- Risk: deletion is intentionally opt-in (`clean --apply`), Linux-specific, and limited to exact marked direct children of a private canonical root. The active protocol is cooperative; producers must hold the documented flock and heartbeat.
- Residual risk/gate: final race fix is proven by fixtures but not independently re-reviewed because the configured three-round fresh-eyes cap was reached.
- Rollback: do not install or invoke `--apply`; remove/disable any operator-installed executable and stop using operator-created roots. Revert the commits to remove repo assets. No host installation or live host deletion was performed by this PR.

## Refs

- Bead `wt-391-forward-d5nj.5`
- GitHub #1254
- Epic B
