### PR TITLE
#1240 chore: centralize source aliases (extracted from #1256)

### DIFF
--- a/apps/agent-playground/tsconfig.json
+++ b/apps/agent-playground/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2022",
     "useDefineForClassFields": true,

--- a/apps/agent-playground/vitest.config.ts
+++ b/apps/agent-playground/vitest.config.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'node:path'
 import { defineConfig } from 'vitest/config'
+import { sandboxSourceAlias } from '../../scripts/vite-sandbox-alias.ts'
 
 const repositoryRoot = resolve(import.meta.dirname, '..', '..')
 
@@ -12,12 +13,7 @@ export default defineConfig({
       { find: /^@hachej\/boring-agent\/shared$/, replacement: resolve(repositoryRoot, 'packages/agent/src/shared/index.ts') },
       { find: /^@hachej\/boring-bash\/server$/, replacement: resolve(repositoryRoot, 'packages/boring-bash/src/server/index.ts') },
       { find: /^@hachej\/boring-bash\/agent$/, replacement: resolve(repositoryRoot, 'packages/boring-bash/src/agent/index.ts') },
-      { find: /^@hachej\/boring-sandbox\/shared$/, replacement: resolve(repositoryRoot, 'packages/boring-sandbox/src/shared/index.ts') },
-      { find: /^@hachej\/boring-sandbox\/providers\/direct$/, replacement: resolve(repositoryRoot, 'packages/boring-sandbox/src/providers/direct/index.ts') },
-      { find: /^@hachej\/boring-sandbox\/providers\/bwrap$/, replacement: resolve(repositoryRoot, 'packages/boring-sandbox/src/providers/bwrap/index.ts') },
-      { find: /^@hachej\/boring-sandbox\/providers\/node-workspace$/, replacement: resolve(repositoryRoot, 'packages/boring-sandbox/src/providers/node-workspace/index.ts') },
-      { find: /^@hachej\/boring-sandbox\/providers\/blaxel$/, replacement: resolve(repositoryRoot, 'packages/boring-sandbox/src/providers/blaxel/index.ts') },
-      { find: /^@hachej\/boring-sandbox\/providers\/vercel-sandbox$/, replacement: resolve(repositoryRoot, 'packages/boring-sandbox/src/providers/vercel-sandbox/index.ts') },
+      sandboxSourceAlias,
     ],
   },
   test: { environment: 'node' },

--- a/apps/full-app/tsconfig.json
+++ b/apps/full-app/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",
@@ -23,12 +24,6 @@
       "@hachej/boring-agent/server": ["../../packages/agent/src/server/index.ts"],
       "@hachej/boring-bash/agent": ["../../packages/boring-bash/src/agent/index.ts"],
       "@hachej/boring-bash/server": ["../../packages/boring-bash/src/server/index.ts"],
-      "@hachej/boring-sandbox/shared": ["../../packages/boring-sandbox/src/shared/index.ts"],
-      "@hachej/boring-sandbox/providers/direct": ["../../packages/boring-sandbox/src/providers/direct/index.ts"],
-      "@hachej/boring-sandbox/providers/bwrap": ["../../packages/boring-sandbox/src/providers/bwrap/index.ts"],
-      "@hachej/boring-sandbox/providers/node-workspace": ["../../packages/boring-sandbox/src/providers/node-workspace/index.ts"],
-      "@hachej/boring-sandbox/providers/vercel-sandbox": ["../../packages/boring-sandbox/src/providers/vercel-sandbox/index.ts"],
-      "@hachej/boring-sandbox/providers/blaxel": ["../../packages/boring-sandbox/src/providers/blaxel/index.ts"],
       "@hachej/boring-core/app/front": ["../../packages/core/src/app/front/index.ts"],
       "@hachej/boring-core/app/server": ["../../packages/core/src/app/server/index.ts"],
       "@hachej/boring-core/app/vite": ["../../packages/core/src/app/vite/index.ts"],

--- a/apps/full-app/vitest.config.ts
+++ b/apps/full-app/vitest.config.ts
@@ -1,6 +1,7 @@
 import path from 'node:path'
 import { defineConfig } from 'vitest/config'
 import { createBoringAppViteAliases } from '../../packages/core/src/app/vite/index.ts'
+import { sandboxSourceAlias } from '../../scripts/vite-sandbox-alias.ts'
 
 const appRoot = import.meta.dirname
 const boringAliases = createBoringAppViteAliases({ appRoot })
@@ -17,12 +18,7 @@ export default defineConfig({
       { find: /^@hachej\/boring-bash\/server$/, replacement: path.resolve(repoRoot, 'packages/boring-bash/src/server/index.ts') },
       { find: /^@hachej\/boring-agent\/shared$/, replacement: path.resolve(repoRoot, 'packages/agent/src/shared/index.ts') },
       { find: /^@hachej\/boring-agent\/server$/, replacement: path.resolve(repoRoot, 'packages/agent/src/server/index.ts') },
-      { find: /^@hachej\/boring-sandbox\/shared$/, replacement: path.resolve(repoRoot, 'packages/boring-sandbox/src/shared/index.ts') },
-      { find: /^@hachej\/boring-sandbox\/providers\/direct$/, replacement: path.resolve(repoRoot, 'packages/boring-sandbox/src/providers/direct/index.ts') },
-      { find: /^@hachej\/boring-sandbox\/providers\/bwrap$/, replacement: path.resolve(repoRoot, 'packages/boring-sandbox/src/providers/bwrap/index.ts') },
-      { find: /^@hachej\/boring-sandbox\/providers\/node-workspace$/, replacement: path.resolve(repoRoot, 'packages/boring-sandbox/src/providers/node-workspace/index.ts') },
-      { find: /^@hachej\/boring-sandbox\/providers\/vercel-sandbox$/, replacement: path.resolve(repoRoot, 'packages/boring-sandbox/src/providers/vercel-sandbox/index.ts') },
-      { find: /^@hachej\/boring-sandbox\/providers\/blaxel$/, replacement: path.resolve(repoRoot, 'packages/boring-sandbox/src/providers/blaxel/index.ts') },
+      sandboxSourceAlias,
       { find: /^@hachej\/boring-core\/app\/server$/, replacement: path.resolve(repoRoot, 'packages/core/src/app/server/index.ts') },
       { find: /^@hachej\/boring-core\/server$/, replacement: path.resolve(repoRoot, 'packages/core/src/server/index.ts') },
       { find: /^@hachej\/boring-workspace\/app\/server$/, replacement: path.resolve(repoRoot, 'packages/workspace/src/app/server/index.ts') },

--- a/packages/agent/tsconfig.json
+++ b/packages/agent/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",
@@ -22,12 +23,6 @@
       "@hachej/boring-agent/front": ["src/front/index.ts"],
       "@hachej/boring-agent/server": ["src/server/index.ts"],
       "@hachej/boring-agent/shared": ["src/shared/index.ts"],
-      "@hachej/boring-sandbox/shared": ["../boring-sandbox/src/shared/index.ts"],
-      "@hachej/boring-sandbox/providers/direct": ["../boring-sandbox/src/providers/direct/index.ts"],
-      "@hachej/boring-sandbox/providers/bwrap": ["../boring-sandbox/src/providers/bwrap/index.ts"],
-      "@hachej/boring-sandbox/providers/node-workspace": ["../boring-sandbox/src/providers/node-workspace/index.ts"],
-      "@hachej/boring-sandbox/providers/vercel-sandbox": ["../boring-sandbox/src/providers/vercel-sandbox/index.ts"],
-      "@hachej/boring-sandbox/providers/blaxel": ["../boring-sandbox/src/providers/blaxel/index.ts"],
       "@agent-test-host": ["test-host/sandbox.ts"],
       "@/*": ["src/*"]
     },

--- a/packages/agent/vitest.config.ts
+++ b/packages/agent/vitest.config.ts
@@ -1,24 +1,20 @@
 import { fileURLToPath, URL } from "node:url";
 import { defineConfig } from "vitest/config";
+import { sandboxSourceAlias } from "../../scripts/vite-sandbox-alias.ts";
 
 export default defineConfig({
   resolve: {
-    alias: {
-      "@": fileURLToPath(new URL("./src", import.meta.url)),
-      "@hachej/boring-bash/agent": fileURLToPath(new URL("../boring-bash/src/agent/index.ts", import.meta.url)),
-      "@hachej/boring-bash/server": fileURLToPath(new URL("../boring-bash/src/server/index.ts", import.meta.url)),
-      "@hachej/boring-agent/core": fileURLToPath(new URL("./src/core/index.ts", import.meta.url)),
-      "@hachej/boring-agent/front": fileURLToPath(new URL("./src/front/index.ts", import.meta.url)),
-      "@hachej/boring-agent/server": fileURLToPath(new URL("./src/server/index.ts", import.meta.url)),
-      "@hachej/boring-agent/shared": fileURLToPath(new URL("./src/shared/index.ts", import.meta.url)),
-      "@agent-test-host": fileURLToPath(new URL("./test-host/sandbox.ts", import.meta.url)),
-      "@hachej/boring-sandbox/shared": fileURLToPath(new URL("../boring-sandbox/src/shared/index.ts", import.meta.url)),
-      "@hachej/boring-sandbox/providers/direct": fileURLToPath(new URL("../boring-sandbox/src/providers/direct/index.ts", import.meta.url)),
-      "@hachej/boring-sandbox/providers/bwrap": fileURLToPath(new URL("../boring-sandbox/src/providers/bwrap/index.ts", import.meta.url)),
-      "@hachej/boring-sandbox/providers/node-workspace": fileURLToPath(new URL("../boring-sandbox/src/providers/node-workspace/index.ts", import.meta.url)),
-      "@hachej/boring-sandbox/providers/vercel-sandbox": fileURLToPath(new URL("../boring-sandbox/src/providers/vercel-sandbox/index.ts", import.meta.url)),
-      "@hachej/boring-sandbox/providers/blaxel": fileURLToPath(new URL("../boring-sandbox/src/providers/blaxel/index.ts", import.meta.url)),
-    },
+    alias: [
+      { find: "@", replacement: fileURLToPath(new URL("./src", import.meta.url)) },
+      { find: "@hachej/boring-bash/agent", replacement: fileURLToPath(new URL("../boring-bash/src/agent/index.ts", import.meta.url)) },
+      { find: "@hachej/boring-bash/server", replacement: fileURLToPath(new URL("../boring-bash/src/server/index.ts", import.meta.url)) },
+      { find: "@hachej/boring-agent/core", replacement: fileURLToPath(new URL("./src/core/index.ts", import.meta.url)) },
+      { find: "@hachej/boring-agent/front", replacement: fileURLToPath(new URL("./src/front/index.ts", import.meta.url)) },
+      { find: "@hachej/boring-agent/server", replacement: fileURLToPath(new URL("./src/server/index.ts", import.meta.url)) },
+      { find: "@hachej/boring-agent/shared", replacement: fileURLToPath(new URL("./src/shared/index.ts", import.meta.url)) },
+      { find: "@agent-test-host", replacement: fileURLToPath(new URL("./test-host/sandbox.ts", import.meta.url)) },
+      sandboxSourceAlias,
+    ],
   },
   test: {
     globals: true,

--- a/packages/boring-sandbox/package.json
+++ b/packages/boring-sandbox/package.json
@@ -18,38 +18,47 @@
       "import": "./dist/index.js"
     },
     "./shared": {
+      "boring-source": "./src/shared/index.ts",
       "types": "./dist/shared/index.d.ts",
       "import": "./dist/shared/index.js"
     },
     "./providers": {
+      "boring-source": "./src/providers/index.ts",
       "types": "./dist/providers/index.d.ts",
       "import": "./dist/providers/index.js"
     },
     "./providers/direct": {
+      "boring-source": "./src/providers/direct/index.ts",
       "types": "./dist/providers/direct/index.d.ts",
       "import": "./dist/providers/direct/index.js"
     },
     "./providers/bwrap": {
+      "boring-source": "./src/providers/bwrap/index.ts",
       "types": "./dist/providers/bwrap/index.d.ts",
       "import": "./dist/providers/bwrap/index.js"
     },
     "./providers/node-workspace": {
+      "boring-source": "./src/providers/node-workspace/index.ts",
       "types": "./dist/providers/node-workspace/index.d.ts",
       "import": "./dist/providers/node-workspace/index.js"
     },
     "./providers/blaxel": {
+      "boring-source": "./src/providers/blaxel/index.ts",
       "types": "./dist/providers/blaxel/index.d.ts",
       "import": "./dist/providers/blaxel/index.js"
     },
     "./providers/vercel-sandbox": {
+      "boring-source": "./src/providers/vercel-sandbox/index.ts",
       "types": "./dist/providers/vercel-sandbox/index.d.ts",
       "import": "./dist/providers/vercel-sandbox/index.js"
     },
     "./providers/runsc": {
+      "boring-source": "./src/providers/runsc/index.ts",
       "types": "./dist/providers/runsc/index.d.ts",
       "import": "./dist/providers/runsc/index.js"
     },
     "./providers/remote-worker": {
+      "boring-source": "./src/providers/remote-worker/index.ts",
       "types": "./dist/providers/remote-worker/index.d.ts",
       "import": "./dist/providers/remote-worker/index.js"
     }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",
@@ -69,24 +70,6 @@
       ],
       "@hachej/boring-tasks/server": [
         "../../plugins/tasks/src/server/index.ts"
-      ],
-      "@hachej/boring-sandbox/shared": [
-        "../boring-sandbox/src/shared/index.ts"
-      ],
-      "@hachej/boring-sandbox/providers/direct": [
-        "../boring-sandbox/src/providers/direct/index.ts"
-      ],
-      "@hachej/boring-sandbox/providers/bwrap": [
-        "../boring-sandbox/src/providers/bwrap/index.ts"
-      ],
-      "@hachej/boring-sandbox/providers/node-workspace": [
-        "../boring-sandbox/src/providers/node-workspace/index.ts"
-      ],
-      "@hachej/boring-sandbox/providers/vercel-sandbox": [
-        "../boring-sandbox/src/providers/vercel-sandbox/index.ts"
-      ],
-      "@hachej/boring-sandbox/providers/blaxel": [
-        "../boring-sandbox/src/providers/blaxel/index.ts"
       ],
       "@hachej/boring-workspace": [
         "../workspace/src/index.ts"

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,5 +1,6 @@
 import { resolve } from "node:path"
 import { configDefaults, defineConfig } from "vitest/config"
+import { sandboxSourceAlias } from "../../scripts/vite-sandbox-alias.ts"
 
 const root = import.meta.dirname
 const repoRoot = resolve(root, "..", "..")
@@ -43,12 +44,7 @@ export default defineConfig({
       { find: /^@hachej\/boring-agent\/server\/agent-host\/testing\/compositionRouteProof$/, replacement: resolve(repoRoot, "packages/agent/src/server/agent-host/testing/compositionRouteProof.ts") },
       { find: /^@hachej\/boring-agent\/eval$/, replacement: resolve(repoRoot, "packages/agent/src/eval/index.ts") },
       { find: /^@hachej\/boring-agent$/, replacement: resolve(repoRoot, "packages/agent/src/front/index.ts") },
-      { find: /^@hachej\/boring-sandbox\/shared$/, replacement: resolve(repoRoot, "packages/boring-sandbox/src/shared/index.ts") },
-      { find: /^@hachej\/boring-sandbox\/providers\/direct$/, replacement: resolve(repoRoot, "packages/boring-sandbox/src/providers/direct/index.ts") },
-      { find: /^@hachej\/boring-sandbox\/providers\/bwrap$/, replacement: resolve(repoRoot, "packages/boring-sandbox/src/providers/bwrap/index.ts") },
-      { find: /^@hachej\/boring-sandbox\/providers\/node-workspace$/, replacement: resolve(repoRoot, "packages/boring-sandbox/src/providers/node-workspace/index.ts") },
-      { find: /^@hachej\/boring-sandbox\/providers\/vercel-sandbox$/, replacement: resolve(repoRoot, "packages/boring-sandbox/src/providers/vercel-sandbox/index.ts") },
-      { find: /^@hachej\/boring-sandbox\/providers\/blaxel$/, replacement: resolve(repoRoot, "packages/boring-sandbox/src/providers/blaxel/index.ts") },
+      sandboxSourceAlias,
       { find: /^@\/(.*)$/, replacement: resolve(repoRoot, "packages/agent/src/$1") },
       { find: /^@hachej\/boring-workspace\/server$/, replacement: resolve(repoRoot, "packages/workspace/src/server/index.ts") },
       { find: /^@hachej\/boring-workspace\/plugin$/, replacement: resolve(repoRoot, "packages/workspace/src/plugin.ts") },

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",
@@ -53,24 +54,6 @@
       ],
       "@hachej/boring-bash/server": [
         "../boring-bash/src/server/index.ts"
-      ],
-      "@hachej/boring-sandbox/shared": [
-        "../boring-sandbox/src/shared/index.ts"
-      ],
-      "@hachej/boring-sandbox/providers/bwrap": [
-        "../boring-sandbox/src/providers/bwrap/index.ts"
-      ],
-      "@hachej/boring-sandbox/providers/direct": [
-        "../boring-sandbox/src/providers/direct/index.ts"
-      ],
-      "@hachej/boring-sandbox/providers/node-workspace": [
-        "../boring-sandbox/src/providers/node-workspace/index.ts"
-      ],
-      "@hachej/boring-sandbox/providers/vercel-sandbox": [
-        "../boring-sandbox/src/providers/vercel-sandbox/index.ts"
-      ],
-      "@hachej/boring-sandbox/providers/blaxel": [
-        "../boring-sandbox/src/providers/blaxel/index.ts"
       ],
       "@/*": [
         "../workspace/src/*"

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'node:path'
 import { defineConfig } from 'vitest/config'
+import { sandboxSourceAlias } from '../../scripts/vite-sandbox-alias.ts'
 
 const repositoryRoot = resolve(import.meta.dirname, '..', '..')
 
@@ -11,12 +12,7 @@ export default defineConfig({
       { find: /^@hachej\/boring-agent\/shared$/, replacement: resolve(repositoryRoot, 'packages/agent/src/shared/index.ts') },
       { find: /^@hachej\/boring-bash\/server$/, replacement: resolve(repositoryRoot, 'packages/boring-bash/src/server/index.ts') },
       { find: /^@hachej\/boring-bash\/agent$/, replacement: resolve(repositoryRoot, 'packages/boring-bash/src/agent/index.ts') },
-      { find: /^@hachej\/boring-sandbox\/shared$/, replacement: resolve(repositoryRoot, 'packages/boring-sandbox/src/shared/index.ts') },
-      { find: /^@hachej\/boring-sandbox\/providers\/direct$/, replacement: resolve(repositoryRoot, 'packages/boring-sandbox/src/providers/direct/index.ts') },
-      { find: /^@hachej\/boring-sandbox\/providers\/bwrap$/, replacement: resolve(repositoryRoot, 'packages/boring-sandbox/src/providers/bwrap/index.ts') },
-      { find: /^@hachej\/boring-sandbox\/providers\/node-workspace$/, replacement: resolve(repositoryRoot, 'packages/boring-sandbox/src/providers/node-workspace/index.ts') },
-      { find: /^@hachej\/boring-sandbox\/providers\/vercel-sandbox$/, replacement: resolve(repositoryRoot, 'packages/boring-sandbox/src/providers/vercel-sandbox/index.ts') },
-      { find: /^@hachej\/boring-sandbox\/providers\/blaxel$/, replacement: resolve(repositoryRoot, 'packages/boring-sandbox/src/providers/blaxel/index.ts') },
+      sandboxSourceAlias,
       { find: /^@hachej\/boring-workspace\/app\/server$/, replacement: resolve(repositoryRoot, 'packages/workspace/src/app/server/index.ts') },
       { find: /^@hachej\/boring-workspace\/app\/front$/, replacement: resolve(repositoryRoot, 'packages/workspace/src/app/front/index.ts') },
       { find: /^@hachej\/boring-workspace\/server$/, replacement: resolve(repositoryRoot, 'packages/workspace/src/server/index.ts') },

--- a/packages/workspace/tsconfig.front.source.json
+++ b/packages/workspace/tsconfig.front.source.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./tsconfig.front.json",
+  "extends": ["../../tsconfig.base.json", "./tsconfig.front.json"],
   "compilerOptions": {
     "composite": false,
     "incremental": true,
@@ -8,9 +8,7 @@
       "@/*": ["./src/*"],
       "@hachej/boring-workspace": ["./src/index.ts"],
       "@hachej/boring-agent/shared": ["../agent/src/shared/index.ts"],
-      "@hachej/boring-bash/server": ["../boring-bash/src/server/index.ts"],
-      "@hachej/boring-sandbox/shared": ["../boring-sandbox/src/shared/index.ts"],
-      "@hachej/boring-sandbox/providers/node-workspace": ["../boring-sandbox/src/providers/node-workspace/index.ts"]
+      "@hachej/boring-bash/server": ["../boring-bash/src/server/index.ts"]
     }
   }
 }

--- a/packages/workspace/tsconfig.server.source.json
+++ b/packages/workspace/tsconfig.server.source.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./tsconfig.server.json",
+  "extends": ["../../tsconfig.base.json", "./tsconfig.server.json"],
   "compilerOptions": {
     "composite": false,
     "incremental": true,
@@ -11,12 +11,6 @@
       "@hachej/boring-agent/server/agent-host/testing/compositionRouteProof": ["../agent/src/server/agent-host/testing/compositionRouteProof.ts"],
       "@hachej/boring-bash/agent": ["../boring-bash/src/agent/index.ts"],
       "@hachej/boring-bash/server": ["../boring-bash/src/server/index.ts"],
-      "@hachej/boring-sandbox/shared": ["../boring-sandbox/src/shared/index.ts"],
-      "@hachej/boring-sandbox/providers/bwrap": ["../boring-sandbox/src/providers/bwrap/index.ts"],
-      "@hachej/boring-sandbox/providers/direct": ["../boring-sandbox/src/providers/direct/index.ts"],
-      "@hachej/boring-sandbox/providers/node-workspace": ["../boring-sandbox/src/providers/node-workspace/index.ts"],
-      "@hachej/boring-sandbox/providers/vercel-sandbox": ["../boring-sandbox/src/providers/vercel-sandbox/index.ts"],
-      "@hachej/boring-sandbox/providers/blaxel": ["../boring-sandbox/src/providers/blaxel/index.ts"],
       "@hachej/boring-ui-plugin-cli/plugin-sources": ["../plugin-cli/src/server/pluginSources.ts"],
       "@hachej/boring-workspace/runtime-server": ["./src/server/runtimeBackend/defineRuntimeServerPlugin.ts"],
       "@hachej/boring-workspace/server": ["./src/server/index.ts"]

--- a/packages/workspace/vitest.config.ts
+++ b/packages/workspace/vitest.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "vitest/config"
 import { resolve } from "node:path"
+import { sandboxSourceAlias } from "../../scripts/vite-sandbox-alias.ts"
 
 const PACKAGES = resolve(import.meta.dirname, "..")
 
@@ -9,26 +10,21 @@ export default defineConfig({
     jsxImportSource: "react",
   },
   resolve: {
-    alias: {
-      "@hachej/boring-bash/agent": resolve(PACKAGES, "boring-bash/src/agent/index.ts"),
-      "@hachej/boring-bash/server": resolve(PACKAGES, "boring-bash/src/server/index.ts"),
-      "@hachej/boring-ui-plugin-cli/plugin-sources": resolve(PACKAGES, "plugin-cli/src/server/pluginSources.ts"),
-      "@hachej/boring-agent/server/agent-host/testing/compositionRouteProof": resolve(PACKAGES, "agent/src/server/agent-host/testing/compositionRouteProof.ts"),
-      "@hachej/boring-agent/server": resolve(PACKAGES, "agent/src/server/index.ts"),
-      "@hachej/boring-agent/shared": resolve(PACKAGES, "agent/src/shared/index.ts"),
-      "@hachej/boring-ui-kit": resolve(PACKAGES, "ui/src/index.ts"),
-      "@boring/agent/server": resolve(PACKAGES, "agent/src/server/index.ts"),
-      "@hachej/boring-sandbox/shared": resolve(PACKAGES, "boring-sandbox/src/shared/index.ts"),
-      "@hachej/boring-sandbox/providers/direct": resolve(PACKAGES, "boring-sandbox/src/providers/direct/index.ts"),
-      "@hachej/boring-sandbox/providers/bwrap": resolve(PACKAGES, "boring-sandbox/src/providers/bwrap/index.ts"),
-      "@hachej/boring-sandbox/providers/node-workspace": resolve(PACKAGES, "boring-sandbox/src/providers/node-workspace/index.ts"),
-      "@hachej/boring-sandbox/providers/vercel-sandbox": resolve(PACKAGES, "boring-sandbox/src/providers/vercel-sandbox/index.ts"),
-      "@hachej/boring-sandbox/providers/blaxel": resolve(PACKAGES, "boring-sandbox/src/providers/blaxel/index.ts"),
-      "@": resolve(import.meta.dirname, "src"),
-      "@hachej/boring-workspace/runtime-server": resolve(import.meta.dirname, "src/server/runtimeBackend/defineRuntimeServerPlugin.ts"),
-      "@hachej/boring-workspace/server": resolve(import.meta.dirname, "src/server/index.ts"),
-      "@hachej/boring-workspace": resolve(import.meta.dirname, "src/index.ts"),
-    },
+    alias: [
+      { find: "@hachej/boring-bash/agent", replacement: resolve(PACKAGES, "boring-bash/src/agent/index.ts") },
+      { find: "@hachej/boring-bash/server", replacement: resolve(PACKAGES, "boring-bash/src/server/index.ts") },
+      { find: "@hachej/boring-ui-plugin-cli/plugin-sources", replacement: resolve(PACKAGES, "plugin-cli/src/server/pluginSources.ts") },
+      { find: "@hachej/boring-agent/server/agent-host/testing/compositionRouteProof", replacement: resolve(PACKAGES, "agent/src/server/agent-host/testing/compositionRouteProof.ts") },
+      { find: "@hachej/boring-agent/server", replacement: resolve(PACKAGES, "agent/src/server/index.ts") },
+      { find: "@hachej/boring-agent/shared", replacement: resolve(PACKAGES, "agent/src/shared/index.ts") },
+      { find: "@hachej/boring-ui-kit", replacement: resolve(PACKAGES, "ui/src/index.ts") },
+      { find: "@boring/agent/server", replacement: resolve(PACKAGES, "agent/src/server/index.ts") },
+      sandboxSourceAlias,
+      { find: "@", replacement: resolve(import.meta.dirname, "src") },
+      { find: "@hachej/boring-workspace/runtime-server", replacement: resolve(import.meta.dirname, "src/server/runtimeBackend/defineRuntimeServerPlugin.ts") },
+      { find: "@hachej/boring-workspace/server", replacement: resolve(import.meta.dirname, "src/server/index.ts") },
+      { find: "@hachej/boring-workspace", replacement: resolve(import.meta.dirname, "src/index.ts") },
+    ],
   },
   test: {
     environment: "jsdom",

--- a/plugins/boring-automation/tsconfig.json
+++ b/plugins/boring-automation/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",
@@ -18,12 +19,6 @@
       "@hachej/boring-agent/core": ["../../packages/agent/src/core/index.ts"],
       "@hachej/boring-bash/agent": ["../../packages/boring-bash/src/agent/index.ts"],
       "@hachej/boring-bash/server": ["../../packages/boring-bash/src/server/index.ts"],
-      "@hachej/boring-sandbox/shared": ["../../packages/boring-sandbox/src/shared/index.ts"],
-      "@hachej/boring-sandbox/providers/bwrap": ["../../packages/boring-sandbox/src/providers/bwrap/index.ts"],
-      "@hachej/boring-sandbox/providers/direct": ["../../packages/boring-sandbox/src/providers/direct/index.ts"],
-      "@hachej/boring-sandbox/providers/node-workspace": ["../../packages/boring-sandbox/src/providers/node-workspace/index.ts"],
-      "@hachej/boring-sandbox/providers/blaxel": ["../../packages/boring-sandbox/src/providers/blaxel/index.ts"],
-      "@hachej/boring-sandbox/providers/vercel-sandbox": ["../../packages/boring-sandbox/src/providers/vercel-sandbox/index.ts"],
       "@hachej/boring-ui-kit": ["../../packages/ui/src/index.ts"],
       "@hachej/boring-workspace": ["../../packages/workspace/src/index.ts"],
       "@hachej/boring-workspace/plugin": ["../../packages/workspace/src/plugin.ts"],

--- a/plugins/boring-automation/vitest.config.ts
+++ b/plugins/boring-automation/vitest.config.ts
@@ -1,28 +1,24 @@
 import { defineConfig } from "vitest/config"
 import { resolve } from "node:path"
 import react from "@vitejs/plugin-react"
+import { sandboxSourceAlias } from "../../scripts/vite-sandbox-alias.ts"
 
 export default defineConfig({
   plugins: [react()],
   resolve: {
-    alias: {
-      "@hachej/boring-agent/server": resolve(import.meta.dirname, "../../packages/agent/src/server/index.ts"),
-      "@hachej/boring-agent/shared": resolve(import.meta.dirname, "../../packages/agent/src/shared/index.ts"),
-      "@hachej/boring-agent/core": resolve(import.meta.dirname, "../../packages/agent/src/core/index.ts"),
-      "@hachej/boring-bash/agent": resolve(import.meta.dirname, "../../packages/boring-bash/src/agent/index.ts"),
-      "@hachej/boring-bash/server": resolve(import.meta.dirname, "../../packages/boring-bash/src/server/index.ts"),
-      "@hachej/boring-sandbox/shared": resolve(import.meta.dirname, "../../packages/boring-sandbox/src/shared/index.ts"),
-      "@hachej/boring-sandbox/providers/bwrap": resolve(import.meta.dirname, "../../packages/boring-sandbox/src/providers/bwrap/index.ts"),
-      "@hachej/boring-sandbox/providers/direct": resolve(import.meta.dirname, "../../packages/boring-sandbox/src/providers/direct/index.ts"),
-      "@hachej/boring-sandbox/providers/node-workspace": resolve(import.meta.dirname, "../../packages/boring-sandbox/src/providers/node-workspace/index.ts"),
-      "@hachej/boring-sandbox/providers/blaxel": resolve(import.meta.dirname, "../../packages/boring-sandbox/src/providers/blaxel/index.ts"),
-      "@hachej/boring-sandbox/providers/vercel-sandbox": resolve(import.meta.dirname, "../../packages/boring-sandbox/src/providers/vercel-sandbox/index.ts"),
-      "@hachej/boring-ui-kit": resolve(import.meta.dirname, "../../packages/ui/src/index.ts"),
-      "@hachej/boring-workspace/plugin": resolve(import.meta.dirname, "../../packages/workspace/src/plugin.ts"),
-      "@hachej/boring-workspace/server": resolve(import.meta.dirname, "../../packages/workspace/src/server/index.ts"),
-      "@hachej/boring-workspace/app/server": resolve(import.meta.dirname, "../../packages/workspace/src/app/server/index.ts"),
-      "@hachej/boring-workspace": resolve(import.meta.dirname, "../../packages/workspace/src/index.ts"),
-    },
+    alias: [
+      { find: "@hachej/boring-agent/server", replacement: resolve(import.meta.dirname, "../../packages/agent/src/server/index.ts") },
+      { find: "@hachej/boring-agent/shared", replacement: resolve(import.meta.dirname, "../../packages/agent/src/shared/index.ts") },
+      { find: "@hachej/boring-agent/core", replacement: resolve(import.meta.dirname, "../../packages/agent/src/core/index.ts") },
+      { find: "@hachej/boring-bash/agent", replacement: resolve(import.meta.dirname, "../../packages/boring-bash/src/agent/index.ts") },
+      { find: "@hachej/boring-bash/server", replacement: resolve(import.meta.dirname, "../../packages/boring-bash/src/server/index.ts") },
+      sandboxSourceAlias,
+      { find: "@hachej/boring-ui-kit", replacement: resolve(import.meta.dirname, "../../packages/ui/src/index.ts") },
+      { find: "@hachej/boring-workspace/plugin", replacement: resolve(import.meta.dirname, "../../packages/workspace/src/plugin.ts") },
+      { find: "@hachej/boring-workspace/server", replacement: resolve(import.meta.dirname, "../../packages/workspace/src/server/index.ts") },
+      { find: "@hachej/boring-workspace/app/server", replacement: resolve(import.meta.dirname, "../../packages/workspace/src/app/server/index.ts") },
+      { find: "@hachej/boring-workspace", replacement: resolve(import.meta.dirname, "../../packages/workspace/src/index.ts") },
+    ],
   },
   test: {
     environment: "node",

--- a/scripts/vite-sandbox-alias.ts
+++ b/scripts/vite-sandbox-alias.ts
@@ -1,0 +1,14 @@
+import { resolve } from 'node:path'
+
+/**
+ * Single source-alias entry for every `@hachej/boring-sandbox/<subpath>` import.
+ *
+ * Vite/vitest configs across the repo used to hand-maintain one alias per
+ * provider subpath. They now spread this one entry instead; TypeScript gets the
+ * equivalent mapping from the `boring-source` export condition declared in
+ * `tsconfig.base.json` and `packages/boring-sandbox/package.json`.
+ */
+export const sandboxSourceAlias = {
+  find: /^@hachej\/boring-sandbox\/(.+)$/,
+  replacement: resolve(import.meta.dirname, '../packages/boring-sandbox/src/$1/index.ts'),
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "customConditions": ["boring-source"]
+  }
+}


### PR DESCRIPTION
## What

Extracts the clean, purely-subtractive half of PR #1256 and re-implements it from
current `main` (`99db0fb47`). No descriptor/registry/runtime-mode code is
included.

Sandbox source resolution is now declared once instead of being hand-maintained
in every consumer config:

- **new** `tsconfig.base.json` — `compilerOptions.customConditions: ["boring-source"]`
- **new** `scripts/vite-sandbox-alias.ts` — one regex alias entry
  (`@hachej/boring-sandbox/<subpath>` → `packages/boring-sandbox/src/<subpath>/index.ts`)
- `packages/boring-sandbox/package.json` — a `"boring-source"` export condition on
  each of the 9 existing subpath exports (`./shared`, `./providers`, and the 7
  provider subpaths). Node and normal bundlers never request this condition, so
  published/runtime resolution is unchanged.

That lets the hand-maintained mappings be deleted:

- **42 `paths` entries removed** from 7 tsconfigs
  (`apps/full-app`, `packages/{agent,cli,core}`,
  `packages/workspace/tsconfig.{front,server}.source.json`,
  `plugins/boring-automation`), each of which now `extends` `tsconfig.base.json`.
- **40 alias entries removed** from 7 vitest configs
  (`apps/{agent-playground,full-app}`, `packages/{agent,cli,core,workspace}`,
  `plugins/boring-automation`), replaced by the single shared
  `sandboxSourceAlias`. Three of those configs used the object alias form and
  were converted to the equivalent array form (Vite preserves order and match
  semantics) so the shared entry can be spliced in at the same position.

Net: **+87 / -143** across 18 files, zero runtime surface.

## Why

Tonight's review of #1256 concluded it is "two PRs wearing one coat":

- **Half A (this PR)** — the alias cleanup — "genuinely good, low-risk,
  mechanical, and solves a real recurring pain. It should land."
- **Half B** — the `SandboxRuntimeModeDescriptorV1` registry — is blocked:
  #1317 (merged 2026-08-17) ratified R-33-14/R-33-15, which reject the
  authority-mixing central type in that half. The author of #1256 reached the
  same conclusion in the PR body and stopped mid-reconciliation. #1256 is also
  59 commits behind `main` with a *semantic* conflict in the remote-worker path.

Rather than rebase 94 files, the review's recommendation was to cut the clean
subtraction fresh from current `main` and let the registry design go back through
#1317 reconciliation on its own schedule. That is exactly this PR.

Re-implemented against today's layout, not cherry-picked: `apps/agent-playground`
has no sandbox `paths` on main (only vitest aliases), `packages/boring-sandbox`
has no self-referencing imports, and the `./runtime-modes` and
`./providers/registry` export entries from #1256 are omitted because those source
directories do not exist on `main`.

Relates to #1240. Extracted from #1256 (which stays open for the registry half).

## Proof

Run in `.worktrees/alias-cleanup-extract` off `origin/main`:

```
pnpm install --prefer-offline
pnpm typecheck        # = pnpm build:packages && pnpm -r run typecheck
```
→ **EXIT=0**, 29 packages `typecheck: Done`, zero `error TS`.

Test suites for every package whose vitest config was touched:

```
pnpm --filter agent-playground        run test
pnpm --filter full-app                run test
pnpm --filter @hachej/boring-agent    run test
pnpm --filter @hachej/boring-ui-cli   run test
pnpm --filter @hachej/boring-core     run test
pnpm --filter @hachej/boring-workspace run test
pnpm --filter @hachej/boring-automation run test
```
Fully green:

| package | result |
|---|---|
| `agent-playground` | 1/1 files, 1/1 tests **pass** |
| `full-app` | 5/5 files, 46/46 tests **pass** |
| `@hachej/boring-agent` | 223 passed / 2 skipped files, 2047 passed / 17 skipped tests **pass** |

Four packages had failures, **all of which reproduce identically on pristine
`origin/main`**. Each was re-run in isolation on the branch and then on a
detached `origin/main` checkout in the same worktree, back to back:

| package | branch | baseline (`origin/main`) | verdict |
|---|---|---|---|
| `@hachej/boring-core` | 16 FAIL | **same 16 FAIL, identical test names** | pre-existing — shared Postgres (`raceConditions`, `postSignupHook`, `authHook`, `createAuth`, `deleteUserCompletely`, `PostgresModelBudgetStore`, `routes`) contended by other agents' concurrent suites on this VM |
| `@hachej/boring-ui-cli` | 2 files FAIL | **same 2 files FAIL** | pre-existing — `cli.integration` + `runtimePluginBrowser.integration` (browser 403s); baseline failed the whole `cli.integration` file at suite level |
| `@hachej/boring-workspace` | 1 file FAIL | **2 files FAIL** (baseline worse) | flaky — 5000ms `testTimeout` under load; a *different* test failed in each of the three runs |
| `@hachej/boring-automation` | 1 FAIL | **same 1 FAIL** | pre-existing — `migrations.test.ts` against the shared Postgres |

No failure anywhere in any run mentions `@hachej/boring-sandbox`, and there are
zero module-resolution errors — which is the shape a regression from this change
would take. Load average on the VM was ~140 during these runs (several other
agents running vitest concurrently).

Sanity check that nothing was left behind:

```
grep -rn 'boring-sandbox' --include='tsconfig*.json' --include='vitest.config.ts' .
```
→ no matches outside `node_modules`.

## Not in scope

- The descriptor registry, `runtimeModeCatalog`, host-policy plumbing, and the
  `'remote-worker'` mode-enum widening from #1256 — all deferred pending the
  #1317 R-33-15 split.
- Do not merge #1256 as a unit; it stays open for that rework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
