### PR TITLE
refactor(workspace): simplify batch upload boundaries

### DIFF
--- a/packages/agent/src/server/__tests__/createStandaloneAgentHostApp.test.ts
+++ b/packages/agent/src/server/__tests__/createStandaloneAgentHostApp.test.ts
@@ -626,6 +626,7 @@ test('createStandaloneAgentHostApp exposes static filesystem bindings on files a
           list: true,
           search: true,
           write: false,
+          upload: false,
           delete: false,
           move: false,
           mkdir: false,

--- a/packages/boring-bash/src/server/__tests__/primaryFilesystemAccess.test.ts
+++ b/packages/boring-bash/src/server/__tests__/primaryFilesystemAccess.test.ts
@@ -157,11 +157,11 @@ describe('primary filesystem access projection', () => {
     const request = () => app.inject({
       method: 'POST',
       url: '/api/v1/files/binary',
-      payload: { path: 'a/raced.txt', ifExists: 'skip', contentBase64: 'eA==' },
+      payload: { path: 'a/raced.txt', ifExists: 'error', contentBase64: 'eA==' },
     })
     const responses = await Promise.all([request(), request()])
     expect(createBinary).toHaveBeenCalledTimes(2)
-    expect(responses.map((response) => response.json().status).sort()).toEqual(['skipped', 'written'])
+    expect(responses.map((response) => response.json().status).sort()).toEqual(['conflict', 'written'])
     await app.close()
   })
 

--- a/packages/boring-bash/src/server/routes/file.ts
+++ b/packages/boring-bash/src/server/routes/file.ts
@@ -682,7 +682,7 @@ export function fileRoutes(
     if (contentBase64 === null) return
     if (!isExactBinaryWritePolicy(body.ifExists)) {
       return reply.code(400).send({
-        error: { code: ERROR_CODE_VALIDATION_ERROR, message: 'ifExists must be error, replace, or skip', field: 'ifExists' },
+        error: { code: ERROR_CODE_VALIDATION_ERROR, message: 'ifExists must be error or replace', field: 'ifExists' },
       })
     }
     if (contentBase64.length > Math.ceil(MAX_UPLOAD_BYTES / 3) * 4) {
@@ -732,14 +732,11 @@ export function fileRoutes(
         return { status: 'written', path } satisfies ExactBinaryWriteOutcome
       } catch (error) {
         if ((error as NodeJS.ErrnoException)?.code !== 'EEXIST') throw error
-        const outcome = {
-          status: body.ifExists === 'skip' ? 'skipped' : 'conflict',
+        return {
+          status: 'conflict',
           path,
           reason: 'already-exists',
-        } as const
-        return body.ifExists === 'skip'
-          ? outcome satisfies ExactBinaryWriteOutcome
-          : reply.code(409).send(outcome satisfies ExactBinaryWriteOutcome)
+        } satisfies ExactBinaryWriteOutcome
       }
     } catch (err) {
       return classifyError(err, reply, 'file')

--- a/packages/boring-bash/src/server/routes/file.upload.test.ts
+++ b/packages/boring-bash/src/server/routes/file.upload.test.ts
@@ -74,13 +74,13 @@ describe('exact binary write route', () => {
     await app.close()
   })
 
-  it.each(['skip', 'error'] as const)('never overwrites an existing file for %s', async (ifExists) => {
+  it('returns a typed conflict without overwriting an existing file', async () => {
     const state = createWorkspace({ 'src/report.txt': 'old' })
     const app = await appFor(state.workspace)
-    const response = await app.inject({ method: 'POST', url: '/api/v1/files/binary', payload: binaryPayload({ ifExists }) })
-    expect(response.statusCode).toBe(ifExists === 'skip' ? 200 : 409)
+    const response = await app.inject({ method: 'POST', url: '/api/v1/files/binary', payload: binaryPayload() })
+    expect(response.statusCode).toBe(200)
     expect(response.json()).toEqual({
-      status: ifExists === 'skip' ? 'skipped' : 'conflict',
+      status: 'conflict',
       path: 'src/report.txt',
       reason: 'already-exists',
     })
@@ -99,7 +99,7 @@ describe('exact binary write route', () => {
     await app.close()
   })
 
-  it.each([undefined, '', 'overwrite', true])('strictly rejects malformed policy %j', async (ifExists) => {
+  it.each([undefined, '', 'overwrite', 'skip', true])('strictly rejects malformed policy %j', async (ifExists) => {
     const state = createWorkspace()
     const app = await appFor(state.workspace)
     const response = await app.inject({ method: 'POST', url: '/api/v1/files/binary', payload: binaryPayload({ ifExists }) })
@@ -133,13 +133,13 @@ describe('exact binary write route', () => {
     const state = createWorkspace({ [path]: 'old' })
     const app = await appFor(state.workspace)
     const response = await app.inject({ method: 'POST', url: '/api/v1/files/binary', payload: binaryPayload({ path }) })
-    expect(response.statusCode).toBe(409)
+    expect(response.statusCode).toBe(200)
     expect(response.json()).toEqual({ status: 'conflict', path, reason: 'already-exists' })
     expect(state.files.get(path)).toBe('old')
     await app.close()
   })
 
-  it('returns 501 rather than weakening error/skip when exclusive create is unavailable', async () => {
+  it('returns 501 rather than weakening exclusive create when unavailable', async () => {
     const state = createWorkspace({}, false)
     const app = await appFor(state.workspace)
     const response = await app.inject({ method: 'POST', url: '/api/v1/files/binary', payload: binaryPayload() })
@@ -156,7 +156,8 @@ describe('exact binary write route', () => {
       payload: binaryPayload({ contentBase64: encoded(value) }),
     })
     const responses = await Promise.all([request(firstApp, 'first'), request(secondApp, 'second')])
-    expect(responses.map((response) => response.statusCode).sort()).toEqual([200, 409])
+    expect(responses.map((response) => response.statusCode)).toEqual([200, 200])
+    expect(responses.map((response) => response.json().status).sort()).toEqual(['conflict', 'written'])
     expect(state.writes).toHaveLength(1)
     expect(['first', 'second']).toContain(state.files.get('src/report.txt'))
     await Promise.all([firstApp.close(), secondApp.close()])

--- a/packages/boring-bash/src/server/routes/filesystems.test.ts
+++ b/packages/boring-bash/src/server/routes/filesystems.test.ts
@@ -37,7 +37,7 @@ describe('filesystemsRoutes', () => {
         label: 'Workspace',
         rootDir: '.',
         access: 'readwrite',
-        capabilities: { read: true, list: true, search: true, write: true, delete: true, move: true, mkdir: true },
+        capabilities: { read: true, list: true, search: true, write: true, upload: true, delete: true, move: true, mkdir: true },
       }],
     })
     await app.close()
@@ -66,15 +66,48 @@ describe('filesystemsRoutes', () => {
       label: 'readonly_docs',
       rootDir: '/',
       access: 'readonly',
-      capabilities: { read: true, list: true, search: true, write: false, delete: false, move: false, mkdir: false },
+      capabilities: { read: true, list: true, search: true, write: false, upload: false, delete: false, move: false, mkdir: false },
     })
     expect(partial).toEqual({
       filesystem: 'partial',
       label: 'partial',
       rootDir: '/',
       access: 'readwrite',
-      capabilities: { read: true, list: true, search: true, write: true, delete: false, move: true, mkdir: false },
+      capabilities: { read: true, list: true, search: true, write: true, upload: false, delete: false, move: true, mkdir: false },
     })
+    await app.close()
+  })
+
+  it('advertises exact upload only when the primary binding supports create and replace', async () => {
+    const app = Fastify()
+    await app.register(filesystemsRoutes, {
+      filesystemBindings: [binding({
+        filesystem: 'user',
+        access: 'readwrite',
+        operations: operations({ write: vi.fn(), writeBinary: vi.fn(), createBinary: vi.fn() }),
+      })],
+    })
+
+    const response = await app.inject({ method: 'GET', url: '/api/v1/filesystems' })
+    expect(response.json().filesystems[0].capabilities).toMatchObject({ write: true, upload: true })
+    await app.close()
+  })
+
+  it.each([
+    { label: 'exclusive create', binary: { writeBinary: vi.fn() } },
+    { label: 'binary replace', binary: { createBinary: vi.fn() } },
+  ])('reports upload unavailable without $label', async ({ binary }) => {
+    const app = Fastify()
+    await app.register(filesystemsRoutes, {
+      filesystemBindings: [binding({
+        filesystem: 'user',
+        access: 'readwrite',
+        operations: operations({ write: vi.fn(), ...binary }),
+      })],
+    })
+
+    const response = await app.inject({ method: 'GET', url: '/api/v1/filesystems' })
+    expect(response.json().filesystems[0].capabilities).toMatchObject({ write: true, upload: false })
     await app.close()
   })
 

--- a/packages/boring-bash/src/server/routes/filesystems.ts
+++ b/packages/boring-bash/src/server/routes/filesystems.ts
@@ -35,6 +35,7 @@ const PRIMARY_FILESYSTEM: FilesystemCatalogEntry = {
     list: true,
     search: true,
     write: true,
+    upload: true,
     delete: true,
     move: true,
     mkdir: true,
@@ -53,6 +54,10 @@ function capabilitiesFor(binding: RuntimeFilesystemBinding): FilesystemCatalogCa
     list: typeof operations.list === 'function' && typeof operations.stat === 'function',
     search: typeof operations.find === 'function',
     write: mutable && typeof operations.write === 'function',
+    upload: mutable
+      && binding.filesystem === USER_FILESYSTEM_ID
+      && typeof operations.createBinary === 'function'
+      && typeof operations.writeBinary === 'function',
     delete: mutable && typeof operations.delete === 'function',
     move: mutable && typeof operations.move === 'function',
     mkdir: mutable && typeof operations.mkdir === 'function',
@@ -81,7 +86,11 @@ export function filesystemsRoutes(
         ? await opts.getFilesystemBindings(request) ?? []
         : opts.filesystemBindings ?? []
       const seen = new Set<string>([USER_FILESYSTEM_ID])
-      const filesystems: FilesystemCatalogEntry[] = [{ ...PRIMARY_FILESYSTEM }]
+      const primaryBinding = bindings.find((binding) => binding.filesystem === USER_FILESYSTEM_ID)
+      const filesystems: FilesystemCatalogEntry[] = [{
+        ...PRIMARY_FILESYSTEM,
+        ...(primaryBinding ? { capabilities: capabilitiesFor(primaryBinding) } : {}),
+      }]
       for (const binding of bindings) {
         if (seen.has(binding.filesystem)) continue
         const entry = catalogEntry(binding)

--- a/packages/boring-bash/src/shared/catalog.ts
+++ b/packages/boring-bash/src/shared/catalog.ts
@@ -25,6 +25,7 @@ export const FILESYSTEM_CATALOG_CAPABILITIES = [
   "list",
   "search",
   "write",
+  "upload",
   "delete",
   "move",
   "mkdir",
@@ -54,6 +55,20 @@ export function isFilesystemCatalogCapabilities(value: unknown): value is Filesy
   return FILESYSTEM_CATALOG_CAPABILITIES.every((capability) => typeof capabilities[capability] === "boolean");
 }
 
+type FilesystemCatalogWireCapabilities = Omit<FilesystemCatalogCapabilities, "upload"> & {
+  upload?: boolean;
+};
+
+function isFilesystemCatalogWireCapabilities(value: unknown): value is FilesystemCatalogWireCapabilities {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const capabilities = value as Record<string, unknown>;
+  return FILESYSTEM_CATALOG_CAPABILITIES.every((capability) => (
+    capability === "upload"
+      ? capabilities[capability] === undefined || typeof capabilities[capability] === "boolean"
+      : typeof capabilities[capability] === "boolean"
+  ));
+}
+
 /** Parses and validates an untrusted `{ filesystems: [...] }` payload into
  * catalog entries, dropping any entry that fails the contract rather than
  * throwing — callers treat the catalog as best-effort. */
@@ -70,7 +85,7 @@ export function parseFilesystemCatalog(value: unknown): FilesystemCatalogEntry[]
     if (!isValidCatalogString(entry.label, CATALOG_STRING_MAX_LENGTH)) continue;
     if (!isValidCatalogString(entry.rootDir, CATALOG_ROOT_DIR_MAX_LENGTH)) continue;
     if (entry.access !== "readonly" && entry.access !== "readwrite") continue;
-    if (!isFilesystemCatalogCapabilities(entry.capabilities)) continue;
+    if (!isFilesystemCatalogWireCapabilities(entry.capabilities)) continue;
     const capabilities = entry.capabilities;
     seen.add(entry.filesystem);
     entries.push({
@@ -79,7 +94,7 @@ export function parseFilesystemCatalog(value: unknown): FilesystemCatalogEntry[]
       rootDir: entry.rootDir as LogicalFilesystemRoot,
       access: entry.access,
       capabilities: Object.fromEntries(
-        FILESYSTEM_CATALOG_CAPABILITIES.map((capability) => [capability, capabilities[capability]]),
+        FILESYSTEM_CATALOG_CAPABILITIES.map((capability) => [capability, capabilities[capability] ?? false]),
       ) as unknown as FilesystemCatalogCapabilities,
     });
   }

--- a/packages/boring-bash/src/shared/exactBinaryWrite.ts
+++ b/packages/boring-bash/src/shared/exactBinaryWrite.ts
@@ -1,10 +1,9 @@
-export const EXACT_BINARY_WRITE_POLICIES = ["error", "replace", "skip"] as const;
+export const EXACT_BINARY_WRITE_POLICIES = ["error", "replace"] as const;
 
 export type ExactBinaryWritePolicy = (typeof EXACT_BINARY_WRITE_POLICIES)[number];
 
 export type ExactBinaryWriteOutcome =
   | { status: "written"; path: string }
-  | { status: "skipped"; path: string; reason: "already-exists" }
   | { status: "conflict"; path: string; reason: "already-exists" };
 
 export function isExactBinaryWritePolicy(value: unknown): value is ExactBinaryWritePolicy {
@@ -25,15 +24,8 @@ export function parseExactBinaryWriteOutcome(
   if (outcome.status === "written") {
     return { status: "written", path: outcome.path };
   }
-  if (
-    (outcome.status === "skipped" || outcome.status === "conflict")
-    && outcome.reason === "already-exists"
-  ) {
-    return {
-      status: outcome.status,
-      path: outcome.path,
-      reason: "already-exists",
-    };
+  if (outcome.status === "conflict" && outcome.reason === "already-exists") {
+    return { status: "conflict", path: outcome.path, reason: "already-exists" };
   }
   throw new TypeError("invalid exact binary write outcome status");
 }

--- a/packages/workspace/src/front/bridge/WorkspaceLink.tsx
+++ b/packages/workspace/src/front/bridge/WorkspaceLink.tsx
@@ -7,7 +7,7 @@ export type WorkspaceLinkTarget =
   | { kind: "openFile"; path: string; mode?: UiFileOpenMode; filesystem?: FilesystemId }
   | { kind: "openSurface"; surfaceKind: string; target: string; filesystem?: FilesystemId; meta?: Record<string, unknown> }
   | { kind: "openPanel"; id: string; component: string; title?: string; params?: Record<string, unknown> }
-  | { kind: "expandToFile"; path: string; filesystem?: FilesystemId; resourceKind?: "file" | "dir" }
+  | { kind: "expandToFile"; path: string; filesystem?: FilesystemId }
 
 export interface WorkspaceLinkProps {
   to: WorkspaceLinkTarget
@@ -35,14 +35,7 @@ export function workspaceLinkCommand(to: WorkspaceLinkTarget): UiCommand {
         },
       }
     case "expandToFile":
-      return {
-        kind: "expandToFile",
-        params: {
-          path: to.path,
-          ...(to.filesystem ? { filesystem: to.filesystem } : {}),
-          ...(to.resourceKind ? { kind: to.resourceKind } : {}),
-        },
-      }
+      return { kind: "expandToFile", params: { path: to.path, ...(to.filesystem ? { filesystem: to.filesystem } : {}) } }
   }
 }
 

--- a/packages/workspace/src/front/bridge/client.ts
+++ b/packages/workspace/src/front/bridge/client.ts
@@ -119,8 +119,7 @@ async function dispatchCommand(
       break
     case "expandToFile": {
       const filesystem = params.filesystem as FilesystemId | undefined
-      const kind = params.kind as "file" | "dir" | undefined
-      if (filesystem || kind) await bridge.expandToFile(params.path as string, { ...(filesystem ? { filesystem } : {}), ...(kind ? { kind } : {}) })
+      if (filesystem) await bridge.expandToFile(params.path as string, { filesystem })
       else await bridge.expandToFile(params.path as string)
       break
     }

--- a/packages/workspace/src/front/bridge/createBridge.ts
+++ b/packages/workspace/src/front/bridge/createBridge.ts
@@ -169,7 +169,7 @@ export function createBridge(store: StoreApi): WorkspaceBridge {
     },
 
     async expandToFile(path, opts) {
-      const parsed = expandToFileSchema.safeParse({ path, filesystem: opts?.filesystem, kind: opts?.kind })
+      const parsed = expandToFileSchema.safeParse({ path, filesystem: opts?.filesystem })
       if (!parsed.success) return err("VALIDATION", parsed.error.issues[0].message)
 
       const state = store.getState()
@@ -180,7 +180,6 @@ export function createBridge(store: StoreApi): WorkspaceBridge {
       emit("tree:expand", {
         path: parsed.data.path,
         ...(parsed.data.filesystem ? { filesystem: parsed.data.filesystem } : {}),
-        ...(parsed.data.kind ? { kind: parsed.data.kind } : {}),
       })
       return ok()
     },

--- a/packages/workspace/src/front/bridge/types.ts
+++ b/packages/workspace/src/front/bridge/types.ts
@@ -22,7 +22,7 @@ export interface BridgeEventMap {
   "file:saved": { path: string }
   "file:dirty": { path: string; dirty: boolean }
   "sidebar:toggled": { collapsed: boolean }
-  "tree:expand": { path: string; filesystem?: FilesystemId; kind?: "file" | "dir" }
+  "tree:expand": { path: string; filesystem?: FilesystemId }
   "notification:shown": { message: string; level: "info" | "warn" | "error" }
   "pane:error": { panelId: string; error: string; stack?: string }
 }
@@ -55,7 +55,7 @@ export interface WorkspaceBridge {
     level?: "info" | "warn" | "error",
   ): Promise<CommandResult>
   navigateToLine(file: string, line: number): Promise<CommandResult>
-  expandToFile(path: string, opts?: { filesystem?: FilesystemId; kind?: "file" | "dir" }): Promise<CommandResult>
+  expandToFile(path: string, opts?: { filesystem?: FilesystemId }): Promise<CommandResult>
   markDirty(path: string): void
   markClean(path: string): void
 

--- a/packages/workspace/src/front/bridge/uiCommandDispatcher.ts
+++ b/packages/workspace/src/front/bridge/uiCommandDispatcher.ts
@@ -221,7 +221,7 @@ export function dispatchUiCommand(cmd: UiCommand, ctx: DispatchContext): void {
       // disagree about the empty-path root representation.
       const parsed = expandToFileSchema.safeParse(cmd.params)
       if (!parsed.success) return
-      const { path, filesystem, kind } = parsed.data
+      const { path, filesystem } = parsed.data
       // Deliberately NOT normalized, unlike openFile: revealing has somewhere
       // to fall back to and openFile does not. `openFile` must resolve to a
       // concrete filesystem or it cannot open anything, so an omitted one
@@ -235,7 +235,7 @@ export function dispatchUiCommand(cmd: UiCommand, ctx: DispatchContext): void {
       ctx.openWorkbenchSources?.()
       const run = (surface: SurfaceShellApi) => {
         try {
-          if (filesystem || kind) surface.expandToFile(path, { ...(filesystem ? { filesystem } : {}), ...(kind ? { kind } : {}) })
+          if (filesystem) surface.expandToFile(path, { filesystem })
           else surface.expandToFile(path)
         } catch (err) {
           // eslint-disable-next-line no-console -- intentional dev signal

--- a/packages/workspace/src/front/bridge/validation.ts
+++ b/packages/workspace/src/front/bridge/validation.ts
@@ -57,19 +57,15 @@ export const navigateToLineSchema = z.object({
 })
 
 const filesystemId = z.string().min(1)
-const fileTreeResourceKind = z.enum(["file", "dir"])
-
 /** A tree reveal names either a path or one explicit filesystem root. */
 export const expandToFileSchema = z.union([
   z.object({
     path: safePath,
     filesystem: filesystemId.optional(),
-    kind: fileTreeResourceKind.optional(),
   }),
   z.object({
     path: z.literal(""),
     filesystem: filesystemId,
-    kind: fileTreeResourceKind.optional(),
   }),
 ])
 

--- a/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
@@ -81,7 +81,7 @@ export interface SurfaceShellApi {
   /** Hide the workbench's left sources/files pane while leaving the workbench open. */
   closeWorkbenchLeftPane: () => void
   /** Reveal/select a file-tree resource without opening an editor pane. */
-  expandToFile: (path: string, options?: { filesystem?: FilesystemId; kind?: "file" | "dir" }) => void
+  expandToFile: (path: string, options?: { filesystem?: FilesystemId }) => void
   /** Current snapshot of open tabs + active tab. */
   getSnapshot: () => SurfaceShellSnapshot
 }
@@ -668,14 +668,12 @@ export function SurfaceShell({
     return true
   }, [])
 
-  const expandToFileSync = useCallback((path: string, options?: { filesystem?: FilesystemId; kind?: "file" | "dir" }) => {
+  const expandToFileSync = useCallback((path: string, options?: { filesystem?: FilesystemId }) => {
     const normalizedPath = path.replace(/\\/g, "/").replace(/^\.\//, "").replace(/\/+/g, "/")
     const filesystem = options?.filesystem
-    const kind = options?.kind
     const request = {
       path: normalizedPath,
       ...(filesystem ? { filesystem } : {}),
-      ...(kind ? { kind } : {}),
     }
     pendingTreeExpandRef.current = request
     setFileTreeRevealRequest({

--- a/packages/workspace/src/front/chrome/artifact-surface/__tests__/SurfaceShell.test.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/__tests__/SurfaceShell.test.tsx
@@ -487,13 +487,12 @@ describe("SurfaceShell", () => {
     await waitFor(() => expect(capturedRevealRequest).toBeNull())
 
     act(() => {
-      surface?.expandToFile("/workspace/reports ", { filesystem: "user", kind: "dir" })
+      surface?.expandToFile("/workspace/reports ", { filesystem: "user" })
     })
     expect(capturedRevealRequests).toContainEqual({
       path: "/workspace/reports ",
       seq: 3,
       filesystem: "user",
-      kind: "dir",
     })
     await waitFor(() => expect(capturedRevealRequest).toBeNull())
 

--- a/packages/workspace/src/front/testing/createMockBridge.ts
+++ b/packages/workspace/src/front/testing/createMockBridge.ts
@@ -184,11 +184,7 @@ export function createMockBridge(options: CreateMockBridgeOptions = {}): MockWor
     }),
 
     expandToFile: spy(async (path, opts) => {
-      emit("tree:expand", {
-        path,
-        ...(opts?.filesystem ? { filesystem: opts.filesystem } : {}),
-        ...(opts?.kind ? { kind: opts.kind } : {}),
-      })
+      emit("tree:expand", { path, ...(opts?.filesystem ? { filesystem: opts.filesystem } : {}) })
       return nextResult()
     }),
 

--- a/packages/workspace/src/plugins/filesystemPlugin/front/FilesystemRootsBinding.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/FilesystemRootsBinding.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, type ReactNode } from "react"
 import { useDataClient } from "./data"
 import { FileTreeRootsProvider } from "./file-tree/FileTreeRootsProvider"
-import type { FileTreeRootConfig } from "./file-tree/FileTreeView"
+import type { FileTreeRootConfig } from "./file-tree/FileTreePane"
 
 const PRIMARY_ROOT: FileTreeRootConfig = {
   filesystem: "user",
@@ -15,6 +15,7 @@ const PRIMARY_ROOT: FileTreeRootConfig = {
     list: true,
     search: true,
     write: true,
+    upload: false,
     delete: true,
     move: true,
     mkdir: true,

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/__tests__/fetchClient.catalog.test.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/__tests__/fetchClient.catalog.test.ts
@@ -6,6 +6,7 @@ const capabilities = {
   list: true,
   search: true,
   write: false,
+  upload: false,
   delete: false,
   move: false,
   mkdir: false,
@@ -17,7 +18,7 @@ describe("FetchClient filesystem catalog", () => {
   it("loads generic roots with auth, credentials, capabilities, and abort signal", async () => {
     const fetchMock = vi.fn(async () => new Response(JSON.stringify({
       filesystems: [
-        { filesystem: "user", label: "Workspace", rootDir: ".", access: "readwrite", capabilities: { ...capabilities, write: true, delete: true, move: true, mkdir: true } },
+        { filesystem: "user", label: "Workspace", rootDir: ".", access: "readwrite", capabilities: { ...capabilities, write: true, upload: true, delete: true, move: true, mkdir: true } },
         { filesystem: "project_alpha", label: "Project alpha", rootDir: "/docs", access: "readonly", capabilities },
       ],
     }), { status: 200 }))
@@ -32,6 +33,16 @@ describe("FetchClient filesystem catalog", () => {
       "https://example.test/api/v1/filesystems",
       expect.objectContaining({ method: "GET", credentials: "include", signal: expect.any(AbortSignal), headers: { Authorization: "Bearer token" } }),
     )
+  })
+
+  it("defaults a missing upload capability to false for mixed-version servers", async () => {
+    const legacyCapabilities = Object.fromEntries(Object.entries(capabilities).filter(([key]) => key !== "upload"))
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+      filesystems: [{ filesystem: "user", label: "Workspace", rootDir: ".", access: "readwrite", capabilities: legacyCapabilities }],
+    }), { status: 200 })))
+
+    const [root] = await new FetchClient({ apiBaseUrl: "" }).getFilesystems()
+    expect(root?.capabilities.upload).toBe(false)
   })
 
   it("discards malformed and duplicate entries without filesystem-specific inference", async () => {

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/__tests__/fetchClient.test.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/__tests__/fetchClient.test.ts
@@ -26,7 +26,7 @@ describe("FetchClient", () => {
       status: "conflict",
       path: "src/file.txt",
       reason: "already-exists",
-    }), { status: 409, statusText: "Conflict" }))
+    }), { status: 200 }))
     const client = new FetchClient({ apiBaseUrl: "" })
     const result = await client.writeBinaryFile("src/file.txt", new Blob(["hello"]), { ifExists: "error" })
     expect(result).toEqual({ status: "conflict", path: "src/file.txt", reason: "already-exists" })
@@ -42,7 +42,7 @@ describe("FetchClient", () => {
     const path = " src/file.txt "
     mockFetch
       .mockResolvedValueOnce(new Response(JSON.stringify({ status: "written", path }), { status: 200 }))
-      .mockResolvedValueOnce(new Response(JSON.stringify({ status: "conflict", path, reason: "already-exists" }), { status: 409 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ status: "conflict", path, reason: "already-exists" }), { status: 200 }))
     const client = new FetchClient({ apiBaseUrl: "" })
     await expect(client.writeBinaryFile(path, new Blob(["first"]), { ifExists: "error" }))
       .resolves.toEqual({ status: "written", path })
@@ -54,15 +54,15 @@ describe("FetchClient", () => {
   it.each([
     [200, { status: "unknown", path: "src/file.txt" }],
     [200, { status: "written", path: 42 }],
-    [409, { status: "conflict", path: "src/file.txt", reason: "unknown" }],
+    [200, { status: "conflict", path: "src/file.txt", reason: "unknown" }],
   ])("rejects malformed exact-write outcome for HTTP %s", async (statusCode, body) => {
     mockFetch.mockResolvedValue(new Response(JSON.stringify(body), {
       status: statusCode,
-      statusText: statusCode === 409 ? "Conflict" : "OK",
+      statusText: "OK",
     }))
     const client = new FetchClient({ apiBaseUrl: "" })
     await expect(client.writeBinaryFile("src/file.txt", new Blob(["hello"]), { ifExists: "error" }))
-      .rejects.toBeInstanceOf(statusCode === 409 ? FetchError : TypeError)
+      .rejects.toBeInstanceOf(TypeError)
   })
 
   it("rejects a typed conflict for a different exact path", async () => {
@@ -70,10 +70,10 @@ describe("FetchClient", () => {
       status: "conflict",
       path: "src/file.txt",
       reason: "already-exists",
-    }), { status: 409, statusText: "Conflict" }))
+    }), { status: 200 }))
     const client = new FetchClient({ apiBaseUrl: "" })
     await expect(client.writeBinaryFile("src/file.txt ", new Blob(["hello"]), { ifExists: "error" }))
-      .rejects.toBeInstanceOf(FetchError)
+      .rejects.toBeInstanceOf(TypeError)
   })
 
   it("passes abort through binary encoding and transport", async () => {

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/fetchClient.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/fetchClient.ts
@@ -250,28 +250,18 @@ export class FetchClient {
     options: { ifExists: ExactBinaryWritePolicy; signal?: AbortSignal },
   ): Promise<ExactBinaryWriteOutcome> {
     const contentBase64 = await blobToBase64(file, options.signal)
-    try {
-      return await this.request<ExactBinaryWriteOutcome>(
-        "POST",
-        "/api/v1/files/binary",
-        { path, contentBase64, ifExists: options.ifExists },
-        undefined,
-        options.signal,
-        async (response) => parseExactBinaryWriteOutcome(await response.json()),
-        "include",
-        0,
-      )
-    } catch (error) {
-      if (error instanceof FetchError && error.status === 409) {
-        try {
-          const outcome = parseExactBinaryWriteOutcome(error.body)
-          if (outcome.status === "conflict" && outcome.path === path) return outcome
-        } catch {
-          // Malformed conflict responses remain transport errors.
-        }
-      }
-      throw error
-    }
+    const outcome = await this.request<ExactBinaryWriteOutcome>(
+      "POST",
+      "/api/v1/files/binary",
+      { path, contentBase64, ifExists: options.ifExists },
+      undefined,
+      options.signal,
+      async (response) => parseExactBinaryWriteOutcome(await response.json()),
+      "include",
+      0,
+    )
+    if (outcome.path !== path) throw new TypeError("exact binary write outcome path mismatch")
+    return outcome
   }
 
   async deleteFile(path: string, options?: { filesystem?: string }): Promise<void> {

--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTree.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTree.tsx
@@ -53,8 +53,10 @@ export interface FileTreeProps {
   revealPath?: string | null
   /** Paths currently being mutated — render a small spinner on those rows. */
   pendingPaths?: ReadonlySet<string>
+  /** Called when a file is activated (double-click/Enter). */
+  onSelect?: (path: string) => void
+  /** Called whenever the typed tree selection changes. */
   onSelectionChange?: (node: FileTreeNode | null) => void
-  onActivateFile?: (path: string) => void
   onExpand?: (path: string) => void
   onCollapse?: (path: string) => void
   onContextMenu?: (event: React.MouseEvent, node: FileTreeNode) => void
@@ -312,8 +314,8 @@ export function FileTree({
   editing,
   revealPath,
   pendingPaths,
+  onSelect,
   onSelectionChange,
-  onActivateFile,
   onExpand,
   onCollapse,
   onContextMenu,
@@ -379,9 +381,9 @@ export function FileTree({
 
   const handleActivate = useCallback(
     (node: { data: FileTreeNode }) => {
-      if (node.data.kind === "file") onActivateFile?.(node.data.path)
+      if (node.data.kind === "file") onSelect?.(node.data.path)
     },
-    [onActivateFile],
+    [onSelect],
   )
 
   const handleSelect = useCallback((nodes: Array<{ data: FileTreeNode }>) => {

--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTreePane.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTreePane.tsx
@@ -1,0 +1,292 @@
+"use client"
+
+import { createPortal } from "react-dom"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { IconButton, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@hachej/boring-ui-kit"
+import { RefreshCwIcon, UploadIcon } from "lucide-react"
+import type { FileTreeBridge } from "../../../../front/bridge/types"
+import { cn } from "../../../../front/lib/utils"
+import type { FilesystemCatalogCapabilities } from "../data/types"
+import type { FilesystemId } from "../../../../shared/types/filesystem"
+import type { PaneProps } from "../../../../shared/types/panel"
+import type { FileTreeRevealRequest, LeftTabParams } from "../../../../shared/plugins/types"
+import { FileTreeView, type FileTreeViewHandle } from "./FileTreeView"
+
+export interface FileTreeRootConfig {
+  filesystem: FilesystemId
+  label: string
+  rootDir?: string
+  access?: "readonly" | "readwrite"
+  capabilities?: FilesystemCatalogCapabilities
+}
+
+export interface FileTreePaneParams extends LeftTabParams {
+  rootDir?: string
+  searchQuery?: string
+  query?: string
+  bridge?: unknown
+  filesystem?: FilesystemId
+  access?: "readonly" | "readwrite"
+  roots?: FileTreeRootConfig[]
+  revealFileTreeRequest?: FileTreeRevealRequest | null
+}
+
+export interface FileTreePaneProps extends Partial<PaneProps<FileTreePaneParams>> {
+  rootDir?: string
+  searchQuery?: string
+  bridge?: FileTreeBridge
+  filesystem?: FilesystemId
+  access?: "readonly" | "readwrite"
+  roots?: FileTreeRootConfig[]
+  className?: string
+}
+
+/**
+ * Default Files panel. Search is owned by the shell's unified catalog;
+ * `searchQuery` remains available for controlled embedding and tests.
+ */
+export function FileTreePane({
+  params,
+  rootDir = ".",
+  searchQuery: controlledSearchQuery,
+  bridge,
+  filesystem = "user",
+  access = "readwrite",
+  roots,
+  className,
+}: FileTreePaneProps) {
+  const effectiveRootDir = params?.rootDir ?? rootDir
+  const effectiveBridge = (params?.bridge as FileTreeBridge | undefined) ?? bridge
+  const effectiveFilesystem = params?.filesystem ?? filesystem
+  const effectiveAccess = params?.access ?? access
+  const effectiveRoots = params?.roots ?? roots
+  const authoritativeRevealRequest = params?.revealFileTreeRequest ?? null
+  const [bridgeRevealRequest, setBridgeRevealRequest] = useState<FileTreeRevealRequest | null>(null)
+  const bridgeRevealSeqRef = useRef(0)
+  useEffect(() => {
+    if (authoritativeRevealRequest) setBridgeRevealRequest(null)
+  }, [authoritativeRevealRequest])
+  const effectiveRevealRequest = authoritativeRevealRequest ?? bridgeRevealRequest
+  const externalSearchQuery =
+    params?.searchQuery ?? params?.query ?? controlledSearchQuery
+  const rootOptions = useMemo<FileTreeRootConfig[]>(() => {
+    if (effectiveRoots?.length) return effectiveRoots
+    return [{
+      filesystem: effectiveFilesystem,
+      label: effectiveFilesystem === "user" ? "Workspace" : effectiveFilesystem,
+      rootDir: effectiveFilesystem === "user" ? effectiveRootDir : "/",
+      access: effectiveAccess,
+      capabilities: {
+        read: true,
+        list: true,
+        search: true,
+        write: effectiveAccess !== "readonly",
+        upload: effectiveAccess !== "readonly",
+        delete: effectiveAccess !== "readonly",
+        move: effectiveAccess !== "readonly",
+        mkdir: effectiveAccess !== "readonly",
+      },
+    }]
+  }, [effectiveAccess, effectiveFilesystem, effectiveRootDir, effectiveRoots])
+  const [selectedFilesystem, setSelectedFilesystem] = useState<FilesystemId>(() => (
+    rootOptions.some((root) => root.filesystem === effectiveFilesystem)
+      ? effectiveFilesystem
+      : rootOptions[0]?.filesystem ?? "user"
+  ))
+  useEffect(() => {
+    setSelectedFilesystem((current) => {
+      if (rootOptions.some((root) => root.filesystem === current)) return current
+      return rootOptions.some((root) => root.filesystem === effectiveFilesystem)
+        ? effectiveFilesystem
+        : rootOptions[0]?.filesystem ?? "user"
+    })
+  }, [effectiveFilesystem, rootOptions])
+  const handledRevealRequestRef = useRef<string | null>(null)
+  useEffect(() => {
+    const requestedFilesystem = effectiveRevealRequest?.filesystem
+    if (!requestedFilesystem) return
+    const requestKey = `${effectiveRevealRequest.seq}:${requestedFilesystem}:${effectiveRevealRequest.path}`
+    if (handledRevealRequestRef.current === requestKey) return
+    if (!rootOptions.some((root) => root.filesystem === requestedFilesystem)) return
+    handledRevealRequestRef.current = requestKey
+    setSelectedFilesystem(requestedFilesystem)
+  }, [effectiveRevealRequest, rootOptions])
+  const handledActiveResourceRef = useRef<string | null>(null)
+  useEffect(() => {
+    const activeResource = effectiveBridge?.getActiveFileResource?.()
+    if (!activeResource) return
+    const resourceKey = `${activeResource.filesystem}:${activeResource.path}`
+    if (handledActiveResourceRef.current === resourceKey) return
+    if (!rootOptions.some((root) => root.filesystem === activeResource.filesystem)) return
+    handledActiveResourceRef.current = resourceKey
+    setSelectedFilesystem(activeResource.filesystem)
+  }, [effectiveBridge, rootOptions])
+  useEffect(() => {
+    if (!effectiveBridge?.subscribe) return
+    const selectConfiguredFilesystem = (nextFilesystem: FilesystemId | undefined) => {
+      if (nextFilesystem && rootOptions.some((root) => root.filesystem === nextFilesystem)) {
+        setSelectedFilesystem(nextFilesystem)
+      }
+    }
+    const unsubscribeOpened = effectiveBridge.subscribe("file:opened", ({ filesystem: openedFilesystem }) => {
+      selectConfiguredFilesystem(openedFilesystem)
+    })
+    const unsubscribeExpanded = effectiveBridge.subscribe("tree:expand", ({ path, filesystem: revealedFilesystem }) => {
+      selectConfiguredFilesystem(revealedFilesystem)
+      // SurfaceShell sends an authoritative prop request alongside its bridge
+      // event. The pane owns root synchronization, but must not retain a second
+      // reveal. Bridge-only callers get a temporary one-shot prop instead.
+      if (authoritativeRevealRequest) return
+      setBridgeRevealRequest({
+        path,
+        ...(revealedFilesystem ? { filesystem: revealedFilesystem } : {}),
+        seq: ++bridgeRevealSeqRef.current,
+      })
+    })
+    return () => {
+      unsubscribeOpened()
+      unsubscribeExpanded()
+    }
+  }, [authoritativeRevealRequest, effectiveBridge, rootOptions])
+  const activeRoot = rootOptions.find((root) => root.filesystem === selectedFilesystem) ?? rootOptions[0]
+  const activeFilesystem = activeRoot?.filesystem ?? "user"
+  const activeRootDir = activeRoot?.rootDir ?? (activeFilesystem === "user" ? effectiveRootDir : "/")
+  const activeAccess = activeRoot?.access ?? effectiveAccess
+  const activeCapabilities = activeRoot?.capabilities
+  const activeRevealRequest = !effectiveRevealRequest?.filesystem || effectiveRevealRequest.filesystem === activeFilesystem
+    ? effectiveRevealRequest
+    : null
+  const handleRevealRequestHandled = useCallback((request: FileTreeRevealRequest) => {
+    setBridgeRevealRequest((current) => current?.seq === request.seq ? null : current)
+  }, [])
+
+  // `FileTreeView` remounts (via the `key` below) whenever the active root
+  // changes, so this ref always targets whichever root is currently
+  // selected in the dropdown — the refresh button never needs to know
+  // which root it's pointed at.
+  const treeRef = useRef<FileTreeViewHandle>(null)
+  const [isRefreshing, setIsRefreshing] = useState(false)
+  const handleRefresh = useCallback(async () => {
+    setIsRefreshing(true)
+    try {
+      await treeRef.current?.refetch()
+    } finally {
+      setIsRefreshing(false)
+    }
+  }, [])
+  const refreshButton = (
+    <IconButton
+      type="button"
+      variant="ghost"
+      size="icon-xs"
+      aria-label="Refresh files"
+      disabled={isRefreshing}
+      onClick={() => void handleRefresh()}
+      className="shrink-0 text-muted-foreground hover:text-foreground"
+    >
+      <RefreshCwIcon className={cn("h-3.5 w-3.5", isRefreshing && "animate-spin")} strokeWidth={2} />
+    </IconButton>
+  )
+  const canUploadActiveRoot = activeFilesystem === "user"
+    && activeAccess !== "readonly"
+    && activeCapabilities?.upload === true
+  const uploadButton = canUploadActiveRoot ? (
+    <IconButton
+      type="button"
+      variant="ghost"
+      size="icon-xs"
+      aria-label="Upload files"
+      onClick={() => treeRef.current?.openUpload()}
+      className="shrink-0 text-muted-foreground hover:text-foreground"
+    >
+      <UploadIcon className="h-3.5 w-3.5" strokeWidth={2} />
+    </IconButton>
+  ) : null
+  const fileActions = (
+    <div className="flex items-center gap-0.5">
+      {uploadButton}
+      {refreshButton}
+    </div>
+  )
+
+  const effectiveSearchQuery = externalSearchQuery || undefined
+
+  // Single-root hosts put refresh in the shell's existing header
+    // action slot when one is available, avoiding a toolbar row whose only
+    // content is one icon. Standalone hosts without that slot retain the local
+    // fallback. Multi-root hosts keep refresh beside the root selector so the
+    // action's active-filesystem scope remains visually explicit. The shell's
+    // search box continues to drive `effectiveSearchQuery` for either shape.
+    if (rootOptions.length <= 1) {
+      const chromeActionsElement = params?.chromeActionsElement
+      return (
+        <div className="flex h-full min-h-0 flex-col">
+          {chromeActionsElement
+            ? createPortal(fileActions, chromeActionsElement)
+            : (
+                <div className="flex shrink-0 items-center justify-end px-1 pt-1">
+                  {fileActions}
+                </div>
+              )}
+          <div className="min-h-0 flex-1">
+            <FileTreeView
+              ref={treeRef}
+              key={`${activeFilesystem}:${activeRootDir}`}
+              rootDir={activeRootDir}
+              searchQuery={effectiveSearchQuery}
+              bridge={effectiveBridge}
+              subscribeToTreeExpand={false}
+              filesystem={activeFilesystem}
+              access={activeAccess}
+              capabilities={activeCapabilities}
+              revealFileTreeRequest={activeRevealRequest}
+              onRevealRequestHandled={handleRevealRequestHandled}
+              className={cn("px-1 [&_[role=treeitem]]:!indent-0", className)}
+            />
+          </div>
+        </div>
+      )
+    }
+    return (
+      <div className="flex h-full min-h-0 flex-col">
+        <div className="flex shrink-0 items-center gap-1 px-1 pt-1">
+          <Select
+            value={activeFilesystem}
+            onValueChange={(value) => setSelectedFilesystem(value as FilesystemId)}
+          >
+            <SelectTrigger
+              size="sm"
+              className="h-7 w-full text-xs"
+              aria-label="File root"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {rootOptions.map((root) => (
+                <SelectItem key={root.filesystem} value={root.filesystem} className="text-xs">
+                  {root.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {fileActions}
+        </div>
+        <div className="min-h-0 flex-1">
+          <FileTreeView
+            ref={treeRef}
+            key={`${activeFilesystem}:${activeRootDir}`}
+            rootDir={activeRootDir}
+            searchQuery={effectiveSearchQuery}
+            bridge={effectiveBridge}
+            subscribeToTreeExpand={false}
+            filesystem={activeFilesystem}
+            access={activeAccess}
+            capabilities={activeCapabilities}
+            revealFileTreeRequest={activeRevealRequest}
+            onRevealRequestHandled={handleRevealRequestHandled}
+            className={cn("px-1 pt-1 [&_[role=treeitem]]:!indent-0", className)}
+          />
+        </div>
+      </div>
+    )
+}

--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTreeRootsProvider.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTreeRootsProvider.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { createContext, useContext, type ReactNode } from "react"
-import type { FileTreeRootConfig } from "./FileTreeView"
+import type { FileTreeRootConfig } from "./FileTreePane"
 
 const FileTreeRootsContext = createContext<readonly FileTreeRootConfig[] | undefined>(undefined)
 

--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTreeView.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTreeView.tsx
@@ -54,24 +54,13 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-  IconButton,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
 } from "@hachej/boring-ui-kit"
-import {
-  RefreshCwIcon,
-  UploadIcon,
-} from "lucide-react"
 import { cn } from "../../../../front/lib/utils"
 import { toast } from "../../../../front/toast"
 import { events, userMeta } from "../../../../front/events"
 import { filesystemEvents } from "../../shared/events"
 import { normalizeUiFilesystem, type FilesystemId } from "../../../../shared/types/filesystem"
-import type { PaneProps } from "../../../../shared/types/panel"
-import type { FileTreeRevealRequest, LeftTabParams } from "../../../../shared/plugins/types"
+import type { FileTreeRevealRequest } from "../../../../shared/plugins/types"
 import { copyToClipboard } from "./clipboard"
 import {
   FileTreeUploadManager,
@@ -210,7 +199,9 @@ export const FileTreeView = forwardRef<FileTreeViewHandle, FileTreeViewProps>(fu
   const canDelete = capabilities?.delete ?? canMutateByAccess
   const canCreate = canWrite || canCreateDir
   const activeFilesystem = normalizeUiFilesystem(filesystem)
-  const canUpload = activeFilesystem === "user" && canWrite && canMutateByAccess
+  const canUpload = activeFilesystem === "user"
+    && canMutateByAccess
+    && capabilities?.upload === true
   const requestFilesystem = activeFilesystem === "user" ? undefined : activeFilesystem
   const getTreeEntries = useCallback(
     (path: string) => requestFilesystem ? dataClient.getTree(path, undefined, requestFilesystem) : dataClient.getTree(path),
@@ -580,10 +571,8 @@ export const FileTreeView = forwardRef<FileTreeViewHandle, FileTreeViewProps>(fu
     const requestKey = `${revealFileTreeRequest.seq}:${revealFileTreeRequest.filesystem ?? ""}:${revealFileTreeRequest.path}`
     if (handledRevealRequestKeyRef.current === requestKey) return
     handledRevealRequestKeyRef.current = requestKey
-    void revealExplicitTreePath(
-      revealFileTreeRequest.path,
-      revealFileTreeRequest.kind,
-    ).then(() => onRevealRequestHandled?.(revealFileTreeRequest))
+    void revealExplicitTreePath(revealFileTreeRequest.path)
+      .then(() => onRevealRequestHandled?.(revealFileTreeRequest))
   }, [onRevealRequestHandled, revealFileTreeRequest, revealExplicitTreePath])
 
   useEffect(() => {
@@ -607,9 +596,9 @@ export const FileTreeView = forwardRef<FileTreeViewHandle, FileTreeViewProps>(fu
     }
     if (subscribeToTreeExpand && bridge?.subscribe) {
       unsubscribers.push(
-        bridge.subscribe("tree:expand", ({ path, filesystem: requestFilesystem, kind }) => {
+        bridge.subscribe("tree:expand", ({ path, filesystem: requestFilesystem }) => {
           if (!requestFilesystem || requestFilesystem === activeFilesystem) {
-            void revealExplicitTreePath(path, kind)
+            void revealExplicitTreePath(path)
           }
         }),
       )
@@ -1014,7 +1003,7 @@ export const FileTreeView = forwardRef<FileTreeViewHandle, FileTreeViewProps>(fu
               onRevealHandled={handleRevealHandled}
               pendingPaths={pendingPaths}
               onSelectionChange={handleSelectionChange}
-              onActivateFile={handleActivateFile}
+              onSelect={handleActivateFile}
               onExpand={handleExpand}
               onContextMenu={handleContextMenu}
               onSubmitEdit={handleSubmitEdit}
@@ -1127,273 +1116,3 @@ export const FileTreeView = forwardRef<FileTreeViewHandle, FileTreeViewProps>(fu
 FileTreeView.displayName = "FileTreeView"
 
 export { clampContextMenuPosition }
-
-export interface FileTreeRootConfig {
-  filesystem: FilesystemId
-  label: string
-  rootDir?: string
-  access?: "readonly" | "readwrite"
-  capabilities?: FilesystemCatalogCapabilities
-}
-
-export interface FileTreePaneParams extends LeftTabParams {
-  rootDir?: string
-  searchQuery?: string
-  query?: string
-  bridge?: unknown
-  filesystem?: FilesystemId
-  access?: "readonly" | "readwrite"
-  roots?: FileTreeRootConfig[]
-  revealFileTreeRequest?: FileTreeRevealRequest | null
-}
-
-export interface FileTreePaneProps extends Partial<PaneProps<FileTreePaneParams>> {
-  rootDir?: string
-  searchQuery?: string
-  bridge?: FileTreeBridge
-  filesystem?: FilesystemId
-  access?: "readonly" | "readwrite"
-  roots?: FileTreeRootConfig[]
-  className?: string
-}
-
-/**
- * Default Files panel. Search is owned by the shell's unified catalog;
- * `searchQuery` remains available for controlled embedding and tests.
- */
-export function FileTreePane({
-  params,
-  rootDir = ".",
-  searchQuery: controlledSearchQuery,
-  bridge,
-  filesystem = "user",
-  access = "readwrite",
-  roots,
-  className,
-}: FileTreePaneProps) {
-  const effectiveRootDir = params?.rootDir ?? rootDir
-  const effectiveBridge = (params?.bridge as FileTreeBridge | undefined) ?? bridge
-  const effectiveFilesystem = params?.filesystem ?? filesystem
-  const effectiveAccess = params?.access ?? access
-  const effectiveRoots = params?.roots ?? roots
-  const authoritativeRevealRequest = params?.revealFileTreeRequest ?? null
-  const [bridgeRevealRequest, setBridgeRevealRequest] = useState<FileTreeRevealRequest | null>(null)
-  const bridgeRevealSeqRef = useRef(0)
-  useEffect(() => {
-    if (authoritativeRevealRequest) setBridgeRevealRequest(null)
-  }, [authoritativeRevealRequest])
-  const effectiveRevealRequest = authoritativeRevealRequest ?? bridgeRevealRequest
-  const externalSearchQuery =
-    params?.searchQuery ?? params?.query ?? controlledSearchQuery
-  const rootOptions = useMemo<FileTreeRootConfig[]>(() => {
-    if (effectiveRoots?.length) return effectiveRoots
-    return [{
-      filesystem: effectiveFilesystem,
-      label: effectiveFilesystem === "user" ? "Workspace" : effectiveFilesystem,
-      rootDir: effectiveFilesystem === "user" ? effectiveRootDir : "/",
-      access: effectiveAccess,
-    }]
-  }, [effectiveAccess, effectiveFilesystem, effectiveRootDir, effectiveRoots])
-  const [selectedFilesystem, setSelectedFilesystem] = useState<FilesystemId>(() => (
-    rootOptions.some((root) => root.filesystem === effectiveFilesystem)
-      ? effectiveFilesystem
-      : rootOptions[0]?.filesystem ?? "user"
-  ))
-  useEffect(() => {
-    setSelectedFilesystem((current) => {
-      if (rootOptions.some((root) => root.filesystem === current)) return current
-      return rootOptions.some((root) => root.filesystem === effectiveFilesystem)
-        ? effectiveFilesystem
-        : rootOptions[0]?.filesystem ?? "user"
-    })
-  }, [effectiveFilesystem, rootOptions])
-  const handledRevealRequestRef = useRef<string | null>(null)
-  useEffect(() => {
-    const requestedFilesystem = effectiveRevealRequest?.filesystem
-    if (!requestedFilesystem) return
-    const requestKey = `${effectiveRevealRequest.seq}:${requestedFilesystem}:${effectiveRevealRequest.path}`
-    if (handledRevealRequestRef.current === requestKey) return
-    if (!rootOptions.some((root) => root.filesystem === requestedFilesystem)) return
-    handledRevealRequestRef.current = requestKey
-    setSelectedFilesystem(requestedFilesystem)
-  }, [effectiveRevealRequest, rootOptions])
-  const handledActiveResourceRef = useRef<string | null>(null)
-  useEffect(() => {
-    const activeResource = effectiveBridge?.getActiveFileResource?.()
-    if (!activeResource) return
-    const resourceKey = `${activeResource.filesystem}:${activeResource.path}`
-    if (handledActiveResourceRef.current === resourceKey) return
-    if (!rootOptions.some((root) => root.filesystem === activeResource.filesystem)) return
-    handledActiveResourceRef.current = resourceKey
-    setSelectedFilesystem(activeResource.filesystem)
-  }, [effectiveBridge, rootOptions])
-  useEffect(() => {
-    if (!effectiveBridge?.subscribe) return
-    const selectConfiguredFilesystem = (nextFilesystem: FilesystemId | undefined) => {
-      if (nextFilesystem && rootOptions.some((root) => root.filesystem === nextFilesystem)) {
-        setSelectedFilesystem(nextFilesystem)
-      }
-    }
-    const unsubscribeOpened = effectiveBridge.subscribe("file:opened", ({ filesystem: openedFilesystem }) => {
-      selectConfiguredFilesystem(openedFilesystem)
-    })
-    const unsubscribeExpanded = effectiveBridge.subscribe("tree:expand", ({ path, filesystem: revealedFilesystem, kind }) => {
-      selectConfiguredFilesystem(revealedFilesystem)
-      // SurfaceShell sends an authoritative prop request alongside its bridge
-      // event. The pane owns root synchronization, but must not retain a second
-      // reveal. Bridge-only callers get a temporary one-shot prop instead.
-      if (authoritativeRevealRequest) return
-      setBridgeRevealRequest({
-        path,
-        ...(revealedFilesystem ? { filesystem: revealedFilesystem } : {}),
-        ...(kind ? { kind } : {}),
-        seq: ++bridgeRevealSeqRef.current,
-      })
-    })
-    return () => {
-      unsubscribeOpened()
-      unsubscribeExpanded()
-    }
-  }, [authoritativeRevealRequest, effectiveBridge, rootOptions])
-  const activeRoot = rootOptions.find((root) => root.filesystem === selectedFilesystem) ?? rootOptions[0]
-  const activeFilesystem = activeRoot?.filesystem ?? "user"
-  const activeRootDir = activeRoot?.rootDir ?? (activeFilesystem === "user" ? effectiveRootDir : "/")
-  const activeAccess = activeRoot?.access ?? effectiveAccess
-  const activeCapabilities = activeRoot?.capabilities
-  const activeRevealRequest = !effectiveRevealRequest?.filesystem || effectiveRevealRequest.filesystem === activeFilesystem
-    ? effectiveRevealRequest
-    : null
-  const handleRevealRequestHandled = useCallback((request: FileTreeRevealRequest) => {
-    setBridgeRevealRequest((current) => current?.seq === request.seq ? null : current)
-  }, [])
-
-  // `FileTreeView` remounts (via the `key` below) whenever the active root
-  // changes, so this ref always targets whichever root is currently
-  // selected in the dropdown — the refresh button never needs to know
-  // which root it's pointed at.
-  const treeRef = useRef<FileTreeViewHandle>(null)
-  const [isRefreshing, setIsRefreshing] = useState(false)
-  const handleRefresh = useCallback(async () => {
-    setIsRefreshing(true)
-    try {
-      await treeRef.current?.refetch()
-    } finally {
-      setIsRefreshing(false)
-    }
-  }, [])
-  const refreshButton = (
-    <IconButton
-      type="button"
-      variant="ghost"
-      size="icon-xs"
-      aria-label="Refresh files"
-      disabled={isRefreshing}
-      onClick={() => void handleRefresh()}
-      className="shrink-0 text-muted-foreground hover:text-foreground"
-    >
-      <RefreshCwIcon className={cn("h-3.5 w-3.5", isRefreshing && "animate-spin")} strokeWidth={2} />
-    </IconButton>
-  )
-  const canUploadActiveRoot = activeFilesystem === "user"
-    && activeAccess !== "readonly"
-    && (activeCapabilities?.write ?? true)
-  const uploadButton = canUploadActiveRoot ? (
-    <IconButton
-      type="button"
-      variant="ghost"
-      size="icon-xs"
-      aria-label="Upload files"
-      onClick={() => treeRef.current?.openUpload()}
-      className="shrink-0 text-muted-foreground hover:text-foreground"
-    >
-      <UploadIcon className="h-3.5 w-3.5" strokeWidth={2} />
-    </IconButton>
-  ) : null
-  const fileActions = (
-    <div className="flex items-center gap-0.5">
-      {uploadButton}
-      {refreshButton}
-    </div>
-  )
-
-  const effectiveSearchQuery = externalSearchQuery || undefined
-
-  // Single-root hosts put refresh in the shell's existing header
-    // action slot when one is available, avoiding a toolbar row whose only
-    // content is one icon. Standalone hosts without that slot retain the local
-    // fallback. Multi-root hosts keep refresh beside the root selector so the
-    // action's active-filesystem scope remains visually explicit. The shell's
-    // search box continues to drive `effectiveSearchQuery` for either shape.
-    if (rootOptions.length <= 1) {
-      const chromeActionsElement = params?.chromeActionsElement
-      return (
-        <div className="flex h-full min-h-0 flex-col">
-          {chromeActionsElement
-            ? createPortal(fileActions, chromeActionsElement)
-            : (
-                <div className="flex shrink-0 items-center justify-end px-1 pt-1">
-                  {fileActions}
-                </div>
-              )}
-          <div className="min-h-0 flex-1">
-            <FileTreeView
-              ref={treeRef}
-              key={`${activeFilesystem}:${activeRootDir}`}
-              rootDir={activeRootDir}
-              searchQuery={effectiveSearchQuery}
-              bridge={effectiveBridge}
-              subscribeToTreeExpand={false}
-              filesystem={activeFilesystem}
-              access={activeAccess}
-              capabilities={activeCapabilities}
-              revealFileTreeRequest={activeRevealRequest}
-              onRevealRequestHandled={handleRevealRequestHandled}
-              className={cn("px-1 [&_[role=treeitem]]:!indent-0", className)}
-            />
-          </div>
-        </div>
-      )
-    }
-    return (
-      <div className="flex h-full min-h-0 flex-col">
-        <div className="flex shrink-0 items-center gap-1 px-1 pt-1">
-          <Select
-            value={activeFilesystem}
-            onValueChange={(value) => setSelectedFilesystem(value as FilesystemId)}
-          >
-            <SelectTrigger
-              size="sm"
-              className="h-7 w-full text-xs"
-              aria-label="File root"
-            >
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {rootOptions.map((root) => (
-                <SelectItem key={root.filesystem} value={root.filesystem} className="text-xs">
-                  {root.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          {fileActions}
-        </div>
-        <div className="min-h-0 flex-1">
-          <FileTreeView
-            ref={treeRef}
-            key={`${activeFilesystem}:${activeRootDir}`}
-            rootDir={activeRootDir}
-            searchQuery={effectiveSearchQuery}
-            bridge={effectiveBridge}
-            subscribeToTreeExpand={false}
-            filesystem={activeFilesystem}
-            access={activeAccess}
-            capabilities={activeCapabilities}
-            revealFileTreeRequest={activeRevealRequest}
-            onRevealRequestHandled={handleRevealRequestHandled}
-            className={cn("px-1 pt-1 [&_[role=treeitem]]:!indent-0", className)}
-          />
-        </div>
-      </div>
-    )
-}

--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTree.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTree.test.tsx
@@ -107,11 +107,11 @@ describe("FileTree", () => {
 
   it("reports selection and activates a clicked file through distinct callbacks", () => {
     const onSelectionChange = vi.fn()
-    const onActivateFile = vi.fn()
-    render(<FileTree files={sampleFiles} onSelectionChange={onSelectionChange} onActivateFile={onActivateFile} height={200} />)
+    const onSelect = vi.fn()
+    render(<FileTree files={sampleFiles} onSelectionChange={onSelectionChange} onSelect={onSelect} height={200} />)
     fireEvent.click(screen.getByText("package.json"))
     expect(onSelectionChange).toHaveBeenCalledWith(expect.objectContaining({ path: "package.json", kind: "file" }))
-    expect(onActivateFile).toHaveBeenCalledWith("package.json")
+    expect(onSelect).toHaveBeenCalledWith("package.json")
   })
 
   it("does NOT crash the panel when a listing entry has no path (react-arborist idAccessor)", () => {

--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx
@@ -40,7 +40,7 @@ vi.mock("../FileTree", () => {
     editing: EditingArg | undefined,
     pending: PendingArg,
     onSelectionChange: ((node: Node | null) => void) | undefined,
-    onActivateFile: ((path: string) => void) | undefined,
+    onSelect: ((path: string) => void) | undefined,
     onContextMenu: ((e: React.MouseEvent, n: Node) => void) | undefined,
     onSubmitEdit: ((p: string, v: string) => void) | undefined,
     onCancelEdit: (() => void) | undefined,
@@ -58,13 +58,13 @@ vi.mock("../FileTree", () => {
           onKeyDown={(event) => {
             if (!isEditingHere && event.key === "Enter") {
               onSelectionChange?.(f)
-              if (f.kind === "file") onActivateFile?.(f.path)
+              if (f.kind === "file") onSelect?.(f.path)
             }
           }}
           onClick={() => {
             if (isEditingHere) return
             onSelectionChange?.(f)
-            if (f.kind === "file") onActivateFile?.(f.path)
+            if (f.kind === "file") onSelect?.(f.path)
           }}
           onContextMenu={(e) => {
             e.preventDefault()
@@ -90,7 +90,7 @@ vi.mock("../FileTree", () => {
           {isPending && <span data-testid="file-tree-pending-spinner" />}
         </div>
         {f.children?.map((c) =>
-          renderNode(c, editing, pending, onSelectionChange, onActivateFile, onContextMenu, onSubmitEdit, onCancelEdit),
+          renderNode(c, editing, pending, onSelectionChange, onSelect, onContextMenu, onSubmitEdit, onCancelEdit),
         )}
       </div>
     )
@@ -105,7 +105,7 @@ vi.mock("../FileTree", () => {
       selectedPath,
       revealPath,
       onSelectionChange,
-      onActivateFile,
+      onSelect,
       onContextMenu,
       onSubmitEdit,
       onCancelEdit,
@@ -119,7 +119,7 @@ vi.mock("../FileTree", () => {
       selectedPath?: string | null
       revealPath?: string | null
       onSelectionChange?: (node: Node | null) => void
-      onActivateFile?: (path: string) => void
+      onSelect?: (path: string) => void
       onContextMenu?: (e: React.MouseEvent, n: Node) => void
       onSubmitEdit?: (p: string, v: string) => void
       onCancelEdit?: () => void
@@ -139,7 +139,7 @@ vi.mock("../FileTree", () => {
             editing,
             pendingPaths,
             onSelectionChange,
-            onActivateFile,
+            onSelect,
             onContextMenu,
             onSubmitEdit,
             onCancelEdit,
@@ -164,7 +164,8 @@ vi.mock("../FileTree", () => {
   }
 })
 
-import { FileTreePane, FileTreeView, clampContextMenuPosition } from "../FileTreeView"
+import { FileTreeView, clampContextMenuPosition } from "../FileTreeView"
+import { FileTreePane } from "../FileTreePane"
 import { events, remoteMeta, userMeta } from "../../../../../front/events"
 import { filesystemEvents } from "../../../shared/events"
 
@@ -389,9 +390,10 @@ describe("FileTreePane", () => {
   })
 
   it("selects the explicit filesystem for reveal requests without sending the request to another root", async () => {
+    mockGetStat.mockResolvedValue({ kind: "dir", size: 0, mtimeMs: 1 })
     const { rerender } = render(
       <FileTreePane
-        params={{ revealFileTreeRequest: { path: "src", seq: 1, filesystem: "company_context", kind: "dir" } }}
+        params={{ revealFileTreeRequest: { path: "src", seq: 1, filesystem: "company_context" } }}
         roots={[
           { filesystem: "user", label: "Workspace", rootDir: "." },
           { filesystem: "company_context", label: "Company", rootDir: "/" },
@@ -408,7 +410,7 @@ describe("FileTreePane", () => {
     await selectRoot("Workspace")
     rerender(
       <FileTreePane
-        params={{ revealFileTreeRequest: { path: "src", seq: 1, filesystem: "company_context", kind: "dir" } }}
+        params={{ revealFileTreeRequest: { path: "src", seq: 1, filesystem: "company_context" } }}
         roots={[
           { filesystem: "user", label: "Workspace", rootDir: "." },
           { filesystem: "company_context", label: "Company", rootDir: "/" },
@@ -454,6 +456,7 @@ describe("FileTreePane", () => {
   })
 
   it("uses an authoritative prop reveal only once when the matching bridge event also arrives", async () => {
+    mockGetStat.mockResolvedValue({ kind: "dir", size: 0, mtimeMs: 1 })
     const expandHandlers: Array<(payload: { filesystem?: string; path: string }) => void> = []
     const bridge = {
       openFile: vi.fn(),
@@ -469,7 +472,7 @@ describe("FileTreePane", () => {
       <FileTreePane
         params={{
           bridge,
-          revealFileTreeRequest: { path: "src", seq: 1, filesystem: "user", kind: "dir" },
+          revealFileTreeRequest: { path: "src", seq: 1, filesystem: "user" },
         }}
         roots={[
           { filesystem: "user", label: "Workspace", rootDir: "." },
@@ -489,6 +492,7 @@ describe("FileTreePane", () => {
   })
 
   it("keeps standalone FileTreeView bridge expansion behavior", async () => {
+    mockGetStat.mockResolvedValue({ kind: "dir", size: 0, mtimeMs: 1 })
     const expandHandlers: Array<(payload: { filesystem?: string; path: string }) => void> = []
     const bridge = {
       openFile: vi.fn(),
@@ -512,6 +516,7 @@ describe("FileTreePane", () => {
   })
 
   it("synchronizes the selected root from identity-bearing open and expand events", async () => {
+    mockGetStat.mockResolvedValue({ kind: "dir", size: 0, mtimeMs: 1 })
     const handlers = new Map<string, Set<(payload: { filesystem?: string; path: string }) => void>>()
     const bridge = {
       openFile: vi.fn().mockResolvedValue({ seq: 1, status: "ok" }),
@@ -574,6 +579,7 @@ describe("FileTreePane", () => {
   })
 
   it("keeps a bridge-only reveal pending until its async catalog root arrives, then consumes it once", async () => {
+    mockGetStat.mockResolvedValue({ kind: "dir", size: 0, mtimeMs: 1 })
     const handlers = new Map<string, Set<(payload: { filesystem?: string; path: string }) => void>>()
     const bridge = {
       openFile: vi.fn(),
@@ -881,8 +887,9 @@ describe("FileTreePane", () => {
     expect(mockGetTree).not.toHaveBeenCalledWith("src/nested/deep.ts")
   })
 
-  it("tree expand bridge events reveal authoritatively typed folders without opening an editor", async () => {
-    const expandHandlers: Array<(payload: { path: string; kind?: "file" | "dir" }) => void> = []
+  it("tree expand bridge events classify folders through stat without opening an editor", async () => {
+    mockGetStat.mockResolvedValue({ kind: "dir", size: 0, mtimeMs: 1 })
+    const expandHandlers: Array<(payload: { path: string }) => void> = []
     const bridge = {
       getActiveFile: () => null,
       openFile: vi.fn().mockResolvedValue({ seq: 1, status: "ok" }),
@@ -897,7 +904,7 @@ describe("FileTreePane", () => {
     await waitFor(() => expect(bridge.subscribe).toHaveBeenCalled())
 
     act(() => {
-      for (const handler of expandHandlers) handler({ path: "/src//", kind: "dir" })
+      for (const handler of expandHandlers) handler({ path: "/src//" })
     })
 
     await waitFor(() => {
@@ -907,20 +914,21 @@ describe("FileTreePane", () => {
     expect(bridge.openFile).not.toHaveBeenCalled()
   })
 
-  it("uses authoritative tree-expand kind for the toolbar upload destination", async () => {
-    const expandHandlers: Array<(payload: { path: string; kind?: "file" | "dir" }) => void> = []
+  it("uses stat-classified tree-expand folders for the toolbar upload destination", async () => {
+    mockGetStat.mockResolvedValue({ kind: "dir", size: 0, mtimeMs: 1 })
+    const expandHandlers: Array<(payload: { path: string }) => void> = []
     const bridge = {
       getActiveFile: () => null,
-      subscribe: vi.fn((event: string, handler: (payload: { path: string; kind?: "file" | "dir" }) => void) => {
+      subscribe: vi.fn((event: string, handler: (payload: { path: string }) => void) => {
         if (event === "tree:expand") expandHandlers.push(handler)
         return vi.fn()
       }),
     }
     render(<FileTreePane bridge={bridge as any} />, { wrapper })
     await waitFor(() => expect(expandHandlers).toHaveLength(1))
-    act(() => expandHandlers[0]?.({ path: "src", kind: "dir" }))
+    act(() => expandHandlers[0]?.({ path: "src" }))
     await waitFor(() => expect(screen.getByTestId("file-tree")).toHaveAttribute("data-selected", "src"))
-    expect(mockGetStat).not.toHaveBeenCalled()
+    expect(mockGetStat).toHaveBeenCalledWith("src")
     fireEvent.click(screen.getByRole("button", { name: "Upload files" }))
     fireEvent.change(screen.getByLabelText("Choose files to upload"), {
       target: { files: [new File(["x"], "bridge.txt")] },
@@ -985,14 +993,15 @@ describe("FileTreePane", () => {
     expect(mockFileListRefetch).not.toHaveBeenCalled()
   })
 
-  it("preserves whitespace in authoritatively typed directory reveals", async () => {
+  it("preserves whitespace in stat-classified directory reveals", async () => {
+    mockGetStat.mockResolvedValue({ kind: "dir", size: 0, mtimeMs: 1 })
     render(
-      <FileTreePane params={{ revealFileTreeRequest: { path: "reports ", seq: 1, kind: "dir" } }} />,
+      <FileTreePane params={{ revealFileTreeRequest: { path: "reports ", seq: 1 } }} />,
       { wrapper },
     )
 
     await waitFor(() => expect(screen.getByTestId("file-tree")).toHaveAttribute("data-selected", "reports "))
-    expect(mockGetStat).not.toHaveBeenCalled()
+    expect(mockGetStat).toHaveBeenCalledWith("reports ")
     fireEvent.click(screen.getByRole("button", { name: "Upload files" }))
     fireEvent.change(screen.getByLabelText("Choose files to upload"), {
       target: { files: [new File(["x"], "inside.txt")] },
@@ -1039,6 +1048,26 @@ describe("FileTreePane", () => {
     await waitFor(() => expect(screen.queryByLabelText("Choose files to upload")).not.toBeInTheDocument())
   })
 
+  it("hides upload actions when exclusive-create capability is unavailable", async () => {
+    const chromeActionsElement = document.createElement("div")
+    render(<FileTreePane
+      params={{ chromeActionsElement }}
+      roots={[{
+        filesystem: "user",
+        label: "Workspace",
+        rootDir: ".",
+        access: "readwrite",
+        capabilities: {
+          read: true, list: true, search: true, write: true, upload: false,
+          delete: true, move: true, mkdir: true,
+        },
+      }]}
+    />, { wrapper })
+
+    await waitFor(() => expect(within(chromeActionsElement).queryByRole("button", { name: "Upload files" })).not.toBeInTheDocument())
+    expect(screen.queryByLabelText("Choose files to upload")).not.toBeInTheDocument()
+  })
+
   it("targets a selected directory and a selected file's parent from the toolbar", async () => {
     render(<FileTreePane />, { wrapper })
     fireEvent.click(await screen.findByText("src"))
@@ -1068,6 +1097,7 @@ describe("FileTreePane", () => {
   })
 
   it("refreshes an expanded folder when an agent/remote change lands inside it", async () => {
+    mockGetStat.mockResolvedValue({ kind: "dir", size: 0, mtimeMs: 1 })
     mockGetTree.mockResolvedValue([{ name: "old.ts", kind: "file", path: "src/old.ts" }])
     const expandHandlers: Array<(payload: { path: string }) => void> = []
     const bridge = {
@@ -1087,7 +1117,7 @@ describe("FileTreePane", () => {
     // Wait for the child to actually render — that guarantees expandedChildren
     // committed (getTree is called synchronously, before its promise resolves).
     act(() => {
-      for (const handler of expandHandlers) handler({ path: "src", kind: "dir" } as any)
+      for (const handler of expandHandlers) handler({ path: "src" } as any)
     })
     await screen.findByText("old.ts")
     mockGetTree.mockClear()
@@ -1132,6 +1162,7 @@ describe("FileTreePane", () => {
   })
 
   it("reveals folder requests forwarded through left-tab params", async () => {
+    mockGetStat.mockResolvedValue({ kind: "dir", size: 0, mtimeMs: 1 })
     const bridge = {
       getActiveFile: () => null,
       openFile: vi.fn().mockResolvedValue({ seq: 1, status: "ok" }),
@@ -1141,7 +1172,7 @@ describe("FileTreePane", () => {
       <FileTreePane
         params={{
           bridge,
-          revealFileTreeRequest: { path: "/src//", seq: 1, kind: "dir" },
+          revealFileTreeRequest: { path: "/src//", seq: 1 },
         }}
       />,
       { wrapper },
@@ -1156,6 +1187,7 @@ describe("FileTreePane", () => {
   })
 
   it("keeps explicit folder reveal ahead of active-file reveal when sources remount", async () => {
+    mockGetStat.mockResolvedValue({ kind: "dir", size: 0, mtimeMs: 1 })
     let emitActiveFile: ((path: string | null) => void) | undefined
     const bridge = {
       getActiveFile: () => "index.ts",
@@ -1170,7 +1202,7 @@ describe("FileTreePane", () => {
       <FileTreePane
         params={{
           bridge,
-          revealFileTreeRequest: { path: "src", seq: 1, kind: "dir" },
+          revealFileTreeRequest: { path: "src", seq: 1 },
         }}
       />,
       { wrapper },
@@ -1443,7 +1475,7 @@ describe("FileTreePane", () => {
         label: "Workspace",
         rootDir: ".",
         access: "readwrite",
-        capabilities: { read: true, list: true, search: true, write: true, mkdir: false, move: false, delete: true },
+        capabilities: { read: true, list: true, search: true, write: true, upload: true, mkdir: false, move: false, delete: true },
       }]} />, { wrapper })
       await waitFor(() => expect(screen.getByText("index.ts")).toBeInTheDocument())
 

--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreeUpload.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreeUpload.test.tsx
@@ -1,7 +1,7 @@
 import { createRef } from "react"
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import type { FetchClient } from "../../data/fetchClient"
+import { FetchError, type FetchClient } from "../../data/fetchClient"
 import { FileTreeUploadManager, type FileTreeUploadManagerHandle } from "../upload/FileTreeUploadManager"
 
 function file(name: string, content = "x") {
@@ -108,6 +108,14 @@ describe("FileTreeUploadManager", () => {
     fireEvent.click(screen.getByRole("button", { name: "Retry retry.txt" }))
     expect(await screen.findByRole("button", { name: "Cancel remaining" })).toBeInTheDocument()
     expect(write.mock.calls[1]?.[2]).toMatchObject({ ifExists: "error" })
+  })
+
+  it.each([400, 403, 404, 501])("does not offer retry for deterministic HTTP %s failures", async (status) => {
+    const write = vi.fn().mockRejectedValue(new FetchError(status, `HTTP ${status}`))
+    const { choose } = setup(write)
+    choose(file("blocked.txt"))
+    fireEvent.click(await screen.findByRole("button", { name: "1 failed" }))
+    expect(screen.queryByRole("button", { name: "Retry blocked.txt" })).not.toBeInTheDocument()
   })
 
   it("aborts an active transport when unmounted", async () => {

--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/upload/useBatchFileUpload.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/upload/useBatchFileUpload.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 import type { ExactBinaryWritePolicy } from "@hachej/boring-bash/shared"
-import type { FetchClient } from "../../data/fetchClient"
+import { FetchError, type FetchClient } from "../../data/fetchClient"
 import { joinPath } from "../treeModel"
 import {
   MAX_CONCURRENT_FILE_UPLOADS,
@@ -78,18 +78,18 @@ export function useBatchFileUpload({ client, onWritten }: UseBatchFileUploadOpti
             if (outcome.status === "written") {
               writtenDestinations.add(row.destination)
               update(row.id, { status: "done", message: undefined })
-            } else if (outcome.status === "conflict") {
+            } else {
               conflicts.push(row)
               update(row.id, { status: "queued", message: "Waiting for conflict decision." })
-            } else {
-              update(row.id, { status: "skipped", message: "A file with this name already exists." })
             }
           } catch (error) {
             if (signal.aborted) return
+            const deterministic = error instanceof FetchError
+              && ((error.status >= 400 && error.status < 500) || error.status === 501)
             update(row.id, {
               status: "failed",
               message: error instanceof Error ? error.message : "Upload failed.",
-              retryable: true,
+              retryable: !deterministic,
             })
           }
         }

--- a/packages/workspace/src/plugins/filesystemPlugin/front/index.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/index.ts
@@ -10,11 +10,8 @@ import { useDataClient, useFileList } from "./data"
 import { DataProvider } from "./data/DataProvider"
 import { FilesystemRootsBinding } from "./FilesystemRootsBinding"
 import { useCatalogRegistry } from "../../../front/registry"
-import {
-  FileTreePane,
-  preloadFileTreeComponent,
-  type FileTreePaneParams,
-} from "./file-tree/FileTreeView"
+import { preloadFileTreeComponent } from "./file-tree/FileTreeView"
+import { FileTreePane, type FileTreePaneParams } from "./file-tree/FileTreePane"
 import { useFileTreeRoots } from "./file-tree/FileTreeRootsProvider"
 import type { WorkspaceSourceProps } from "../../../shared/types/panel"
 import { FilesystemFilePanelBinding } from "./filePanelBinding"

--- a/packages/workspace/src/shared/plugins/types.ts
+++ b/packages/workspace/src/shared/plugins/types.ts
@@ -98,7 +98,6 @@ export interface FileTreeRevealRequest {
   path: string
   seq: number
   filesystem?: FilesystemId
-  kind?: "file" | "dir"
 }
 
 export interface LeftTabParams {

--- a/packages/workspace/src/shared/ui-bridge.ts
+++ b/packages/workspace/src/shared/ui-bridge.ts
@@ -24,7 +24,7 @@ export type UiCommand =
   | { kind: 'closeWorkbenchLeftPane'; params: Record<string, never> }
   | { kind: 'showNotification'; params: { msg: string; level?: 'info' | 'warn' | 'error' } }
   | { kind: 'navigateToLine'; params: { file: string; line: number } }
-  | { kind: 'expandToFile'; params: { path: string; filesystem?: FilesystemId; kind?: 'file' | 'dir' } }
+  | { kind: 'expandToFile'; params: { path: string; filesystem?: FilesystemId } }
   | { kind: string; params: Record<string, unknown> }
 
 export interface CommandResult {


### PR DESCRIPTION
## Summary
- restore the public `FileTree.onSelect` contract and fix the UI-review fixture typecheck regression from #1336
- advertise batch upload only when the primary runtime supports both exclusive create and binary replacement; fail closed for old remote workers
- keep legacy filesystem catalogs compatible while normalizing missing upload capability to false
- simplify exact binary conflict transport to typed `written | conflict` outcomes and remove the unused wire-level skip mode
- remove unused file-tree resource-kind tunneling across the shared workspace bridge
- extract Files pane/root/chrome ownership into `FileTreePane.tsx`, reducing `FileTreeView.tsx` from 1,280 lines at the original merge base to 1,118

## Why a follow-up
PR #1336 was merged while its CI was red. The typecheck failure was real (`FileTree.onSelect` was removed from a public component); the changed-unit failure was an unrelated 5-second CLI integration-test timeout. A thermonuclear review also found capability and structural issues worth fixing before release.

## Scope
This follow-up is **+513/-434 (net +79)** across 32 files. Most additions are the extracted `FileTreePane` module and focused capability tests; it removes shared protocol surface and controller code rather than adding another feature layer.

## Validation
- thermonuclear final verdict: **APPROVE**, no blocker/high/medium findings
- root `pnpm typecheck`: passed all 32 projects, including the previously failing workspace-components fixture
- boring-bash focused tests: 41 passed
- workspace focused tests: 204 passed
- agent standalone-host focused tests: 34 passed
- package typechecks: boring-bash and workspace passed
- formerly timed-out CLI selector cases: 4 passed with a 30s harness timeout
- `git diff --check`: passed

## Residual
The existing 2.4k-line `FileTreePane.test.tsx` integration suite remains large. The reviewer judged splitting its shared harness optional and not a merge blocker. Blaxel/Vercel staging remains provider-specific because a two-consumer shared helper would currently be callback-heavy without deleting meaningful complexity.

Follow-up to #1336.
