### PR TITLE
fix(core): keep OAuth callbacks on the initiating host

### DIFF
--- a/packages/core/docs/README.md
+++ b/packages/core/docs/README.md
@@ -64,7 +64,11 @@ identity match, then the workspace/agent surfaces warm in the background (see
   `CoreWorkspaceAgentFront` (in `app/front`) is the full composed shell used by child apps
   (e.g. `apps/full-app/src/front/main.tsx`). There is no `BoringApp` component.
 - **Auth** — `createAuth` wraps better-auth; `authHook` populates `req.user`;
-  `requireWorkspaceMember(role)` is a preHandler for membership/role checks.
+  `requireWorkspaceMember(role)` is a preHandler for membership/role checks. Child apps that
+  serve auth from multiple hosts may pass `createCoreWorkspaceAgentServer({ authBaseURL: {
+  allowedHosts, protocol } })`; entries must be exact `host[:port]` values (no wildcards,
+  schemes, or paths). This changes only Better Auth callback resolution: `config.auth.url`
+  remains canonical, forwarded host/protocol headers are not trusted, and unlisted hosts fail closed.
 - **Stores** — `UserStore` / `WorkspaceStore` / `AuthProvider` interfaces with Postgres
   implementations; `CORE_STORES=local` selects in-memory dev stores for the base app
   factory (note: `createCoreWorkspaceAgentServer` requires `CORE_STORES=postgres`).

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.telemetry.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.telemetry.test.ts
@@ -14,6 +14,7 @@ const agentMock = vi.hoisted(() => ({
 }))
 
 const coreAppMock = vi.hoisted(() => ({
+  authOptions: [] as Array<Record<string, unknown> | undefined>,
   debugLogs: [] as unknown[][],
 }))
 
@@ -95,10 +96,12 @@ vi.mock('@hachej/boring-workspace/server', () => ({
 }))
 
 vi.mock('../../../server/auth/index.js', () => ({
+  assertCoreDynamicAuthBaseURL: () => {},
   authHook: async () => {},
-  createAuth: () => ({
-    handler: vi.fn(),
-  }),
+  createAuth: (_config: CoreConfig, _db: unknown, options?: Record<string, unknown>) => {
+    coreAppMock.authOptions.push(options)
+    return { handler: vi.fn() }
+  },
 }))
 
 vi.mock('../../../server/app/index.js', () => ({
@@ -198,6 +201,7 @@ describe('createCoreWorkspaceAgentServer telemetry wiring', () => {
   beforeEach(() => {
     resetTelemetryEnv()
     agentMock.registerOptions.length = 0
+    coreAppMock.authOptions.length = 0
     coreAppMock.debugLogs.length = 0
     dbMock.rows.length = 0
     dbMock.insert.mockClear()
@@ -243,6 +247,25 @@ describe('createCoreWorkspaceAgentServer telemetry wiring', () => {
       code: ERROR_CODES.INVALID_SIGNUP_AGENT_DEFAULTS,
     })
     expect(agentMock.registerOptions).toHaveLength(0)
+  })
+
+  it('passes the dynamic auth base URL into Core auth creation', async () => {
+    const authBaseURL = {
+      allowedHosts: ['app.example.test', 'agent.example.test'],
+      protocol: 'https' as const,
+    }
+    const app = await createCoreWorkspaceAgentServer({
+      authBaseURL,
+      config: makeBootConfig(),
+      serveFrontend: false,
+    })
+
+    try {
+      expect(coreAppMock.authOptions).toHaveLength(1)
+      expect(coreAppMock.authOptions[0]).toMatchObject({ baseURL: authBaseURL })
+    } finally {
+      await app.close()
+    }
   })
 
   it('uses the core DB telemetry env helper by default and passes the sink to agent routes', async () => {
@@ -446,6 +469,8 @@ describe('createCoreWorkspaceAgentServer telemetry wiring', () => {
 
       const forwarded = handler.mock.calls[0]?.[0]
       expect(forwarded).toBeInstanceOf(Request)
+      expect(forwarded?.headers.get('host')).toBe('legal.example:443')
+      expect(forwarded?.headers.get('x-forwarded-host')).toBe('attacker.example')
       expect(forwarded?.headers.get(TRUSTED_SIGNUP_HOSTNAME_HEADER)).toBe('legal.example')
     } finally {
       await app.close()

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.test.ts
@@ -51,6 +51,21 @@ describe('createCoreWorkspaceAgentServer', () => {
     })).rejects.toThrow(/directory plugin entries must omit hotReload or set hotReload: false/)
   })
 
+  it('fails fast when dynamic auth config is null', async () => {
+    await expect(createCoreWorkspaceAgentServer({
+      authBaseURL: null as never,
+    })).rejects.toThrow(/authBaseURL must be an object/)
+  })
+
+  it('fails fast when dynamic auth is configured with a wildcard host', async () => {
+    await expect(createCoreWorkspaceAgentServer({
+      authBaseURL: {
+        allowedHosts: ['*.example.test'],
+        protocol: 'https',
+      },
+    })).rejects.toThrow(/authBaseURL\.allowedHosts/)
+  })
+
   it('preserves root SPA bytes when the optional root handler is absent or declines', async () => {
     const appRoot = await mkdtemp(`${tmpdir()}/boring-core-root-`)
     await mkdir(resolve(appRoot, 'dist/front'), { recursive: true })

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -78,9 +78,11 @@ import type { CoreConfig } from '../../shared/types.js'
 import { ERROR_CODES, HttpError } from '../../shared/errors.js'
 import { safeCapture, type TelemetrySink } from '../../shared/telemetry.js'
 import {
+  assertCoreDynamicAuthBaseURL,
   authHook,
   createAuth,
   type BetterAuthInstance,
+  type CoreDynamicAuthBaseURL,
 } from '../../server/auth/index.js'
 import { REQUEST_SCOPE_WORKSPACE_HEADER } from '../../server/auth/requestWorkspaceScope.js'
 import {
@@ -257,6 +259,8 @@ export interface CreateCoreWorkspaceAgentServerOptions {
   /** Compatibility only for Core's workspace-bridge admission; Host effects use effectAdmission. */
   admitEffect?: (ctx: { workspaceId: string; requestId: string }) => Promise<void>
   appRoot?: string
+  /** Opt into host-local auth callback URLs for an exact host allowlist. */
+  authBaseURL?: CoreDynamicAuthBaseURL
   config?: CoreConfig
   loadConfigOptions?: LoadConfigOptions
   plugins?: CoreWorkspacePluginEntry[]
@@ -939,6 +943,7 @@ async function createCoreRuntime(
   signupAgentDefaults: ValidatedSignupAgentDefaults,
   customTelemetry?: TelemetrySink,
   requestScopeResolver?: CoreRequestScopeResolver,
+  authBaseURL?: CoreDynamicAuthBaseURL,
 ): Promise<{
   app: CoreWorkspaceAgentServer
   sql: postgres.Sql
@@ -969,6 +974,7 @@ async function createCoreRuntime(
       : 'noop-env'
   app.log.debug({ telemetry: { source: telemetrySource } }, 'resolved telemetry sink')
   const auth = createAuth(config, db, {
+    baseURL: authBaseURL,
     workspaceStore,
     signupAgentDefaults,
     logger: app.log,
@@ -1025,6 +1031,7 @@ export async function createCoreWorkspaceAgentServer(
     )
   }
   assertCoreStaticPluginEntries(options.plugins)
+  if (options.authBaseURL !== undefined) assertCoreDynamicAuthBaseURL(options.authBaseURL)
 
   const rawConfig = options.config ?? (await loadConfig(resolveCoreLoadConfigOptions(options)))
   // BORING_AGENT_FLEET=1 composes the config-driven production fleet
@@ -1061,6 +1068,7 @@ export async function createCoreWorkspaceAgentServer(
     signupAgentDefaults,
     options.telemetry,
     options.requestScopeResolver,
+    options.authBaseURL,
   )
   const appRoot = options.appRoot
   const serveFrontend =

--- a/packages/core/src/app/server/index.ts
+++ b/packages/core/src/app/server/index.ts
@@ -5,6 +5,7 @@ export {
   type CoreFrontendRootHandler,
   type CreateCoreWorkspaceAgentServerOptions,
 } from './createCoreWorkspaceAgentServer.js'
+export type { CoreDynamicAuthBaseURL } from '../../server/auth/index.js'
 export type { CoreRequestScope, CoreRequestScopeResolver } from '../../server/app/index.js'
 export {
   startCoreWorkspaceAgentDevServer,

--- a/packages/core/src/server/auth/__tests__/createAuth.dynamicBaseURL.test.ts
+++ b/packages/core/src/server/auth/__tests__/createAuth.dynamicBaseURL.test.ts
@@ -1,0 +1,131 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import postgres from 'postgres'
+import type { CoreConfig } from '../../../shared/types'
+import { createDatabase, type Database } from '../../db/connection'
+import { runMigrations } from '../../db/migrate'
+import { createAuth, type BetterAuthInstance } from '../createAuth'
+
+const TEST_DB_URL = process.env.DATABASE_URL ?? 'postgres://ubuntu:test@localhost/boring_ui_test'
+
+function makeConfig(): CoreConfig {
+  return {
+    appId: 'test-app',
+    appName: 'Test App',
+    appLogo: null,
+    port: 0,
+    host: '127.0.0.1',
+    staticDir: null,
+    databaseUrl: TEST_DB_URL,
+    stores: 'postgres',
+    cors: {
+      origins: ['https://app.example.test', 'https://agent.example.test'],
+      credentials: true,
+    },
+    bodyLimit: 16 * 1024 * 1024,
+    logLevel: 'silent' as CoreConfig['logLevel'],
+    encryption: { workspaceSettingsKey: 'a'.repeat(64) },
+    auth: {
+      secret: 's'.repeat(64),
+      url: 'https://canonical.example.test',
+      sessionTtlSeconds: 3600,
+      sessionCookieSecure: true,
+      google: {
+        clientId: 'google-client-id',
+        clientSecret: 'google-client-secret',
+      },
+    },
+    features: {
+      githubOauth: false,
+      googleOauth: true,
+      invitesEnabled: true,
+      sendWelcomeEmail: true,
+      inviteTtlDays: 7,
+    },
+  }
+}
+
+let auth: BetterAuthInstance
+let db: Database
+let rawSql: postgres.Sql
+const oauthStates: string[] = []
+
+beforeAll(async () => {
+  const config = makeConfig()
+  await runMigrations(config)
+  const connection = createDatabase(config)
+  db = connection.db
+  rawSql = connection.sql
+  auth = createAuth(config, db, {
+    baseURL: {
+      allowedHosts: ['app.example.test', 'agent.example.test'],
+      protocol: 'https',
+    },
+  })
+})
+
+afterAll(async () => {
+  for (const state of oauthStates) {
+    await rawSql`DELETE FROM verification_tokens WHERE identifier = ${state}`
+  }
+  await rawSql.end()
+})
+
+async function startGoogleSignIn(
+  host: string,
+  forwardedHost?: string,
+): Promise<{ response: Response; redirectURI?: string }> {
+  const headers = new Headers({
+    'content-type': 'application/json',
+    host,
+  })
+  if (forwardedHost) headers.set('x-forwarded-host', forwardedHost)
+
+  const response = await auth.handler(new Request(
+    'https://canonical.example.test/auth/sign-in/social',
+    {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        provider: 'google',
+        disableRedirect: true,
+        callbackURL: '/',
+      }),
+    },
+  ))
+
+  const body = await response.json() as { url: string }
+  const authorizationURL = new URL(body.url)
+  const state = authorizationURL.searchParams.get('state')
+  if (state) oauthStates.push(state)
+  return {
+    response,
+    redirectURI: authorizationURL.searchParams.get('redirect_uri') ?? undefined,
+  }
+}
+
+describe('createAuth dynamic base URL behavior', () => {
+  it.each(['app.example.test', 'agent.example.test'])(
+    'uses the initiating allowed Host for Google callback on %s',
+    async (host) => {
+      const result = await startGoogleSignIn(host)
+
+      expect(result.response.status).toBe(200)
+      expect(result.redirectURI).toBe(`https://${host}/auth/callback/google`)
+      expect(result.response.headers.get('set-cookie')).toBeTruthy()
+      expect(result.response.headers.get('set-cookie')).not.toMatch(/;\s*domain=/i)
+    },
+  )
+
+  it('rejects an unlisted Host', async () => {
+    await expect(startGoogleSignIn('evil.example.test')).rejects.toThrow(
+      /Host "evil\.example\.test" is not in the allowed hosts list/,
+    )
+  })
+
+  it('does not let X-Forwarded-Host override an allowed Host', async () => {
+    const result = await startGoogleSignIn('app.example.test', 'agent.example.test')
+
+    expect(result.response.status).toBe(200)
+    expect(result.redirectURI).toBe('https://app.example.test/auth/callback/google')
+  })
+})

--- a/packages/core/src/server/auth/__tests__/createAuth.providers.test.ts
+++ b/packages/core/src/server/auth/__tests__/createAuth.providers.test.ts
@@ -18,7 +18,16 @@ vi.mock('better-auth/adapters/drizzle', () => ({
   drizzleAdapter: drizzleAdapterMock,
 }))
 
-import { createAuth } from '../createAuth'
+import { createAuth, type CoreDynamicAuthBaseURL } from '../createAuth'
+
+const indirectFallbackConfig = {
+  allowedHosts: ['app.example.test'],
+  protocol: 'https' as const,
+  fallback: 'https://app.example.test',
+}
+// @ts-expect-error fallback is forbidden even when supplied through structural assignment.
+const invalidFallbackConfig: CoreDynamicAuthBaseURL = indirectFallbackConfig
+void invalidFallbackConfig
 
 function makeConfig(overrides?: Partial<CoreConfig>): CoreConfig {
   return {
@@ -51,13 +60,84 @@ function makeConfig(overrides?: Partial<CoreConfig>): CoreConfig {
   }
 }
 
-function getSocialProviders() {
+function getBetterAuthOptions() {
   expect(betterAuthMock).toHaveBeenCalled()
-  const options = betterAuthMock.mock.calls.at(-1)?.[0] as {
+  return betterAuthMock.mock.calls.at(-1)?.[0] as {
+    advanced: Record<string, unknown>
+    baseURL: unknown
     socialProviders: Record<string, unknown>
   }
-  return options.socialProviders
 }
+
+function getSocialProviders() {
+  return getBetterAuthOptions().socialProviders
+}
+
+describe('createAuth base URL', () => {
+  beforeEach(() => {
+    betterAuthMock.mockClear()
+    drizzleAdapterMock.mockClear()
+  })
+
+  it('preserves the canonical static config when no dynamic option is provided', () => {
+    createAuth(makeConfig(), {} as never)
+
+    const options = getBetterAuthOptions()
+    expect(options.baseURL).toBe('http://localhost:3000')
+    expect(options.advanced).not.toHaveProperty('trustedProxyHeaders')
+  })
+
+  it('snapshots dynamic allowed hosts and disables forwarded-header trust', () => {
+    const baseURL: CoreDynamicAuthBaseURL = {
+      allowedHosts: ['app.example.test', 'agent.example.test'],
+      protocol: 'https',
+    }
+
+    createAuth(makeConfig(), {} as never, { baseURL })
+
+    const options = getBetterAuthOptions()
+    expect(options.baseURL).toEqual(baseURL)
+    expect(options.baseURL).not.toBe(baseURL)
+    expect(Object.isFrozen(options.baseURL)).toBe(true)
+    expect(Object.isFrozen((options.baseURL as CoreDynamicAuthBaseURL).allowedHosts)).toBe(true)
+    expect(options.advanced.trustedProxyHeaders).toBe(false)
+
+    baseURL.allowedHosts[0] = '*.attacker.test'
+    baseURL.protocol = 'http'
+    ;(baseURL as unknown as { fallback?: string }).fallback = 'https://attacker.test'
+    expect(options.baseURL).toEqual({
+      allowedHosts: ['app.example.test', 'agent.example.test'],
+      protocol: 'https',
+    })
+  })
+
+  it('rejects null instead of silently restoring the canonical static URL', () => {
+    expect(() => createAuth(makeConfig(), {} as never, {
+      baseURL: null as never,
+    })).toThrow(/authBaseURL must be an object/)
+    expect(betterAuthMock).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['an empty allowlist', { allowedHosts: [], protocol: 'https' }],
+    ['a wildcard', { allowedHosts: ['*.example.test'], protocol: 'https' }],
+    ['a scheme', { allowedHosts: ['https://app.example.test'], protocol: 'https' }],
+    ['a path', { allowedHosts: ['app.example.test/auth'], protocol: 'https' }],
+    ['userinfo', { allowedHosts: ['user@app.example.test'], protocol: 'https' }],
+    ['an invalid port', { allowedHosts: ['app.example.test:65536'], protocol: 'https' }],
+    ['an invalid protocol', { allowedHosts: ['app.example.test'], protocol: 'auto' }],
+    ['a fallback', {
+      allowedHosts: ['app.example.test'],
+      protocol: 'https',
+      fallback: 'https://app.example.test',
+    }],
+  ])('rejects dynamic base URL config with %s', (_label, baseURL) => {
+    expect(() => createAuth(makeConfig(), {} as never, {
+      baseURL: baseURL as never,
+    })).toThrow(/authBaseURL/)
+    expect(betterAuthMock).not.toHaveBeenCalled()
+  })
+})
 
 describe('createAuth social providers', () => {
   beforeEach(() => {

--- a/packages/core/src/server/auth/createAuth.ts
+++ b/packages/core/src/server/auth/createAuth.ts
@@ -57,7 +57,63 @@ function buildMailTransport(config: CoreConfig): MailTransport | null {
   return createMailTransport(config.auth.mail.transportUrl, config.auth.mail.from, env)
 }
 
+export interface CoreDynamicAuthBaseURL {
+  /** Exact host or host:port values allowed to originate auth callbacks. */
+  allowedHosts: string[]
+  /** Explicit protocol used for callback URLs on every allowed host. */
+  protocol: 'http' | 'https'
+  /** Unlisted hosts always fail closed; Better Auth's fallback is deliberately forbidden. */
+  fallback?: never
+}
+
+const EXACT_AUTH_HOST_RE = /^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*(?::\d{1,5})?|\[[0-9a-fA-F:]+\](?::\d{1,5})?)$/
+const EXACT_AUTH_HOST_MESSAGE = 'authBaseURL.allowedHosts must be a non-empty list of exact host[:port] values'
+
+export function assertCoreDynamicAuthBaseURL(baseURL: unknown): asserts baseURL is CoreDynamicAuthBaseURL {
+  if (typeof baseURL !== 'object' || baseURL === null) {
+    throw new Error('authBaseURL must be an object')
+  }
+  const candidate = baseURL as Record<string, unknown>
+  if (!Array.isArray(candidate.allowedHosts) || candidate.allowedHosts.length === 0) {
+    throw new Error(EXACT_AUTH_HOST_MESSAGE)
+  }
+  if (candidate.protocol !== 'http' && candidate.protocol !== 'https') {
+    throw new Error('authBaseURL.protocol must be "http" or "https"')
+  }
+  if ('fallback' in candidate) {
+    throw new Error('authBaseURL.fallback is not supported; unlisted hosts must be rejected')
+  }
+
+  for (const host of candidate.allowedHosts) {
+    if (typeof host !== 'string' || host.trim() !== host || !EXACT_AUTH_HOST_RE.test(host)) {
+      throw new Error(`${EXACT_AUTH_HOST_MESSAGE}: ${String(host)}`)
+    }
+    const port = (host.startsWith('[') ? /\]:(\d+)$/.exec(host) : /:(\d+)$/.exec(host))?.[1]
+    if (port && (Number(port) < 1 || Number(port) > 65_535)) {
+      throw new Error(`${EXACT_AUTH_HOST_MESSAGE}: ${host}`)
+    }
+    try {
+      // The URL parser validates domain, IPv4, and bracketed IPv6 syntax.
+      new URL(`${candidate.protocol}://${host}`)
+    } catch {
+      throw new Error(`${EXACT_AUTH_HOST_MESSAGE}: ${host}`)
+    }
+  }
+}
+
+function snapshotCoreDynamicAuthBaseURL(baseURL: unknown): CoreDynamicAuthBaseURL {
+  assertCoreDynamicAuthBaseURL(baseURL)
+  const snapshot: CoreDynamicAuthBaseURL = {
+    allowedHosts: [...baseURL.allowedHosts],
+    protocol: baseURL.protocol,
+  }
+  Object.freeze(snapshot.allowedHosts)
+  return Object.freeze(snapshot)
+}
+
 export interface CreateAuthOptions {
+  /** Dynamic request-host base URL; absent preserves config.auth.url as the static base URL. */
+  baseURL?: CoreDynamicAuthBaseURL
   workspaceStore?: WorkspaceStore
   /** Boot-compiled, fleet-validated signup map from the full server composer. */
   signupAgentDefaults?: ValidatedSignupAgentDefaults
@@ -94,6 +150,10 @@ async function createReplayableRequest(request: Request): Promise<Request> {
 }
 
 export function createAuth(config: CoreConfig, db: Database, opts?: CreateAuthOptions): Auth<any> {
+  const dynamicBaseURL = opts?.baseURL === undefined
+    ? undefined
+    : snapshotCoreDynamicAuthBaseURL(opts.baseURL)
+
   const transport = buildMailTransport(config)
   const telemetry = opts?.telemetry ?? noopTelemetry
   const emailVerificationEnabled = isCoreEmailVerificationEnabled(config)
@@ -174,7 +234,7 @@ export function createAuth(config: CoreConfig, db: Database, opts?: CreateAuthOp
   const auth = betterAuth({
     database: drizzleAdapter(db, { provider: 'pg', schema }),
     secret: config.auth.secret,
-    baseURL: config.auth.url,
+    baseURL: dynamicBaseURL ?? config.auth.url,
     basePath: '/auth',
     trustedOrigins: config.cors.origins,
     databaseHooks: {
@@ -212,6 +272,7 @@ export function createAuth(config: CoreConfig, db: Database, opts?: CreateAuthOp
       },
       cookiePrefix: config.appId,
       useSecureCookies: config.auth.sessionCookieSecure,
+      ...(dynamicBaseURL ? { trustedProxyHeaders: false } : {}),
     },
     user: {
       modelName: 'users',

--- a/packages/core/src/server/auth/index.ts
+++ b/packages/core/src/server/auth/index.ts
@@ -1,5 +1,9 @@
-export { createAuth, validatePasswordStrength } from './createAuth.js'
-export type { BetterAuthInstance, CreateAuthOptions } from './createAuth.js'
+export { assertCoreDynamicAuthBaseURL, createAuth, validatePasswordStrength } from './createAuth.js'
+export type {
+  BetterAuthInstance,
+  CoreDynamicAuthBaseURL,
+  CreateAuthOptions,
+} from './createAuth.js'
 export { createPostSignupHook } from './postSignupHook.js'
 export type { PostSignupHookDeps } from './postSignupHook.js'
 export { authHook } from './authHook.js'

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -73,6 +73,7 @@ export {
 } from './auth/index.js'
 export type {
   BetterAuthInstance,
+  CoreDynamicAuthBaseURL,
   CreateAuthOptions,
   AuthHookOptions,
   PostSignupHookDeps,


### PR DESCRIPTION
## Summary

- add an opt-in `authBaseURL` seam for exact multi-host Better Auth callback resolution
- keep canonical `config.auth.url` unchanged for mail, CSP, runtime config, and internal URLs
- fail closed on unlisted/malformed hosts and forbid Better Auth fallback/wildcard patterns
- ignore forwarded-host spoofing, preserve host-only cookies, and snapshot/freeze caller config
- cover app-host and agent-host Google redirect URIs with database-backed integration tests

Closes #1349.
Unblocks hachej/seneca#90.

## Verification

- `pnpm --filter @hachej/boring-core exec vitest run --no-file-parallelism src/server/auth/__tests__/createAuth.dynamicBaseURL.test.ts src/server/auth/__tests__/createAuth.providers.test.ts src/app/server/__tests__/createCoreWorkspaceAgentServer.test.ts src/app/server/__tests__/createCoreWorkspaceAgentServer.telemetry.test.ts` — 41/41 passed
- `pnpm --filter @hachej/boring-core typecheck` — passed
- `pnpm --filter @hachej/boring-core build` — passed, including declarations and artifact assertions
- independent auth/security + thermonuclear review — initial fail-closed/mutation findings fixed; final review clean

## Known unrelated local failures

The full Core suite reached 1,338/1,341 passing. Three failures reproduce in isolation in untouched database/concurrency tests (`deleteUserCompletely.test.ts` and `PostgresModelBudgetStore.test.ts`); this PR does not change those paths. CI remains authoritative on a clean database.

## Deployment contract

Callers must supply exact `host[:port]` values and a fixed `http`/`https` protocol. The reverse proxy must preserve the authoritative `Host` header. `X-Forwarded-Host` and `X-Forwarded-Proto` are deliberately ignored for dynamic auth resolution.