### PR TITLE
fix(ci): keep aborted tool snapshots terminal

### DIFF
--- a/packages/agent/src/server/pi-chat/__tests__/piChatHistory.test.ts
+++ b/packages/agent/src/server/pi-chat/__tests__/piChatHistory.test.ts
@@ -152,6 +152,47 @@ describe('buildPiChatHistory', () => {
     ])
   })
 
+  it('terminalizes unresolved tools under an aborted assistant without overwriting terminal output', () => {
+    const history = buildPiChatHistory(
+      [
+        {
+          id: 'entry-explicit-abort',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'toolCall', id: 'call-explicit-abort', name: 'read', state: 'aborted' }],
+            stopReason: 'stop',
+            timestamp: 1,
+          },
+        },
+        {
+          id: 'entry-aborted-assistant',
+          message: {
+            role: 'assistant',
+            content: [
+              { type: 'toolCall', id: 'call-unresolved', name: 'grep', state: 'input-available' },
+              { type: 'toolCall', id: 'call-output', name: 'bash', state: 'output-available', output: 'done' },
+              { type: 'toolCall', id: 'call-error', name: 'write', state: 'output-error', errorText: 'failed' },
+            ],
+            stopReason: 'aborted',
+            timestamp: 2,
+          },
+        },
+      ],
+      { sessionId: 'session-1' },
+    )
+
+    expect(history[0]).toMatchObject({ role: 'assistant', status: 'done' })
+    expect(history[0]?.parts).toEqual([
+      expect.objectContaining({ id: 'call-explicit-abort', state: 'aborted' }),
+    ])
+    expect(history[1]).toMatchObject({ role: 'assistant', status: 'aborted' })
+    expect(history[1]?.parts).toEqual([
+      expect.objectContaining({ id: 'call-unresolved', state: 'aborted' }),
+      expect.objectContaining({ id: 'call-output', state: 'output-available', output: 'done' }),
+      expect.objectContaining({ id: 'call-error', state: 'output-error', errorText: 'failed' }),
+    ])
+  })
+
   it('uses stable fallback ids only when Pi entry ids are unavailable', () => {
     const history = buildPiChatHistory(
       [

--- a/packages/agent/src/server/pi-chat/piChatHistory.ts
+++ b/packages/agent/src/server/pi-chat/piChatHistory.ts
@@ -126,6 +126,7 @@ function toolInputFromCall(part: RecordLike): unknown {
 
 function assistantParts(message: RecordLike, messageId: string): BoringChatPart[] {
   const content = message.content
+  const assistantAborted = message.stopReason === 'aborted'
   if (typeof content === 'string') return [{ type: 'text', id: `${messageId}:text:0`, text: content }]
   if (!Array.isArray(content)) return []
 
@@ -150,7 +151,9 @@ function assistantParts(message: RecordLike, messageId: string): BoringChatPart[
         ? 'output-error'
         : part.state === 'output-available'
           ? 'output-available'
-          : 'input-available'
+          : part.state === 'aborted' || assistantAborted
+            ? 'aborted'
+            : 'input-available'
       return [
         {
           type: 'tool-call',

--- a/packages/agent/src/server/testing/__tests__/scriptedPiHarness.test.ts
+++ b/packages/agent/src/server/testing/__tests__/scriptedPiHarness.test.ts
@@ -113,6 +113,66 @@ describe('createScriptedPiHarness', () => {
     expect(JSON.stringify(events)).not.toContain('PI_NATIVE_ASSISTANT_DONE')
   })
 
+  it('marks the active assistant and unresolved tool call aborted in snapshots', async () => {
+    const harness = createScriptedPiHarness({ tools: [], cwd: '/workspace' })
+    const adapter = await harness.getPiSessionAdapter({ sessionId: 's1', content: '' }, {
+      abortSignal: new AbortController().signal,
+      workdir: '/workspace',
+    })
+    const toolCallStarted = new Promise<void>((resolve) => {
+      adapter.subscribe((event) => {
+        if (event.type !== 'message_update') return
+        if (event.assistantMessageEvent.type === 'toolcall_end') resolve()
+      })
+    })
+
+    const prompt = adapter.prompt('inspect workspace')
+    await toolCallStarted
+    await adapter.abort()
+    await prompt
+
+    const assistant = adapter.readSnapshot().messages.find((message) => (message as { role?: unknown }).role === 'assistant') as {
+      stopReason?: unknown
+      content?: Array<Record<string, unknown>>
+    } | undefined
+    expect(assistant).toMatchObject({ stopReason: 'aborted' })
+    expect(assistant?.content).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: 'toolCall', id: 'tool-1', state: 'aborted' }),
+    ]))
+  })
+
+  it('preserves completed tool output when the active assistant is aborted', async () => {
+    const harness = createScriptedPiHarness({ tools: [], cwd: '/workspace' })
+    const adapter = await harness.getPiSessionAdapter({ sessionId: 's1', content: '' }, {
+      abortSignal: new AbortController().signal,
+      workdir: '/workspace',
+    })
+    const toolCompleted = new Promise<void>((resolve) => {
+      adapter.subscribe((event) => {
+        if (event.type === 'tool_execution_end') resolve()
+      })
+    })
+
+    const prompt = adapter.prompt('inspect workspace')
+    await toolCompleted
+    await adapter.abort()
+    await prompt
+
+    const assistant = adapter.readSnapshot().messages.find((message) => (message as { role?: unknown }).role === 'assistant') as {
+      stopReason?: unknown
+      content?: Array<Record<string, unknown>>
+    } | undefined
+    expect(assistant).toMatchObject({ stopReason: 'aborted' })
+    expect(assistant?.content).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: 'toolCall',
+        id: 'tool-1',
+        state: 'output-available',
+        output: 'TOOL_E2E_OUTPUT',
+      }),
+    ]))
+  })
+
   it('continues the next queued follow-up after an abort', async () => {
     const harness = createScriptedPiHarness({ tools: [], cwd: '/workspace' })
     const adapter = await harness.getPiSessionAdapter({ sessionId: 's1', content: '' }, {

--- a/packages/agent/src/server/testing/scriptedPiHarness.ts
+++ b/packages/agent/src/server/testing/scriptedPiHarness.ts
@@ -20,6 +20,7 @@ interface ScriptedFollowUp {
 
 interface ScriptedRun {
   cancelled: boolean
+  assistantMessage?: ScriptedMessage
 }
 
 type ScriptedSessionRecord = SessionSummary
@@ -273,13 +274,15 @@ class ScriptedPiSessionAdapter implements PiAgentSessionAdapter {
 
   async abort(): Promise<void> {
     if (!this.streaming) return
+    const activeAssistant = this.activeRun?.assistantMessage
     if (this.activeRun) this.activeRun.cancelled = true
+    if (activeAssistant) abortAssistantMessage(activeAssistant)
     this.activeRun = undefined
     this.streaming = false
     this.emit({
       type: 'agent_end',
       status: 'aborted',
-      messages: [{ role: 'assistant', stopReason: 'aborted' }],
+      messages: [activeAssistant ?? { role: 'assistant', stopReason: 'aborted' }],
       willRetry: false,
     })
   }
@@ -336,6 +339,7 @@ class ScriptedPiSessionAdapter implements PiAgentSessionAdapter {
     if (followUp) this.emit({ type: 'queue_update', followUp: this.followUpTexts() })
     if (!(await this.tick(run))) return
     this.messages.push(assistantMessage)
+    run.assistantMessage = assistantMessage
     this.emit({ type: 'message_start', message: assistantMessage })
     if (!(await this.tick(run))) return
     for (const [index, reasoningText] of reasoningTexts.entries()) {
@@ -417,6 +421,17 @@ class ScriptedPiSessionAdapter implements PiAgentSessionAdapter {
     for (const subscriber of this.subscribers) {
       subscriber(event as AgentSessionEvent)
     }
+  }
+}
+
+function abortAssistantMessage(message: ScriptedMessage): void {
+  message.stopReason = 'aborted'
+  if (!Array.isArray(message.content)) return
+
+  for (const part of message.content) {
+    if (typeof part !== 'object' || part === null || Array.isArray(part) || part.type !== 'toolCall') continue
+    if (part.state === 'output-available' || part.state === 'output-error' || part.state === 'aborted') continue
+    part.state = 'aborted'
   }
 }
 

--- a/tools/ui-review/fixtures/workspace-components/src/fixtures.tsx
+++ b/tools/ui-review/fixtures/workspace-components/src/fixtures.tsx
@@ -109,7 +109,7 @@ export function UiReviewComponentFixture({ name }: { name: string }) {
 function renderFixture(name: string): ReactNode {
   switch (name) {
     case "file-tree":
-      return <FileTree files={generateFileTreeNodes(100)} height={560} onActivateFile={() => {}} />
+      return <FileTree files={generateFileTreeNodes(100)} height={560} onSelect={() => {}} />
     case "code-editor":
       return (
         <CodeEditor


### PR DESCRIPTION
## Summary

- make scripted abort snapshots mutate the canonical active assistant and terminalize unresolved tools
- preserve explicit aborted tools during history projection and defensively terminalize unresolved tools under aborted assistants
- keep completed/error tool outputs intact
- update the stale UI review FileTree fixture to the current `onSelect` API

Closes #1353.

## Verification

- focused agent regressions: 13/13 passed with no type errors
- property-baseline E2E: 5/5 consecutive runs passed
- agent typecheck: passed
- UI review fixture typecheck: passed after required dependency builds
- independent review: clean
- `git diff --check`: passed

## Release context

These are the two full-main-CI blockers observed after PR #1352. Once this lands and main CI is green, cut a replacement patch release because v0.1.102 failed before npm publishing.