### PR TITLE
fix(agent): raise prompt upload limit to 10 MB

### DIFF
--- a/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
+++ b/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
@@ -995,14 +995,14 @@ describe('PiChatPanel sandbox shell', () => {
     render(<PiChatPanel serverResourcesEnabled={false} storageScope="scope-a" fetch={fetchMock as unknown as typeof fetch} createRemoteSession={remoteFactory(remote)} />)
 
     const textarea = await screen.findByLabelText('Agent prompt')
-    const oversizedFile = new File([new Uint8Array((4 * 1024 * 1024) + 1)], 'large.txt', { type: 'text/plain' })
+    const oversizedFile = new File([new Uint8Array((10 * 1024 * 1024) + 1)], 'large.txt', { type: 'text/plain' })
     fireEvent.paste(textarea, {
       clipboardData: {
         items: [{ kind: 'file', getAsFile: () => oversizedFile }],
       },
     })
 
-    await screen.findByText('Files must be under 4 MB each.')
+    await screen.findByText('Files must be 10 MB or smaller.')
     expect(remote.prompt).not.toHaveBeenCalled()
   })
 

--- a/packages/agent/src/front/chat/components/PiChatComposerSurface.tsx
+++ b/packages/agent/src/front/chat/components/PiChatComposerSurface.tsx
@@ -39,7 +39,7 @@ import {
 import { noticeSurfaceClass } from './noticeStyles'
 
 const MAX_PROMPT_ATTACHMENTS = 2
-const MAX_PROMPT_ATTACHMENT_BYTES = 4 * 1024 * 1024
+const MAX_PROMPT_ATTACHMENT_BYTES = 10 * 1024 * 1024
 const COMPOSER_INPUT_GROUP_MIN_HEIGHT = 56
 const COMPOSER_TEXTAREA_MAX_HEIGHT = 160
 const COMPOSER_MULTILINE_EXTRA_HEIGHT = 8
@@ -378,7 +378,7 @@ export function PiChatComposerSurface<
           maxFileSize={MAX_PROMPT_ATTACHMENT_BYTES}
           onError={(err) => {
             if (err.code === 'max_files') onAttachmentNotice(`Up to ${MAX_PROMPT_ATTACHMENTS} attachments per message.`)
-            else if (err.code === 'max_file_size') onAttachmentNotice('Files must be under 4 MB each.')
+            else if (err.code === 'max_file_size') onAttachmentNotice('Files must be 10 MB or smaller.')
             else if (err.code === 'accept') onAttachmentNotice("That file type isn't supported here.")
             else onAttachmentNotice(err.message || 'Attachment rejected.')
           }}


### PR DESCRIPTION
## Summary
- raise the browser prompt attachment limit from 4 MiB to 10 MiB
- update the validation message and oversized-file regression
- align the browser with the existing 10 MiB upload endpoint and prompt-image limits

The existing 16 MiB request body limit still accommodates a base64-encoded 10 MiB attachment.

## Validation
- `pnpm --filter @hachej/boring-ui-kit build`
- `pnpm --filter @hachej/boring-agent exec vitest run src/front/chat/__tests__/PiChatPanel.test.tsx` (70 passed)
- `git diff --check`