### PR TITLE
[br-wt-391-forward-srj0] Make frozen-chat forks seamless

### DIFF
--- a/packages/agent/src/front/chat/PiChatPanel.tsx
+++ b/packages/agent/src/front/chat/PiChatPanel.tsx
@@ -1227,7 +1227,7 @@ export function PiChatPanel<
   const disabled = !policy || sessionsLoading || composerBlocked
   const isStreaming = isPiBusyStatus(status)
   const submitStatus = initialHydrationPromptAllowed ? 'ready' : toPromptSubmitStatus(status)
-  const submitDisabled = !policy || sessionsLoading || modelSelectionBlocked || (composerBlocked && !isStreaming)
+  const submitDisabled = !policy || sessionsLoading || modelSelectionBlocked || Boolean(forkTransition?.forking) || (composerBlocked && !isStreaming)
   const mergedToolRenderers = useMemo(() => mergeShadcnToolRenderers(toolRenderers), [toolRenderers])
   const debugMessages = useMemo(() => messages.map(toDebugUiMessage), [messages])
 

--- a/packages/agent/src/front/chat/PiChatPanel.tsx
+++ b/packages/agent/src/front/chat/PiChatPanel.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type { ChangeEvent, KeyboardEvent as ReactKeyboardEvent, ReactNode } from 'react'
-import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
 import { Button } from '@hachej/boring-ui-kit'
 import { AgentGatewayErrorCode } from '../../shared/gateway/errors'
 import type { PromptInputFilePart } from '../primitives/prompt-input'
@@ -11,7 +11,7 @@ import {
   WORKSPACE_COMMAND_NOTIFY_EVENT,
   type CommandNotifyPayload,
 } from '../../shared/agentPluginEvents'
-import type { PiChatEvent, PiChatStatus } from '../../shared/chat'
+import type { BoringChatMessage, PiChatEvent, PiChatStatus } from '../../shared/chat'
 import type { AvailableModel, ModelSelection, ThinkingLevel } from '../chatPanelSettings'
 import { DEFAULT_THINKING } from '../chatPanelSettings'
 import { cn } from '../lib'
@@ -35,8 +35,8 @@ import {
 } from './chatPanelWorkspaceWarmup'
 import { useComposerContributions, type ComposerDraftUpdate } from './composerContributions'
 import { selectMessagesForRender, selectQueuePreview, selectRuntimeNotices } from './pi/selectors'
-import { piChatErrorCode, type RemotePiSession, type RemotePiSessionOptions } from './pi/remotePiSession'
-import type { PiChatRuntimeNotice } from './pi/piChatReducer'
+import { piChatErrorCode, toOptimisticUserMessage, type RemotePiSession, type RemotePiSessionOptions } from './pi/remotePiSession'
+import type { OptimisticUserMessage, PiChatRuntimeNotice } from './pi/piChatReducer'
 import {
   InitialDraftAutoSubmitGuard,
   createPiComposerPolicyController,
@@ -86,12 +86,32 @@ const EMPTY_BLOCKERS: never[] = []
 /** Stable id for the notice that surfaces a rejected run (so re-rejections replace
  * it rather than stacking, and the next admit can retract it). */
 const RUN_REJECTED_NOTICE_ID = 'run-rejected'
+const EMPTY_SESSION_BINDING_SUBSCRIBE = () => () => {}
+const EMPTY_SESSION_BINDING_SNAPSHOT = () => ''
 
 export type { ComposerBlocker, ComposerBlockerAction, PanelNotice }
 
 export type { ChatPanelRuntimeDependenciesWarmupStatus, ChatPanelWorkspaceWarmupStatus }
 
 export type ChatSubmitSource = 'composer' | 'suggestion' | 'auto-submit'
+
+export interface PiChatForkResult {
+  sessionId: string
+  agentTypeId?: string
+}
+
+export interface PiChatSessionBinding {
+  getSnapshot(): string
+  subscribe(listener: () => void): () => void
+}
+
+interface PiChatForkTransition {
+  sourceSessionId: string
+  targetSessionId?: string
+  forking: boolean
+  optimisticMessage: OptimisticUserMessage
+  preservedMessages: BoringChatMessage[]
+}
 
 export interface ChatSubmitContext {
   files: PromptInputFilePart[]
@@ -181,7 +201,11 @@ export interface PiChatPanelProps<
   /** Creates and selects a session when the host controls sessionId. */
   onCreateSession?: () => void | Promise<void>
   /** Natively forks a controlled frozen session and delivers its first prompt. */
-  onForkSession?: (sourceSessionId: string, prompt: Parameters<RemotePiSession['prompt']>[0]) => void | Promise<void>
+  onForkSession?: (sourceSessionId: string, prompt: Parameters<RemotePiSession['prompt']>[0]) => PiChatForkResult | void | Promise<PiChatForkResult | void>
+  /** Stable mounted-timeline identity. Hosts that rebind a pane in place keep this unchanged. */
+  timelineKey?: string
+  /** Stable host binding that can swap the remote session beneath a mounted panel. */
+  sessionBinding?: PiChatSessionBinding
   onBeforeSubmit?: (draft: string, context: ChatSubmitContext) => false | void | boolean | Promise<false | void | boolean>
   onReloadAgentPlugins?: () => Promise<AgentPluginReloadResult | string>
   onCommandResult?: (message: string) => void
@@ -250,6 +274,8 @@ export function PiChatPanel<
   onSessionReset,
   onCreateSession,
   onForkSession,
+  timelineKey,
+  sessionBinding,
   onBeforeSubmit,
   onReloadAgentPlugins,
   onCommandResult,
@@ -264,8 +290,22 @@ export function PiChatPanel<
   onTurnComplete,
   renderNoticeAction,
 }: PiChatPanelProps<TComposerBlocker>) {
-  const externalSessionId = sessionId?.trim() || undefined
+  const controlledExternalSessionId = sessionId?.trim() || undefined
+  const boundExternalSessionId = useSyncExternalStore(
+    sessionBinding?.subscribe ?? EMPTY_SESSION_BINDING_SUBSCRIBE,
+    sessionBinding?.getSnapshot ?? EMPTY_SESSION_BINDING_SNAPSHOT,
+    sessionBinding?.getSnapshot ?? EMPTY_SESSION_BINDING_SNAPSHOT,
+  ).trim() || undefined
+  const [forkBinding, setForkBinding] = useState<{ sourceSessionId: string; targetSessionId: string } | null>(null)
+  const externalSessionId = boundExternalSessionId
+    ?? (forkBinding && forkBinding.sourceSessionId === controlledExternalSessionId
+      ? forkBinding.targetSessionId
+      : controlledExternalSessionId)
   const showSessionSidebar = showSessions ?? externalSessionId === undefined
+  useEffect(() => {
+    if (!forkBinding || controlledExternalSessionId === forkBinding.sourceSessionId) return
+    setForkBinding(null)
+  }, [controlledExternalSessionId, forkBinding])
   const onDataRef = useRef(onData)
   onDataRef.current = onData
   // Ref so the (memoized) session-options closure can fire onTurnComplete without
@@ -413,6 +453,7 @@ export function PiChatPanel<
   const [serverSkillsRefreshKey, setServerSkillsRefreshKey] = useState(0)
   const [localSubmittedSessionId, setLocalSubmittedSessionId] = useState<string | undefined>()
   const localSubmittedSessionRef = useRef<string | undefined>(undefined)
+  const [forkTransition, setForkTransition] = useState<PiChatForkTransition | null>(null)
   const { attachmentNotice, setAttachmentNotice } = useAttachmentNotice()
   const composerContributions = useComposerContributions()
   const contributedCommands = useMemo(
@@ -474,8 +515,21 @@ export function PiChatPanel<
     [activeSessionId, composerBlockers],
   )
   const canonicalMessages = selectedChatState ? selectMessagesForRender(selectedChatState) : []
+  const transitionApplies = Boolean(forkTransition && (
+    activeSessionId === forkTransition.sourceSessionId
+    || activeSessionId === forkTransition.targetSessionId
+    || (externalSessionId && !forkTransition.targetSessionId)
+  ))
+  const transitionBaseMessages = transitionApplies && forkTransition
+    && activeSessionId !== forkTransition.sourceSessionId
+    && (!selectedChatState?.hydrated || canonicalMessages.length === 0)
+    ? forkTransition.preservedMessages
+    : canonicalMessages
+  const messages = transitionApplies && forkTransition
+    && !transitionBaseMessages.some((message) => message.clientNonce === forkTransition.optimisticMessage.clientNonce)
+    ? [...transitionBaseMessages, forkTransition.optimisticMessage]
+    : transitionBaseMessages
   const queuePreview = selectedChatState ? selectQueuePreview(selectedChatState) : []
-  const messages = canonicalMessages
   const userHistory = useMemo(() => selectComposerHistoryFromCanonicalUsers(canonicalMessages), [canonicalMessages])
   // A session attached with autoStart:false (external sessionId hosts) reports
   // status 'idle' with hydrated:false until the /state snapshot lands. Treat that
@@ -509,7 +563,10 @@ export function PiChatPanel<
           dismissible: true,
         }]
       : []
-    const combined = [...fromState, ...sessionNotice, ...largeStateNotice, ...localNotices]
+    const forkNotice = forkTransition?.forking
+      ? [{ id: 'runtime-fork-transition', level: 'info' as const, text: 'Continuing this chat in the current runtime…' }]
+      : []
+    const combined = [...fromState, ...sessionNotice, ...largeStateNotice, ...forkNotice, ...localNotices]
       .filter((notice) => !dismissedNoticeIds.has(notice.id))
       .filter((notice) => !('errorCode' in notice) || notice.errorCode !== AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH)
     // A terminal chat error (history failed to load, no messages present)
@@ -519,7 +576,21 @@ export function PiChatPanel<
     // but only when there's genuinely no history, matching the gate in
     // RuntimeNotices/PiConversationSurface (see terminalChatErrors.ts).
     return filterCompetingNoiseNotices(combined, messages.length === 0)
-  }, [debug, debugState?.largeStateWarning, dismissedNoticeIds, localNotices, messages.length, selectedChatState, sessionsError])
+  }, [debug, debugState?.largeStateWarning, dismissedNoticeIds, forkTransition, localNotices, messages.length, selectedChatState, sessionsError])
+
+  useEffect(() => {
+    if (!forkTransition) return
+    if (!forkTransition.targetSessionId && activeSessionId && activeSessionId !== forkTransition.sourceSessionId) {
+      setForkTransition((current) => current?.optimisticMessage.clientNonce === forkTransition.optimisticMessage.clientNonce
+        ? { ...current, targetSessionId: activeSessionId }
+        : current)
+      return
+    }
+    if (!forkTransition.targetSessionId) return
+    if (activeSessionId !== forkTransition.targetSessionId || !selectedChatState?.hydrated) return
+    if (!canonicalMessages.some((message) => message.clientNonce === forkTransition.optimisticMessage.clientNonce)) return
+    setForkTransition((current) => current?.optimisticMessage.clientNonce === forkTransition.optimisticMessage.clientNonce ? null : current)
+  }, [activeSessionId, canonicalMessages, forkTransition, selectedChatState?.hydrated])
 
   const addLocalNotice = useCallback((notice: PanelNotice) => {
     setLocalNotices((previous) => {
@@ -793,12 +864,32 @@ export function PiChatPanel<
         }
         return state
       },
-      prompt: (payload: Parameters<RemotePiSession['prompt']>[0]) => selectedPiSession.prompt(payload).catch((error) => {
-        throw Object.assign(new Error(errorMessage(error, 'Could not send your message.'), { cause: error }), {
-          errorCode: piChatErrorCode(error),
-          forkPrompt: payload,
+      prompt: (payload: Parameters<RemotePiSession['prompt']>[0]) => {
+        const transition: PiChatForkTransition = {
+          sourceSessionId: activeChatSessionId,
+          forking: false,
+          optimisticMessage: toOptimisticUserMessage(payload),
+          preservedMessages: selectMessagesForRender(selectedPiSession.getState()),
+        }
+        setForkTransition(transition)
+        return selectedPiSession.prompt(payload).then((receipt) => {
+          setForkTransition((current) => current?.optimisticMessage.clientNonce === payload.clientNonce ? null : current)
+          return receipt
+        }).catch((error) => {
+          const errorCode = piChatErrorCode(error)
+          if (errorCode === AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH) {
+            setForkTransition((current) => current?.optimisticMessage.clientNonce === payload.clientNonce
+              ? { ...current, forking: true }
+              : current)
+          } else {
+            setForkTransition((current) => current?.optimisticMessage.clientNonce === payload.clientNonce ? null : current)
+          }
+          throw Object.assign(new Error(errorMessage(error, 'Could not send your message.'), { cause: error }), {
+            errorCode,
+            forkPrompt: payload,
+          })
         })
-      }),
+      },
       followUp: selectedPiSession.followUp.bind(selectedPiSession),
       clearQueue: selectedPiSession.clearQueue.bind(selectedPiSession),
       interrupt: selectedPiSession.interrupt.bind(selectedPiSession),
@@ -917,14 +1008,25 @@ export function PiChatPanel<
         const forkPrompt = (error as { forkPrompt?: Parameters<RemotePiSession['prompt']>[0] }).forkPrompt
         try {
           if (!forkPrompt) throw new Error('The rejected prompt could not be recovered for the fork.')
-          if (externalSessionId) {
-            if (!onForkSession) throw new Error('The chat host cannot fork this frozen session.')
-            await onForkSession(activeChatSessionId, forkPrompt)
-          } else {
-            await sessions.create({ forkSessionId: activeChatSessionId, forkPrompt })
+          const forked = externalSessionId
+            ? onForkSession
+              ? await onForkSession(activeChatSessionId, forkPrompt)
+              : await Promise.reject(new Error('The chat host cannot fork this frozen session.'))
+            : await sessions.create({ forkSessionId: activeChatSessionId, forkPrompt })
+          const targetSessionId = forked && 'sessionId' in forked
+            ? forked.sessionId
+            : forked && 'id' in forked
+              ? forked.id
+              : undefined
+          if (externalSessionId && targetSessionId) {
+            setForkBinding({ sourceSessionId: externalSessionId, targetSessionId })
           }
+          setForkTransition((current) => current?.optimisticMessage.clientNonce === forkPrompt.clientNonce
+            ? { ...current, ...(targetSessionId ? { targetSessionId } : {}) }
+            : current)
           return undefined
         } catch (forkError) {
+          setForkTransition((current) => current?.optimisticMessage.clientNonce === forkPrompt?.clientNonce ? null : current)
           restoreSubmittedDraft()
           surfaceRunRejected(forkError)
           return false
@@ -1315,7 +1417,7 @@ export function PiChatPanel<
               }}
               onSuggestionSubmit={({ text, files, source }) => sendComposerMessage({ text, files, source })}
               onRestoreDraft={setComposerDraft}
-              windowResetKey={activeSessionId}
+              windowResetKey={timelineKey ?? activeSessionId}
             />
 
             {composerSurface}

--- a/packages/agent/src/front/chat/PiChatPanel.tsx
+++ b/packages/agent/src/front/chat/PiChatPanel.tsx
@@ -109,6 +109,7 @@ interface PiChatForkTransition {
   sourceSessionId: string
   targetSessionId?: string
   forking: boolean
+  blocksFollowUp: boolean
   optimisticMessage: OptimisticUserMessage
   preservedMessages: BoringChatMessage[]
 }
@@ -868,6 +869,9 @@ export function PiChatPanel<
         const transition: PiChatForkTransition = {
           sourceSessionId: activeChatSessionId,
           forking: false,
+          blocksFollowUp: selectRuntimeNotices(selectedPiSession.getState()).some(
+            (notice) => notice.errorCode === AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH,
+          ),
           optimisticMessage: toOptimisticUserMessage(payload),
           preservedMessages: selectMessagesForRender(selectedPiSession.getState()),
         }
@@ -968,6 +972,7 @@ export function PiChatPanel<
   }, [addLocalNotice, dropLocalNotice])
 
   const sendComposerMessage = useCallback(async ({ text, files, source = 'composer', preserveExistingDraft = false }: ComposerSendPayload) => {
+    if (transitionApplies && (forkTransition?.forking || forkTransition?.blocksFollowUp)) return false
     if (!policy) {
       addLocalNotice({ id: 'composer-no-session', level: 'warning', text: 'Create or select a chat session before sending.', dismissible: true })
       return false
@@ -1040,7 +1045,7 @@ export function PiChatPanel<
       surfaceRunRejected(error)
       return false
     }
-  }, [activeChatSessionId, clearLocalSubmitted, dropLocalNotice, externalSessionId, markLocalSubmitted, onForkSession, onPromptSubmitStarted, policy, selectedPiSession, sessions.create, setComposerDraft, surfaceRunRejected])
+  }, [activeChatSessionId, clearLocalSubmitted, dropLocalNotice, externalSessionId, forkTransition, markLocalSubmitted, onForkSession, onPromptSubmitStarted, policy, selectedPiSession, sessions.create, setComposerDraft, surfaceRunRejected, transitionApplies])
 
   const availableAssistantSlashCommands = useMemo(
     () => policy ? actionableSlashCommands : actionableSlashCommands.filter((command) => command.clickBehavior === 'insert'),
@@ -1227,7 +1232,7 @@ export function PiChatPanel<
   const disabled = !policy || sessionsLoading || composerBlocked
   const isStreaming = isPiBusyStatus(status)
   const submitStatus = initialHydrationPromptAllowed ? 'ready' : toPromptSubmitStatus(status)
-  const submitDisabled = !policy || sessionsLoading || modelSelectionBlocked || Boolean(forkTransition?.forking) || (composerBlocked && !isStreaming)
+  const submitDisabled = !policy || sessionsLoading || modelSelectionBlocked || Boolean(transitionApplies && (forkTransition?.forking || forkTransition?.blocksFollowUp)) || (composerBlocked && !isStreaming)
   const mergedToolRenderers = useMemo(() => mergeShadcnToolRenderers(toolRenderers), [toolRenderers])
   const debugMessages = useMemo(() => messages.map(toDebugUiMessage), [messages])
 

--- a/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
+++ b/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
@@ -669,6 +669,10 @@ describe('PiChatPanel sandbox shell', () => {
     expect(screen.getByText('committed from /state')).toBeTruthy()
     expect(document.querySelector('[data-boring-agent-part="message-timeline"]')).toBe(timeline)
     expect(screen.getByText('Continuing this chat in the current runtime…')).toBeTruthy()
+    expect((document.querySelector('[data-boring-agent-part="composer-submit"]') as HTMLButtonElement).disabled).toBe(true)
+    fireEvent.change(textarea, { target: { value: 'must not replace the pending transition' } })
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+    expect(onForkSession).toHaveBeenCalledTimes(1)
 
     await act(async () => {
       forkResult.resolve({ sessionId: 'pi-current' })

--- a/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
+++ b/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
@@ -615,9 +615,8 @@ describe('PiChatPanel sandbox shell', () => {
         errorCode: AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH,
       }],
     }))
-    sourceRemote.prompt.mockRejectedValueOnce(Object.assign(new Error('scope mismatch'), {
-      errorCode: AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH,
-    }))
+    const sourcePrompt = deferred<Awaited<ReturnType<RemotePiSession['prompt']>>>()
+    sourceRemote.prompt.mockReturnValueOnce(sourcePrompt.promise)
     const targetRemote = new FakeRemotePiSession(remoteState({
       sessionId: 'pi-current',
       hydrated: false,
@@ -660,19 +659,26 @@ describe('PiChatPanel sandbox shell', () => {
     fireEvent.change(textarea, { target: { value: 'continue controlled chat' } })
     fireEvent.keyDown(textarea, { key: 'Enter' })
 
+    await waitFor(() => expect(sourceRemote.prompt).toHaveBeenCalledOnce())
+    expect(screen.getByText('continue controlled chat').closest('[data-boring-agent-part="message"]')?.getAttribute('data-boring-agent-message-status')).toBe('pending')
+    expect(screen.getByText('committed from /state')).toBeTruthy()
+    expect(document.querySelector('[data-boring-agent-part="message-timeline"]')).toBe(timeline)
+    expect((document.querySelector('[data-boring-agent-part="composer-submit"]') as HTMLButtonElement).disabled).toBe(true)
+    fireEvent.change(textarea, { target: { value: 'must not replace the pending transition' } })
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+    expect(sourceRemote.followUp).not.toHaveBeenCalled()
+    await act(async () => {
+      sourcePrompt.reject(Object.assign(new Error('scope mismatch'), {
+        errorCode: AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH,
+      }))
+      await sourcePrompt.promise.catch(() => undefined)
+    })
     await waitFor(() => expect(onForkSession).toHaveBeenCalledWith(
       'pi-1',
       expect.objectContaining({ message: 'continue controlled chat' }),
     ))
     const forkPrompt = onForkSession.mock.calls[0]?.[1]
-    expect(screen.getByText('continue controlled chat').closest('[data-boring-agent-part="message"]')?.getAttribute('data-boring-agent-message-status')).toBe('pending')
-    expect(screen.getByText('committed from /state')).toBeTruthy()
-    expect(document.querySelector('[data-boring-agent-part="message-timeline"]')).toBe(timeline)
     expect(screen.getByText('Continuing this chat in the current runtime…')).toBeTruthy()
-    expect((document.querySelector('[data-boring-agent-part="composer-submit"]') as HTMLButtonElement).disabled).toBe(true)
-    fireEvent.change(textarea, { target: { value: 'must not replace the pending transition' } })
-    fireEvent.keyDown(textarea, { key: 'Enter' })
-    expect(onForkSession).toHaveBeenCalledTimes(1)
 
     await act(async () => {
       forkResult.resolve({ sessionId: 'pi-current' })

--- a/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
+++ b/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
@@ -605,9 +605,9 @@ describe('PiChatPanel sandbox shell', () => {
     })
   })
 
-  test('uses the controlled host fork and hides the scope mismatch transport notice', async () => {
-    const remote = new FakeRemotePiSession(remoteState({
-      status: 'error',
+  test('keeps frozen history mounted with an optimistic prompt while rebinding to the fork', async () => {
+    const sourceRemote = new FakeRemotePiSession(remoteState({
+      status: 'idle',
       notices: [{
         id: 'terminal-session-error',
         level: 'error',
@@ -615,22 +615,38 @@ describe('PiChatPanel sandbox shell', () => {
         errorCode: AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH,
       }],
     }))
-    remote.prompt.mockRejectedValueOnce(Object.assign(new Error('scope mismatch'), {
+    sourceRemote.prompt.mockRejectedValueOnce(Object.assign(new Error('scope mismatch'), {
       errorCode: AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH,
     }))
+    const targetRemote = new FakeRemotePiSession(remoteState({
+      sessionId: 'pi-current',
+      hydrated: false,
+      committedMessages: [],
+      connection: { state: 'connecting' },
+    }))
+    const createRemoteSession = vi.fn((options: RemotePiSessionOptions) => {
+      const remote = options.sessionId === 'pi-current' ? targetRemote : sourceRemote
+      remote.state = { ...remote.state, sessionId: options.sessionId }
+      remote.onEvent = options.onEvent as ((event: unknown) => void) | undefined
+      return remote as unknown as RemotePiSession
+    })
+    const forkResult = deferred<{ sessionId: string }>()
     const onForkSession = vi.fn()
     function ControlledForkPanel() {
       const [controlledSessionId, setControlledSessionId] = useState('pi-1')
       return (
         <PiChatPanel
           sessionId={controlledSessionId}
+          timelineKey="stable-pane"
           showSessions={false}
           serverResourcesEnabled={false}
           storageScope="scope-a"
-          createRemoteSession={remoteFactory(remote)}
+          createRemoteSession={createRemoteSession}
           onForkSession={async (sourceSessionId, forkPrompt) => {
             onForkSession(sourceSessionId, forkPrompt)
-            setControlledSessionId('pi-current')
+            const result = await forkResult.promise
+            setControlledSessionId(result.sessionId)
+            return result
           }}
         />
       )
@@ -638,6 +654,8 @@ describe('PiChatPanel sandbox shell', () => {
     render(<ControlledForkPanel />)
 
     expect(document.querySelector('[data-runtime-notice-id="terminal-session-error"]')).toBeNull()
+    const timeline = document.querySelector('[data-boring-agent-part="message-timeline"]')
+    expect(screen.getByText('committed from /state')).toBeTruthy()
     const textarea = screen.getByLabelText('Agent prompt')
     fireEvent.change(textarea, { target: { value: 'continue controlled chat' } })
     fireEvent.keyDown(textarea, { key: 'Enter' })
@@ -646,8 +664,34 @@ describe('PiChatPanel sandbox shell', () => {
       'pi-1',
       expect.objectContaining({ message: 'continue controlled chat' }),
     ))
-    expect(remote.prompt).toHaveBeenCalledTimes(1)
-    expect(document.querySelector('[data-pi-chat-session-id="pi-current"]')).toBeTruthy()
+    const forkPrompt = onForkSession.mock.calls[0]?.[1]
+    expect(screen.getByText('continue controlled chat').closest('[data-boring-agent-part="message"]')?.getAttribute('data-boring-agent-message-status')).toBe('pending')
+    expect(screen.getByText('committed from /state')).toBeTruthy()
+    expect(document.querySelector('[data-boring-agent-part="message-timeline"]')).toBe(timeline)
+    expect(screen.getByText('Continuing this chat in the current runtime…')).toBeTruthy()
+
+    await act(async () => {
+      forkResult.resolve({ sessionId: 'pi-current' })
+      await forkResult.promise
+    })
+    await waitFor(() => expect(document.querySelector('[data-pi-chat-session-id="pi-current"]')).toBeTruthy())
+    expect(screen.getByText('committed from /state')).toBeTruthy()
+    expect(screen.getByText('continue controlled chat')).toBeTruthy()
+    expect(document.querySelector('[data-boring-agent-part="message-timeline"]')).toBe(timeline)
+
+    act(() => targetRemote.setState(remoteState({
+      sessionId: 'pi-current',
+      hydrated: true,
+      committedMessages: [
+        { id: 'u1', role: 'user', status: 'done', parts: [{ type: 'text', id: 'u1:text', text: 'committed from /state' }] },
+        { id: 'u2', role: 'user', status: 'done', clientNonce: forkPrompt.clientNonce, parts: [{ type: 'text', id: 'u2:text', text: 'continue controlled chat' }] },
+      ],
+      streamingMessage: { id: 'a2', role: 'assistant', status: 'streaming', parts: [{ type: 'text', id: 'a2:text', text: 'reply streaming in place' }] },
+    })))
+    await waitFor(() => expect(screen.getByText('reply streaming in place')).toBeTruthy())
+    expect(screen.getByText('continue controlled chat').closest('[data-boring-agent-part="message"]')?.getAttribute('data-boring-agent-message-status')).toBe('done')
+    expect(document.querySelector('[data-boring-agent-part="message-timeline"]')).toBe(timeline)
+    expect(screen.queryByText('Continuing this chat in the current runtime…')).toBeNull()
   })
 
   test('fires onTurnComplete per turn-settle event, including back-to-back queued turns', async () => {

--- a/packages/agent/src/front/chat/components/ChatNotices.tsx
+++ b/packages/agent/src/front/chat/components/ChatNotices.tsx
@@ -54,6 +54,7 @@ export function RuntimeNoticeMessages({
     notice.id === 'connection-reconnecting' ||
     notice.id === 'auto-retry' ||
     notice.id === 'large-state-warning' ||
+    notice.id === 'runtime-fork-transition' ||
     notice.id.startsWith('command:') ||
     notice.id.startsWith('composer-warning:'),
   )

--- a/packages/agent/src/front/chat/pi/remotePiSession.ts
+++ b/packages/agent/src/front/chat/pi/remotePiSession.ts
@@ -751,7 +751,7 @@ export function piChatErrorCode(error: unknown): string | undefined {
   return errorResponseCode(error)
 }
 
-function toOptimisticUserMessage(payload: PromptPayload | FollowUpPayload): OptimisticUserMessage {
+export function toOptimisticUserMessage(payload: PromptPayload | FollowUpPayload): OptimisticUserMessage {
   const displayText = payload.displayMessage ?? payload.message
   return {
     id: `optimistic:${payload.clientNonce}`,

--- a/packages/agent/src/front/index.ts
+++ b/packages/agent/src/front/index.ts
@@ -10,6 +10,8 @@ export type {
   AgentPluginReloadResult,
   ComposerBlocker,
   ComposerBlockerAction,
+  PiChatForkResult,
+  PiChatSessionBinding,
   PiChatPanelProps,
   PiChatPanelProps as ChatPanelProps,
 } from './chat/PiChatPanel'

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -873,6 +873,11 @@ export function WorkspaceAgentFront<
   const chatPaneStateRef = useRef(chatPaneState)
   chatPaneStateRef.current = chatPaneState
   const chatPaneBindingsRef = useRef(new Map<string, MutablePiChatSessionBinding>())
+  const chatPaneBindingsWorkspaceRef = useRef(workspaceId)
+  if (chatPaneBindingsWorkspaceRef.current !== workspaceId) {
+    chatPaneBindingsWorkspaceRef.current = workspaceId
+    chatPaneBindingsRef.current.clear()
+  }
   const chatPaneBinding = useCallback((paneId: string, initialSessionId = workspaceSessionRefFromKey(paneId).sessionId) => {
     const existing = chatPaneBindingsRef.current.get(paneId)
     if (existing) return existing
@@ -1892,10 +1897,12 @@ export function WorkspaceAgentFront<
         : replaceActivePane(paneState.ids, paneState.activeId, nextSessionKey)
       return { workspaceId, ids, activeId: nextSessionKey }
     })
-    return alreadyVisible
-      ? nextAgentTypeId ? rawSwitch(nextSessionId, nextAgentTypeId) : rawSwitch(nextSessionId)
-      : nextAgentTypeId ? resolvedSwitch(nextSessionId, nextAgentTypeId) : resolvedSwitch(nextSessionId)
-  }, [chatPaneState, chatSessionKey, rawSwitch, resolvedSwitch, workspaceId])
+    if (alreadyVisible) {
+      const target = boundChatSessionRef(nextSessionKey)
+      return target.agentTypeId ? rawSwitch(target.sessionId, target.agentTypeId) : rawSwitch(target.sessionId)
+    }
+    return nextAgentTypeId ? resolvedSwitch(nextSessionId, nextAgentTypeId) : resolvedSwitch(nextSessionId)
+  }, [boundChatSessionRef, chatPaneState, chatSessionKey, rawSwitch, resolvedSwitch, workspaceId])
   useEffect(() => {
     switchSessionForSurfaceRef.current = switchToChatPane
   }, [switchToChatPane])
@@ -1912,9 +1919,9 @@ export function WorkspaceAgentFront<
         activeId: nextSessionKey,
       }
     })
-    const ref = workspaceSessionRefFromKey(nextSessionKey)
+    const ref = boundChatSessionRef(nextSessionKey)
     return ref.agentTypeId ? rawSwitch(ref.sessionId, ref.agentTypeId) : rawSwitch(ref.sessionId)
-  }, [chatSessionKey, rawSwitch, workspaceId])
+  }, [boundChatSessionRef, chatSessionKey, rawSwitch, workspaceId])
 
   const openChatPane = useCallback((nextSessionId: string, nextAgentTypeId?: string) => {
     setLeftOverlay(null)
@@ -2426,8 +2433,8 @@ export function WorkspaceAgentFront<
   const topBarLeftContent = topBarLeft ? (
     <div className="flex min-w-0 items-center gap-2">{topBarLeft}</div>
   ) : undefined
-  const activeChatPaneRef = activeChatPaneId ? workspaceSessionRefFromKey(activeChatPaneId) : null
-  const openChatPaneRefs = useMemo(() => chatPaneIds.map((id) => workspaceSessionRefFromKey(id)), [chatPaneIds])
+  const activeChatPaneRef = activeChatPaneId ? boundChatSessionRef(activeChatPaneId) : null
+  const openChatPaneRefs = useMemo(() => chatPaneIds.map((id) => boundChatSessionRef(id)), [boundChatSessionRef, chatPaneIds])
   const pinnedRefs = useMemo(() => pinnedIds.map((id) => workspaceSessionRefFromKey(id)), [pinnedIds])
   const navParams = {
     sessions: resolvedSessions,

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -2119,11 +2119,11 @@ export function WorkspaceAgentFront<
     chatPaneStateRef.current = nextState
     setChatPaneState(nextState)
     if (nextActiveId && current.activeId === sessionKey) {
-      const next = workspaceSessionRefFromKey(nextActiveId)
+      const next = boundChatSessionRef(nextActiveId)
       if (next.agentTypeId) rawSwitch(next.sessionId, next.agentTypeId)
       else rawSwitch(next.sessionId)
     }
-  }, [chatSessionKey, createChatPaneTransaction, rawSwitch, workspaceId])
+  }, [boundChatSessionRef, chatSessionKey, createChatPaneTransaction, rawSwitch, workspaceId])
 
   const createChatPaneAfter = useCallback((afterId: string, placementDirection?: ChatPaneSplitDirection, ownerAgentTypeId = fleetModeEnabled ? newChatAgentTypeId : undefined) => (
     createChatPaneTransaction(afterId, "insert", placementDirection, ownerAgentTypeId)
@@ -2134,22 +2134,26 @@ export function WorkspaceAgentFront<
     const current = chatPaneState.workspaceId === workspaceId
       ? chatPaneState
       : { workspaceId, ids: [chatSessionKey], activeId: chatSessionKey }
-    const deletingIndex = current.ids.indexOf(sessionKey)
+    const paneId = current.ids.find((candidate) => {
+      const bound = boundChatSessionRef(candidate)
+      return workspaceSessionKey(bound.sessionId, bound.agentTypeId) === sessionKey
+    }) ?? sessionKey
+    const deletingIndex = current.ids.indexOf(paneId)
     let nextActiveId = current.activeId
     if (deletingIndex >= 0) {
-      const nextIds = current.ids.filter((id) => id !== sessionKey)
-      nextActiveId = current.activeId === sessionKey
+      const nextIds = current.ids.filter((id) => id !== paneId)
+      nextActiveId = current.activeId === paneId
         ? nextIds[Math.max(0, deletingIndex - 1)] ?? nextIds[0] ?? null
         : current.activeId
       setChatPaneState({ workspaceId, ids: nextIds, activeId: nextActiveId })
-      if (nextActiveId && current.activeId === sessionKey) {
-        const next = workspaceSessionRefFromKey(nextActiveId)
+      if (nextActiveId && current.activeId === paneId) {
+        const next = boundChatSessionRef(nextActiveId)
         if (next.agentTypeId) resolvedSwitch(next.sessionId, next.agentTypeId)
         else resolvedSwitch(next.sessionId)
       }
     }
     return resolvedDelete(sessionId, sessionAgentTypeId)
-  }, [chatPaneState, chatSessionKey, resolvedDelete, resolvedSwitch, workspaceId])
+  }, [boundChatSessionRef, chatPaneState, chatSessionKey, resolvedDelete, resolvedSwitch, workspaceId])
 
   // "New chat" from the left bar. With a split already open, the new session
   // gets its OWN dedicated pane (inserted after the active one) so the existing
@@ -2222,7 +2226,7 @@ export function WorkspaceAgentFront<
   const workbenchBlocked = workspaceWarmupStatus.status !== "ready"
   const workbenchOverlay = workbenchBlocked ? <WorkbenchWarmupOverlay status={workspaceWarmupStatus} /> : undefined
   const renameChatSession = useCallback(async (sessionKey: string, title: string) => {
-    const ref = workspaceSessionRefFromKey(sessionKey)
+    const ref = boundChatSessionRef(sessionKey)
     if (onRenameSession) {
       await onRenameSession(ref.sessionId, title, ref.agentTypeId)
       return
@@ -2237,7 +2241,7 @@ export function WorkspaceAgentFront<
     })
     if (!response.ok) throw new Error(`rename failed (${response.status})`)
     await sessionApi?.refresh?.({ background: true })
-  }, [apiBaseUrl, onRenameSession, resolvedRequestHeaders, selectedAgentTypeId, sessionApi])
+  }, [apiBaseUrl, boundChatSessionRef, onRenameSession, resolvedRequestHeaders, selectedAgentTypeId, sessionApi])
 
   const reloadAgentPluginsForSession = useCallback(async (ref: { agentTypeId: string; sessionId: string }) => {
     const endpoint = `${apiBaseUrl?.replace(/\/$/, "") ?? ""}/api/v1/agents/${encodeURIComponent(ref.agentTypeId)}/reload`

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -5,6 +5,7 @@ import {
   usePiSessions as useDefaultPiSessions,
   useAddressedAgentSelection as useDefaultAddressedAgentSelection,
   searchPiSessions,
+  type PiChatSessionBinding,
   type SlashCommand,
   type ToolRendererOverrides,
 } from "@hachej/boring-agent/front"
@@ -90,13 +91,34 @@ function parseAgentOverlayId(id: string | null): { agentTypeId: string } | null 
   }
 }
 
+interface MutablePiChatSessionBinding extends PiChatSessionBinding {
+  setSessionId(sessionId: string): void
+}
+
+function createMutablePiChatSessionBinding(initialSessionId: string): MutablePiChatSessionBinding {
+  let sessionId = initialSessionId
+  const listeners = new Set<() => void>()
+  return {
+    getSnapshot: () => sessionId,
+    subscribe: (listener) => {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+    setSessionId: (nextSessionId) => {
+      if (nextSessionId === sessionId) return
+      sessionId = nextSessionId
+      for (const listener of listeners) listener()
+    },
+  }
+}
+
 interface PendingCreatePane {
   afterId: string
   knownIds: Set<string>
   workspaceId: string
   placementDirection?: ChatPaneSplitDirection
   createdId?: string
-  mode: "insert" | "replace"
+  mode: "insert" | "replace" | "rebind"
 }
 
 export interface WorkspaceAgentSession {
@@ -850,6 +872,18 @@ export function WorkspaceAgentFront<
   )
   const chatPaneStateRef = useRef(chatPaneState)
   chatPaneStateRef.current = chatPaneState
+  const chatPaneBindingsRef = useRef(new Map<string, MutablePiChatSessionBinding>())
+  const chatPaneBinding = useCallback((paneId: string, initialSessionId = workspaceSessionRefFromKey(paneId).sessionId) => {
+    const existing = chatPaneBindingsRef.current.get(paneId)
+    if (existing) return existing
+    const binding = createMutablePiChatSessionBinding(initialSessionId)
+    chatPaneBindingsRef.current.set(paneId, binding)
+    return binding
+  }, [])
+  const boundChatSessionRef = useCallback((paneId: string) => {
+    const ref = workspaceSessionRefFromKey(paneId)
+    return { ...ref, sessionId: chatPaneBinding(paneId, ref.sessionId).getSnapshot() }
+  }, [chatPaneBinding])
   const [pendingChatPanePlacement, setPendingChatPanePlacement] = useState<ChatPanePendingPlacement | null>(null)
   const [chatPaneSplitPending, setChatPaneSplitPending] = useState(false)
   const consumePendingChatPanePlacement = useCallback((paneId: string) => {
@@ -1440,6 +1474,7 @@ export function WorkspaceAgentFront<
   const autoCreateSessionRef = useRef(false)
   const pendingLastSessionDeleteRef = useRef<Set<string>>(new Set())
   const pendingCreatePaneRef = useRef<PendingCreatePane | null>(null)
+  const [seamlessFork, setSeamlessFork] = useState<{ workspaceId: string; paneId: string; targetSessionId?: string } | null>(null)
   const optimisticCreatedPaneKeysRef = useRef<Set<string>>(new Set())
   const surfaceOpenRef = useRef(surfaceOpen)
   const surfaceKeyRef = useRef(resolvedSurfaceStorageKey)
@@ -1760,10 +1795,10 @@ export function WorkspaceAgentFront<
       // trustworthy than it, so leave the layout untouched until the real
       // session list arrives.
       if (remoteSessionsPending && current.ids.length > 0 && !pendingCreatedId) return current
-      const currentActiveRef = current.activeId ? workspaceSessionRefFromKey(current.activeId) : undefined
+      const currentActiveRef = current.activeId ? boundChatSessionRef(current.activeId) : undefined
       const activeOwnerIsExplicit = Boolean(effectiveActiveSessionAgentTypeId)
       const currentMatchesControlledSession = activeOwnerIsExplicit
-        ? current.activeId === chatSessionKey
+        ? currentActiveRef?.sessionId === chatSessionId && currentActiveRef.agentTypeId === effectiveActiveSessionAgentTypeId
         : currentActiveRef?.sessionId === chatSessionId
       const resolvedDesiredSessionId = !pendingCreatedId
         && current.activeId
@@ -1782,14 +1817,18 @@ export function WorkspaceAgentFront<
       const ids = prunedIds.length > 0 ? prunedIds : [resolvedDesiredSessionId]
       const activeId = current.activeId && ids.includes(current.activeId) ? current.activeId : ids[0] ?? resolvedDesiredSessionId
       const nextIds = pendingCreatedId
-        ? pendingCreatePane?.mode === "replace"
-          ? replaceActivePane(ids, pendingCreatePane.afterId, pendingCreatedId)
-          : insertPaneAfter(ids, pendingCreatePane?.afterId, pendingCreatedId)
+        ? pendingCreatePane?.mode === "rebind"
+          ? ids
+          : pendingCreatePane?.mode === "replace"
+            ? replaceActivePane(ids, pendingCreatePane.afterId, pendingCreatedId)
+            : insertPaneAfter(ids, pendingCreatePane?.afterId, pendingCreatedId)
         : resolvedDesiredSessionId === activeId || ids.includes(resolvedDesiredSessionId)
           ? ids
           : replaceActivePane(ids, activeId, resolvedDesiredSessionId)
-      const nextActiveId = pendingCreatedId && nextIds.includes(pendingCreatedId)
-        ? pendingCreatedId
+      const nextActiveId = pendingCreatedId && pendingCreatePane?.mode === "rebind" && nextIds.includes(pendingCreatePane.afterId)
+        ? pendingCreatePane.afterId
+        : pendingCreatedId && nextIds.includes(pendingCreatedId)
+          ? pendingCreatedId
         : nextIds.includes(resolvedDesiredSessionId)
           ? resolvedDesiredSessionId
           : nextIds[0] ?? resolvedDesiredSessionId
@@ -1801,7 +1840,7 @@ export function WorkspaceAgentFront<
       ) return previous
       return { workspaceId, ids: nextIds, activeId: nextActiveId }
     })
-  }, [autoSubmitSessionId, chatSessionId, chatSessionKey, effectiveActiveSessionAgentTypeId, remoteSessionsPending, remoteSessionsTransitioning, resolvedSessions, resolvedSessionsByKey, sessionListAuthoritative, workspaceId])
+  }, [autoSubmitSessionId, boundChatSessionRef, chatSessionId, chatSessionKey, effectiveActiveSessionAgentTypeId, remoteSessionsPending, remoteSessionsTransitioning, resolvedSessions, resolvedSessionsByKey, sessionListAuthoritative, workspaceId])
   const [initialHydrationPromptStarted, setInitialHydrationPromptStarted] = useState<{ workspaceId: string; ids: Set<string> }>(() => ({
     workspaceId,
     ids: new Set(),
@@ -1831,6 +1870,9 @@ export function WorkspaceAgentFront<
   const chatPaneIds = activeChatPaneState.ids.length > 0 ? activeChatPaneState.ids : [chatSessionKey]
   useEffect(() => {
     openChatSessionIdsRef.current = new Set(chatPaneIds)
+    chatPaneBindingsRef.current = new Map(
+      [...chatPaneBindingsRef.current].filter(([paneId]) => chatPaneIds.includes(paneId)),
+    )
   }, [chatPaneIds])
   const activeChatPaneId = activeChatPaneState.activeId ?? chatPaneIds[0] ?? chatSessionKey
 
@@ -2002,14 +2044,44 @@ export function WorkspaceAgentFront<
   ) => {
     if (!sessionApi) return Promise.reject(new Error("This chat provider cannot create native forks."))
     if (pendingCreatePaneRef.current) return Promise.reject(new Error("Another chat is still being created."))
-    return createChatPaneTransaction(
-      paneId,
-      "replace",
-      undefined,
-      ownerAgentTypeId,
-      { forkSessionId: sourceSessionId, forkPrompt },
-    )
-  }, [createChatPaneTransaction, sessionApi])
+    const pendingCreatePane: PendingCreatePane = {
+      afterId: paneId,
+      knownIds: new Set(resolvedSessions.map(workspaceSessionKeyFor)),
+      workspaceId,
+      mode: "rebind",
+    }
+    pendingCreatePaneRef.current = pendingCreatePane
+    setSeamlessFork({ workspaceId, paneId })
+    let created: ReturnType<typeof resolvedCreate>
+    try {
+      created = resolvedCreate(
+        `fork:${sourceSessionId}`,
+        ownerAgentTypeId,
+        { forkSessionId: sourceSessionId, forkPrompt },
+      )
+    } catch (error) {
+      if (pendingCreatePaneRef.current === pendingCreatePane) pendingCreatePaneRef.current = null
+      setSeamlessFork(null)
+      throw error
+    }
+    return Promise.resolve(created).then((session) => {
+      const id = createdSessionId(session)
+      if (!id) throw new Error("The native fork did not return a session id.")
+      if (pendingCreatePaneRef.current !== pendingCreatePane) throw new Error("The native fork lost its pane binding.")
+      const returnedAgentTypeId = typeof (session as { agentTypeId?: unknown } | null)?.agentTypeId === "string"
+        ? (session as { agentTypeId: string }).agentTypeId
+        : ownerAgentTypeId
+      pendingCreatePane.createdId = workspaceSessionKey(id, returnedAgentTypeId)
+      chatPaneBinding(paneId, sourceSessionId).setSessionId(id)
+      setSeamlessFork({ workspaceId, paneId, targetSessionId: id })
+      scheduleActiveAgentComposerFocus()
+      return { sessionId: id, agentTypeId: returnedAgentTypeId }
+    }).catch((error) => {
+      if (pendingCreatePaneRef.current === pendingCreatePane) pendingCreatePaneRef.current = null
+      setSeamlessFork(null)
+      throw error
+    })
+  }, [chatPaneBinding, resolvedCreate, resolvedSessions, sessionApi, workspaceId])
 
   const closeChatPane = useCallback((sessionKey: string) => {
     if (pendingCreatePaneRef.current) return
@@ -2195,6 +2267,8 @@ export function WorkspaceAgentFront<
       ...chatParams,
       ...(delayAutoSubmitDraft ? { autoSubmitInitialDraft: false, initialDraft: undefined } : {}),
       sessionId,
+      timelineKey: sessionKey,
+      sessionBinding: chatPaneBinding(sessionKey, sessionId),
       agentTypeId: sessionRef.agentTypeId ?? selectedAgentTypeId,
       apiBaseUrl,
       workspaceId,
@@ -2252,7 +2326,7 @@ export function WorkspaceAgentFront<
       ...(resolvedHotReloadEnabled !== undefined ? { hotReloadEnabled: resolvedHotReloadEnabled } : {}),
     }
     },
-    [apiBaseUrl, chatParams, chatRemoteSessionOptions, createChatSession, delayAutoSubmitDraft, forkFrozenChatSession, resolvedRequestHeaders, surfaceDispatch, extraCommands, workspaceWarmupStatus, hydrateMessages, emptySessionIds, resolvedHotReloadEnabled, pluginToolRenderers, reloadAgentPluginsForSession, selectedAgentTypeId, sessionSourceIsCurrent, workspaceId],
+    [apiBaseUrl, chatPaneBinding, chatParams, chatRemoteSessionOptions, createChatSession, delayAutoSubmitDraft, forkFrozenChatSession, resolvedRequestHeaders, surfaceDispatch, extraCommands, workspaceWarmupStatus, hydrateMessages, emptySessionIds, resolvedHotReloadEnabled, pluginToolRenderers, reloadAgentPluginsForSession, selectedAgentTypeId, sessionSourceIsCurrent, workspaceId],
   )
   const centerParams = useMemo(
     () => makeCenterParams(chatSessionKey),
@@ -2282,14 +2356,14 @@ export function WorkspaceAgentFront<
     }
   }), [chatHeaderAgentLabelById, chatPaneIds, defaultSessionTitle, makeCenterParams, sessionTitleById])
   const providerChatPaneSessionRefs = useMemo(
-    () => chatPaneIds.map(workspaceSessionRefFromKey),
-    [chatPaneIds],
+    () => chatPaneIds.map(boundChatSessionRef),
+    [boundChatSessionRef, chatPaneIds],
   )
   const providerChatPaneSessionIds = useMemo(
     () => providerChatPaneSessionRefs.map((ref) => ref.sessionId),
     [providerChatPaneSessionRefs],
   )
-  const providerActiveSessionRef = workspaceSessionRefFromKey(activeChatPaneId)
+  const providerActiveSessionRef = boundChatSessionRef(activeChatPaneId)
   const providerActiveSessionId = providerActiveSessionRef.sessionId
   const attentionSessions = useMemo(() => {
     const refs = new Map<string, WorkspaceSessionRef>()
@@ -2381,17 +2455,17 @@ export function WorkspaceAgentFront<
   const chatPaneSessionActions = useMemo(() => ({
     isPinned: (sessionKey: string) => pinnedIds.includes(sessionKey),
     onTogglePin: (sessionKey: string) => {
-      const ref = workspaceSessionRefFromKey(sessionKey)
+      const ref = boundChatSessionRef(sessionKey)
       toggleSessionPinned(ref.sessionId, ref.agentTypeId)
     },
     ...(canRenameSessions ? { onRename: renameChatSession } : {}),
     ...(canDeleteSessions ? {
       onDelete: async (sessionKey: string) => {
-        const ref = workspaceSessionRefFromKey(sessionKey)
+        const ref = boundChatSessionRef(sessionKey)
         await deleteSessionAndPane(ref.sessionId, ref.agentTypeId)
       },
     } : {}),
-  }), [canDeleteSessions, canRenameSessions, deleteSessionAndPane, pinnedIds, renameChatSession, toggleSessionPinned])
+  }), [boundChatSessionRef, canDeleteSessions, canRenameSessions, deleteSessionAndPane, pinnedIds, renameChatSession, toggleSessionPinned])
   const commandPaletteSessionSearch = useMemo(() => (
     isPluginTabsLayout
       ? {
@@ -2586,7 +2660,13 @@ export function WorkspaceAgentFront<
       headerInsetEnd={!surfaceOpen}
     />
   ) : null)
-  const mainContent = remoteSessionsTransitioning ? (
+  const seamlessForkInProgress = seamlessFork?.workspaceId === workspaceId
+  useEffect(() => {
+    if (!seamlessFork?.targetSessionId || seamlessFork.workspaceId !== workspaceId) return
+    if (remoteSessionsTransitioning || effectiveActiveSessionId !== seamlessFork.targetSessionId) return
+    setSeamlessFork(null)
+  }, [effectiveActiveSessionId, remoteSessionsTransitioning, seamlessFork, workspaceId])
+  const mainContent = remoteSessionsTransitioning && !seamlessForkInProgress ? (
     <ChatSessionTransitionState />
   ) : (
     <ChatLayout

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -872,23 +872,6 @@ export function WorkspaceAgentFront<
   )
   const chatPaneStateRef = useRef(chatPaneState)
   chatPaneStateRef.current = chatPaneState
-  const chatPaneBindingsRef = useRef(new Map<string, MutablePiChatSessionBinding>())
-  const chatPaneBindingsWorkspaceRef = useRef(workspaceId)
-  if (chatPaneBindingsWorkspaceRef.current !== workspaceId) {
-    chatPaneBindingsWorkspaceRef.current = workspaceId
-    chatPaneBindingsRef.current.clear()
-  }
-  const chatPaneBinding = useCallback((paneId: string, initialSessionId = workspaceSessionRefFromKey(paneId).sessionId) => {
-    const existing = chatPaneBindingsRef.current.get(paneId)
-    if (existing) return existing
-    const binding = createMutablePiChatSessionBinding(initialSessionId)
-    chatPaneBindingsRef.current.set(paneId, binding)
-    return binding
-  }, [])
-  const boundChatSessionRef = useCallback((paneId: string) => {
-    const ref = workspaceSessionRefFromKey(paneId)
-    return { ...ref, sessionId: chatPaneBinding(paneId, ref.sessionId).getSnapshot() }
-  }, [chatPaneBinding])
   const [pendingChatPanePlacement, setPendingChatPanePlacement] = useState<ChatPanePendingPlacement | null>(null)
   const [chatPaneSplitPending, setChatPaneSplitPending] = useState(false)
   const consumePendingChatPanePlacement = useCallback((paneId: string) => {
@@ -969,6 +952,23 @@ export function WorkspaceAgentFront<
     requestHeaders: resolvedRequestHeaders,
     enabled: remoteSessionHookEnabled,
   }), [apiBaseUrl, defaultAgentTypeId, remoteSessionHookEnabled, resolvedRequestHeaders, resolvedSessionStorageKey, workspaceId])
+  const chatPaneBindingsRef = useRef(new Map<string, MutablePiChatSessionBinding>())
+  const chatPaneBindingsSourceRef = useRef(chatPaneSourceIdentity)
+  if (chatPaneBindingsSourceRef.current !== chatPaneSourceIdentity) {
+    chatPaneBindingsSourceRef.current = chatPaneSourceIdentity
+    chatPaneBindingsRef.current.clear()
+  }
+  const chatPaneBinding = useCallback((paneId: string, initialSessionId = workspaceSessionRefFromKey(paneId).sessionId) => {
+    const existing = chatPaneBindingsRef.current.get(paneId)
+    if (existing) return existing
+    const binding = createMutablePiChatSessionBinding(initialSessionId)
+    chatPaneBindingsRef.current.set(paneId, binding)
+    return binding
+  }, [])
+  const boundChatSessionRef = useCallback((paneId: string) => {
+    const ref = workspaceSessionRefFromKey(paneId)
+    return { ...ref, sessionId: chatPaneBinding(paneId, ref.sessionId).getSnapshot() }
+  }, [chatPaneBinding])
   const chatPaneSourceIdentityRef = useRef(chatPaneSourceIdentity)
   useIsomorphicLayoutEffect(() => {
     if (chatPaneSourceIdentityRef.current === chatPaneSourceIdentity) return
@@ -1805,19 +1805,24 @@ export function WorkspaceAgentFront<
       const currentMatchesControlledSession = activeOwnerIsExplicit
         ? currentActiveRef?.sessionId === chatSessionId && currentActiveRef.agentTypeId === effectiveActiveSessionAgentTypeId
         : currentActiveRef?.sessionId === chatSessionId
+      const currentActiveSourceRef = current.activeId ? workspaceSessionRefFromKey(current.activeId) : undefined
+      const currentActiveIsRebound = Boolean(currentActiveRef && currentActiveSourceRef && currentActiveRef.sessionId !== currentActiveSourceRef.sessionId)
       const resolvedDesiredSessionId = !pendingCreatedId
         && current.activeId
-        && (!canPruneMissingSessions || resolvedSessionsByKey.has(current.activeId))
+        && (!canPruneMissingSessions || currentActiveIsRebound || Boolean(currentActiveRef && resolvedSessionsByKey.has(workspaceSessionKey(currentActiveRef.sessionId, currentActiveRef.agentTypeId))))
         && currentMatchesControlledSession
         ? current.activeId
         : desiredSessionId
       const rawIds = current.ids.length > 0 ? current.ids : [resolvedDesiredSessionId]
       const prunedIds = canPruneMissingSessions
-        ? rawIds.filter((id) => (
-            resolvedSessionsByKey.has(id)
-            || optimisticCreatedPaneKeysRef.current.has(id)
-            || id === pendingCreatedId
-          ))
+        ? rawIds.filter((id) => {
+            const sourceRef = workspaceSessionRefFromKey(id)
+            const boundRef = boundChatSessionRef(id)
+            return boundRef.sessionId !== sourceRef.sessionId
+              || resolvedSessionsByKey.has(workspaceSessionKey(boundRef.sessionId, boundRef.agentTypeId))
+              || optimisticCreatedPaneKeysRef.current.has(id)
+              || id === pendingCreatedId
+          })
         : rawIds
       const ids = prunedIds.length > 0 ? prunedIds : [resolvedDesiredSessionId]
       const activeId = current.activeId && ids.includes(current.activeId) ? current.activeId : ids[0] ?? resolvedDesiredSessionId
@@ -1883,22 +1888,26 @@ export function WorkspaceAgentFront<
 
   const switchToChatPane = useCallback((nextSessionId: string, nextAgentTypeId?: string) => {
     setLeftOverlay(null)
-    const nextSessionKey = workspaceSessionKey(nextSessionId, nextAgentTypeId)
+    const requestedSessionKey = workspaceSessionKey(nextSessionId, nextAgentTypeId)
     const current = chatPaneState.workspaceId === workspaceId
       ? chatPaneState
       : { workspaceId, ids: [chatSessionKey], activeId: chatSessionKey }
-    const alreadyVisible = current.ids.includes(nextSessionKey)
+    const retainedPaneId = current.ids.find((paneId) => (
+      workspaceSessionKey(boundChatSessionRef(paneId).sessionId, boundChatSessionRef(paneId).agentTypeId) === requestedSessionKey
+    ))
+    const nextPaneId = retainedPaneId ?? requestedSessionKey
+    const alreadyVisible = current.ids.includes(nextPaneId)
     setChatPaneState((previous) => {
       const paneState = previous.workspaceId === workspaceId
         ? previous
         : { workspaceId, ids: [chatSessionKey], activeId: chatSessionKey }
-      const ids = paneState.ids.includes(nextSessionKey)
+      const ids = paneState.ids.includes(nextPaneId)
         ? paneState.ids
-        : replaceActivePane(paneState.ids, paneState.activeId, nextSessionKey)
-      return { workspaceId, ids, activeId: nextSessionKey }
+        : replaceActivePane(paneState.ids, paneState.activeId, nextPaneId)
+      return { workspaceId, ids, activeId: nextPaneId }
     })
     if (alreadyVisible) {
-      const target = boundChatSessionRef(nextSessionKey)
+      const target = boundChatSessionRef(nextPaneId)
       return target.agentTypeId ? rawSwitch(target.sessionId, target.agentTypeId) : rawSwitch(target.sessionId)
     }
     return nextAgentTypeId ? resolvedSwitch(nextSessionId, nextAgentTypeId) : resolvedSwitch(nextSessionId)

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -1818,6 +1818,7 @@ describe("WorkspaceAgentFront", () => {
     }))
     const mounts = vi.fn()
     const unmounts = vi.fn()
+    const switchSession = vi.fn()
     let observedBinding: WorkspaceChatPanelProps["sessionBinding"]
     const FrozenChat = (props: WorkspaceChatPanelProps) => {
       observedBinding = props.sessionBinding
@@ -1841,6 +1842,7 @@ describe("WorkspaceAgentFront", () => {
     render(
       <WorkspaceAgentFront
         workspaceId="transparent-frozen-fork"
+        workspaceLayout="plugin-tabs"
         chatPanel={FrozenChat}
         useSessions={(options) => ({
           sourceIdentity: options.sourceIdentity,
@@ -1850,7 +1852,7 @@ describe("WorkspaceAgentFront", () => {
           activeSession: { id: "stale", agentTypeId: "default", title: "Frozen session" },
           loading: false,
           workspaceId: options.workspaceId,
-          switch: vi.fn(),
+          switch: switchSession,
           delete: vi.fn(),
           create,
         })}
@@ -1876,6 +1878,10 @@ describe("WorkspaceAgentFront", () => {
     expect(unmounts).toHaveBeenCalledTimes(unmountCountBeforeFork)
     expect(screen.getByTestId("frozen-history")).toBe(history)
     expect(screen.getByTestId("frozen-history")).toHaveAttribute("data-timeline-key", stableTimelineKey)
+
+    await user.click(within(screen.getByLabelText("App navigation")).getByRole("button", { name: "Frozen session" }))
+    expect(switchSession).toHaveBeenLastCalledWith("forked", "default")
+    expect(screen.getByTestId("frozen-history")).toBe(history)
   })
 
   it("rejects a frozen fork while another pane creation is pending", async () => {

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -1819,6 +1819,26 @@ describe("WorkspaceAgentFront", () => {
     const mounts = vi.fn()
     const unmounts = vi.fn()
     const switchSession = vi.fn()
+    let publishFork: (() => void) | undefined
+    const useForkSessions: UseWorkspaceAgentSessions = (options) => {
+      const [sessions, setSessions] = useState<WorkspaceAgentSession[]>([
+        { id: "stale", agentTypeId: "default", title: "Frozen session" },
+      ])
+      publishFork = () => setSessions([{ id: "forked", agentTypeId: "default", title: "Continued session" }])
+      const active = sessions[0]
+      return {
+        sourceIdentity: options.sourceIdentity,
+        sessions,
+        activeSessionId: active?.id ?? null,
+        activeSessionAgentTypeId: active?.agentTypeId ?? null,
+        activeSession: active ?? null,
+        loading: false,
+        workspaceId: options.workspaceId,
+        switch: switchSession,
+        delete: vi.fn(),
+        create,
+      }
+    }
     let observedBinding: WorkspaceChatPanelProps["sessionBinding"]
     const FrozenChat = (props: WorkspaceChatPanelProps) => {
       observedBinding = props.sessionBinding
@@ -1844,18 +1864,7 @@ describe("WorkspaceAgentFront", () => {
         workspaceId="transparent-frozen-fork"
         workspaceLayout="plugin-tabs"
         chatPanel={FrozenChat}
-        useSessions={(options) => ({
-          sourceIdentity: options.sourceIdentity,
-          sessions: [{ id: "stale", agentTypeId: "default", title: "Frozen session" }],
-          activeSessionId: "stale",
-          activeSessionAgentTypeId: "default",
-          activeSession: { id: "stale", agentTypeId: "default", title: "Frozen session" },
-          loading: false,
-          workspaceId: options.workspaceId,
-          switch: switchSession,
-          delete: vi.fn(),
-          create,
-        })}
+        useSessions={useForkSessions}
         persistenceEnabled={false}
       />,
     )
@@ -1879,7 +1888,8 @@ describe("WorkspaceAgentFront", () => {
     expect(screen.getByTestId("frozen-history")).toBe(history)
     expect(screen.getByTestId("frozen-history")).toHaveAttribute("data-timeline-key", stableTimelineKey)
 
-    await user.click(within(screen.getByLabelText("App navigation")).getByRole("button", { name: "Frozen session" }))
+    act(() => publishFork?.())
+    await user.click(await within(screen.getByLabelText("App navigation")).findByRole("button", { name: "Continued session" }))
     expect(switchSession).toHaveBeenLastCalledWith("forked", "default")
     expect(screen.getByTestId("frozen-history")).toBe(history)
   })

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -1808,7 +1808,7 @@ describe("WorkspaceAgentFront", () => {
     expect(create).toHaveBeenCalledWith()
   })
 
-  it("replaces a frozen pane with the current-scope native fork", async () => {
+  it("rebinds a frozen pane to the native fork without remounting its timeline", async () => {
     const user = userEvent.setup()
     const create = vi.fn(async (input?: { forkSessionId?: string }) => ({
       id: "forked",
@@ -1816,15 +1816,27 @@ describe("WorkspaceAgentFront", () => {
       title: "Continued session",
       ...(input ?? {}),
     }))
-    const FrozenChat = (props: WorkspaceChatPanelProps) => (
-      <button
-        type="button"
-        data-session-id={props.sessionId}
-        onClick={() => void props.onForkSession?.("stale", { message: "continue", clientNonce: "nonce" })}
-      >
-        Send frozen message
-      </button>
-    )
+    const mounts = vi.fn()
+    const unmounts = vi.fn()
+    let observedBinding: WorkspaceChatPanelProps["sessionBinding"]
+    const FrozenChat = (props: WorkspaceChatPanelProps) => {
+      observedBinding = props.sessionBinding
+      useEffect(() => {
+        mounts()
+        return () => unmounts()
+      }, [])
+      return (
+        <div data-testid="frozen-history" data-session-id={props.sessionId} data-timeline-key={props.timelineKey}>
+          <span>Frozen history stays mounted</span>
+          <button
+            type="button"
+            onClick={() => void props.onForkSession?.("stale", { message: "continue", clientNonce: "nonce" })}
+          >
+            Send frozen message
+          </button>
+        </div>
+      )
+    }
 
     render(
       <WorkspaceAgentFront
@@ -1846,11 +1858,24 @@ describe("WorkspaceAgentFront", () => {
       />,
     )
 
+    await waitFor(() => expect(screen.getByTestId("frozen-history")).toHaveAttribute("data-session-id", "stale"))
+    await act(async () => { await new Promise((resolve) => setTimeout(resolve, 0)) })
+    const history = screen.getByTestId("frozen-history")
+    const stableTimelineKey = history.getAttribute("data-timeline-key")
+    const mountCountBeforeFork = mounts.mock.calls.length
+    const unmountCountBeforeFork = unmounts.mock.calls.length
     await user.click(screen.getByRole("button", { name: "Send frozen message" }))
     await waitFor(() => expect(create).toHaveBeenCalledWith({
       forkSessionId: "stale",
       forkPrompt: { message: "continue", clientNonce: "nonce" },
     }))
+    await waitFor(() => expect(create).toHaveBeenCalledOnce())
+    expect(screen.getByTestId("frozen-history")).toHaveAttribute("data-session-id", "stale")
+    expect(observedBinding?.getSnapshot()).toBe("forked")
+    expect(mounts).toHaveBeenCalledTimes(mountCountBeforeFork)
+    expect(unmounts).toHaveBeenCalledTimes(unmountCountBeforeFork)
+    expect(screen.getByTestId("frozen-history")).toBe(history)
+    expect(screen.getByTestId("frozen-history")).toHaveAttribute("data-timeline-key", stableTimelineKey)
   })
 
   it("rejects a frozen fork while another pane creation is pending", async () => {


### PR DESCRIPTION
Closes #1323

Keeps the mounted transcript and stable timeline identity while a frozen chat forks. The prompt is shown optimistically at Enter, the remote session binding swaps beneath the pane, and server hydration reconciles the nonce in place before streaming continues.

Proof, independent review, and RC-fixture demo will be attached before owner validation.