### PR TITLE
fix(data-bridge): preserve safe BSL argument errors

### DIFF
--- a/plugins/data-bridge/python/bsl_worker.py
+++ b/plugins/data-bridge/python/bsl_worker.py
@@ -19,6 +19,7 @@ MODEL_CACHE: Dict[str, Any] = {}
 BSL_INVALID_SYNTAX = "DATA_BRIDGE_BSL_INVALID_SYNTAX"
 BSL_DEFERRED_RESULT = "DATA_BRIDGE_BSL_DEFERRED_RESULT"
 BSL_NON_TABULAR_RESULT = "DATA_BRIDGE_BSL_NON_TABULAR_RESULT"
+BSL_INVALID_ARGUMENTS = "DATA_BRIDGE_BSL_INVALID_ARGUMENTS"
 BSL_EXECUTION_FAILED = "DATA_BRIDGE_BSL_EXECUTION_FAILED"
 
 
@@ -68,6 +69,24 @@ def _guard_query(query: str) -> None:
             raise ValueError("private/dunder attribute access is not allowed")
 
 
+def _safe_evaluation_error(error: BaseException) -> BaseException:
+    diagnostic = str(error)
+    if error.__class__.__name__ != "SignatureValidationError":
+        return error
+
+    if "SemanticAggregateOp" in diagnostic and "`aggs`" in diagnostic:
+        return BslQueryError(
+            BSL_INVALID_ARGUMENTS,
+            "Invalid semantic aggregation arguments: pass measure names positionally, for example "
+            "aggregate(\"measure\"); named aggregate aliases require callable expressions",
+        )
+
+    return BslQueryError(
+        BSL_INVALID_ARGUMENTS,
+        "BSL operation received invalid argument types; check the operation arguments",
+    )
+
+
 def _dtype_for_value(value):
     dtype = str(value)
     if dtype.startswith("int"):
@@ -102,7 +121,10 @@ def _query_to_table(payload: Dict[str, Any]) -> Dict[str, Any]:
     evaluated = safe_eval(payload["query"], context={**models, "sm": model, "ibis": ibis, "_": _})
 
     if isinstance(evaluated, Failure):
-        raise evaluated.failure()
+        failure = evaluated.failure()
+        if isinstance(failure, BaseException):
+            raise _safe_evaluation_error(failure)
+        raise RuntimeError(str(failure))
 
     if not isinstance(evaluated, Success):
         failure = evaluated.failure()

--- a/plugins/data-bridge/src/server/bsl/fixtures/bsl_worker_validation.py
+++ b/plugins/data-bridge/src/server/bsl/fixtures/bsl_worker_validation.py
@@ -37,6 +37,10 @@ class Failure:
         return self.value
 
 
+class SignatureValidationError(Exception):
+    pass
+
+
 class Dtype:
     def __str__(self):
         return "int64"
@@ -124,6 +128,10 @@ def main():
             return Success(42)
         if query == "column":
             return Success(Column())
+        if query == "invalidAggregate":
+            return Failure(SignatureValidationError(
+                "SemanticAggregateOp validation failed for `aggs`: private diagnostic: /secret/model.yml"
+            ))
         if query == "failure":
             return Failure(ValueError("private diagnostic: /secret/model.yml"))
         return Success(Table())
@@ -135,13 +143,14 @@ def main():
         {"modelPath": "/tmp/model.yml", "model": "semanticModel", "query": "scalar", "limit": 10},
         {"modelPath": "/tmp/model.yml", "model": "semanticModel", "query": "column", "limit": 10},
         {"modelPath": "/tmp/model.yml", "model": "semanticModel", "query": "table", "limit": 10},
+        {"modelPath": "/tmp/model.yml", "model": "semanticModel", "query": "invalidAggregate", "limit": 10},
         {"modelPath": "/tmp/model.yml", "model": "semanticModel", "query": "failure", "limit": 10},
     ]
     diagnostics = io.StringIO()
     with contextlib.redirect_stderr(diagnostics):
         results = worker._query_batch({"queries": queries})
 
-    assert [result["ok"] for result in results] == [False, False, False, False, True, False]
+    assert [result["ok"] for result in results] == [False, False, False, False, True, False, False]
     assert [results[index]["error"]["code"] for index in range(4)] == [
         worker.BSL_INVALID_SYNTAX,
         worker.BSL_DEFERRED_RESULT,
@@ -150,6 +159,13 @@ def main():
     ]
     assert results[4]["output"]["rows"] == [{"value": 1}]
     assert results[5]["error"] == {
+        "code": worker.BSL_INVALID_ARGUMENTS,
+        "message": (
+            "Invalid semantic aggregation arguments: pass measure names positionally, for example "
+            'aggregate("measure"); named aggregate aliases require callable expressions'
+        ),
+    }
+    assert results[6]["error"] == {
         "code": worker.BSL_EXECUTION_FAILED,
         "message": "BSL expression could not be evaluated; check the selected model and expression",
     }

--- a/plugins/data-bridge/src/shared/index.ts
+++ b/plugins/data-bridge/src/shared/index.ts
@@ -5,6 +5,7 @@ export const DATA_BRIDGE_BSL_ERROR_CODES = {
   invalidSyntax: "DATA_BRIDGE_BSL_INVALID_SYNTAX",
   deferredResult: "DATA_BRIDGE_BSL_DEFERRED_RESULT",
   nonTabularResult: "DATA_BRIDGE_BSL_NON_TABULAR_RESULT",
+  invalidArguments: "DATA_BRIDGE_BSL_INVALID_ARGUMENTS",
   executionFailed: "DATA_BRIDGE_BSL_EXECUTION_FAILED",
 } as const
 


### PR DESCRIPTION
Closes #1328

## Summary
- classify Ibis signature failures separately from unknown execution failures
- return a sanitized remediation for invalid semantic aggregate arguments
- keep private diagnostics and unknown failures confined to stderr

## Verification
- `python3 -m py_compile plugins/data-bridge/python/bsl_worker.py plugins/data-bridge/src/server/bsl/fixtures/bsl_worker_validation.py`
- `pnpm --filter @hachej/boring-data-bridge exec vitest run src/server/bsl/pythonBslWorker.test.ts`
- replayed the Healio failing expression against the real BSL runtime; response now identifies positional measure names / callable aliases

## Known unrelated checkout issue
Full package typecheck currently resolves mixed Fastify/workspace artifacts between the canonical checkout and nested worktree and fails in unchanged server files. The focused worker test passes.