### PR TITLE
fix(workspace): polish mobile workbench takeover

### DIFF
--- a/apps/agent-playground/index.html
+++ b/apps/agent-playground/index.html
@@ -2,7 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <!-- interactive-widget=resizes-content: Android Chrome >= 108 otherwise
+         leaves the layout viewport at full height when the software keyboard
+         opens, so the composer of a fixed-height `overflow: hidden` shell ends
+         up underneath it. iOS ignores the key; `useKeyboardInset()` covers it
+         there via `--keyboard-inset`. -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content" />
     <title>@boring/agent — standalone</title>
   </head>
   <body>

--- a/apps/full-app/index.html
+++ b/apps/full-app/index.html
@@ -2,7 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <!-- interactive-widget=resizes-content: Android Chrome >= 108 otherwise
+         leaves the layout viewport at full height when the software keyboard
+         opens, so the composer of a fixed-height `overflow: hidden` shell ends
+         up underneath it. iOS ignores the key; `useKeyboardInset()` covers it
+         there via `--keyboard-inset`. -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content" />
     <link rel="icon" type="image/svg+xml" href="/logo.svg" />
     <link rel="alternate icon" type="image/png" href="/favicon-64.png" />
     <link rel="apple-touch-icon" href="/logo.png" />

--- a/apps/workspace-playground/e2e/mobile-plugin-overlay-chrome.spec.ts
+++ b/apps/workspace-playground/e2e/mobile-plugin-overlay-chrome.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "@playwright/test"
+
+test.use({
+  viewport: { width: 390, height: 844 },
+  hasTouch: true,
+  isMobile: true,
+  deviceScaleFactor: 2,
+})
+
+test("plugin overlay header clears the compact navigation control", async ({ page }) => {
+  await page.goto("/")
+  await expect(page.locator('main[aria-label="Chat"]')).toBeVisible({ timeout: 30_000 })
+  await expect(page.locator('.dv-chat-stage, [data-boring-workspace-part="mobile-chat-pane"]').first()).toBeVisible()
+
+  await page.getByRole("button", { name: "Open app navigation" }).tap()
+  await page.getByRole("button", { name: "Tasks" }).tap()
+
+  const overlay = page.locator('[data-boring-workspace-part="tasks-overlay"]')
+  const navigationControl = page.getByRole("button", { name: "Open app navigation" })
+  const headerIdentity = overlay.locator("header > div").first()
+
+  await expect(overlay).toBeVisible()
+  const [navigationBox, identityBox] = await Promise.all([
+    navigationControl.boundingBox(),
+    headerIdentity.boundingBox(),
+  ])
+
+  expect(navigationBox).not.toBeNull()
+  expect(identityBox).not.toBeNull()
+  expect(identityBox!.x).toBeGreaterThanOrEqual(navigationBox!.x + navigationBox!.width)
+})

--- a/apps/workspace-playground/e2e/mobile-shots.spec.ts
+++ b/apps/workspace-playground/e2e/mobile-shots.spec.ts
@@ -1,0 +1,74 @@
+import { test } from "@playwright/test"
+import { mkdirSync } from "node:fs"
+import { resolve } from "node:path"
+
+// Diagnostic probe, not a CI spec: zero assertions, hardcoded settle waits,
+// screenshots to disk. It only runs when explicitly demanded so the standard
+// e2e suite neither pays ~25s of settle waits nor picks up its console spew.
+test.skip(!process.env.MOBILE_SHOT_DIR, "diagnostic only — set MOBILE_SHOT_DIR to run")
+
+const OUT = process.env.MOBILE_SHOT_DIR || resolve(process.cwd(), "mobile-shots")
+mkdirSync(OUT, { recursive: true })
+
+function wire(page: import("@playwright/test").Page, tag: string) {
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") console.log(`[${tag}][console.${m.type()}] ${m.text().slice(0, 400)}`)
+  })
+  page.on("pageerror", (e) => console.log(`[${tag}][pageerror] ${String(e).slice(0, 600)}`))
+  page.on("requestfailed", (r) => console.log(`[${tag}][requestfailed] ${r.url().slice(0, 200)} :: ${r.failure()?.errorText}`))
+}
+
+async function probe(page: import("@playwright/test").Page, tag: string) {
+  const info = await page.evaluate(() => {
+    const root = document.getElementById("root")
+    return {
+      inner: [window.innerWidth, window.innerHeight],
+      docScrollW: document.documentElement.scrollWidth,
+      rootChildren: root?.children.length ?? -1,
+      rootHTMLLen: root?.innerHTML.length ?? -1,
+      rootHTMLHead: (root?.innerHTML ?? "").slice(0, 300),
+      parts: Array.from(document.querySelectorAll("[data-boring-workspace-part]")).map((el) => el.getAttribute("data-boring-workspace-part")),
+      visButtons: Array.from(document.querySelectorAll("button")).filter((b) => (b as HTMLElement).offsetParent !== null).length,
+    }
+  })
+  console.log(`[${tag}] PROBE ${JSON.stringify(info)}`)
+  await page.screenshot({ path: resolve(OUT, `diag-${tag}.png`) })
+}
+
+test("diag desktop", async ({ page }) => {
+  wire(page, "desktop")
+  await page.setViewportSize({ width: 1440, height: 900 })
+  await page.goto("/")
+  await page.waitForTimeout(6000)
+  await probe(page, "desktop")
+})
+
+test("diag mobile-nomobileflag", async ({ browser }) => {
+  const ctx = await browser.newContext({ viewport: { width: 390, height: 844 }, baseURL: `http://127.0.0.1:${Number(process.env.PLAYWRIGHT_VITE_PORT) || 5380}` })
+  const page = await ctx.newPage()
+  wire(page, "m-noflag")
+  await page.goto("/")
+  await page.waitForTimeout(6000)
+  await probe(page, "m-noflag")
+  await ctx.close()
+})
+
+test("diag mobile-full", async ({ browser }) => {
+  const ctx = await browser.newContext({ viewport: { width: 390, height: 844 }, hasTouch: true, isMobile: true, deviceScaleFactor: 2, baseURL: `http://127.0.0.1:${Number(process.env.PLAYWRIGHT_VITE_PORT) || 5380}` })
+  const page = await ctx.newPage()
+  wire(page, "m-full")
+  await page.goto("/")
+  await page.waitForTimeout(6000)
+  await probe(page, "m-full")
+  await ctx.close()
+})
+
+test("diag desktop-then-resize", async ({ page }) => {
+  wire(page, "resize")
+  await page.setViewportSize({ width: 1440, height: 900 })
+  await page.goto("/")
+  await page.waitForTimeout(5000)
+  await page.setViewportSize({ width: 390, height: 844 })
+  await page.waitForTimeout(2500)
+  await probe(page, "resize")
+})

--- a/apps/workspace-playground/index.html
+++ b/apps/workspace-playground/index.html
@@ -2,7 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <!-- interactive-widget=resizes-content: Android Chrome >= 108 otherwise
+         leaves the layout viewport at full height when the software keyboard
+         opens, so the composer of a fixed-height `overflow: hidden` shell ends
+         up underneath it. iOS ignores the key; `useKeyboardInset()` covers it
+         there via `--keyboard-inset`. -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content" />
     <title>Workspace Playground</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/packages/cli/index.html
+++ b/packages/cli/index.html
@@ -2,7 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <!-- interactive-widget=resizes-content: Android Chrome >= 108 otherwise
+         leaves the layout viewport at full height when the software keyboard
+         opens, so the composer of a fixed-height `overflow: hidden` shell ends
+         up underneath it. iOS ignores the key; `useKeyboardInset()` covers it
+         there via `--keyboard-inset`. -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content" />
     <title>Boring UI</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -25,7 +30,9 @@
       :root[data-theme="light"] { color-scheme: light; --boot-bg: #fbfaf8; --boot-sidebar: #f7f6f3; --boot-fg: #25231f; --boot-border: #e7e4de; --boot-skeleton: #efede9; --boot-muted: #77716a; }
       * { box-sizing: border-box; }
       body { margin: 0; background: var(--boot-bg); color: var(--boot-fg); font-family: Geist, system-ui, sans-serif; }
-      .boot-shell { display: flex; min-height: 100vh; overflow: hidden; background: var(--boot-bg); }
+      /* dvh, not vh: `100vh` is the *large* viewport on mobile, so with the URL
+         bar showing the boot shell overflows the visible area by its height. */
+      .boot-shell { display: flex; min-height: 100vh; min-height: 100dvh; overflow: hidden; background: var(--boot-bg); }
       .boot-sidebar { width: 268px; flex: none; padding: 16px; border-right: 1px solid var(--boot-border); background: var(--boot-sidebar); }
       .boot-brand, .boot-row { display: flex; align-items: center; gap: 12px; }
       .boot-brand { height: 32px; padding-left: 32px; }

--- a/packages/cli/src/front/app.css
+++ b/packages/cli/src/front/app.css
@@ -1,7 +1,21 @@
+/* The app shell is a fixed-height, non-scrolling frame; every scroll region
+ * lives inside it. `html` sizes to the *dynamic* viewport rather than `100%`,
+ * because on mobile the layout viewport is the large viewport — with the URL
+ * bar showing, a `height: 100%` root is taller than what is visible and the
+ * bottom chrome (composer, status bar) is cut off with nothing to scroll. */
+html {
+  height: 100%;
+  height: 100dvh;
+}
+
 html,
 body,
 #root {
-  height: 100%;
   margin: 0;
   overflow: hidden;
+}
+
+body,
+#root {
+  height: 100%;
 }

--- a/packages/ui/src/alert-dialog.tsx
+++ b/packages/ui/src/alert-dialog.tsx
@@ -58,7 +58,10 @@ function AlertDialogContent({
         data-slot="alert-dialog-content"
         data-size={size}
         className={cn(
-          "group/alert-dialog-content fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 data-[size=sm]:max-w-xs data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[size=default]:sm:max-w-lg",
+          // Mirrors dialog.tsx: compact viewports top-align so confirm dialogs
+          // (and their action buttons) cannot land behind the software keyboard;
+          // `sm:` restores the classic centred dialog.
+          "group/alert-dialog-content fixed top-[max(1rem,env(safe-area-inset-top,0px))] left-[50%] z-50 grid max-h-[calc(100dvh-var(--keyboard-inset,0px))] w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-0 gap-4 overflow-y-auto rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[size=sm]:max-w-xs data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[size=default]:sm:max-w-lg sm:top-[50%] sm:translate-y-[-50%]",
           className
         )}
         {...props}

--- a/packages/ui/src/command.tsx
+++ b/packages/ui/src/command.tsx
@@ -72,7 +72,8 @@ function CommandInput({
       <CommandPrimitive.Input
         data-slot="command-input"
         className={cn(
-          "flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+          // text-base below md: iOS auto-zooms the page on focus for inputs under 16px.
+          "flex h-10 w-full rounded-md bg-transparent py-3 text-base outline-hidden md:text-sm placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         {...props}

--- a/packages/ui/src/dialog.tsx
+++ b/packages/ui/src/dialog.tsx
@@ -57,7 +57,12 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg',
+          // Compact viewports top-align: `fixed` resolves against the layout viewport, which
+          // the software keyboard never shrinks, so a centred dialog puts its lower half (and
+          // any footer) behind the keyboard. `sm:` restores the classic centred dialog.
+          // The height cap only subtracts `--keyboard-inset` (published on <html> by the host
+          // app, `0px` by default) so it stays a no-op for full-bleed `h-[100dvh]` consumers.
+          'fixed top-[max(1rem,env(safe-area-inset-top,0px))] left-[50%] z-50 grid max-h-[calc(100dvh-var(--keyboard-inset,0px))] w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-0 gap-4 overflow-y-auto rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:top-[50%] sm:max-w-lg sm:translate-y-[-50%]',
           className,
         )}
         {...props}

--- a/packages/ui/src/safe-area.test.tsx
+++ b/packages/ui/src/safe-area.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import * as React from 'react'
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { describe, expect, it } from 'vitest'
+import { AlertDialog, AlertDialogContent } from './alert-dialog'
+import { Dialog, DialogContent } from './dialog'
+import { Sheet, SheetContent } from './sheet'
+import { Toaster } from './toast'
+
+// These primitives only render through a portal once mounted, so assertions run against
+// the live document rather than a server-rendered string.
+function mount(node: React.ReactNode): () => void {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const root = createRoot(host)
+  act(() => {
+    root.render(node)
+  })
+  return () => {
+    act(() => {
+      root.unmount()
+    })
+    host.remove()
+  }
+}
+
+function classesOf(selector: string): string {
+  const el = document.querySelector(selector)
+  if (!el) throw new Error(`missing element: ${selector}`)
+  return el.className
+}
+
+describe('safe-area and keyboard insets', () => {
+  it('pads sheet content away from the notch and home indicator on every side', () => {
+    const sides = ['top', 'right', 'bottom', 'left'] as const
+    const expected: Record<(typeof sides)[number], string[]> = {
+      top: ['pt-[env(safe-area-inset-top,0px)]', 'pl-[env(safe-area-inset-left,0px)]'],
+      right: ['pt-[env(safe-area-inset-top,0px)]', 'pr-[env(safe-area-inset-right,0px)]', 'pb-[env(safe-area-inset-bottom,0px)]'],
+      bottom: ['pb-[calc(1rem+env(safe-area-inset-bottom,0px))]', 'pr-[env(safe-area-inset-right,0px)]', 'pl-[env(safe-area-inset-left,0px)]'],
+      left: ['pt-[env(safe-area-inset-top,0px)]', 'pl-[env(safe-area-inset-left,0px)]', 'pb-[env(safe-area-inset-bottom,0px)]'],
+    }
+
+    for (const side of sides) {
+      const unmount = mount(
+        <Sheet open>
+          <SheetContent side={side}>content</SheetContent>
+        </Sheet>,
+      )
+      const className = classesOf('[data-slot="sheet-content"]')
+      for (const cls of expected[side]) expect(className, side).toContain(cls)
+      // The background/border must still bleed to the physical edge: insets are padding,
+      // never margin or an offset from the anchored edge.
+      expect(className, side).toContain('bg-background')
+      unmount()
+    }
+  })
+
+  it('top-aligns dialogs on compact viewports and re-centres from sm up', () => {
+    const unmount = mount(
+      <Dialog open>
+        <DialogContent>body</DialogContent>
+      </Dialog>,
+    )
+    const className = classesOf('[data-slot="dialog-content"]')
+    expect(className).toContain('top-[max(1rem,env(safe-area-inset-top,0px))]')
+    expect(className).toContain('translate-y-0')
+    expect(className).toContain('sm:top-[50%]')
+    expect(className).toContain('sm:translate-y-[-50%]')
+    // Height cap only subtracts the keyboard inset, so full-bleed h-[100dvh] consumers
+    // are unaffected while a raised keyboard shrinks the dialog instead of hiding it.
+    expect(className).toContain('max-h-[calc(100dvh-var(--keyboard-inset,0px))]')
+    unmount()
+  })
+
+  it('gives alert dialogs the same compact top-anchor and keyboard height cap as dialogs', () => {
+    const unmount = mount(
+      <AlertDialog open>
+        <AlertDialogContent>confirm</AlertDialogContent>
+      </AlertDialog>,
+    )
+    const className = classesOf('[data-slot="alert-dialog-content"]')
+    expect(className).toContain('top-[max(1rem,env(safe-area-inset-top,0px))]')
+    expect(className).toContain('translate-y-0')
+    expect(className).toContain('sm:top-[50%]')
+    expect(className).toContain('sm:translate-y-[-50%]')
+    expect(className).toContain('max-h-[calc(100dvh-var(--keyboard-inset,0px))]')
+    unmount()
+  })
+
+  it('keeps toasts out of the home-indicator gesture strip in every position', () => {
+    const positions = {
+      'bottom-right': ['bottom-[calc(1rem+env(safe-area-inset-bottom,0px))]', 'right-[calc(1rem+env(safe-area-inset-right,0px))]'],
+      'bottom-left': ['bottom-[calc(1rem+env(safe-area-inset-bottom,0px))]', 'left-[calc(1rem+env(safe-area-inset-left,0px))]'],
+      'top-right': ['top-[calc(1rem+env(safe-area-inset-top,0px))]', 'right-[calc(1rem+env(safe-area-inset-right,0px))]'],
+      'top-left': ['top-[calc(1rem+env(safe-area-inset-top,0px))]', 'left-[calc(1rem+env(safe-area-inset-left,0px))]'],
+    } as const
+
+    for (const [position, expected] of Object.entries(positions)) {
+      const unmount = mount(<Toaster position={position as keyof typeof positions} />)
+      const className = classesOf('[data-testid="toaster"]')
+      for (const cls of expected) expect(className, position).toContain(cls)
+      unmount()
+    }
+  })
+})

--- a/packages/ui/src/sheet.tsx
+++ b/packages/ui/src/sheet.tsx
@@ -60,21 +60,25 @@ function SheetContent({
         data-slot="sheet-content"
         className={cn(
           "fixed z-50 flex flex-col gap-4 bg-background shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:animate-in data-[state=open]:duration-500",
+          // Safe-area insets live on the root so the background/border still bleed to the
+          // physical screen edge while content clears the notch and home indicator.
           side === "right" &&
-            "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+            "inset-y-0 right-0 h-full w-3/4 border-l pt-[env(safe-area-inset-top,0px)] pr-[env(safe-area-inset-right,0px)] pb-[env(safe-area-inset-bottom,0px)] data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
           side === "left" &&
-            "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+            "inset-y-0 left-0 h-full w-3/4 border-r pt-[env(safe-area-inset-top,0px)] pb-[env(safe-area-inset-bottom,0px)] pl-[env(safe-area-inset-left,0px)] data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
           side === "top" &&
-            "inset-x-0 top-0 h-auto border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+            "inset-x-0 top-0 h-auto border-b pt-[env(safe-area-inset-top,0px)] pr-[env(safe-area-inset-right,0px)] pl-[env(safe-area-inset-left,0px)] data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
           side === "bottom" &&
-            "inset-x-0 bottom-0 h-auto border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+            "inset-x-0 bottom-0 h-auto border-t pr-[env(safe-area-inset-right,0px)] pb-[calc(1rem+env(safe-area-inset-bottom,0px))] pl-[env(safe-area-inset-left,0px)] data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
           className
         )}
         {...props}
       >
         {children}
         {showCloseButton && (
-          <SheetPrimitive.Close className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-secondary">
+          // Absolute positioning resolves against the padding box, so the root insets above
+          // do not move this button; it needs its own offsets to clear the notch.
+          <SheetPrimitive.Close className="absolute top-[calc(1rem+env(safe-area-inset-top,0px))] right-[calc(1rem+env(safe-area-inset-right,0px))] rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-secondary">
             <span aria-hidden="true" className="text-base leading-none">×</span>
             <span className="sr-only">Close</span>
           </SheetPrimitive.Close>

--- a/packages/ui/src/toast.tsx
+++ b/packages/ui/src/toast.tsx
@@ -111,10 +111,16 @@ export function Toaster({ position = 'bottom-right', className }: ToasterProps) 
       data-testid="toaster"
       className={cn(
         'pointer-events-none fixed z-[1000] flex w-[340px] max-w-[calc(100vw-2rem)] flex-col gap-2',
-        position === 'bottom-right' && 'bottom-4 right-4 items-end',
-        position === 'bottom-left' && 'bottom-4 left-4 items-start',
-        position === 'top-right' && 'top-4 right-4 items-end',
-        position === 'top-left' && 'top-4 left-4 items-start',
+        // Offsets stack on top of the safe area so toasts never sit in the home-indicator
+        // gesture strip, where a dismiss swipe would hit the OS instead of the toast.
+        position === 'bottom-right' &&
+          'bottom-[calc(1rem+env(safe-area-inset-bottom,0px))] right-[calc(1rem+env(safe-area-inset-right,0px))] items-end',
+        position === 'bottom-left' &&
+          'bottom-[calc(1rem+env(safe-area-inset-bottom,0px))] left-[calc(1rem+env(safe-area-inset-left,0px))] items-start',
+        position === 'top-right' &&
+          'top-[calc(1rem+env(safe-area-inset-top,0px))] right-[calc(1rem+env(safe-area-inset-right,0px))] items-end',
+        position === 'top-left' &&
+          'top-[calc(1rem+env(safe-area-inset-top,0px))] left-[calc(1rem+env(safe-area-inset-left,0px))] items-start',
         className,
       )}
     >

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ComponentType, type ReactNode } from "react"
-import { Bot } from "lucide-react"
+import { Bot, Search } from "lucide-react"
+import { IconButton } from "@hachej/boring-ui-kit"
 import {
   PiChatPanel as DefaultPiChatPanel,
   usePiSessions as useDefaultPiSessions,
@@ -9,7 +10,7 @@ import {
   type ToolRendererOverrides,
 } from "@hachej/boring-agent/front"
 import { WorkspaceProvider, type WorkspaceProviderProps } from "../../front/provider/WorkspaceProvider"
-import { ChatLayout, TopBar, ThemeToggle, type ChatLayoutProps, type ChatPanePendingPlacement, type ChatPaneSplitDirection } from "../../front/layout"
+import { ChatLayout, TopBar, ThemeToggle, useKeyboardInset, type ChatLayoutProps, type ChatPanePendingPlacement, type ChatPaneSplitDirection } from "../../front/layout"
 import { WORKSPACE_COMPOSER_STOP_REASONS, emitWorkspaceComposerStop } from "../../front/chrome/chat/composerStop"
 import type { WorkspaceChatPanelProps } from "../../front/chrome/chat/types"
 import type {
@@ -766,6 +767,9 @@ export function WorkspaceAgentFront<
 }: WorkspaceAgentFrontProps<TSession>) {
   const viewport = useViewportWidth()
   const mobileShellActive = mobileShellEnabled && isCompactViewport(viewport)
+  // Publishes `--keyboard-inset` on <html> for every surface below. This is the
+  // outermost component that always mounts, so it is the one place it belongs.
+  useKeyboardInset()
   const externalPluginsEnabled = externalPlugins !== false
   const resolvedFrontPluginHotReload = externalPluginsEnabled ? frontPluginHotReload : false
   const resolvedHotReloadEnabled = externalPluginsEnabled ? hotReloadEnabled : false
@@ -2318,6 +2322,33 @@ export function WorkspaceAgentFront<
   const topBarLeftContent = topBarLeft ? (
     <div className="flex min-w-0 items-center gap-2">{topBarLeft}</div>
   ) : undefined
+  // At compact the mobile chat bar already carries the real session title, so a
+  // top bar above it is a second title row over the same chat — three stacked
+  // headers before the first pixel of transcript. It is dropped there, except
+  // when the host supplied opaque chrome of its own (brand + site nav, sign-in,
+  // version badge) that lives nowhere else; that bar then shows the app name
+  // rather than repeating the session title.
+  const hostSuppliedTopBarChrome = Boolean(topBarLeftContent) || topBarRight != null
+  const showTopBar = !mobileShellActive || hostSuppliedTopBarChrome
+  // The two actions the top bar owned that ARE relocatable follow it into the
+  // mobile bar when it is gone. The command palette especially: a phone has no
+  // ⌘K, so this button is its only entry point.
+  const mobileChatBarActions = mobileShellActive && !showTopBar ? (
+    <>
+      <IconButton
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        className="mobile-shell-bar-action"
+        onClick={openCommandPalette}
+        aria-label="Search catalogs and commands"
+        title="Search"
+      >
+        <Search className="size-4" />
+      </IconButton>
+      {showThemeToggle ? <ThemeToggle /> : null}
+    </>
+  ) : undefined
   const activeChatPaneRef = activeChatPaneId ? workspaceSessionRefFromKey(activeChatPaneId) : null
   const openChatPaneRefs = useMemo(() => chatPaneIds.map((id) => workspaceSessionRefFromKey(id)), [chatPaneIds])
   const pinnedRefs = useMemo(() => pinnedIds.map((id) => workspaceSessionRefFromKey(id)), [pinnedIds])
@@ -2571,6 +2602,7 @@ export function WorkspaceAgentFront<
       chatPaneSplitPending={chatPaneSplitPending}
       pendingChatPanePlacement={pendingChatPanePlacement}
       onPendingChatPanePlacementConsumed={consumePendingChatPanePlacement}
+      chatTopActions={mobileChatBarActions}
       onDropChatSession={openChatPane}
       flashChatPaneId={flashChatPane?.workspaceId === workspaceId ? flashChatPane.id : null}
       surface={surfaceOpen ? "artifact-surface" : null}
@@ -2707,9 +2739,12 @@ export function WorkspaceAgentFront<
     </PluginTabsWorkspaceShell>
   ) : (
     <div className="flex h-full min-h-0 flex-col">
+      {showTopBar ? (
       <TopBar
         appTitle={appTitle}
-        sessionTitle={remoteSessionsTransitioning ? "Loading sessions…" : resolvedSessionTitle ?? defaultSessionTitle}
+        sessionTitle={mobileShellActive
+          ? undefined
+          : remoteSessionsTransitioning ? "Loading sessions…" : resolvedSessionTitle ?? defaultSessionTitle}
         // The non-plugin-tabs shell shows the active chat's title in its bar,
         // so it is a chat header too and names its Agent like the others.
         // Undefined below two Agents, which is when the map itself is null.
@@ -2718,6 +2753,7 @@ export function WorkspaceAgentFront<
         topBarLeft={topBarLeftContent}
         topBarRight={topBarRightContent}
       />
+      ) : null}
       {mainContent}
     </div>
   )

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -2335,18 +2335,20 @@ export function WorkspaceAgentFront<
   // ⌘K, so this button is its only entry point.
   const mobileChatBarActions = mobileShellActive && !showTopBar ? (
     <>
+      {/* 44px hit area: the UI-review mobile touch-target gate requires it and
+          the merged bar is a phone-only surface. */}
       <IconButton
         type="button"
         variant="ghost"
         size="icon-sm"
-        className="mobile-shell-bar-action"
+        className="mobile-shell-bar-action size-11"
         onClick={openCommandPalette}
         aria-label="Search catalogs and commands"
         title="Search"
       >
         <Search className="size-4" />
       </IconButton>
-      {showThemeToggle ? <ThemeToggle /> : null}
+      {showThemeToggle ? <ThemeToggle className="size-11" /> : null}
     </>
   ) : undefined
   const activeChatPaneRef = activeChatPaneId ? workspaceSessionRefFromKey(activeChatPaneId) : null

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -3933,4 +3933,61 @@ describe("WorkspaceAgentFront", () => {
     expect(captured.at(-1)?.hydrateMessages).toBe(true)
     expect(captured.at(-1)?.allowPromptDuringInitialHydration).toBe(true)
   })
+
+  describe("compact top-bar gating", () => {
+    function setViewport(width: number) {
+      Object.defineProperty(window, "innerWidth", { configurable: true, writable: true, value: width })
+      window.dispatchEvent(new Event("resize"))
+    }
+
+    afterEach(() => {
+      setViewport(1024)
+    })
+
+    function renderFront(props: Partial<Parameters<typeof WorkspaceAgentFront>[0]>) {
+      return render(
+        <WorkspaceAgentFront
+          workspaceId="topbar-gating"
+          workspaceLayout="plugin-tabs"
+          chatPanel={SessionIdChatPanel}
+          sessions={[{ id: "s1", title: "Focused session" }]}
+          activeSessionId="s1"
+          {...props}
+        />,
+      )
+    }
+
+    it("drops the top bar at compact and relocates its actions into the mobile chat bar", () => {
+      setViewport(390)
+      renderFront({})
+
+      // No second title row above the mobile bar.
+      expect(screen.queryByTestId("topbar"))?.toBeNull()
+      const bar = document.querySelector('[data-boring-workspace-part="mobile-chat-bar"]')
+      expect(bar).not.toBeNull()
+      // A phone has no ⌘K: the palette button and theme toggle live in the bar.
+      expect(within(bar as HTMLElement).getByRole("button", { name: "Search catalogs and commands" })).toBeInTheDocument()
+      expect(within(bar as HTMLElement).getByRole("button", { name: "Toggle theme" })).toBeInTheDocument()
+    })
+
+    it("keeps host-supplied top-bar chrome alive at compact instead of dropping it", () => {
+      setViewport(390)
+      renderFront({ topBarRight: <button type="button">Sign in</button> })
+
+      // The relocated actions are NOT duplicated into the chat bar when the
+      // host supplied its own chrome.
+      expect(screen.queryByRole("button", { name: "Search catalogs and commands" })).toBeNull()
+      // Host chrome is opaque and lives nowhere else: it stays reachable inside
+      // the app-navigation drawer (Sheet mounts it lazily, so open first).
+      fireEvent.click(screen.getByRole("button", { name: "Open app navigation" }))
+      expect(document.body.textContent).toContain("Sign in")
+    })
+
+    it("keeps the classic top bar on desktop widths", () => {
+      renderFront({ workspaceLayout: "classic" })
+
+      expect(document.querySelector('[data-boring-workspace-part="topbar"]')).not.toBeNull()
+      expect(document.querySelector('[data-boring-workspace-part="mobile-chat-bar"]')).toBeNull()
+    })
+  })
 })

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -180,7 +180,7 @@ describe("WorkspaceAgentFront", () => {
     expect(MockEventSource.instances.filter((instance) => instance.url.includes("/api/v1/agent-plugins/events"))).toHaveLength(0)
   })
 
-  it("externalPlugins=true preserves explicit front and chat plugin reload UX", () => {
+  it("externalPlugins=true preserves explicit front and chat plugin reload UX", async () => {
     MockEventSource.instances = []
     vi.stubGlobal("EventSource", MockEventSource)
     let captured: WorkspaceChatPanelProps | undefined
@@ -200,10 +200,12 @@ describe("WorkspaceAgentFront", () => {
     )
 
     expect(MockEventSource.instances.filter((instance) => instance.url.includes("/api/v1/agent-plugins/events"))).toHaveLength(1)
-    expect(captured?.hotReloadEnabled).toBe(true)
+    // The chat pane mounts under the code-split dock stage, so capture lands
+    // one microtask after render.
+    await waitFor(() => expect(captured?.hotReloadEnabled).toBe(true))
   })
 
-  it("externalPlugins=false disables front and chat plugin reload UX", () => {
+  it("externalPlugins=false disables front and chat plugin reload UX", async () => {
     MockEventSource.instances = []
     vi.stubGlobal("EventSource", MockEventSource)
     let captured: WorkspaceChatPanelProps | undefined
@@ -223,7 +225,7 @@ describe("WorkspaceAgentFront", () => {
     )
 
     expect(MockEventSource.instances.filter((instance) => instance.url.includes("/api/v1/agent-plugins/events"))).toHaveLength(0)
-    expect(captured?.hotReloadEnabled).toBe(false)
+    await waitFor(() => expect(captured?.hotReloadEnabled).toBe(false))
   })
 
   it("keeps the chat shell in transition while remote sessions are still loading without an active session", () => {
@@ -340,7 +342,7 @@ describe("WorkspaceAgentFront", () => {
     expect(refresh).not.toHaveBeenCalled()
   })
 
-  it("renders a known active session while remote sessions are still loading", () => {
+  it("renders a known active session while remote sessions are still loading", async () => {
     const PendingChatPanel = (props: WorkspaceChatPanelProps) => (
       <div data-testid="chat-panel">Chat {props.sessionId} hydrate={String(props.hydrateMessages)}</div>
     )
@@ -362,11 +364,11 @@ describe("WorkspaceAgentFront", () => {
       />,
     )
 
-    expect(screen.getByTestId("chat-panel")).toHaveTextContent("Chat known-active hydrate=true")
+    expect(await screen.findByTestId("chat-panel")).toHaveTextContent("Chat known-active hydrate=true")
     expect(screen.queryByText("Loading sessions…")).not.toBeInTheDocument()
   })
 
-  it("renders the chat shell when remote sessions fail instead of pinning loading", () => {
+  it("renders the chat shell when remote sessions fail instead of pinning loading", async () => {
     const FailedChatPanel = (props: WorkspaceChatPanelProps) => (
       <div data-testid="chat-panel">Chat {props.sessionId} hydrate={String(props.hydrateMessages)}</div>
     )
@@ -388,7 +390,7 @@ describe("WorkspaceAgentFront", () => {
       />,
     )
 
-    expect(screen.getByTestId("chat-panel")).toHaveTextContent("Chat default hydrate=false")
+    expect(await screen.findByTestId("chat-panel")).toHaveTextContent("Chat default hydrate=false")
   })
 
   it("keeps session history closed by default and opens it from the rail button", async () => {

--- a/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
@@ -289,11 +289,15 @@ export function SurfaceShell({
   // illegal combinations like "hidden but source-open" and lets full-block
   // collapse restore the same active source (Files, Macro, …) on uncollapse.
   const [leftState, setLeftState] = useState<WorkbenchLeftState>(() => initialWorkbenchLeftState(storageKey, defaultLeftTab))
+  // Mobile workspace takeover (hideLevelOneHeader) is a full-bleed single pane:
+  // no level-one header, activity rail, or source pane should consume viewport
+  // width that belongs to the artifact surface.
+  const fullBleed = hideLevelOneHeader
   // The far-right activity rail is structural and never disappears on desktop.
   // Legacy "hidden" state now means rail-only; hostRailOnly additionally hides
   // the editor and source content while preserving that same rail.
   const leftBlockCollapsed = false
-  const sourcePaneOpen = !hostRailOnly && leftState.mode === "source"
+  const sourcePaneOpen = !hostRailOnly && !fullBleed && leftState.mode === "source"
   const activeLeftTab = leftState.activeTab
   const setActiveLeftTab = useCallback((tab: string) => {
     setLeftState((state) => setWorkbenchActiveTab(state, tab))
@@ -930,7 +934,6 @@ export function SurfaceShell({
   const workbenchRailWidth = 44
   const workbenchHeaderHeight = 44
   const workbenchSidebarWidth = sourcePaneOpen ? sidebarWidth : workbenchRailWidth
-
   return (
     <div
       ref={containerRef}
@@ -997,7 +1000,7 @@ export function SurfaceShell({
               allowedPanels={allowedPanels}
             />
           </div>
-          <EmptyWorkbenchOverlay api={api} />
+          <EmptyWorkbenchOverlay api={api} showFallbackBar={!hideLevelOneHeader} />
         </div>
 
         {sourcePaneOpen ? (
@@ -1029,14 +1032,17 @@ export function SurfaceShell({
           className={cn(
             "relative z-10 flex min-h-0 shrink-0 flex-col overflow-hidden border-l border-border",
             !hideLevelOneHeader && "mt-11",
+            fullBleed && "hidden",
           )}
           style={{
-            width: workbenchSidebarWidth,
-            minWidth: workbenchSidebarWidth,
-            maxWidth: workbenchSidebarWidth,
+            width: fullBleed ? 0 : workbenchSidebarWidth,
+            minWidth: fullBleed ? 0 : workbenchSidebarWidth,
+            maxWidth: fullBleed ? 0 : workbenchSidebarWidth,
             height: hideLevelOneHeader ? "100%" : `calc(100% - ${workbenchHeaderHeight}px)`,
           }}
           aria-label={hostRailOnly ? "Workbench activity rail" : "Workbench sources and activity rail"}
+          aria-hidden={fullBleed ? true : undefined}
+          inert={fullBleed ? true : undefined}
         >
           <WorkbenchLeftPane
             rootDir={rootDir}
@@ -1059,7 +1065,16 @@ export function SurfaceShell({
   )
 }
 
-function EmptyWorkbenchOverlay({ api }: { api: DockviewApi | null }) {
+function EmptyWorkbenchOverlay({
+  api,
+  showFallbackBar = true,
+}: {
+  api: DockviewApi | null
+  /** Desktop keeps an empty header-height strip so the top edge reads as chrome
+   * even with no tabs; on mobile takeover there is no header above, so the bar
+   * is pure dead space and the empty state can center without offset. */
+  showFallbackBar?: boolean
+}) {
   const [empty, setEmpty] = useState(true)
   useEffect(() => {
     if (!api) return
@@ -1076,11 +1091,13 @@ function EmptyWorkbenchOverlay({ api }: { api: DockviewApi | null }) {
   return (
     <>
       {/* Fallback top bar so icons are always visible even with no tabs */}
-      <div className="pointer-events-none absolute inset-x-0 top-0 flex items-center gap-0.5 border-b border-[color:oklch(from_var(--border)_l_c_h/0.4)] bg-background px-1" style={{ height: 44 }}>
-        <div className="flex-1" />
-      </div>
+      {showFallbackBar ? (
+        <div className="pointer-events-none absolute inset-x-0 top-0 flex items-center gap-0.5 border-b border-[color:oklch(from_var(--border)_l_c_h/0.4)] bg-background px-1" style={{ height: 44 }}>
+          <div className="flex-1" />
+        </div>
+      ) : null}
 
-      <div className="pointer-events-none absolute inset-0 flex flex-col items-start justify-center gap-2 px-6 pt-12 pb-10">
+      <div className={cn("pointer-events-none absolute inset-0 flex flex-col items-start justify-center gap-2 px-6 pb-10", showFallbackBar && "pt-12")}>
         <div className="flex items-center gap-2 text-[11px] font-medium tracking-tight text-muted-foreground/75">
           <span className="inline-block h-px w-3 bg-[color:var(--accent)]" aria-hidden="true" />
           Workbench

--- a/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
@@ -293,11 +293,23 @@ export function SurfaceShell({
   // no level-one header, activity rail, or source pane should consume viewport
   // width that belongs to the artifact surface.
   const fullBleed = hideLevelOneHeader
+  // …but the sources are still reachable on demand. In full-bleed the source
+  // pane is an explicit, session-scoped overlay: never restored from the
+  // persisted desktop `leftState` (which would steal the whole phone viewport
+  // on load), only opened when the user taps for it in this session.
+  const [fullBleedSourceOpen, setFullBleedSourceOpen] = useState(false)
   // The far-right activity rail is structural and never disappears on desktop.
   // Legacy "hidden" state now means rail-only; hostRailOnly additionally hides
   // the editor and source content while preserving that same rail.
   const leftBlockCollapsed = false
-  const sourcePaneOpen = !hostRailOnly && !fullBleed && leftState.mode === "source"
+  const sourcePaneOpen = !hostRailOnly && (fullBleed ? fullBleedSourceOpen : leftState.mode === "source")
+  // Full-bleed sources cover the artifact surface instead of splitting it —
+  // there is no room for a two-column split at phone widths.
+  const sourceOverlay = fullBleed && sourcePaneOpen
+  // Rail is only truly gone while the full-bleed source overlay is closed.
+  const railHidden = fullBleed && !sourcePaneOpen
+  const fullBleedRef = useRef(fullBleed)
+  fullBleedRef.current = fullBleed
   const activeLeftTab = leftState.activeTab
   const setActiveLeftTab = useCallback((tab: string) => {
     setLeftState((state) => setWorkbenchActiveTab(state, tab))
@@ -374,12 +386,17 @@ export function SurfaceShell({
   }, [])
 
   const openSourcePane = useCallback((tab?: string): void => {
-    setLeftState((state) => openWorkbenchSource(state, tab))
+    // In full-bleed the overlay is session-scoped truth: mirroring it into the
+    // persisted desktop `leftState` would leak mode:"source" to the next
+    // desktop load (the exact regression this split exists to prevent).
+    if (!fullBleedRef.current) setLeftState((state) => openWorkbenchSource(state, tab))
+    setFullBleedSourceOpen(true)
     onHostExpand?.()
   }, [onHostExpand])
 
   const closeSourcePane = useCallback((): void => {
-    setLeftState(showWorkbenchRail)
+    if (!fullBleedRef.current) setLeftState(showWorkbenchRail)
+    setFullBleedSourceOpen(false)
   }, [])
 
   const toggleHostWorkbench = useCallback((): void => {
@@ -402,6 +419,9 @@ export function SurfaceShell({
   const activateDockviewPanel = useCallback((config: OpenPanelConfig & { title: string }): boolean => {
     const api = apiRef.current
     if (!api) return false
+    // In full-bleed the source overlay covers the artifact surface, so opening
+    // anything from it must dismiss it — otherwise the tap looks like a no-op.
+    if (fullBleedRef.current) setFullBleedSourceOpen(false)
     const existing = api.getPanel(config.id)
     if (existing) {
       if (config.params) existing.api.updateParameters(config.params)
@@ -979,7 +999,7 @@ export function SurfaceShell({
 
       <div
         data-boring-workspace-part="workbench-body"
-        className="flex h-full min-h-0 w-full"
+        className={cn("flex h-full min-h-0 w-full", sourceOverlay && "relative")}
         style={{ height: "100%" }}
       >
         <div
@@ -993,6 +1013,9 @@ export function SurfaceShell({
             data-boring-state={sourcePaneOpen ? "expanded" : "rail"}
             className="workbench-dockview h-full"
             data-collapsed-sources={!sourcePaneOpen ? "true" : undefined}
+            // Full-bleed renders no WorkbenchHeaderActions, so the 72px gutter
+            // that reserves room for them is pure dead space on a phone.
+            data-full-bleed={fullBleed ? "true" : undefined}
           >
             <ArtifactSurfacePane
               storageKey={storageKey}
@@ -1000,10 +1023,14 @@ export function SurfaceShell({
               allowedPanels={allowedPanels}
             />
           </div>
-          <EmptyWorkbenchOverlay api={api} showFallbackBar={!hideLevelOneHeader} />
+          <EmptyWorkbenchOverlay
+            api={api}
+            showFallbackBar={!hideLevelOneHeader}
+            onOpenSources={openSourcePane}
+          />
         </div>
 
-        {sourcePaneOpen ? (
+        {sourcePaneOpen && !sourceOverlay ? (
           <div
             data-boring-workspace-part="workbench-source-resize"
             role="separator"
@@ -1032,33 +1059,40 @@ export function SurfaceShell({
           className={cn(
             "relative z-10 flex min-h-0 shrink-0 flex-col overflow-hidden border-l border-border",
             !hideLevelOneHeader && "mt-11",
-            fullBleed && "hidden",
+            railHidden && "hidden",
+            sourceOverlay && "absolute inset-0 z-30 border-l-0 bg-background",
           )}
           style={{
-            width: fullBleed ? 0 : workbenchSidebarWidth,
-            minWidth: fullBleed ? 0 : workbenchSidebarWidth,
-            maxWidth: fullBleed ? 0 : workbenchSidebarWidth,
+            width: railHidden ? 0 : sourceOverlay ? "100%" : workbenchSidebarWidth,
+            minWidth: railHidden ? 0 : sourceOverlay ? "100%" : workbenchSidebarWidth,
+            maxWidth: railHidden ? 0 : sourceOverlay ? "100%" : workbenchSidebarWidth,
             height: hideLevelOneHeader ? "100%" : `calc(100% - ${workbenchHeaderHeight}px)`,
           }}
           aria-label={hostRailOnly ? "Workbench activity rail" : "Workbench sources and activity rail"}
-          aria-hidden={fullBleed ? true : undefined}
-          inert={fullBleed ? true : undefined}
+          aria-hidden={railHidden ? true : undefined}
+          inert={railHidden ? true : undefined}
         >
-          <WorkbenchLeftPane
-            rootDir={rootDir}
-            bridge={bridge}
-            defaultTab={defaultLeftTab}
-            activeTab={activeLeftTab}
-            activePanelId={activeSurfacePanelId}
-            onActiveTabChange={setActiveLeftTab}
-            revealFileTreeRequest={fileTreeRevealRequest}
-            onOpenPanel={openPanelSync}
-            onReloadAgentPlugins={onReloadAgentPlugins}
-            onExpand={openSourcePane}
-            onCloseSourcePane={closeSourcePane}
-            railOnly={!sourcePaneOpen}
-            railSide="right"
-          />
+          {/* The hidden-rail state is display:none + inert; mounting the pane
+           * anyway would keep its registry subscription and debounce timer
+           * alive for zero visible pixels, so it unmounts instead. The aside
+           * shell stays so layout/a11y tests and the overlay CTA keep working. */}
+          {railHidden ? null : (
+            <WorkbenchLeftPane
+              rootDir={rootDir}
+              bridge={bridge}
+              defaultTab={defaultLeftTab}
+              activeTab={activeLeftTab}
+              activePanelId={activeSurfacePanelId}
+              onActiveTabChange={setActiveLeftTab}
+              revealFileTreeRequest={fileTreeRevealRequest}
+              onOpenPanel={openPanelSync}
+              onReloadAgentPlugins={onReloadAgentPlugins}
+              onExpand={openSourcePane}
+              onCloseSourcePane={closeSourcePane}
+              railOnly={!sourcePaneOpen}
+              railSide="right"
+            />
+          )}
         </aside>
       </div>
     </div>
@@ -1068,12 +1102,16 @@ export function SurfaceShell({
 function EmptyWorkbenchOverlay({
   api,
   showFallbackBar = true,
+  onOpenSources,
 }: {
   api: DockviewApi | null
   /** Desktop keeps an empty header-height strip so the top edge reads as chrome
    * even with no tabs; on mobile takeover there is no header above, so the bar
    * is pure dead space and the empty state can center without offset. */
   showFallbackBar?: boolean
+  /** Compact (mobile takeover) only: the empty state is the whole screen, so it
+   * owns the primary action instead of describing chrome that isn't rendered. */
+  onOpenSources?: () => void
 }) {
   const [empty, setEmpty] = useState(true)
   useEffect(() => {
@@ -1088,6 +1126,7 @@ function EmptyWorkbenchOverlay({
     }
   }, [api])
   if (!empty) return null
+  const compact = !showFallbackBar
   return (
     <>
       {/* Fallback top bar so icons are always visible even with no tabs */}
@@ -1097,16 +1136,47 @@ function EmptyWorkbenchOverlay({
         </div>
       ) : null}
 
-      <div className={cn("pointer-events-none absolute inset-0 flex flex-col items-start justify-center gap-2 px-6 pb-10", showFallbackBar && "pt-12")}>
-        <div className="flex items-center gap-2 text-[11px] font-medium tracking-tight text-muted-foreground/75">
+      <div
+        data-testid="empty-workbench"
+        className={cn(
+          "pointer-events-none absolute inset-0 flex flex-col justify-center gap-2",
+          // Compact: the block is the entire screen, so it centers and uses the
+          // same 16px gutter as the mobile bars/composer instead of the 24px
+          // desktop gutter, with no header above to counterweight.
+          compact ? "items-center px-4 text-center" : "items-start px-6 pb-10",
+          showFallbackBar && "pt-12",
+        )}
+      >
+        <div
+          className={cn(
+            "flex items-center gap-2 text-[11px] font-medium text-foreground/70",
+            compact ? "uppercase tracking-wide" : "tracking-tight",
+          )}
+        >
           <span className="inline-block h-px w-3 bg-[color:var(--accent)]" aria-hidden="true" />
           Workbench
         </div>
         <div className="text-[15px] font-medium tracking-tight text-foreground">Nothing open yet</div>
-        <p className="max-w-[280px] text-[12.5px] leading-relaxed text-muted-foreground/85">
-          Open a source item, or let the agent produce an artifact here.
-        </p>
-
+        {compact ? (
+          <>
+            <p className="max-w-[280px] text-sm leading-relaxed text-muted-foreground">
+              Browse the workspace sources to open a file, or ask the agent to produce an artifact here.
+            </p>
+            <button
+              type="button"
+              data-testid="empty-workbench-cta"
+              onClick={() => onOpenSources?.()}
+              className="pointer-events-auto mt-2 flex min-h-11 w-full max-w-[280px] items-center justify-center gap-2 rounded-lg border border-border bg-card px-4 text-sm font-medium text-foreground transition-colors active:bg-muted"
+            >
+              <PanelRightOpen className="size-4" strokeWidth={1.75} aria-hidden="true" />
+              Browse sources
+            </button>
+          </>
+        ) : (
+          <p className="max-w-[280px] text-[12.5px] leading-relaxed text-muted-foreground">
+            Open a source item, or let the agent produce an artifact here.
+          </p>
+        )}
       </div>
     </>
   )

--- a/packages/workspace/src/front/chrome/artifact-surface/__tests__/SurfaceShell.test.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/__tests__/SurfaceShell.test.tsx
@@ -140,6 +140,23 @@ describe("SurfaceShell", () => {
     expect(screen.getByRole("button", { name: "Close workbench" })).toBeInTheDocument()
   })
 
+  it("hides the pinned activity rail and empty header strip on mobile full-bleed takeover", () => {
+    renderSurface("workspace-a", { hideLevelOneHeader: true })
+
+    const shell = screen.getByTestId("surface-shell")
+    const header = shell.querySelector('[data-boring-workspace-part="workbench-level-one-header"]')
+    const rail = shell.querySelector<HTMLElement>('[data-boring-workspace-part="surface-sidebar"]')
+
+    // No level-one header is rendered at all.
+    expect(header).toBeNull()
+    // The collapsed rail collapses to nothing so the workbench content spans
+    // the full viewport width instead of leaving a dead icon sliver.
+    expect(rail).not.toBeNull()
+    expect(rail).toHaveStyle({ width: "0px" })
+    expect(rail).toHaveClass("hidden")
+    expect(rail).toHaveAttribute("aria-hidden", "true")
+  })
+
   it("lets the collapsed activity rail fill the host and reopen the Workbench", () => {
     const onHostExpand = vi.fn()
     renderSurface("workspace-a", { hostRailOnly: true, onHostExpand })
@@ -153,6 +170,10 @@ describe("SurfaceShell", () => {
     expect(body).toHaveStyle({ height: "100%" })
     expect(rail).toHaveStyle({ height: "calc(100% - 44px)" })
     expect(rail).toHaveAttribute("data-boring-state", "host-collapsed")
+    // The desktop rail remains an interactive source/page launcher even while
+    // the editor body is collapsed; only the mobile full-bleed takeover is inert.
+    expect(rail).not.toHaveAttribute("aria-hidden")
+    expect(rail).not.toHaveAttribute("inert")
     expect(rail).toHaveClass("border-border")
     expect(rail?.parentElement).toBe(body)
     expect(header).toHaveClass("border-border")

--- a/packages/workspace/src/front/chrome/artifact-surface/__tests__/SurfaceShell.test.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/__tests__/SurfaceShell.test.tsx
@@ -157,6 +157,60 @@ describe("SurfaceShell", () => {
     expect(rail).toHaveAttribute("aria-hidden", "true")
   })
 
+  it("gives the compact empty workbench a real tap target that opens the sources", () => {
+    renderSurface("workspace-a", { hideLevelOneHeader: true })
+
+    const shell = screen.getByTestId("surface-shell")
+    const emptyState = screen.getByTestId("empty-workbench")
+    const cta = screen.getByTestId("empty-workbench-cta")
+
+    // The overlay stays inert, but the one action on it must be tappable.
+    expect(emptyState).toHaveClass("pointer-events-none")
+    expect(cta).toHaveClass("pointer-events-auto")
+    expect(cta).toHaveClass("min-h-11")
+    expect(emptyState).toHaveClass("items-center", "text-center", "px-4")
+    expect(emptyState).not.toHaveClass("pb-10")
+    // Copy must not name affordances the takeover removed.
+    expect(emptyState.textContent).not.toContain("Open a source item")
+
+    const rail = shell.querySelector<HTMLElement>('[data-boring-workspace-part="surface-sidebar"]')
+    expect(rail).toHaveAttribute("aria-hidden", "true")
+
+    fireEvent.click(cta)
+
+    // Sources take over the whole surface rather than splitting a phone width.
+    expect(rail).not.toHaveAttribute("aria-hidden")
+    expect(rail).not.toHaveAttribute("inert")
+    expect(rail).not.toHaveClass("hidden")
+    expect(rail).toHaveClass("absolute", "inset-0")
+    expect(rail).toHaveStyle({ width: "100%" })
+    expect(capturedWorkbenchProps.railOnly).toBe(false)
+    // No drag handle: there is no split to resize.
+    expect(shell.querySelector('[data-boring-workspace-part="workbench-source-resize"]')).toBeNull()
+  })
+
+  it("keeps the desktop empty workbench free of the compact call to action", () => {
+    renderSurface("workspace-a")
+
+    const emptyState = screen.getByTestId("empty-workbench")
+    expect(screen.queryByTestId("empty-workbench-cta")).toBeNull()
+    expect(emptyState).toHaveClass("items-start", "px-6", "pb-10")
+    expect(emptyState.textContent).toContain("Open a source item")
+  })
+
+  it("only reserves the header-actions gutter on the dockview strip when a header is rendered", () => {
+    const { unmount } = renderSurface("workspace-a")
+    const tabs = () =>
+      screen.getByTestId("surface-shell").querySelector('[data-boring-workspace-part="surface-tabs"]')
+
+    expect(tabs()).toHaveClass("workbench-dockview")
+    expect(tabs()).not.toHaveAttribute("data-full-bleed")
+    unmount()
+
+    renderSurface("workspace-a", { hideLevelOneHeader: true })
+    expect(tabs()).toHaveAttribute("data-full-bleed", "true")
+  })
+
   it("lets the collapsed activity rail fill the host and reopen the Workbench", () => {
     const onHostExpand = vi.fn()
     renderSurface("workspace-a", { hostRailOnly: true, onHostExpand })

--- a/packages/workspace/src/front/chrome/management/ManagementOverlaySurface.tsx
+++ b/packages/workspace/src/front/chrome/management/ManagementOverlaySurface.tsx
@@ -40,7 +40,10 @@ export function ManagementOverlaySurface({
     >
       <header className={cn(
         "flex h-12 shrink-0 items-center justify-between border-b border-border/60",
-        headerInsetStart ? "pl-12" : "pl-4",
+        // Same token as the mobile bars (front/layout/mobileShell.tsx): both
+        // reserve the leading gutter for the SAME floating app-left control, so
+        // they must not each guess a different number.
+        headerInsetStart ? "pl-[var(--mobile-header-inset-start,3.25rem)]" : "pl-4",
         headerInsetEnd ? "pr-16" : "pr-4",
       )}>
         <div className="flex min-w-0 flex-1 items-center gap-2">

--- a/packages/workspace/src/front/components/CommandPalette.tsx
+++ b/packages/workspace/src/front/components/CommandPalette.tsx
@@ -153,9 +153,12 @@ export function CommandPalette({ sessionSearch }: CommandPaletteProps = {}) {
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
+      {/* Fit the dialog to its content (capped) instead of a fixed 520px: on
+          phones a half-empty fixed-height dialog reads as a broken screen.
+          Desktop keeps the same 520px ceiling. */}
       <DialogContent
         className="cmdk-shell flex flex-col gap-0 overflow-hidden border-border/60 bg-background p-0 shadow-none backdrop-blur-0 [&>button.dialog-close]:hidden"
-        style={{ height: "min(520px, calc(100dvh - 2rem))", width: "min(640px, calc(100vw - 2rem))", maxWidth: 640 }}
+        style={{ maxHeight: "min(520px, calc(100dvh - 2rem))", width: "min(640px, calc(100vw - 2rem))", maxWidth: 640 }}
         showCloseButton={false}
         onPointerDownOutside={() => setOpen(false)}
         onEscapeKeyDown={() => setOpen(false)}

--- a/packages/workspace/src/front/components/CommandPalette.tsx
+++ b/packages/workspace/src/front/components/CommandPalette.tsx
@@ -155,10 +155,21 @@ export function CommandPalette({ sessionSearch }: CommandPaletteProps = {}) {
     <Dialog open={open} onOpenChange={setOpen}>
       {/* Fit the dialog to its content (capped) instead of a fixed 520px: on
           phones a half-empty fixed-height dialog reads as a broken screen.
-          Desktop keeps the same 520px ceiling. */}
+          Desktop keeps the same 520px ceiling.
+
+          The height budget subtracts the safe-area top and the software
+          keyboard: `100dvh` tracks browser chrome but NOT the keyboard, so a
+          keyboard-aware cap is the only way the footer stays reachable while
+          the user is typing. `--keyboard-inset` is published on <html> by the
+          host app and defaults to 0px, so this is inert where it is unset. */}
       <DialogContent
         className="cmdk-shell flex flex-col gap-0 overflow-hidden border-border/60 bg-background p-0 shadow-none backdrop-blur-0 [&>button.dialog-close]:hidden"
-        style={{ maxHeight: "min(520px, calc(100dvh - 2rem))", width: "min(640px, calc(100vw - 2rem))", maxWidth: 640 }}
+        style={{
+          maxHeight:
+            "min(520px, calc(100dvh - 2rem - var(--sa-top, env(safe-area-inset-top, 0px)) - var(--keyboard-inset, 0px)))",
+          width: "min(640px, calc(100vw - 2rem))",
+          maxWidth: 640,
+        }}
         showCloseButton={false}
         onPointerDownOutside={() => setOpen(false)}
         onEscapeKeyDown={() => setOpen(false)}
@@ -181,8 +192,12 @@ export function CommandPalette({ sessionSearch }: CommandPaletteProps = {}) {
             loading={isCatalogMode && catalogGroups.some((group) => group.loading)}
           />
 
+          {/* The compact floor keeps the shell from collapsing between
+              keystrokes. The dialog is content-sized, so a query that cuts
+              eight rows down to one would otherwise shrink the palette
+              mid-typing and drag the input out from under the user's finger. */}
           <CommandList
-            className="min-h-0 flex-1 overflow-y-auto py-1"
+            className="min-h-[12rem] flex-1 overflow-y-auto py-1 sm:min-h-0"
             style={{ maxHeight: "none" }}
           >
             <CommandEmpty className="py-10 text-center text-sm text-muted-foreground">
@@ -255,13 +270,18 @@ function PaletteSearchHeader({
        * reported as a "strange border".
        *
        * Mode switcher sits inline ahead of the input on wide viewports.
-       * The input wraps to its own full-width row when space is narrow.
+       *
+       * Below `sm:` the two controls cannot share a 358px row, and letting
+       * flex-wrap decide demoted the SEARCH FIELD to the second row — the
+       * palette opened on a row of tabs. So compact ordering is explicit
+       * instead of emergent: the input takes the first full-width row and the
+       * mode switcher becomes a full-width segmented strip underneath it.
        */}
-      <div className="command-palette-search-layout relative flex flex-wrap items-stretch [&>[data-slot=command-input-wrapper]]:h-auto [&>[data-slot=command-input-wrapper]]:min-w-[15rem] [&>[data-slot=command-input-wrapper]]:flex-1">
+      <div className="command-palette-search-layout relative flex flex-wrap items-stretch max-sm:border-b max-sm:border-border/60 [&>[data-slot=command-input-wrapper]]:order-first [&>[data-slot=command-input-wrapper]]:h-auto [&>[data-slot=command-input-wrapper]]:basis-full sm:[&>[data-slot=command-input-wrapper]]:order-none sm:[&>[data-slot=command-input-wrapper]]:min-w-[15rem] sm:[&>[data-slot=command-input-wrapper]]:flex-1 sm:[&>[data-slot=command-input-wrapper]]:basis-auto">
         <div
           role="group"
           aria-label="Palette mode"
-          className="my-2 ml-3 inline-flex shrink-0 self-center rounded-md border border-border/60 bg-muted/40 p-0.5"
+          className="mx-3 mt-2 mb-2 inline-flex basis-full justify-center self-center rounded-md border border-border/60 bg-muted/40 p-0.5 sm:my-2 sm:mr-0 sm:mb-0 sm:ml-3 sm:basis-auto sm:shrink-0 sm:justify-start"
         >
           {hasChatMode ? (
             <ModeButton
@@ -583,14 +603,17 @@ function ModeButton({
       aria-pressed={active}
       onClick={onClick}
       className={[
-        "command-palette-mode-button h-7 gap-1.5 px-2 text-xs font-medium",
+        "command-palette-mode-button h-7 gap-1.5 px-2 text-xs font-medium max-sm:flex-1",
         active
           ? "bg-background text-foreground shadow-sm"
           : "text-muted-foreground hover:text-foreground",
       ].join(" ")}
     >
       {icon}
-      {label}
+      {/* Icon-only below `sm:` so three buttons plus the 44px coarse-pointer
+          minimum still fit one row. `sr-only` (not `hidden`) keeps the
+          accessible name — an icon-only control still has to announce. */}
+      <span className="sr-only sm:not-sr-only">{label}</span>
     </Button>
   )
 }

--- a/packages/workspace/src/front/components/WorkspaceLoadingState.tsx
+++ b/packages/workspace/src/front/components/WorkspaceLoadingState.tsx
@@ -96,7 +96,9 @@ export function WorkspaceLoadingState({
       data-boring-workspace-part="workspace-loading-shell"
       className={cn(
         "flex h-full w-full flex-col bg-background text-foreground",
-        fullscreen ? "min-h-screen" : "min-h-[240px]",
+        // dvh rather than `min-h-screen` (100vh): on mobile the large viewport
+        // is taller than what is visible, so the skeleton overflows the fold.
+        fullscreen ? "min-h-[100dvh]" : "min-h-[240px]",
         className,
       )}
     >

--- a/packages/workspace/src/front/components/__tests__/CommandPalette.test.tsx
+++ b/packages/workspace/src/front/components/__tests__/CommandPalette.test.tsx
@@ -640,6 +640,69 @@ describe("CommandPalette", () => {
     })
   })
 
+  describe("responsive layout", () => {
+    async function openPalette() {
+      render(<CommandPalette />, { wrapper: createWrapper() })
+      fireKeydown("p", { metaKey: true })
+      await waitFor(() => {
+        expect(screen.getByRole("dialog")).toBeInTheDocument()
+      })
+    }
+
+    function getSearchLayout(): HTMLElement {
+      const layout = document.querySelector(".command-palette-search-layout")
+      if (!(layout instanceof HTMLElement)) throw new Error("search layout not rendered")
+      return layout
+    }
+
+    it("puts the input ahead of the mode switcher on compact viewports only", async () => {
+      await openPalette()
+      const layout = getSearchLayout()
+      const wrapper = layout.querySelector("[data-slot=command-input-wrapper]")
+      expect(wrapper).toBeInTheDocument()
+
+      // jsdom has no layout engine, so the compact ordering is asserted through
+      // the responsive utilities that produce it: the input claims the first
+      // full-width row below `sm:` and returns to the inline row above it.
+      expect(layout.className).toContain("[&>[data-slot=command-input-wrapper]]:order-first")
+      expect(layout.className).toContain("[&>[data-slot=command-input-wrapper]]:basis-full")
+      expect(layout.className).toContain("sm:[&>[data-slot=command-input-wrapper]]:order-none")
+      expect(layout.className).toContain("sm:[&>[data-slot=command-input-wrapper]]:basis-auto")
+      // The 15rem input floor is what forced the wrap; it must not apply compact.
+      expect(layout.className).not.toContain(" [&>[data-slot=command-input-wrapper]]:min-w-[15rem]")
+      expect(layout.className).toContain("sm:[&>[data-slot=command-input-wrapper]]:min-w-[15rem]")
+
+      const modeGroup = screen.getByRole("group", { name: "Palette mode" })
+      expect(modeGroup.className).toContain("basis-full")
+      expect(modeGroup.className).toContain("sm:basis-auto")
+    })
+
+    it("keeps mode button accessible names when the labels are visually hidden", async () => {
+      await openPalette()
+      for (const name of ["Sources", "Commands"]) {
+        const button = screen.getByRole("button", { name })
+        const label = button.querySelector("span.sr-only")
+        expect(label).not.toBeNull()
+        expect(label).toHaveTextContent(name)
+        // `sr-only`, not `hidden`: the name must survive the icon-only layout.
+        expect(label?.className).toContain("sm:not-sr-only")
+      }
+    })
+
+    it("caps the dialog height against the safe area and the software keyboard", async () => {
+      await openPalette()
+      const maxHeight = screen.getByRole("dialog").getAttribute("style") ?? ""
+      expect(maxHeight).toContain("100dvh")
+      expect(maxHeight).toContain("var(--keyboard-inset, 0px)")
+      expect(maxHeight).toContain("var(--sa-top, env(safe-area-inset-top, 0px))")
+    })
+
+    it("keeps the palette input at 16px so iOS does not zoom on focus", async () => {
+      await openPalette()
+      expect(getPaletteInput().className).toContain("text-base")
+    })
+  })
+
   describe("recent items", () => {
     it("saves selected catalog rows as RecentEntry with type catalog", async () => {
       const user = userEvent.setup()

--- a/packages/workspace/src/front/detached/DetachedPanelPopover.tsx
+++ b/packages/workspace/src/front/detached/DetachedPanelPopover.tsx
@@ -21,12 +21,14 @@ export function DetachedPanelPopover({
   return (
     <div
       data-boring-workspace-part="detached-panel-popover"
-      className="absolute z-[120] flex max-h-[calc(100vh-2rem)] max-w-[calc(100vw-2rem)] flex-col overflow-hidden rounded-2xl border border-border/70 bg-background shadow-2xl"
+      className="absolute z-[120] flex max-h-[calc(100dvh-2rem)] max-w-[calc(100vw-2rem)] flex-col overflow-hidden rounded-2xl border border-border/70 bg-background shadow-2xl"
       style={{
         left: position.left,
         top: position.top,
         width: `min(${resolvedSize.width}px, calc(100vw - 2rem))`,
-        height: `min(${resolvedSize.height}px, calc(100vh - 2rem))`,
+        // dvh: `100vh` is the large viewport on mobile, so a popover clamped to
+        // it still runs ~60px past the visible area while the URL bar shows.
+        height: `min(${resolvedSize.height}px, calc(100dvh - 2rem))`,
       }}
       role="dialog"
       aria-label={ariaLabel}

--- a/packages/workspace/src/front/dock/dockview-overrides.css
+++ b/packages/workspace/src/front/dock/dockview-overrides.css
@@ -56,14 +56,6 @@
   height: 44px !important;
 }
 
-/* When the full left block is collapsed, the icon rail disappears. Reserve
-   header-only space for the overlaid "Show workspace menu" button so it does
-   not sit on top of the first dockview tab. This is not a full-height column. */
-.workbench-dockview[data-left-block-collapsed="true"] .dv-tabs-and-actions-container,
-.workbench-dockview[data-left-block-collapsed="true"] .tabs-and-actions-container {
-  padding-left: 44px !important;
-}
-
 /* The app shell renders fixed top-right workbench/full-workspace controls
    over this 44px tab strip. Reserve enough room so dockview's built-in open-tabs
    overflow trigger sits left of that chrome instead of underneath it.
@@ -72,6 +64,27 @@
 .workbench-dockview .dv-tabs-and-actions-container,
 .workbench-dockview .tabs-and-actions-container {
   padding-right: 72px !important;
+}
+
+/* Mobile full-bleed takeover renders no WorkbenchHeaderActions, so nothing is
+   overlaid on the right edge of the strip. Reclaim the 72px gutter — on a 390px
+   viewport it was 18% of the width reserved for controls that aren't there. */
+.workbench-dockview[data-full-bleed="true"] .dv-tabs-and-actions-container,
+.workbench-dockview[data-full-bleed="true"] .tabs-and-actions-container {
+  padding-right: 8px !important;
+}
+
+/* At phone widths the tab strip is the only navigation chrome left, so tabs
+   share the row instead of hitting the 120px floor and overflowing after two. */
+@media (max-width: 639px) {
+  .workbench-dockview .dv-shell .dv-tab,
+  .workbench-dockview .dv-shell .tab,
+  .workbench-dockview.dv-shell .dv-tab,
+  .workbench-dockview.dv-shell .tab {
+    min-width: 0;
+    max-width: 60vw;
+    flex: 1 1 0;
+  }
 }
 
 /* Tab base — pill-style, rounded top */

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -139,8 +139,12 @@ export function ChatLayout(props: ChatLayoutProps) {
   )
   const commandRegistry = useCommandRegistry()
   const mobileShell = props.mobileShellEnabled === true && isCompactViewport(viewport)
-  const effectiveNavWidth = mobileShell ? Math.min(Math.max(280, Math.floor(viewport * 0.86)), 360) : clamp(navWidth, 200, 360)
-  const effectiveSidebarWidth = mobileShell ? viewport : clamp(sidebarWidth, 200, Math.max(240, Math.floor(viewport * 0.5)))
+  // Desktop-only widths. The mobile drawers are `absolute` boxes pinned by
+  // their insets, so they size themselves from the real containing block —
+  // measuring `window.innerWidth` in JS instead both fought the right inset and
+  // hard-floored the nav drawer at 280px, overflowing any narrower host.
+  const effectiveNavWidth = clamp(navWidth, 200, 360)
+  const effectiveSidebarWidth = clamp(sidebarWidth, 200, Math.max(240, Math.floor(viewport * 0.5)))
   const surfaceMax = mobileShell ? viewport : Math.max(480, Math.floor(viewport * 0.72))
   const effectiveSurfaceWidth = mobileShell ? viewport : clamp(surfaceWidth, 480, surfaceMax)
   const uiSurface = getFunction<() => SurfaceShellApi | null>(props.centerParams, "getSurface")
@@ -189,6 +193,11 @@ export function ChatLayout(props: ChatLayoutProps) {
     if (chatCollapsed) setChatCollapsed(false)
     closeSurface?.()
   }, [chatCollapsed, closeSurface, setChatCollapsed])
+  // Hoisted so ChatPaneStageDock's memoized StageContext value (which captures
+  // renderPane) stays stable across ChatLayout re-renders.
+  const renderChatPane = useCallback((pane: { panel?: string; params?: Record<string, unknown> }) => (
+    <PanelSlot id={pane.panel ?? centerId} params={pane.params ?? props.centerParams} />
+  ), [centerId, props.centerParams])
   const toggleSurface = useCallback(() => {
     if (surfaceOpen) {
       collapseWorkbench()
@@ -226,6 +235,19 @@ export function ChatLayout(props: ChatLayoutProps) {
     })
     setChatRailPulse(false)
   }, [chatCollapsed, props.chatOverlay, props.onOpenSurface, setChatCollapsed, surfaceOpen])
+
+  // Identity-stable workbench PanelSlot params: a fresh object literal here
+  // would re-render the whole surface pane on every ChatLayout render.
+  const fullBleedSurfaceParams = useMemo(() => ({ ...props.surfaceParams, hideLevelOneHeader: true }), [props.surfaceParams])
+  const railOnlySurfaceParams = useMemo(() => ({
+    ...props.surfaceParams,
+    hostRailOnly: !surfaceOpen,
+    showCloseAction: true,
+    onClose: collapseWorkbench,
+    onHostExpand: openWorkbenchSplit,
+    hostFullscreen: chatCollapsed,
+    onHostToggleFullscreen: toggleChatCollapsed,
+  }), [props.surfaceParams, surfaceOpen, collapseWorkbench, openWorkbenchSplit, chatCollapsed, toggleChatCollapsed])
 
   useKeyboardShortcuts({
     shortcuts: useMemo(() => {
@@ -448,14 +470,25 @@ export function ChatLayout(props: ChatLayoutProps) {
         aria-modal={navIsTopDrawer}
         tabIndex={-1}
         className={cn(
-          mobileShell ? "absolute inset-y-0 left-0 z-50 h-full shadow-2xl" : "relative h-full shrink-0",
           "min-h-0 overflow-hidden bg-background",
-          "transition-[width,min-width,max-width] duration-[280ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
+          mobileShell
+            // Compact: a sheet. `inset-y-0 left-0` + a CSS width places it, and
+            // it slides on `transform` — animating `width` here relaid out the
+            // whole viewport every frame for 280ms.
+            ? cn(
+                "absolute inset-y-0 left-0 z-50 h-full w-[min(86%,360px)] shadow-2xl",
+                "transition-transform duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
+                navOpen ? "translate-x-0" : "-translate-x-full",
+              )
+            : cn(
+                "relative h-full shrink-0",
+                "transition-[width,min-width,max-width] duration-[280ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
+              ),
           navOpen
             ? "border-r border-[color:oklch(from_var(--border)_l_c_h/0.6)]"
             : "pointer-events-none z-0",
         )}
-        style={{
+        style={mobileShell ? undefined : {
           width: navOpen ? effectiveNavWidth : 0,
           minWidth: navOpen ? effectiveNavWidth : 0,
           maxWidth: navOpen ? effectiveNavWidth : 0,
@@ -465,6 +498,11 @@ export function ChatLayout(props: ChatLayoutProps) {
         <div
           className={cn(
             "h-full min-h-0 overflow-hidden",
+            // Full-bleed on a phone means the last session row would sit under
+            // the home indicator / rounded corners without these. The keyboard
+            // inset matters on iOS, where the layout viewport never shrinks:
+            // without it the drawer's bottom rows hide behind the keyboard.
+            mobileShell && "pb-[calc(var(--sa-bottom,0px)+var(--keyboard-inset,0px))] pl-[var(--sa-left,0px)]",
             "transition-opacity duration-[200ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
             navOpen ? "opacity-100" : "invisible pointer-events-none opacity-0",
           )}
@@ -490,12 +528,20 @@ export function ChatLayout(props: ChatLayoutProps) {
         aria-modal={sidebarIsTopDrawer}
         tabIndex={-1}
         className={cn(
-          mobileShell ? "absolute inset-0 z-40 h-full" : "relative h-full shrink-0",
           "min-h-0 overflow-hidden bg-background",
-          "transition-[width,min-width,max-width] duration-[280ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
+          mobileShell
+            ? cn(
+                "absolute inset-0 z-40 h-full",
+                "transition-transform duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
+                sidebarOpen ? "translate-x-0" : "-translate-x-full pointer-events-none",
+              )
+            : cn(
+                "relative h-full shrink-0",
+                "transition-[width,min-width,max-width] duration-[280ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
+              ),
           sidebarOpen && "border-r border-[color:oklch(from_var(--border)_l_c_h/0.6)]",
         )}
-        style={{
+        style={mobileShell ? undefined : {
           width: sidebarOpen ? effectiveSidebarWidth : 0,
           minWidth: sidebarOpen ? effectiveSidebarWidth : 0,
           maxWidth: sidebarOpen ? effectiveSidebarWidth : 0,
@@ -505,6 +551,7 @@ export function ChatLayout(props: ChatLayoutProps) {
         <div
           className={cn(
             "h-full min-h-0 overflow-hidden",
+            mobileShell && "pb-[calc(var(--sa-bottom,0px)+var(--keyboard-inset,0px))] pl-[var(--sa-left,0px)] pr-[var(--sa-right,0px)]",
             "transition-opacity duration-[200ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
             sidebarOpen ? "opacity-100" : "opacity-0",
           )}
@@ -531,21 +578,32 @@ export function ChatLayout(props: ChatLayoutProps) {
             // z-index 999) so the chat-left overlay can stack above them
             // without escaping into page-level chrome.
             "relative isolate h-full min-h-0 min-w-0 overflow-hidden bg-background",
-            mobileShell && !chatHidden && "flex flex-col",
-            // Animate flex-grow (not just width) so the chat slides open/closed
-            // like the fixed-width nav/workbench panes instead of snapping.
-            "transition-[flex-grow,flex-basis,width,min-width,max-width] duration-[280ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
-            chatHidden
-              ? "min-w-0 flex-[0_0_0px]"
-              : "flex-1 border-r border-[color:oklch(from_var(--border)_l_c_h/0.6)]",
+            mobileShell
+              // Compact: the workbench takes over as an `inset-0` overlay above
+              // this stage, so there is nothing to resize — no layout-property
+              // animation of a full-viewport element.
+              ? "flex min-w-0 flex-1 flex-col"
+              : cn(
+                  // Animate flex-grow (not just width) so the chat slides
+                  // open/closed like the fixed-width nav/workbench panes
+                  // instead of snapping.
+                  "transition-[flex-grow,flex-basis,width,min-width,max-width] duration-[280ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
+                  chatHidden
+                    ? "min-w-0 flex-[0_0_0px]"
+                    : "flex-1 border-r border-[color:oklch(from_var(--border)_l_c_h/0.6)]",
+                ),
           )}
         >
           {mobileShell && !chatHidden ? (
             <MobileChatBar
+              pane={activeMobileChatPane}
+              totalPanes={chatPanes.length}
               canOpenNav={Boolean(props.onOpenNav)}
               canOpenWorkspace={canControlSurface}
               onOpenNav={props.onOpenNav}
               onOpenWorkspace={toggleSurface}
+              actions={props.chatTopActions}
+              onClosePane={props.onCloseChatPane}
             />
           ) : null}
           <div
@@ -558,15 +616,7 @@ export function ChatLayout(props: ChatLayoutProps) {
             {hasChatPanes && mobileShell && activeMobileChatPane ? (
               <MobileSingleChatPane
                 pane={activeMobileChatPane}
-                totalPanes={chatPanes.length}
-                topActions={props.chatTopActions}
-                onClosePane={props.onCloseChatPane}
-                renderPane={(pane) => (
-                  <PanelSlot
-                    id={pane.panel ?? centerId}
-                    params={pane.params ?? props.centerParams}
-                  />
-                )}
+                renderPane={renderChatPane}
               />
             ) : hasChatPanes ? (
               <ChatPaneStage
@@ -583,12 +633,7 @@ export function ChatLayout(props: ChatLayoutProps) {
                 flashPaneId={props.flashChatPaneId}
                 storageKey={props.storageKey}
                 onDropSession={props.onDropChatSession}
-                renderPane={(pane) => (
-                  <PanelSlot
-                    id={pane.panel ?? centerId}
-                    params={pane.params ?? props.centerParams}
-                  />
-                )}
+                renderPane={renderChatPane}
               />
             ) : (
               <PanelSlot id={centerId} params={props.centerParams} />
@@ -604,22 +649,36 @@ export function ChatLayout(props: ChatLayoutProps) {
             aria-label={surfaceOpen ? "Workbench" : "Workbench activity rail"}
             aria-hidden={mobileShell && !surfaceOpen}
             className={cn(
-              mobileShell ? "absolute inset-0 z-40" : "relative",
               "h-full min-h-0 overflow-hidden bg-background",
-              // Collapsed/mobile workbench fills available width; otherwise it is a side panel.
-              (chatCollapsed || mobileWorkspaceOpen) && surfaceOpen ? "min-w-0 flex-1" : "shrink-0",
-              "transition-[flex-grow,flex-basis,width,min-width,max-width] duration-[280ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
-              !mobileShell && surfaceOpen && "border-l border-border",
+              mobileShell
+                // Compact: an `inset-0` sheet that slides in on `transform`.
+                // It is the full viewport, so animating its width repainted and
+                // relaid out every pixel on screen — dockview grid included —
+                // for 280ms on every open/close.
+                ? cn(
+                    "absolute inset-0 z-40",
+                    "transition-transform duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
+                    surfaceOpen ? "translate-x-0" : "pointer-events-none translate-x-full",
+                  )
+                : cn(
+                    "relative",
+                    // Collapsed workbench fills available width; otherwise it is a side panel.
+                    chatCollapsed && surfaceOpen ? "min-w-0 flex-1" : "shrink-0",
+                    "transition-[flex-grow,flex-basis,width,min-width,max-width] duration-[280ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
+                    surfaceOpen && "border-l border-border",
+                  ),
             )}
             style={
-              (chatCollapsed || mobileWorkspaceOpen) && surfaceOpen
-                ? { width: "auto", minWidth: 0, maxWidth: "none", flex: "1 1 0%", willChange: "width" }
-                : {
-                    width: surfaceOpen ? effectiveSurfaceWidth : mobileShell ? 0 : 44,
-                    minWidth: surfaceOpen ? effectiveSurfaceWidth : mobileShell ? 0 : 44,
-                    maxWidth: surfaceOpen ? effectiveSurfaceWidth : mobileShell ? 0 : 44,
-                    willChange: "width",
-                  }
+              mobileShell
+                ? undefined
+                : chatCollapsed && surfaceOpen
+                  ? { width: "auto", minWidth: 0, maxWidth: "none", flex: "1 1 0%", willChange: "width" }
+                  : {
+                      width: surfaceOpen ? effectiveSurfaceWidth : 44,
+                      minWidth: surfaceOpen ? effectiveSurfaceWidth : 44,
+                      maxWidth: surfaceOpen ? effectiveSurfaceWidth : 44,
+                      willChange: "width",
+                    }
             }
           >
             <div
@@ -632,14 +691,21 @@ export function ChatLayout(props: ChatLayoutProps) {
               {mobileWorkspaceOpen ? (
                 <div className="flex h-full min-h-0 flex-col">
                   <MobileWorkspaceBar onBack={focusChat} />
-                  <div className="min-h-0 flex-1 overflow-hidden">
+                  {/* The takeover is full-bleed, which is exactly what puts the
+                      last row of a tree/diff under the home indicator and the
+                      edges under the rounded corners. Padding (not
+                      `scroll-padding-bottom`) because the scroll containers are
+                      nested inside arbitrary panels this level cannot reach,
+                      and `scroll-padding` only affects programmatic/snap
+                      scrolling — it would not clear a resting last row. */}
+                  <div className="min-h-0 flex-1 overflow-hidden pb-[calc(var(--sa-bottom,0px)+var(--keyboard-inset,0px))] pl-[var(--sa-left,0px)] pr-[var(--sa-right,0px)]">
                     {props.surfaceOverlay ? (
                       <div className="relative h-full min-h-0">
                         {props.surfaceOverlay}
                       </div>
                     ) : <PanelSlot
                       id={surfaceId}
-                      params={{ ...props.surfaceParams, hideLevelOneHeader: true }}
+                      params={fullBleedSurfaceParams}
                     />}
                   </div>
                 </div>
@@ -655,15 +721,7 @@ export function ChatLayout(props: ChatLayoutProps) {
                 </WorkbenchOverlayFrame>
               ) : <PanelSlot
                 id={surfaceId}
-                params={{
-                  ...props.surfaceParams,
-                  hostRailOnly: !surfaceOpen,
-                  showCloseAction: true,
-                  onClose: collapseWorkbench,
-                  onHostExpand: openWorkbenchSplit,
-                  hostFullscreen: chatCollapsed,
-                  onHostToggleFullscreen: toggleChatCollapsed,
-                }}
+                params={railOnlySurfaceParams}
               />}
             </div>
             {surfaceOpen && !chatCollapsed && !mobileShell ? (
@@ -892,11 +950,15 @@ function PanelSlot({ id, params }: { id: string; params?: Record<string, unknown
   const components = useMemo(() => registry.getComponents(), [registry, registrySnapshot])
   const Component = components[id] as ComponentType<PaneProps<Record<string, unknown> | undefined>> | undefined
   const api = useMemo(() => createPanelApi(id), [id])
+  // Stable merged params: a fresh object literal here would defeat every
+  // downstream React.memo/useMemo keyed on `params` and re-render the whole
+  // pane tree on each ChatLayout render (resize, streaming state, …).
+  const mergedParams = useMemo(() => ({ ...params, debug }), [params, debug])
   if (!Component) return null
   return (
     <Suspense fallback={<LoadingState centered />}>
       <Component
-        params={{ ...params, debug }}
+        params={mergedParams}
         api={api as PaneProps["api"]}
         containerApi={{} as PaneProps["containerApi"]}
       />

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -477,8 +477,12 @@ export function ChatLayout(props: ChatLayoutProps) {
             // whole viewport every frame for 280ms.
             ? cn(
                 "absolute inset-y-0 left-0 z-50 h-full w-[min(86%,360px)] shadow-2xl",
-                "transition-transform duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
-                navOpen ? "translate-x-0" : "-translate-x-full",
+                // `visibility` rides the same transition: painted while it
+                // slides out, properly hidden once off-screen — a translated-
+                // but-"visible" dialog violates the UI-review modal gates at
+                // the closed checkpoint.
+                "transition-[transform,visibility] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
+                navOpen ? "translate-x-0 visible" : "-translate-x-full invisible",
               )
             : cn(
                 "relative h-full shrink-0",
@@ -532,8 +536,8 @@ export function ChatLayout(props: ChatLayoutProps) {
           mobileShell
             ? cn(
                 "absolute inset-0 z-40 h-full",
-                "transition-transform duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
-                sidebarOpen ? "translate-x-0" : "-translate-x-full pointer-events-none",
+                "transition-[transform,visibility] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
+                sidebarOpen ? "translate-x-0 visible" : "-translate-x-full pointer-events-none invisible",
               )
             : cn(
                 "relative h-full shrink-0",
@@ -657,8 +661,8 @@ export function ChatLayout(props: ChatLayoutProps) {
                 // for 280ms on every open/close.
                 ? cn(
                     "absolute inset-0 z-40",
-                    "transition-transform duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
-                    surfaceOpen ? "translate-x-0" : "pointer-events-none translate-x-full",
+                    "transition-[transform,visibility] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
+                    surfaceOpen ? "translate-x-0 visible" : "pointer-events-none invisible translate-x-full",
                   )
                 : cn(
                     "relative",

--- a/packages/workspace/src/front/layout/ChatPaneStage.tsx
+++ b/packages/workspace/src/front/layout/ChatPaneStage.tsx
@@ -3,6 +3,7 @@ import { LoadingState } from "@hachej/boring-ui-kit"
 import type { ReactNode } from "react"
 import { cn } from "../lib/utils"
 import { decodeWorkspaceSessionDrag, type WorkspaceSessionRef } from "../sessionIdentity"
+import { COMPACT_MAX_WIDTH } from "./breakpoints"
 
 /**
  * The dockview stage is code-split: the compact mobile shell never renders it
@@ -10,6 +11,13 @@ import { decodeWorkspaceSessionDrag, type WorkspaceSessionRef } from "../session
  * download dockview-react at all. Desktop pays one extra chunk hop on mount.
  */
 const ChatPaneStageDock = lazy(() => import("./ChatPaneStageDock").then((m) => ({ default: m.ChatPaneStageDock })))
+
+// Warm the chunk at boot on desktop-sized viewports so the Suspense window is
+// effectively closed before first paint; compact viewports never fetch it —
+// that is the entire point of the split.
+if (typeof window !== "undefined" && window.innerWidth >= COMPACT_MAX_WIDTH) {
+  void import("./ChatPaneStageDock")
+}
 
 /**
  * Synchronous fallback for the chunk hop. Deliberately does NOT render the

--- a/packages/workspace/src/front/layout/ChatPaneStage.tsx
+++ b/packages/workspace/src/front/layout/ChatPaneStage.tsx
@@ -1,7 +1,25 @@
+import { lazy, Suspense } from "react"
 import type { ReactNode } from "react"
 import { cn } from "../lib/utils"
 import { decodeWorkspaceSessionDrag, type WorkspaceSessionRef } from "../sessionIdentity"
-import { ChatPaneStageDock } from "./ChatPaneStageDock"
+
+/**
+ * The dockview stage is code-split: the compact mobile shell never renders it
+ * (it renders `MobileSingleChatPane` instead), so a phone should not parse or
+ * download dockview-react at all. Desktop pays one extra chunk hop on mount.
+ */
+const ChatPaneStageDock = lazy(() => import("./ChatPaneStageDock").then((m) => ({ default: m.ChatPaneStageDock })))
+
+/**
+ * Synchronous fallback for the chunk hop: renders just the active pane body,
+ * so the transcript is present and readable on first paint instead of a
+ * spinner. Dock chrome (headers, splits) appears once the chunk lands.
+ */
+function ActivePaneFallback({ panes, activePaneId, renderPane }: Pick<ChatPaneStageProps, "panes" | "activePaneId" | "renderPane">) {
+  const active = panes.find((pane) => pane.id === activePaneId) ?? panes[0]
+  if (!active) return null
+  return <div className="relative h-full min-h-0">{renderPane(active)}</div>
+}
 
 export interface ChatPaneDescriptor {
   id: string
@@ -75,7 +93,20 @@ export interface ChatPaneStageProps {
  * workspace.
  */
 export function ChatPaneStage(props: ChatPaneStageProps) {
-  return <ChatPaneStageDock {...props} />
+  return (
+    <Suspense fallback={
+      <ActivePaneFallback panes={props.panes} activePaneId={props.activePaneId} renderPane={props.renderPane} />
+    }>
+      <ChatPaneStageDock {...props} />
+    </Suspense>
+  )
+}
+
+export function readablePaneTitle(title: string | undefined, id: string | undefined): string {
+  const trimmed = title?.trim()
+  const isMachineId = trimmed === id
+    || Boolean(trimmed && /(?:^|::)[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i.test(trimmed))
+  return trimmed && !isMachineId ? trimmed : "New chat"
 }
 
 export function paneTitle(pane: { title?: string | null }): string {

--- a/packages/workspace/src/front/layout/ChatPaneStage.tsx
+++ b/packages/workspace/src/front/layout/ChatPaneStage.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense } from "react"
+import { LoadingState } from "@hachej/boring-ui-kit"
 import type { ReactNode } from "react"
 import { cn } from "../lib/utils"
 import { decodeWorkspaceSessionDrag, type WorkspaceSessionRef } from "../sessionIdentity"
@@ -11,14 +12,14 @@ import { decodeWorkspaceSessionDrag, type WorkspaceSessionRef } from "../session
 const ChatPaneStageDock = lazy(() => import("./ChatPaneStageDock").then((m) => ({ default: m.ChatPaneStageDock })))
 
 /**
- * Synchronous fallback for the chunk hop: renders just the active pane body,
- * so the transcript is present and readable on first paint instead of a
- * spinner. Dock chrome (headers, splits) appears once the chunk lands.
+ * Synchronous fallback for the chunk hop. Deliberately does NOT render the
+ * pane content: mounting the pane here and again under the dock would remount
+ * it once the chunk lands, aborting and re-firing the chat session's event
+ * stream subscription. A phone never sees this fallback at all — the compact
+ * shell renders `MobileSingleChatPane` instead of this component.
  */
-function ActivePaneFallback({ panes, activePaneId, renderPane }: Pick<ChatPaneStageProps, "panes" | "activePaneId" | "renderPane">) {
-  const active = panes.find((pane) => pane.id === activePaneId) ?? panes[0]
-  if (!active) return null
-  return <div className="relative h-full min-h-0">{renderPane(active)}</div>
+function DockFallback() {
+  return <LoadingState centered />
 }
 
 export interface ChatPaneDescriptor {
@@ -94,9 +95,7 @@ export interface ChatPaneStageProps {
  */
 export function ChatPaneStage(props: ChatPaneStageProps) {
   return (
-    <Suspense fallback={
-      <ActivePaneFallback panes={props.panes} activePaneId={props.activePaneId} renderPane={props.renderPane} />
-    }>
+    <Suspense fallback={<DockFallback />}>
       <ChatPaneStageDock {...props} />
     </Suspense>
   )

--- a/packages/workspace/src/front/layout/ChatPaneStageDock.tsx
+++ b/packages/workspace/src/front/layout/ChatPaneStageDock.tsx
@@ -23,7 +23,7 @@ import { Button, Dialog, DialogContent, DialogDescription, DialogHeader, DialogT
 import { cn } from "../lib/utils"
 import { CornerChromeButton } from "./cornerChrome"
 import { WorkspaceTranscriptLoadingSurface } from "../components/WorkspaceLoadingState"
-import { CHAT_SESSION_DRAG_TYPE, dispatchChatSessionDragPayload, PaneFocusRing, paneTitle, type ChatPaneDescriptor, type ChatPaneStageProps } from "./ChatPaneStage"
+import { CHAT_SESSION_DRAG_TYPE, dispatchChatSessionDragPayload, PaneFocusRing, paneTitle, readablePaneTitle, type ChatPaneDescriptor, type ChatPaneStageProps } from "./ChatPaneStage"
 import { workspaceSessionKey } from "../sessionIdentity"
 
 type ChatPaneStageDockProps = ChatPaneStageProps
@@ -33,12 +33,9 @@ const PANE_MIN_WIDTH = 280
 const PERSIST_DEBOUNCE_MS = 300
 const SINGLE_PANE_LOADING_MIN_MS = 120
 
-export function readablePaneTitle(title: string | undefined, id: string | undefined): string {
-  const trimmed = title?.trim()
-  const isMachineId = trimmed === id
-    || Boolean(trimmed && /(?:^|::)[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i.test(trimmed))
-  return trimmed && !isMachineId ? trimmed : "New chat"
-}
+// Lives in ChatPaneStage (the light module) so the compact shell can use it
+// without pulling this dockview chunk in.
+export { readablePaneTitle } from "./ChatPaneStage"
 
 interface StageContextValue {
   panes: ChatPaneDescriptor[]

--- a/packages/workspace/src/front/layout/ThemeToggle.tsx
+++ b/packages/workspace/src/front/layout/ThemeToggle.tsx
@@ -14,7 +14,7 @@ import { useTheme } from "../provider/WorkspaceProvider"
  * that class in sync with the active theme here. SSR-safe: the class sync runs
  * inside an effect guarded by a `document` check.
  */
-export function ThemeToggle() {
+export function ThemeToggle({ className }: { className?: string }) {
   const { theme, toggleTheme } = useTheme()
   const isDark = theme === "dark"
 
@@ -28,6 +28,7 @@ export function ThemeToggle() {
       type="button"
       variant="ghost"
       size="icon-sm"
+      className={className}
       onClick={toggleTheme}
       aria-label="Toggle theme"
       title={isDark ? "Switch to light theme" : "Switch to dark theme"}

--- a/packages/workspace/src/front/layout/__tests__/hostViewportMeta.test.ts
+++ b/packages/workspace/src/front/layout/__tests__/hostViewportMeta.test.ts
@@ -8,6 +8,10 @@ import { describe, expect, it } from "vitest"
  * `viewport-fit=cover`, so a host that ships the default viewport meta silently
  * disables every inset in the shell. This guards the hosts against that
  * regression, which is otherwise invisible on desktop and in jsdom.
+ *
+ * The same hosts must also opt into `interactive-widget=resizes-content`:
+ * Android Chrome >= 108 otherwise keeps the layout viewport at full height
+ * when the software keyboard opens, putting the composer underneath it.
  */
 function repoRoot(): string {
   let dir = dirname(new URL(import.meta.url).pathname)
@@ -34,5 +38,13 @@ describe("host viewport meta", () => {
 
     expect(meta, `${host} declares no viewport meta`).not.toBeNull()
     expect(meta?.[0]).toContain("viewport-fit=cover")
+  })
+
+  it.each(HOSTS)("%s opts into interactive-widget=resizes-content so the keyboard shrinks the layout viewport", (host) => {
+    const html = readFileSync(join(root, host), "utf8")
+    const meta = html.match(/<meta\s+name="viewport"[^>]*>/)
+
+    expect(meta, `${host} declares no viewport meta`).not.toBeNull()
+    expect(meta?.[0]).toContain("interactive-widget=resizes-content")
   })
 })

--- a/packages/workspace/src/front/layout/__tests__/mobileShell.test.tsx
+++ b/packages/workspace/src/front/layout/__tests__/mobileShell.test.tsx
@@ -3,9 +3,11 @@ import { describe, expect, it, vi } from "vitest"
 import { MobileChatBar, MobileSingleChatPane, MobileWorkspaceBar } from "../mobileShell"
 
 describe("mobile chat chrome", () => {
-  it("keeps the top bar concise and safe-area aware", () => {
+  it("collapses to a single bar: nav pill, the real session title, workspace pill", () => {
     render(
       <MobileChatBar
+        pane={{ id: "pane-a", title: "Planning" }}
+        totalPanes={1}
         canOpenNav
         canOpenWorkspace
         onOpenNav={() => {}}
@@ -13,19 +15,71 @@ describe("mobile chat chrome", () => {
       />,
     )
 
-    const bar = screen.getByText("Chat").closest('[data-boring-workspace-part="mobile-chat-bar"]')
-    expect(bar?.className).toContain("env(safe-area-inset-top)")
-    expect(screen.queryByText("One active thread on mobile")).toBeNull()
+    const bar = document.querySelector('[data-boring-workspace-part="mobile-chat-bar"]')
+    expect(bar).toBeTruthy()
+    // The static "Chat" label used to sit between two copies of the real title.
+    expect(screen.queryByText("Chat")).toBeNull()
+    expect(screen.getByText("Planning")).toBeTruthy()
+    expect(screen.getByRole("button", { name: "Sessions" })).toBeTruthy()
+    expect(screen.getByRole("button", { name: "Workspace" })).toBeTruthy()
+  })
+
+  it("carries the status-bar inset exactly once, on the bar itself", () => {
+    render(
+      <>
+        <MobileChatBar
+          pane={{ id: "pane-a", title: "Planning" }}
+          totalPanes={1}
+          canOpenNav={false}
+          canOpenWorkspace={false}
+          onOpenWorkspace={() => {}}
+        />
+        <MobileSingleChatPane pane={{ id: "pane-a", title: "Planning" }} renderPane={() => <div>Transcript</div>} />
+      </>,
+    )
+
+    const bar = document.querySelector('[data-boring-workspace-part="mobile-chat-bar"]')
+    expect(bar?.className).toContain("--sa-top")
+
+    // The pane below the bar owns no header at all any more, so it cannot
+    // re-apply the top inset under the bar that already applied it.
+    const pane = document.querySelector('[data-boring-workspace-part="mobile-chat-pane"]')
+    expect(pane?.className ?? "").not.toContain("--sa-top")
+    for (const node of Array.from(pane?.querySelectorAll("*") ?? [])) {
+      expect(node.className.toString()).not.toContain("--sa-top")
+    }
+  })
+
+  it("reserves the leading gutter from the shared token on both bars", () => {
+    const { unmount } = render(
+      <MobileChatBar canOpenNav={false} canOpenWorkspace={false} onOpenWorkspace={() => {}} />,
+    )
+    const chatBar = document.querySelector('[data-boring-workspace-part="mobile-chat-bar"]')
+    expect(chatBar?.className).toContain("--mobile-header-inset-start")
+    expect(chatBar?.className).toContain("min-h-[var(--mobile-bar-height,3rem)]")
+    unmount()
+
+    render(<MobileWorkspaceBar onBack={() => {}} />)
+    const workspaceBar = document.querySelector('[data-boring-workspace-part="mobile-workspace-bar"]')
+    expect(workspaceBar?.className).toContain("--mobile-header-inset-start")
+    expect(workspaceBar?.className).toContain("min-h-[var(--mobile-bar-height,3rem)]")
+  })
+
+  it("falls back to a generic title when no chat pane is open", () => {
+    render(<MobileChatBar canOpenNav={false} canOpenWorkspace={false} onOpenWorkspace={() => {}} />)
+    expect(screen.getByText("Chat")).toBeTruthy()
   })
 
   it("hides the close action when this is the sole remaining pane", () => {
     const onClosePane = vi.fn()
     render(
-      <MobileSingleChatPane
+      <MobileChatBar
         pane={{ id: "pane-a", title: "Planning" }}
         totalPanes={1}
+        canOpenNav={false}
+        canOpenWorkspace={false}
+        onOpenWorkspace={() => {}}
         onClosePane={onClosePane}
-        renderPane={() => <div>Transcript</div>}
       />,
     )
 
@@ -35,11 +89,13 @@ describe("mobile chat chrome", () => {
   it("uses an accessible touch target for the close action when more than one pane exists", () => {
     const onClosePane = vi.fn()
     render(
-      <MobileSingleChatPane
+      <MobileChatBar
         pane={{ id: "pane-a", title: "Planning" }}
         totalPanes={2}
+        canOpenNav={false}
+        canOpenWorkspace={false}
+        onOpenWorkspace={() => {}}
         onClosePane={onClosePane}
-        renderPane={() => <div>Transcript</div>}
       />,
     )
 
@@ -52,11 +108,13 @@ describe("mobile chat chrome", () => {
   it("normalizes machine UUID titles to New chat", () => {
     const id = "123e4567-e89b-12d3-a456-426614174000"
     render(
-      <MobileSingleChatPane
+      <MobileChatBar
         pane={{ id, title: id }}
         totalPanes={2}
+        canOpenNav={false}
+        canOpenWorkspace={false}
+        onOpenWorkspace={() => {}}
         onClosePane={() => {}}
-        renderPane={() => <div>Transcript</div>}
       />,
     )
 
@@ -70,83 +128,104 @@ describe("mobile chat chrome", () => {
     expect(screen.queryByText("One active panel on mobile")).toBeNull()
   })
 
-  it("tags both chat-bar pills for coarse-pointer target escalation", () => {
-    render(<MobileChatBar canOpenNav canOpenWorkspace onOpenNav={() => {}} onOpenWorkspace={() => {}} />)
+  it("gives every bar pill a resting fill, a pressed state and a focus ring", () => {
+    const { unmount } = render(
+      <MobileChatBar canOpenNav canOpenWorkspace onOpenNav={() => {}} onOpenWorkspace={() => {}} />,
+    )
 
     for (const name of ["Sessions", "Workspace"]) {
       const pill = screen.getByRole("button", { name })
       expect(pill.className).toContain("mobile-shell-bar-action")
+      expect(pill.className).toContain("bg-muted/60")
+      expect(pill.className).toContain("active:bg-muted")
+      expect(pill.className).toContain("active:scale-[0.97]")
       expect(pill.className).toContain("motion-reduce:transition-none")
       expect(pill.className).toContain("focus-visible:ring-2")
     }
-  })
+    unmount()
 
-  it("tags the workspace back pill for coarse-pointer target escalation", () => {
     render(<MobileWorkspaceBar onBack={() => {}} />)
-
     const back = screen.getByRole("button", { name: "Chat" })
     expect(back.className).toContain("mobile-shell-bar-action")
+    expect(back.className).toContain("active:bg-muted")
     expect(back.className).toContain("motion-reduce:transition-none")
   })
 
-  it("pads the single-pane header for the status-bar inset", () => {
+  it("renders host-supplied actions in the merged bar", () => {
     render(
-      <MobileSingleChatPane pane={{ id: "pane-a", title: "Planning" }} totalPanes={1} renderPane={() => <div>Transcript</div>} />,
+      <MobileChatBar
+        canOpenNav={false}
+        canOpenWorkspace={false}
+        onOpenWorkspace={() => {}}
+        actions={<button type="button">Search catalogs and commands</button>}
+      />,
     )
-
-    const pane = screen.getByText("Planning").closest('[data-boring-workspace-part="mobile-chat-pane"]')
-    const header = pane?.firstElementChild
-    expect(header?.className).toContain("env(safe-area-inset-top)")
+    expect(screen.getByRole("button", { name: "Search catalogs and commands" })).toBeTruthy()
   })
 
-  it("names the owning Agent under the title, alongside the multi-pane notice", () => {
+  it("keeps the Agent alone in the subtitle and the pane count in a non-truncating pill", () => {
     render(
-      <MobileSingleChatPane
+      <MobileChatBar
         pane={{ id: "pane-a", title: "Planning", agentLabel: "Coder" }}
-        totalPanes={2}
-        renderPane={() => <div>Transcript</div>}
+        totalPanes={3}
+        canOpenNav={false}
+        canOpenWorkspace={false}
+        onOpenWorkspace={() => {}}
       />,
     )
 
     const subtitle = document.querySelector('[data-boring-workspace-part="mobile-chat-pane-subtitle"]')
-    expect(subtitle?.textContent).toBe("Coder · Showing 1 of 2 chats — split panes are disabled on mobile.")
-    expect(subtitle?.className).toContain("truncate")
+    // The explanatory sentence used to share this truncating 11px line and was
+    // the first thing cut off; only the Agent is here now, at 12px.
+    expect(subtitle?.textContent).toBe("Coder")
+    expect(subtitle?.className).toContain("text-xs")
+
+    const count = document.querySelector('[data-boring-workspace-part="mobile-chat-pane-count"]')
+    expect(count?.className).toContain("shrink-0")
+    expect(count?.className).not.toContain("truncate")
+    expect(count?.textContent).toContain("1/3")
+    // The sentence itself survives for assistive tech.
+    expect(count?.textContent).toContain("split panes are disabled on mobile")
   })
 
-  it("shows only the Agent when it is the sole pane, and nothing without one", () => {
-    const { rerender } = render(
-      <MobileSingleChatPane
-        pane={{ id: "pane-a", title: "Planning", agentLabel: "Coder" }}
-        totalPanes={1}
-        renderPane={() => <div>Transcript</div>}
-      />,
-    )
-    expect(
-      document.querySelector('[data-boring-workspace-part="mobile-chat-pane-subtitle"]')?.textContent,
-    ).toBe("Coder")
-
-    rerender(
-      <MobileSingleChatPane
+  it("shows no subtitle and no count pill for a single pane without an Agent", () => {
+    render(
+      <MobileChatBar
         pane={{ id: "pane-a", title: "Planning" }}
         totalPanes={1}
-        renderPane={() => <div>Transcript</div>}
+        canOpenNav={false}
+        canOpenWorkspace={false}
+        onOpenWorkspace={() => {}}
       />,
     )
     expect(document.querySelector('[data-boring-workspace-part="mobile-chat-pane-subtitle"]')).toBeNull()
+    expect(document.querySelector('[data-boring-workspace-part="mobile-chat-pane-count"]')).toBeNull()
   })
 
-  it("gives the close action a reduced-motion-safe hover and a focus ring", () => {
+  it("gives the close action a reduced-motion-safe pressed state and a focus ring", () => {
     render(
-      <MobileSingleChatPane
+      <MobileChatBar
         pane={{ id: "pane-a", title: "Planning" }}
         totalPanes={2}
+        canOpenNav={false}
+        canOpenWorkspace={false}
+        onOpenWorkspace={() => {}}
         onClosePane={() => {}}
-        renderPane={() => <div>Transcript</div>}
       />,
     )
 
     const close = screen.getByRole("button", { name: "Close Planning pane" })
     expect(close.className).toContain("motion-reduce:transition-none")
+    expect(close.className).toContain("active:bg-muted")
     expect(close.className).toContain("focus-visible:ring-2")
+  })
+
+  it("renders the pane body without a header of its own", () => {
+    render(<MobileSingleChatPane pane={{ id: "pane-a", title: "Planning" }} renderPane={() => <div>Transcript</div>} />)
+    const pane = document.querySelector('[data-boring-workspace-part="mobile-chat-pane"]')
+    expect(pane?.children.length).toBe(1)
+    expect(pane?.firstElementChild?.getAttribute("data-boring-workspace-part")).toBe("chat-pane")
+    expect(screen.getByText("Transcript")).toBeTruthy()
+    expect(screen.queryByText("Planning")).toBeNull()
   })
 })

--- a/packages/workspace/src/front/layout/__tests__/presets.test.tsx
+++ b/packages/workspace/src/front/layout/__tests__/presets.test.tsx
@@ -1502,7 +1502,9 @@ describe("ChatLayout compact shell", () => {
     )
 
     const nav = screen.getByRole("dialog", { name: "Session browser" })
-    expect(nav.className).toContain("transition-transform")
+    // `visibility` rides the same transition so the drawer stays painted while
+    // it slides out and is hidden (not merely translated) once off-screen.
+    expect(nav.className).toContain("transition-[transform,visibility]")
     expect(nav.className).not.toContain("transition-[width,min-width,max-width]")
   })
 

--- a/packages/workspace/src/front/layout/__tests__/presets.test.tsx
+++ b/packages/workspace/src/front/layout/__tests__/presets.test.tsx
@@ -736,7 +736,8 @@ describe("ChatLayout component", () => {
       ["chat", "session-list"],
     )
 
-    expect(screen.getByLabelText("Chat session First")).toHaveAttribute("data-boring-state", "inactive")
+    // The dockview stage is code-split and mounts after its chunk resolves.
+    expect(await screen.findByLabelText("Chat session First")).toHaveAttribute("data-boring-state", "inactive")
     expect(screen.getByLabelText("Chat session Second")).toHaveAttribute("data-boring-state", "active")
     expect(document.querySelector(".dv-chat-stage")).not.toBeNull()
     expect(screen.getByRole("button", { name: "New chat" })).toBeInTheDocument()
@@ -774,7 +775,7 @@ describe("ChatLayout component", () => {
       ["chat", "session-list"],
     )
 
-    await user.click(screen.getByLabelText("Close First pane"))
+    await user.click(await screen.findByLabelText("Close First pane"))
     expect(closePane).toHaveBeenCalledWith("s1")
     expect(setActive).not.toHaveBeenCalled()
 
@@ -1453,5 +1454,113 @@ describe("ChatLayout component", () => {
     expect(document.body.style.overflow).toBe(previousOverflow)
 
     result.unmount()
+  })
+})
+
+describe("ChatLayout compact shell", () => {
+  afterEach(() => {
+    setViewport(1280)
+  })
+
+  it("sizes the mobile drawers from CSS insets, never from window.innerWidth", () => {
+    setViewport(320)
+    renderWithRegistry(
+      <ChatLayout
+        mobileShellEnabled
+        nav="session-list"
+        navParams={{ onClose: vi.fn() }}
+        center="chat"
+        sidebar="workbench-left"
+        sidebarParams={{ onClose: vi.fn() }}
+      />,
+      ["session-list", "chat", "workbench-left"],
+    )
+
+    // A JS pixel width both fought the drawer's own right inset and hard-floored
+    // the nav drawer at 280px, overflowing anything narrower by construction.
+    const nav = screen.getByRole("dialog", { name: "Session browser" })
+    expect(nav.style.width).toBe("")
+    expect(nav.style.minWidth).toBe("")
+    expect(nav.style.willChange).toBe("")
+    expect(nav.className).toContain("w-[min(86%,360px)]")
+
+    const sidebar = screen.getByRole("dialog", { name: "Workbench left panel" })
+    expect(sidebar.style.width).toBe("")
+    expect(sidebar.className).toContain("inset-0")
+  })
+
+  it("animates the compact drawers on transform, not on layout properties", () => {
+    setViewport(375)
+    renderWithRegistry(
+      <ChatLayout
+        mobileShellEnabled
+        nav="session-list"
+        navParams={{ onClose: vi.fn() }}
+        center="chat"
+      />,
+      ["session-list", "chat"],
+    )
+
+    const nav = screen.getByRole("dialog", { name: "Session browser" })
+    expect(nav.className).toContain("transition-transform")
+    expect(nav.className).not.toContain("transition-[width,min-width,max-width]")
+  })
+
+  it("keeps the desktop drawers on explicit widths", () => {
+    setViewport(1280)
+    renderWithRegistry(
+      <ChatLayout
+        nav="session-list"
+        navParams={{ onClose: vi.fn() }}
+        center="chat"
+      />,
+      ["session-list", "chat"],
+    )
+
+    const nav = screen.getByRole("dialog", { name: "Session browser" })
+    expect(nav).toHaveStyle({ width: "260px" })
+    expect(nav.className).toContain("transition-[width,min-width,max-width]")
+  })
+
+  it("renders exactly one mobile bar, carrying the real session title", () => {
+    setViewport(375)
+    renderWithRegistry(
+      <ChatLayout
+        mobileShellEnabled
+        center="chat"
+        nav={null}
+        onOpenNav={vi.fn()}
+        chatPanes={[{ id: "pane-a", title: "Planning" }, { id: "pane-b", title: "Review" }]}
+        activeChatPaneId="pane-a"
+      />,
+      ["session-list", "chat"],
+    )
+
+    expect(document.querySelectorAll('[data-boring-workspace-part="mobile-chat-bar"]').length).toBe(1)
+    expect(screen.getByText("Planning")).toBeInTheDocument()
+    expect(screen.queryByText("Chat")).toBeNull()
+    expect(document.querySelector('[data-boring-workspace-part="mobile-chat-pane-count"]')?.textContent).toContain("1/2")
+  })
+
+  it("insets the full-bleed workbench takeover for the home indicator", () => {
+    setViewport(375)
+    renderWithRegistry(
+      <ChatLayout
+        mobileShellEnabled
+        center="chat"
+        nav={null}
+        surface="empty"
+        surfaceParams={{ onClose: vi.fn() }}
+      />,
+      ["session-list", "chat", "empty"],
+    )
+
+    const bar = document.querySelector('[data-boring-workspace-part="mobile-workspace-bar"]')
+    const content = bar?.nextElementSibling
+    // Bottom inset includes the keyboard inset so iOS (whose layout viewport
+    // never shrinks for the keyboard) keeps workbench content above it.
+    expect(content?.className).toContain("pb-[calc(var(--sa-bottom,0px)+var(--keyboard-inset,0px))]")
+    expect(content?.className).toContain("pl-[var(--sa-left,0px)]")
+    expect(content?.className).toContain("pr-[var(--sa-right,0px)]")
   })
 })

--- a/packages/workspace/src/front/layout/__tests__/viewportHooks.test.ts
+++ b/packages/workspace/src/front/layout/__tests__/viewportHooks.test.ts
@@ -1,0 +1,271 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { act, renderHook } from "@testing-library/react"
+
+import { KEYBOARD_INSET_PROPERTY, useKeyboardInset } from "../useKeyboardInset"
+import { useIsCompactViewport, useViewportWidth } from "../useViewportWidth"
+
+/**
+ * Both hooks exist to *not* do work: they coalesce a burst of viewport events
+ * into one rAF and skip the write when the value is unchanged. Neither is
+ * observable unless the frame queue is under test control, so rAF is stubbed
+ * with a manual queue rather than advanced with fake timers.
+ */
+let frames: Array<(() => void) | null> = []
+
+function flushFrames() {
+  const pending = frames
+  frames = []
+  for (const frame of pending) frame?.()
+}
+
+/** jsdom has no visualViewport at all; every field the hooks read is stubbed. */
+class FakeVisualViewport extends EventTarget {
+  height = 800
+  offsetTop = 0
+  scale = 1
+}
+
+function setVisualViewport(viewport: FakeVisualViewport | undefined) {
+  Object.defineProperty(window, "visualViewport", {
+    configurable: true,
+    writable: true,
+    value: viewport,
+  })
+}
+
+function setInnerHeight(height: number) {
+  Object.defineProperty(window, "innerHeight", { configurable: true, writable: true, value: height })
+}
+
+function setInnerWidth(width: number) {
+  Object.defineProperty(window, "innerWidth", { configurable: true, writable: true, value: width })
+}
+
+function readInset(): string {
+  return document.documentElement.style.getPropertyValue(KEYBOARD_INSET_PROPERTY)
+}
+
+beforeEach(() => {
+  frames = []
+  vi.stubGlobal("requestAnimationFrame", (callback: () => void) => frames.push(callback))
+  // Maps ids as `frames[id - 1]`, valid only while these tests are the sole
+  // rAF schedulers in the environment (ids are 1-based indices into `frames`).
+  vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+    frames[id - 1] = null
+  })
+  setInnerHeight(800)
+  setInnerWidth(1280)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  setVisualViewport(undefined)
+  document.documentElement.style.removeProperty(KEYBOARD_INSET_PROPERTY)
+})
+
+describe("useKeyboardInset", () => {
+  it("publishes 0px when the host has no visualViewport", () => {
+    setVisualViewport(undefined)
+
+    renderHook(() => useKeyboardInset())
+
+    expect(readInset()).toBe("0px")
+  })
+
+  it("publishes the strip covered by the keyboard, coalesced to one frame", () => {
+    const viewport = new FakeVisualViewport()
+    setVisualViewport(viewport)
+
+    renderHook(() => useKeyboardInset())
+    expect(readInset()).toBe("0px")
+
+    act(() => {
+      viewport.height = 500
+      viewport.dispatchEvent(new Event("resize"))
+      viewport.dispatchEvent(new Event("scroll"))
+      viewport.dispatchEvent(new Event("resize"))
+    })
+
+    // Three events, one queued frame, and nothing written until it runs.
+    expect(frames).toHaveLength(1)
+    expect(readInset()).toBe("0px")
+
+    act(() => flushFrames())
+    expect(readInset()).toBe("300px")
+  })
+
+  it("subtracts the amount Safari has already panned the page up", () => {
+    const viewport = new FakeVisualViewport()
+    viewport.height = 500
+    viewport.offsetTop = 120
+    setVisualViewport(viewport)
+
+    renderHook(() => useKeyboardInset())
+
+    expect(readInset()).toBe("180px")
+  })
+
+  it("never publishes a negative inset", () => {
+    const viewport = new FakeVisualViewport()
+    viewport.height = 900
+    setVisualViewport(viewport)
+
+    renderHook(() => useKeyboardInset())
+
+    expect(readInset()).toBe("0px")
+  })
+
+  it("freezes the published inset while pinch-zoomed and converges on unzoom", () => {
+    const viewport = new FakeVisualViewport()
+    setVisualViewport(viewport)
+    setInnerHeight(800)
+
+    const { unmount } = renderHook(() => useKeyboardInset())
+
+    // Keyboard open: the real inset.
+    viewport.height = 400
+    act(() => viewport.dispatchEvent(new Event("resize")))
+    flushFrames()
+    expect(readInset()).toBe("400px")
+
+    // Pinch-zoom shrinks visualViewport too, but is not a keyboard: the last
+    // real value must be frozen instead of publishing a phantom inset.
+    viewport.scale = 2
+    act(() => viewport.dispatchEvent(new Event("resize")))
+    flushFrames()
+    expect(readInset()).toBe("400px")
+
+    // Unzooming fires another resize; the hook converges on the real value.
+    viewport.scale = 1
+    viewport.height = 800
+    act(() => viewport.dispatchEvent(new Event("resize")))
+    flushFrames()
+    expect(readInset()).toBe("0px")
+
+    unmount()
+  })
+
+  it("resets to 0px and detaches its listeners on unmount", () => {
+    const viewport = new FakeVisualViewport()
+    setVisualViewport(viewport)
+
+    const { unmount } = renderHook(() => useKeyboardInset())
+    act(() => {
+      viewport.height = 500
+      viewport.dispatchEvent(new Event("resize"))
+      flushFrames()
+    })
+    expect(readInset()).toBe("300px")
+
+    unmount()
+    expect(readInset()).toBe("0px")
+
+    viewport.height = 200
+    viewport.dispatchEvent(new Event("resize"))
+    expect(frames).toHaveLength(0)
+    expect(readInset()).toBe("0px")
+  })
+})
+
+describe("useViewportWidth", () => {
+  it("coalesces a burst of resize events into a single frame", () => {
+    const { result } = renderHook(() => useViewportWidth())
+    expect(result.current).toBe(1280)
+
+    act(() => {
+      setInnerWidth(390)
+      window.dispatchEvent(new Event("resize"))
+      window.dispatchEvent(new Event("resize"))
+      window.dispatchEvent(new Event("resize"))
+    })
+
+    expect(frames).toHaveLength(1)
+    expect(result.current).toBe(1280)
+
+    act(() => flushFrames())
+    expect(result.current).toBe(390)
+  })
+
+  it("does not re-render when the width is unchanged", () => {
+    let renders = 0
+    const { result } = renderHook(() => {
+      renders += 1
+      return useViewportWidth()
+    })
+
+    const baseline = renders
+    act(() => {
+      // A keyboard opening or a URL bar collapsing resizes the height only.
+      setInnerHeight(500)
+      window.dispatchEvent(new Event("resize"))
+      flushFrames()
+    })
+
+    expect(renders).toBe(baseline)
+    expect(result.current).toBe(1280)
+  })
+
+  it("cancels a pending frame on unmount", () => {
+    const { unmount } = renderHook(() => useViewportWidth())
+
+    act(() => {
+      setInnerWidth(390)
+      window.dispatchEvent(new Event("resize"))
+    })
+    expect(frames).toHaveLength(1)
+
+    unmount()
+    expect(frames[0]).toBeNull()
+
+    window.dispatchEvent(new Event("resize"))
+    expect(frames).toHaveLength(1)
+  })
+})
+
+describe("useIsCompactViewport", () => {
+  function stubMatchMedia(initialMatches: boolean) {
+    const listeners = new Set<(event: MediaQueryListEvent) => void>()
+    const query = {
+      matches: initialMatches,
+      media: "",
+      addEventListener: (_: string, listener: (event: MediaQueryListEvent) => void) => {
+        listeners.add(listener)
+      },
+      removeEventListener: (_: string, listener: (event: MediaQueryListEvent) => void) => {
+        listeners.delete(listener)
+      },
+    }
+    const matchMedia = vi.fn(() => query)
+    vi.stubGlobal("matchMedia", matchMedia)
+    return {
+      matchMedia,
+      emit(matches: boolean) {
+        query.matches = matches
+        for (const listener of listeners) listener({ matches } as MediaQueryListEvent)
+      },
+      listenerCount: () => listeners.size,
+    }
+  }
+
+  it("queries the compact breakpoint with an exclusive upper bound", () => {
+    const media = stubMatchMedia(false)
+
+    renderHook(() => useIsCompactViewport())
+
+    expect(media.matchMedia).toHaveBeenCalledWith("(max-width: 639px)")
+  })
+
+  it("flips on the media change alone, without any resize event", () => {
+    const media = stubMatchMedia(false)
+
+    const { result, unmount } = renderHook(() => useIsCompactViewport())
+    expect(result.current).toBe(false)
+
+    act(() => media.emit(true))
+    expect(result.current).toBe(true)
+    expect(frames).toHaveLength(0)
+
+    unmount()
+    expect(media.listenerCount()).toBe(0)
+  })
+})

--- a/packages/workspace/src/front/layout/index.ts
+++ b/packages/workspace/src/front/layout/index.ts
@@ -4,6 +4,9 @@ export { TopBar } from "./TopBar"
 export { ThemeToggle } from "./ThemeToggle"
 /** Tier 2 entry: declarative LayoutConfig with stock responsive chrome. */
 export { ResponsiveDockviewShell } from "./ResponsiveDockviewShell"
+export { useViewportWidth, useViewportHeight, useIsCompactViewport } from "./useViewportWidth"
+/** Publishes the `--keyboard-inset` CSS contract; mount once per shell. */
+export { useKeyboardInset, KEYBOARD_INSET_PROPERTY } from "./useKeyboardInset"
 export {
   COMPACT_MAX_WIDTH,
   WIDE_MIN_WIDTH,

--- a/packages/workspace/src/front/layout/mobileShell.tsx
+++ b/packages/workspace/src/front/layout/mobileShell.tsx
@@ -1,96 +1,111 @@
 import type { ReactNode } from "react"
 import { ArrowLeft, X } from "lucide-react"
-import { paneTitle, type ChatPaneDescriptor } from "./ChatPaneStage"
-import { readablePaneTitle } from "./ChatPaneStageDock"
+import { cn } from "../lib/utils"
+import { paneTitle, readablePaneTitle, type ChatPaneDescriptor } from "./ChatPaneStage"
 
-export function MobileSingleChatPane({
+/**
+ * One declared height for every mobile bar. `--mobile-bar-height` is the
+ * `:root` token (globals.css); the literal is the fallback so this file stays
+ * correct on its own. Both bars and the (now merged) chat header are the same
+ * row, so there is exactly one number to change.
+ */
+const MOBILE_BAR_CLASS = cn(
+  "flex min-h-[var(--mobile-bar-height,3rem)] items-center gap-2 border-b border-border bg-background pb-2",
+  // The floating app-left control sits in the leading gutter. Both this bar and
+  // ManagementOverlaySurface reserve it with the SAME token so they cannot
+  // disagree about how much room it needs.
+  "pl-[calc(var(--mobile-header-inset-start,3.25rem)+var(--sa-left,0px))]",
+  "pr-[calc(0.75rem+var(--sa-right,0px))]",
+  "pt-[calc(0.5rem+var(--sa-top,0px))]",
+)
+
+/**
+ * Pills are the only navigation in the mobile shell and are tapped, not
+ * hovered: they carry a resting fill so they read as buttons, and an `active:`
+ * state so the tap is acknowledged before it resolves. `before:-inset-y-1`
+ * expands the hit area without growing the drawn control.
+ */
+const MOBILE_PILL_CLASS = cn(
+  "mobile-shell-bar-action relative inline-flex min-h-10 shrink-0 items-center gap-1 rounded-full",
+  "border border-transparent bg-muted/60 px-3 text-sm font-semibold text-foreground",
+  "before:absolute before:-inset-y-1 before:inset-x-0 before:content-['']",
+  "transition-[background-color,transform] motion-reduce:transition-none",
+  "hover:bg-muted active:bg-muted active:scale-[0.97]",
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
+)
+
+/**
+ * The single mobile chat header. It used to be two stacked bars — this one and
+ * a second title row inside `MobileSingleChatPane` — which showed the session
+ * title twice under a static "Chat" label. One row, one title.
+ */
+export function MobileChatBar({
   pane,
   totalPanes,
-  topActions,
-  onClosePane,
-  renderPane,
-}: {
-  pane: ChatPaneDescriptor
-  totalPanes: number
-  topActions?: ReactNode
-  onClosePane?: (id: string) => void
-  renderPane: (pane: ChatPaneDescriptor) => ReactNode
-}) {
-  const title = readablePaneTitle(paneTitle(pane), pane.id)
-  const agentLabel = pane.agentLabel
-  // Mobile has one full-width bar and an existing secondary line, so the Agent
-  // is spelled out rather than hidden behind a tooltip a touch user cannot open.
-  const subtitle = [
-    agentLabel,
-    totalPanes > 1 ? `Showing 1 of ${totalPanes} chats — split panes are disabled on mobile.` : undefined,
-  ].filter(Boolean).join(" · ")
-  return (
-    <div data-boring-workspace-part="mobile-chat-pane" className="flex h-full min-h-0 flex-col bg-background">
-      <div className="flex min-h-11 items-center gap-2 border-b border-border pb-2 pl-[calc(0.75rem+env(safe-area-inset-left))] pr-[calc(0.75rem+env(safe-area-inset-right))] pt-[calc(0.5rem+env(safe-area-inset-top))]">
-        <div className="min-w-0 flex-1">
-          <div className="truncate text-sm font-semibold">{title}</div>
-          {subtitle ? (
-            <div
-              data-boring-workspace-part="mobile-chat-pane-subtitle"
-              className="truncate text-[11px] font-medium text-muted-foreground"
-            >
-              {subtitle}
-            </div>
-          ) : null}
-        </div>
-        {topActions ? <div className="flex shrink-0 items-center gap-1">{topActions}</div> : null}
-        {onClosePane && totalPanes > 1 ? (
-          <button
-            type="button"
-            className="inline-flex size-11 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors motion-reduce:transition-none hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-            onClick={() => onClosePane(pane.id)}
-            aria-label={`Close ${title} pane`}
-          >
-            <X className="size-4" aria-hidden="true" />
-          </button>
-        ) : null}
-      </div>
-      <div data-boring-workspace-part="chat-pane" data-boring-state="active" className="min-h-0 flex-1 overflow-hidden">
-        {renderPane(pane)}
-      </div>
-    </div>
-  )
-}
-
-export function MobileChatBar({
   canOpenNav,
   canOpenWorkspace,
   onOpenNav,
   onOpenWorkspace,
+  actions,
+  onClosePane,
 }: {
+  pane?: ChatPaneDescriptor
+  totalPanes?: number
   canOpenNav: boolean
   canOpenWorkspace: boolean
   onOpenNav?: () => void
   onOpenWorkspace: () => void
+  /** Chrome the surrounding shell owns (e.g. the command palette) when it has
+   *  no top bar of its own at this width. */
+  actions?: ReactNode
+  onClosePane?: (id: string) => void
 }) {
+  const panes = totalPanes ?? 0
+  const title = pane ? readablePaneTitle(paneTitle(pane), pane.id) : "Chat"
+  // Only the Agent goes in the subtitle. The pane count used to be glued onto
+  // the same truncating line, so the one fact it carried was the first thing
+  // cut off; it is a non-truncating pill now.
+  const subtitle = pane?.agentLabel
   return (
-    <div
-      data-boring-workspace-part="mobile-chat-bar"
-      className="flex min-h-12 items-center gap-2 border-b border-border bg-background pb-2 pl-[calc(4rem+env(safe-area-inset-left))] pr-[calc(0.5rem+env(safe-area-inset-right))] pt-[calc(0.5rem+env(safe-area-inset-top))]"
-    >
+    <div data-boring-workspace-part="mobile-chat-bar" className={MOBILE_BAR_CLASS}>
       {canOpenNav ? (
-        <button
-          type="button"
-          className="mobile-shell-bar-action inline-flex min-h-10 items-center rounded-full border border-border px-3 text-sm font-semibold text-foreground transition-colors motion-reduce:transition-none hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-          onClick={onOpenNav}
-        >
+        <button type="button" className={MOBILE_PILL_CLASS} onClick={onOpenNav}>
           Sessions
         </button>
       ) : null}
       <div className="min-w-0 flex-1">
-        <div className="truncate text-sm font-semibold">Chat</div>
+        <div className="truncate text-sm font-semibold">{title}</div>
+        {subtitle ? (
+          <div
+            data-boring-workspace-part="mobile-chat-pane-subtitle"
+            className="truncate text-xs font-medium leading-tight text-muted-foreground"
+          >
+            {subtitle}
+          </div>
+        ) : null}
       </div>
-      {canOpenWorkspace ? (
+      {panes > 1 ? (
+        <span
+          data-boring-workspace-part="mobile-chat-pane-count"
+          className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-xs font-semibold tabular-nums text-muted-foreground"
+        >
+          <span aria-hidden="true">{`1/${panes}`}</span>
+          <span className="sr-only">{`Showing 1 of ${panes} chats — split panes are disabled on mobile.`}</span>
+        </span>
+      ) : null}
+      {actions ? <div className="flex shrink-0 items-center gap-1">{actions}</div> : null}
+      {pane && onClosePane && panes > 1 ? (
         <button
           type="button"
-          className="mobile-shell-bar-action inline-flex min-h-10 items-center rounded-full border border-border px-3 text-sm font-semibold text-foreground transition-colors motion-reduce:transition-none hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-          onClick={onOpenWorkspace}
+          className="inline-flex size-11 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-[background-color,transform] motion-reduce:transition-none hover:bg-muted hover:text-foreground active:bg-muted active:scale-[0.97] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+          onClick={() => onClosePane(pane.id)}
+          aria-label={`Close ${title} pane`}
         >
+          <X className="size-4" aria-hidden="true" />
+        </button>
+      ) : null}
+      {canOpenWorkspace ? (
+        <button type="button" className={MOBILE_PILL_CLASS} onClick={onOpenWorkspace}>
           Workspace
         </button>
       ) : null}
@@ -98,17 +113,31 @@ export function MobileChatBar({
   )
 }
 
+/**
+ * Body of the single visible chat pane. Its header moved into `MobileChatBar`
+ * above — the two were always rendered together, so two headers were two
+ * safe-area insets and two copies of the same title.
+ */
+export function MobileSingleChatPane({
+  pane,
+  renderPane,
+}: {
+  pane: ChatPaneDescriptor
+  renderPane: (pane: ChatPaneDescriptor) => ReactNode
+}) {
+  return (
+    <div data-boring-workspace-part="mobile-chat-pane" className="flex h-full min-h-0 flex-col bg-background">
+      <div data-boring-workspace-part="chat-pane" data-boring-state="active" className="min-h-0 flex-1 overflow-hidden">
+        {renderPane(pane)}
+      </div>
+    </div>
+  )
+}
+
 export function MobileWorkspaceBar({ onBack }: { onBack: () => void }) {
   return (
-    <div
-      data-boring-workspace-part="mobile-workspace-bar"
-      className="flex min-h-12 items-center gap-2 border-b border-border bg-background pb-2 pl-[calc(4rem+env(safe-area-inset-left))] pr-[calc(0.5rem+env(safe-area-inset-right))] pt-[calc(0.5rem+env(safe-area-inset-top))]"
-    >
-      <button
-        type="button"
-        className="mobile-shell-bar-action inline-flex min-h-10 items-center gap-1 rounded-full border border-border px-3 text-sm font-semibold text-foreground transition-colors motion-reduce:transition-none hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-        onClick={onBack}
-      >
+    <div data-boring-workspace-part="mobile-workspace-bar" className={MOBILE_BAR_CLASS}>
+      <button type="button" className={MOBILE_PILL_CLASS} onClick={onBack}>
         <ArrowLeft className="size-4" aria-hidden="true" />
         Chat
       </button>

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -844,7 +844,7 @@ export function AppLeftPane({
         </div>
       </section>
 
-      {bottomSlot ? <footer data-boring-workspace-part="app-left-footer" className="shrink-0 border-t border-border/40 p-2">{bottomSlot}</footer> : null}
+      {bottomSlot ? <footer data-boring-workspace-part="app-left-footer" className="shrink-0 border-t border-border/40 p-2 pb-[calc(0.5rem+env(safe-area-inset-bottom,0px))]">{bottomSlot}</footer> : null}
     </aside>
   )
 }

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneActions.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneActions.tsx
@@ -237,10 +237,11 @@ export function FleetNewChatAction({
   )
 }
 
-/** Small keyboard-shortcut hint badge (e.g. ⌘K), Linear/Stripe-style. */
+/** Small keyboard-shortcut hint badge (e.g. ⌘K), Linear/Stripe-style. Hidden
+ * on coarse pointers — a keyboard chord is meaningless on a phone. */
 export function KbdHint({ keys }: { keys: string }) {
   return (
-    <kbd aria-hidden="true" className="rounded border border-border/60 bg-foreground/[0.08] px-1.5 py-px text-[10px] font-medium leading-[1.4] tracking-wide text-muted-foreground">
+    <kbd aria-hidden="true" className="pointer-coarse:hidden rounded border border-border/60 bg-foreground/[0.08] px-1.5 py-px text-[10px] font-medium leading-[1.4] tracking-wide text-muted-foreground">
       {keys}
     </kbd>
   )

--- a/packages/workspace/src/front/layout/useKeyboardInset.ts
+++ b/packages/workspace/src/front/layout/useKeyboardInset.ts
@@ -1,0 +1,85 @@
+"use client"
+
+import { useEffect } from "react"
+
+/**
+ * Public CSS contract: `--keyboard-inset` is the height, in px, of the strip at
+ * the bottom of the layout viewport currently covered by the software keyboard.
+ * It is always set and always a px length; it is `0px` on desktop, on hosts
+ * without `visualViewport`, and whenever the keyboard is closed. Layout chrome
+ * (composer, docked toolbars) should offset with
+ * `calc(var(--keyboard-inset) + var(--sa-bottom))` rather than measuring itself.
+ *
+ * The `0px` default also lives on `:root` in `packages/workspace/src/globals.css`
+ * so the variable resolves before this hook has ever mounted.
+ */
+export const KEYBOARD_INSET_PROPERTY = "--keyboard-inset"
+
+/**
+ * iOS never resizes the *layout* viewport for the keyboard, and Android Chrome
+ * >= 108 only does so when the host opts in with
+ * `interactive-widget=resizes-content`. In both cases `visualViewport` is the
+ * only surface that reports the covered strip: `innerHeight` keeps describing
+ * the layout viewport while `visualViewport.height` shrinks, and `offsetTop`
+ * accounts for the amount Safari has already panned the page up.
+ */
+function readKeyboardInset(): number {
+  const viewport = typeof window === "undefined" ? undefined : window.visualViewport
+  if (!viewport) return 0
+  // Pinch-zoom also shrinks `visualViewport.height` while `innerHeight` stands
+  // still, which would publish a phantom keyboard inset mid-zoom. While the
+  // user is zoomed in we freeze the last value; when scale returns to 1 the
+  // accompanying `resize` re-runs this and converges on the real inset.
+  if (viewport.scale > 1) return Number.NaN
+  return Math.max(0, window.innerHeight - (viewport.height + viewport.offsetTop))
+}
+
+/**
+ * Publishes `--keyboard-inset` on `<html>` for as long as the caller is mounted.
+ *
+ * Mount this once, as high in the tree as the shell that owns the viewport —
+ * mounting it twice is harmless (both writers compute the same value) but
+ * pointless.
+ */
+export function useKeyboardInset(): void {
+  useEffect(() => {
+    const root = document.documentElement
+    const viewport = window.visualViewport
+    let frame = 0
+    let last = ""
+
+    const write = () => {
+      frame = 0
+      // Sub-pixel viewport heights are common on Android; rounding keeps the
+      // style write (and any layout it triggers) out of the animation loop
+      // once the keyboard has settled.
+      const inset = readKeyboardInset()
+      // Zoomed: keep the previously published value rather than writing a
+      // phantom positive inset (see readKeyboardInset).
+      if (Number.isNaN(inset)) return
+      const next = `${Math.round(inset)}px`
+      if (next === last) return
+      last = next
+      root.style.setProperty(KEYBOARD_INSET_PROPERTY, next)
+    }
+
+    // visualViewport fires `resize` and `scroll` on every frame of the keyboard
+    // animation and of pinch-zoom panning; coalesce to one write per frame.
+    const schedule = () => {
+      if (frame === 0) frame = requestAnimationFrame(write)
+    }
+
+    write()
+    viewport?.addEventListener("resize", schedule)
+    viewport?.addEventListener("scroll", schedule)
+
+    return () => {
+      if (frame !== 0) cancelAnimationFrame(frame)
+      viewport?.removeEventListener("resize", schedule)
+      viewport?.removeEventListener("scroll", schedule)
+      // Reset rather than remove: the contract says the property is always a
+      // valid px length, including in hosts that never loaded globals.css.
+      root.style.setProperty(KEYBOARD_INSET_PROPERTY, "0px")
+    }
+  }, [])
+}

--- a/packages/workspace/src/front/layout/useViewportWidth.ts
+++ b/packages/workspace/src/front/layout/useViewportWidth.ts
@@ -1,11 +1,132 @@
+"use client"
+
 import { useEffect, useState } from "react"
 
+import { COMPACT_MAX_WIDTH } from "./breakpoints"
+
+/**
+ * Width assumed when there is no DOM (SSR / node test env).
+ *
+ * Kept at a desktop width deliberately. Every consumer of these hooks gates a
+ * whole shell (`mobileShell`, dockview vs. sheet chrome) and both defaults are
+ * wrong half the time; what differs is the cost of being wrong. The hosts in
+ * this repo are client-rendered, so the value only shows up in a server-rendered
+ * embedding, where the workspace is a desktop IDE surface first — flipping to
+ * mobile would make the common case paint the mobile shell and snap to desktop
+ * on hydration, and would tear down/rebuild the dockview tree while doing it.
+ * A server-rendered host that knows better should render the compact shell from
+ * its own request-side hint rather than from a guess made here.
+ */
+const SSR_FALLBACK_WIDTH = 1200
+
+/** `max-width` is inclusive, so mirror `width < COMPACT_MAX_WIDTH` with -1px. */
+const COMPACT_MEDIA_QUERY = `(max-width: ${COMPACT_MAX_WIDTH - 1}px)`
+
+function readWidth(): number {
+  return typeof window === "undefined" ? SSR_FALLBACK_WIDTH : window.innerWidth
+}
+
+function readHeight(): number {
+  if (typeof window === "undefined") return 0
+  // visualViewport excludes the software keyboard and the collapsed URL bar,
+  // which is what layout actually has to fit into.
+  return window.visualViewport?.height ?? window.innerHeight
+}
+
+/**
+ * Current layout-viewport width in px.
+ *
+ * `resize` fires once per frame through an iOS rotate animation and on every
+ * keyboard open, and each state change here re-renders a shell that relayouts
+ * dockview. So the handler is rAF-coalesced and the state write is skipped when
+ * the width did not actually change (height-only resizes are the common case).
+ *
+ * Prefer {@link useIsCompactViewport} when all you need is the breakpoint
+ * boolean — it re-renders on the flip, not on every pixel.
+ */
 export function useViewportWidth(): number {
-  const [width, setWidth] = useState(() => typeof window === "undefined" ? 1200 : window.innerWidth)
+  const [width, setWidth] = useState(readWidth)
+
   useEffect(() => {
-    const onResize = () => setWidth(window.innerWidth)
+    let frame = 0
+    const measure = () => {
+      frame = 0
+      setWidth((previous) => (previous === window.innerWidth ? previous : window.innerWidth))
+    }
+    const onResize = () => {
+      if (frame === 0) frame = requestAnimationFrame(measure)
+    }
+
+    // The mount-time state was read before hydration/layout; re-read once.
+    measure()
     window.addEventListener("resize", onResize)
-    return () => window.removeEventListener("resize", onResize)
+    return () => {
+      if (frame !== 0) cancelAnimationFrame(frame)
+      window.removeEventListener("resize", onResize)
+    }
   }, [])
+
   return width
+}
+
+/**
+ * Current *visual* viewport height in px — i.e. excluding the software keyboard.
+ *
+ * Same rAF-coalescing and same-value dedupe as {@link useViewportWidth}. Use it
+ * only when a measurement has to reach JS; pure styling should go through
+ * `100dvh` and `--keyboard-inset` instead.
+ */
+export function useViewportHeight(): number {
+  const [height, setHeight] = useState(readHeight)
+
+  useEffect(() => {
+    let frame = 0
+    const measure = () => {
+      frame = 0
+      setHeight((previous) => {
+        const next = readHeight()
+        return previous === next ? previous : next
+      })
+    }
+    const onResize = () => {
+      if (frame === 0) frame = requestAnimationFrame(measure)
+    }
+
+    measure()
+    window.addEventListener("resize", onResize)
+    const viewport = window.visualViewport
+    viewport?.addEventListener("resize", onResize)
+    viewport?.addEventListener("scroll", onResize)
+    return () => {
+      if (frame !== 0) cancelAnimationFrame(frame)
+      window.removeEventListener("resize", onResize)
+      viewport?.removeEventListener("resize", onResize)
+      viewport?.removeEventListener("scroll", onResize)
+    }
+  }, [])
+
+  return height
+}
+
+/**
+ * True in the compact (mobile-shell) tier, driven by `matchMedia` so the
+ * consumer re-renders on the breakpoint flip only — not once per resize frame.
+ */
+export function useIsCompactViewport(): boolean {
+  const [compact, setCompact] = useState(() => {
+    if (typeof window === "undefined") return SSR_FALLBACK_WIDTH < COMPACT_MAX_WIDTH
+    return window.matchMedia?.(COMPACT_MEDIA_QUERY).matches ?? window.innerWidth < COMPACT_MAX_WIDTH
+  })
+
+  useEffect(() => {
+    const query = window.matchMedia?.(COMPACT_MEDIA_QUERY)
+    if (!query) return
+    const onChange = (event: MediaQueryListEvent) => setCompact(event.matches)
+
+    setCompact(query.matches)
+    query.addEventListener("change", onChange)
+    return () => query.removeEventListener("change", onChange)
+  }, [])
+
+  return compact
 }

--- a/packages/workspace/src/globals.css
+++ b/packages/workspace/src/globals.css
@@ -116,6 +116,28 @@
   --surface-chat: var(--boring-surface-chat);
   --surface-workbench: var(--boring-surface-workbench);
   --surface-workbench-left: var(--boring-surface-workbench-left);
+
+  /* Mobile viewport insets — public contract, see front/layout/useKeyboardInset.
+   *
+   * `--sa-*` aliases the safe-area env() values so chrome can write
+   * `var(--sa-bottom)` instead of repeating the env() + fallback everywhere
+   * (they only resolve non-zero when the host declares `viewport-fit=cover`,
+   * which host viewport metas are tested for).
+   *
+   * `--keyboard-inset` is the height of the strip covered by the software
+   * keyboard. It is rewritten on `<html>` by `useKeyboardInset()`; this
+   * declaration is the always-present `0px` default so the variable resolves
+   * on desktop and before that hook ever mounts. */
+  --sa-top: env(safe-area-inset-top, 0px);
+  --sa-right: env(safe-area-inset-right, 0px);
+  --sa-bottom: env(safe-area-inset-bottom, 0px);
+  --sa-left: env(safe-area-inset-left, 0px);
+  --keyboard-inset: 0px;
+  /* Mobile chrome metrics. The mobile shell bars and the management overlay
+   * leading gutter both consume these, so there is exactly one number to
+   * change per metric; component-side literals are only no-token fallbacks. */
+  --mobile-bar-height: 3rem;
+  --mobile-header-inset-start: 3.25rem;
 }
 
 [data-theme="dark"] {
@@ -196,6 +218,20 @@
   code, kbd, pre, samp, .font-mono, [class*="font-mono"] {
     font-family: var(--font-mono);
     font-feature-settings: "ss02", "ss03", "zero";
+  }
+  /* iOS Safari auto-zooms the page when a focused control renders below 16px,
+   * and never zooms back out — the dense 12-14px fields used across workspace
+   * chrome leave the user stranded at 1.3x with the layout cut off.
+   *
+   * `pointer: coarse` matches on the *primary* pointer only, so touchscreen
+   * laptops (primary pointer = trackpad/mouse) keep the dense desktop sizing;
+   * this fires on phones and tablets, where the chrome is the mobile shell and
+   * 16px controls are what the touch target sizing already assumes. `1em`
+   * keeps any control that is deliberately larger than 16px unchanged. */
+  @media (pointer: coarse) {
+    input, textarea, select {
+      font-size: max(16px, 1em);
+    }
   }
 }
 

--- a/packages/workspace/src/shared/plugins/appLeftOverlayChrome.ts
+++ b/packages/workspace/src/shared/plugins/appLeftOverlayChrome.ts
@@ -1,4 +1,4 @@
-import { createContext, createElement, useContext, type ReactNode } from "react"
+import { createContext, createElement, useContext, type Context, type ReactNode } from "react"
 
 export interface AppLeftOverlayChromeValue {
   headerInsetStart: boolean
@@ -10,7 +10,18 @@ const defaultValue: AppLeftOverlayChromeValue = {
   headerInsetEnd: false,
 }
 
-const AppLeftOverlayChromeContext = createContext<AppLeftOverlayChromeValue>(defaultValue)
+// The plugin API and app host ship as separate entry bundles. Both can contain
+// this module, and two module-local React contexts do not communicate. Anchor
+// the context identity on globalThis so dist plugins consume the source host's
+// provider (and vice versa) instead of silently falling back to false insets.
+const GLOBAL_CONTEXT_KEY = "__hachej_boring_workspace_app_left_overlay_chrome__" as const
+type ContextRegistry = typeof globalThis & {
+  [GLOBAL_CONTEXT_KEY]?: Context<AppLeftOverlayChromeValue>
+}
+const contextRegistry = globalThis as ContextRegistry
+const AppLeftOverlayChromeContext = contextRegistry[GLOBAL_CONTEXT_KEY]
+  ?? createContext<AppLeftOverlayChromeValue>(defaultValue)
+contextRegistry[GLOBAL_CONTEXT_KEY] = AppLeftOverlayChromeContext
 
 export function AppLeftOverlayChromeProvider({
   value,

--- a/plugins/tasks/src/front/TasksOverlay.tsx
+++ b/plugins/tasks/src/front/TasksOverlay.tsx
@@ -44,7 +44,7 @@ export function TasksOverlay({ onClose }: BoringFrontAppLeftOverlayProps) {
     <div data-boring-workspace-part="tasks-overlay" className="flex h-full min-h-0 flex-col bg-background">
       <header className={[
         "flex h-12 shrink-0 items-center justify-between border-b border-border/60",
-        headerInsetStart ? "pl-12" : "pl-4",
+        headerInsetStart ? "pl-[calc(var(--mobile-header-inset-start,3.25rem)+var(--sa-left,0px))]" : "pl-4",
         headerInsetEnd ? "pr-16" : "pr-4",
       ].join(" ")}
       >

--- a/tools/ui-review/src/review-specs/workspace-command-palette/spec.ts
+++ b/tools/ui-review/src/review-specs/workspace-command-palette/spec.ts
@@ -38,6 +38,9 @@ export const workspaceCommandPaletteSpec: UiReviewSpec = {
     }),
     ready: async (page, timeoutMs) => {
       await expect(page.getByRole("main", { name: "Chat" })).toBeVisible({ timeout: timeoutMs })
+      // The dock stage is code-split; wait for either it or the compact single
+      // pane so no checkpoint ever captures the chunk's Suspense fallback.
+      await expect(page.locator('.dv-chat-stage, [data-boring-workspace-part="mobile-chat-pane"]').first()).toBeVisible({ timeout: timeoutMs })
     },
   },
   viewports,

--- a/tools/ui-review/src/review-specs/workspace-command-palette/spec.ts
+++ b/tools/ui-review/src/review-specs/workspace-command-palette/spec.ts
@@ -126,6 +126,11 @@ export const workspaceCommandPaletteSpec: UiReviewSpec = {
       // DOM visibility can precede paint. Prefer the latest replayable Wait
       // whose screenshot differs from a prior post-bootstrap closed state;
       // encoded PNG byte size is not a monotonic paint signal.
+      // The pHash threshold is viewport-aware: the whole-viewport hash is
+      // calibrated against desktop, where the palette covers a large share of
+      // the frame. At compact the dialog is deliberately small and top-anchored,
+      // so opening it legitimately moves the full-page pHash by only a few bits
+      // — a strict >4 would reject every genuinely painted mobile state.
       const painted = [...waits].reverse().find((state) => {
         const closed = ordered.filter((candidate) => {
           const palette = candidate.normalizedState.palette as Record<string, unknown> | undefined
@@ -133,11 +138,12 @@ export const workspaceCommandPaletteSpec: UiReviewSpec = {
             && candidate.ordinal < state.ordinal
             && palette?.dialogVisible === false
         }).at(-1)
+        const minimumPHashDistance = state.viewport.name === "mobile" ? 1 : 5
         return closed !== undefined
           && state.screenshotDigest !== closed.screenshotDigest
           && typeof state.screenshotPHash === "string"
           && typeof closed.screenshotPHash === "string"
-          && hexadecimalHammingDistance(state.screenshotPHash, closed.screenshotPHash) > 4
+          && hexadecimalHammingDistance(state.screenshotPHash, closed.screenshotPHash) >= minimumPHashDistance
       })
       return painted
     },


### PR DESCRIPTION
## Summary

- Make the mobile Workbench takeover full-bleed by removing desktop-only header, rail, and source-pane width.
- Keep the desktop collapsed activity rail interactive.
- Let the command palette size to its content on phones instead of rendering a half-empty fixed-height dialog.
- AAA pass: software-keyboard handling end to end (`--keyboard-inset` from `visualViewport`, consumed by composer-adjacent chrome, dialogs and palette; `interactive-widget=resizes-content` on every host), compact top-bar gating with relocated palette/theme actions, session-scoped full-bleed source overlay, safe-area primitives in the ui kit (dialog, alert-dialog, sheet, toast, command).
- Phone-tier performance: dockview stage is code-split out of the compact tier entirely; drawer animations on transform; stable panel params; hidden-rail subtree unmounted.
- Regression coverage for mobile full-bleed, keyboard insets (incl. pinch-zoom freeze), top-bar gating, host viewport metas, and desktop rail accessibility states.

## Validation

- \`pnpm --filter @hachej/boring-workspace test --run --maxWorkers=6\` (green per-file/batch; see proof comment for the contention note)
- \`pnpm --filter @hachej/boring-ui-kit test\`
- \`pnpm -r --workspace-concurrency=4 run typecheck\`
- \`pnpm lint:invariants\`
- Manual 390x844 screenshots via \`MOBILE_SHOT_DIR=<dir> pnpm --filter workspace-playground test:e2e -- mobile-shots\`.

Current-head proof: bcdc729da / [proof comment](https://github.com/hachej/boring-ui/pull/1362#issuecomment-5382216844).

## Review notes

- Read-only Sol/code review found and fixed a regression where \`hostRailOnly\` incorrectly made the visible desktop activity rail inert.
- Wave-2 integrated findings from three fresh-context adversarial reviews (thermo maintainability, UX correctness, test honesty); dispositions in the proof comment.