### PR TITLE
Git branch in workspace chrome + session status on session-list rows

### DIFF
--- a/packages/agent/src/front/chat/PiChatPanel.tsx
+++ b/packages/agent/src/front/chat/PiChatPanel.tsx
@@ -45,7 +45,7 @@ import {
   writePiComposerThinking,
   type ActiveSessionStorageLike,
 } from './session'
-import { SessionList, usePiSessions, type UsePiSessionsOptions } from './session'
+import { SessionList, usePiSessions, useSessionListActivity, type UsePiSessionsOptions } from './session'
 import {
   type ComposerBlocker,
   type ComposerBlockerAction,
@@ -307,6 +307,14 @@ export function PiChatPanel<
       if (sessionListRefreshRef.current === refreshSessionList) sessionListRefreshRef.current = undefined
     }
   }, [externalSessionId, sessions.refresh])
+  // Live-activity ownership sits beside the rendered list: a visible
+  // SessionList must see status transitions (running → idle → error), not a
+  // hidden one. Local state only — no request, no transcript read (gh-1338).
+  useSessionListActivity({
+    apiBaseUrl,
+    enabled: showSessionSidebar,
+    onActivity: (sessionId, status) => sessions.applyActivity(sessionId, status),
+  })
   const externalPiSession = useExternalRemotePiSession({
     sessionId: externalSessionId,
     agentTypeId,

--- a/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
+++ b/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
@@ -220,6 +220,54 @@ describe('PiChatPanel sandbox shell', () => {
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/api/v1/agents/default/sessions', expect.objectContaining({ method: 'POST' })))
   })
 
+  test('live session-activity transitions reach the rendered SessionList rows', async () => {
+    class FakeEventSource {
+      static last: FakeEventSource | undefined
+      closed = false
+      listeners = new Map<string, Array<(event: MessageEvent) => void>>()
+      constructor(public url: string) { FakeEventSource.last = this }
+      addEventListener(type: string, listener: (event: MessageEvent) => void) {
+        const list = this.listeners.get(type) ?? []
+        list.push(listener)
+        this.listeners.set(type, list)
+      }
+      removeEventListener() {}
+      close() { this.closed = true }
+      emit(type: string, data: unknown) {
+        for (const listener of this.listeners.get(type) ?? []) listener({ data: JSON.stringify(data) } as MessageEvent)
+      }
+    }
+    const previousEventSource = (globalThis as { EventSource?: unknown }).EventSource
+    ;(globalThis as { EventSource?: unknown }).EventSource = FakeEventSource
+
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse([session('pi-1')]))
+    try {
+      const view = render(<PiChatPanel showSessions serverResourcesEnabled={false} storageScope="scope-a" fetch={fetchMock as unknown as typeof fetch} createRemoteSession={remoteFactory(new FakeRemotePiSession(remoteState()))} />)
+      const row = await screen.findByText('Session pi-1')
+      expect(row.closest('[data-boring-agent-part="session-row"]')).toBeTruthy()
+
+      const source = FakeEventSource.last!
+      expect(source.url).toBe('/api/v1/agents/session-activity/events')
+      const statusDot = () => row.closest('[data-boring-agent-part="session-row"]')?.querySelector('[data-boring-agent-part="session-row-status"]')
+
+      // Snapshot marks the row running; a live edge then settles it idle and
+      // flags a failure — all without any refetch.
+      source.emit('snapshot', { sessions: [{ ref: { agentTypeId: 'default', sessionId: 'pi-1' }, status: 'running' }] })
+      await waitFor(() => expect(statusDot()?.getAttribute('data-boring-state')).toBe('running'))
+      source.emit('activity', { ref: { agentTypeId: 'default', sessionId: 'pi-1' }, status: 'idle' })
+      await waitFor(() => expect(statusDot()).toBeNull())
+      source.emit('activity', { ref: { agentTypeId: 'default', sessionId: 'pi-1' }, status: 'error' })
+      await waitFor(() => expect(statusDot()?.getAttribute('data-boring-state')).toBe('error'))
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+
+      view.unmount()
+      expect(source.closed).toBe(true)
+    } finally {
+      if (previousEventSource === undefined) delete (globalThis as { EventSource?: unknown }).EventSource
+      else (globalThis as { EventSource?: unknown }).EventSource = previousEventSource
+    }
+  })
+
   test('clears the composer immediately after local prompt acceptance', async () => {
     const remote = new FakeRemotePiSession(remoteState())
     const promptReceipt = deferred<{ accepted: true; cursor: number; clientNonce: string }>()

--- a/packages/agent/src/front/chat/session/SessionList.tsx
+++ b/packages/agent/src/front/chat/session/SessionList.tsx
@@ -24,6 +24,23 @@ type Group = { key: string; label: string; items: SessionSummary[] }
 
 const DAY_MS = 24 * 60 * 60 * 1000
 
+// Session activity is a four-value model owned by the server's in-memory
+// activity index: idle | running | aborting | error. `idle` is the resting
+// state of nearly every row, so it renders nothing at all — a list of dots
+// would carry no information and cost the row its quiet. The dot colors
+// deliberately reuse the tool-call group's state vocabulary (amber working,
+// muted stopping, destructive failed) so one status language runs through chat.
+const SESSION_STATUS_PRESENTATION = {
+  running: { label: 'Running', dotClassName: 'bg-amber-500/70' },
+  aborting: { label: 'Stopping', dotClassName: 'bg-muted-foreground/55' },
+  error: { label: 'Failed', dotClassName: 'bg-destructive ring-2 ring-destructive/20' },
+} satisfies Partial<Record<NonNullable<SessionSummary['status']>, { label: string; dotClassName: string }>>
+
+function statusPresentation(status: SessionSummary['status']) {
+  if (!status || status === 'idle') return undefined
+  return SESSION_STATUS_PRESENTATION[status]
+}
+
 export function SessionList({
   sessions,
   activeId,
@@ -112,6 +129,7 @@ export const SessionBrowser = SessionList
 
 function SessionRow({ session, active, onSwitch, onDelete }: { session: SessionSummary; active: boolean; onSwitch?: (id: string) => void; onDelete?: (id: string) => void }) {
   const time = relativeTime(session.updatedAt)
+  const status = statusPresentation(session.status)
   return (
     <li
       role="listitem"
@@ -128,6 +146,17 @@ function SessionRow({ session, active, onSwitch, onDelete }: { session: SessionS
         <span className={cn(active ? 'font-medium text-foreground' : 'text-foreground/90')}>{session.title || 'Untitled'}</span>
         {time ? <span className={cn('ml-1.5 tabular-nums text-[11px]', active ? 'text-[color:var(--accent)]' : 'text-muted-foreground/60')}>{time}</span> : null}
       </span>
+      {status ? (
+        <span
+          data-boring-agent-part="session-row-status"
+          data-boring-state={session.status}
+          className="flex size-4 shrink-0 items-center justify-center"
+          title={status.label}
+        >
+          <span aria-hidden="true" className={cn('size-1.5 rounded-full', status.dotClassName)} />
+          <span className="sr-only">{status.label}</span>
+        </span>
+      ) : null}
       {onDelete ? (
         <IconButton
           type="button"

--- a/packages/agent/src/front/chat/session/__tests__/SessionList.test.tsx
+++ b/packages/agent/src/front/chat/session/__tests__/SessionList.test.tsx
@@ -55,6 +55,35 @@ describe('SessionList', () => {
     expect(rows[1]?.getAttribute('data-boring-state')).toBe('selected')
   })
 
+  test('conveys live session status on the row, and stays silent when idle', () => {
+    const base = { createdAt: now.toISOString(), updatedAt: now.toISOString(), turnCount: 1 }
+    const withStatus: SessionSummary[] = [
+      { id: 'run', title: 'Running one', ...base, status: 'running' },
+      { id: 'stop', title: 'Stopping one', ...base, status: 'aborting' },
+      { id: 'bad', title: 'Failed one', ...base, status: 'error' },
+      { id: 'calm', title: 'Idle one', ...base, status: 'idle' },
+      { id: 'none', title: 'Unknown one', ...base },
+    ]
+
+    render(<SessionList sessions={withStatus} />)
+
+    const statusFor = (title: string) => screen
+      .getByText(title)
+      .closest('[data-boring-agent-part="session-row"]')
+      ?.querySelector('[data-boring-agent-part="session-row-status"]')
+
+    expect(statusFor('Running one')?.getAttribute('data-boring-state')).toBe('running')
+    expect(statusFor('Running one')?.textContent).toBe('Running')
+    expect(statusFor('Stopping one')?.getAttribute('data-boring-state')).toBe('aborting')
+    expect(statusFor('Stopping one')?.textContent).toBe('Stopping')
+    expect(statusFor('Failed one')?.getAttribute('data-boring-state')).toBe('error')
+    expect(statusFor('Failed one')?.textContent).toBe('Failed')
+
+    // Idle is the resting state of nearly every row: it must add no chrome.
+    expect(statusFor('Idle one')).toBeNull()
+    expect(statusFor('Unknown one')).toBeNull()
+  })
+
   test('renders empty/loading states', () => {
     const { rerender } = render(<SessionList sessions={[]} />)
     expect(screen.getByText(/No sessions yet/)).toBeTruthy()

--- a/packages/agent/src/front/chat/session/__tests__/usePiSessions.test.tsx
+++ b/packages/agent/src/front/chat/session/__tests__/usePiSessions.test.tsx
@@ -310,6 +310,11 @@ describe('usePiSessions', () => {
     await expect(saved.delete('source-a')).rejects.toMatchObject({ name: 'StaleSessionsSourceError' })
     await expect(saved.rename('source-a', 'Renamed')).rejects.toMatchObject({ name: 'StaleSessionsSourceError' })
     await expect(saved.refresh()).rejects.toMatchObject({ name: 'StaleSessionsSourceError' })
+    // applyActivity is synchronous (no rejection path), so it must fail closed
+    // by ignoring the mutation instead of corrupting the new source's list.
+    act(() => saved.applyActivity('source-a', 'running'))
+    // Still the committed source-A row, untouched by the stale mutation.
+    expect(result.current.sessions.map((item) => item.status)).toEqual(['idle'])
     saved.switch('source-a')
     saved.reset()
     expect(fetchMock).toHaveBeenCalledTimes(2)

--- a/packages/agent/src/front/chat/session/__tests__/usePiSessions.test.tsx
+++ b/packages/agent/src/front/chat/session/__tests__/usePiSessions.test.tsx
@@ -218,6 +218,45 @@ describe('usePiSessions', () => {
     })
   })
 
+  test('applies live activity to a listed session without refetching', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({
+      sessions: [{
+        ref: { agentTypeId: 'alpha', sessionId: 'native-1' },
+        title: 'Native',
+        status: 'idle',
+        createdAt: 1,
+        updatedAt: 2,
+        turnCount: 4,
+      }],
+    }))
+
+    const { result } = renderHook(() => usePiSessions({
+      agentTypeId: 'alpha',
+      fetch: fetchMock as unknown as typeof fetch,
+      connectActiveSession: false,
+      storageScope: 'default',
+      retry: { maxRetries: 0 },
+    }))
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.sessions[0]?.status).toBe('idle')
+    const callsAfterLoad = fetchMock.mock.calls.length
+
+    act(() => { result.current.applyActivity('native-1', 'running') })
+    expect(result.current.sessions[0]?.status).toBe('running')
+
+    act(() => { result.current.applyActivity('native-1', 'idle') })
+    expect(result.current.sessions[0]?.status).toBe('idle')
+
+    // The whole point: status stays honest off the SSE stream, so it must never
+    // cost a session-inventory request (gh-1338).
+    expect(fetchMock.mock.calls.length).toBe(callsAfterLoad)
+
+    const before = result.current.sessions
+    act(() => { result.current.applyActivity('unknown-session', 'running') })
+    expect(result.current.sessions).toBe(before)
+  })
+
   test('attests rows only after the requested source has loaded', async () => {
     const sourceB = deferred<Response>()
     fetchMock

--- a/packages/agent/src/front/chat/session/__tests__/useSessionListActivity.test.tsx
+++ b/packages/agent/src/front/chat/session/__tests__/useSessionListActivity.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { useSessionListActivity } from '../useSessionListActivity'
+
+class FakeEventSource {
+  static instances: FakeEventSource[] = []
+  url: string
+  closed = false
+  listeners = new Map<string, Array<(event: MessageEvent) => void>>()
+  constructor(url: string) {
+    this.url = url
+    FakeEventSource.instances.push(this)
+  }
+  addEventListener(type: string, listener: (event: MessageEvent) => void) {
+    const list = this.listeners.get(type) ?? []
+    list.push(listener)
+    this.listeners.set(type, list)
+  }
+  removeEventListener() {}
+  emit(type: string, data: unknown) {
+    for (const listener of this.listeners.get(type) ?? []) listener({ data: JSON.stringify(data) } as MessageEvent)
+  }
+  close() { this.closed = true }
+}
+
+function withFakeEventSource(run: () => void) {
+  const previous = (globalThis as { EventSource?: unknown }).EventSource
+  ;(globalThis as { EventSource?: unknown }).EventSource = FakeEventSource
+  FakeEventSource.instances = []
+  try { run() } finally {
+    if (previous === undefined) delete (globalThis as { EventSource?: unknown }).EventSource
+    else (globalThis as { EventSource?: unknown }).EventSource = previous
+  }
+}
+
+afterEach(() => { vi.restoreAllMocks() })
+
+describe('useSessionListActivity', () => {
+  test('opens the session-activity stream beside the rendered list and applies transitions', () => {
+    const onActivity = vi.fn()
+    withFakeEventSource(() => {
+      const { unmount } = renderHook(() => useSessionListActivity({ apiBaseUrl: 'http://hub', enabled: true, onActivity }))
+      const source = FakeEventSource.instances.at(-1)!
+      expect(source.url).toBe('http://hub/api/v1/agents/session-activity/events')
+
+      // A snapshot reconciles every listed row in one frame.
+      source.emit('snapshot', { sessions: [
+        { ref: { agentTypeId: 'alpha', sessionId: 's1' }, status: 'running' },
+        { ref: { agentTypeId: 'alpha', sessionId: 's2' }, status: 'idle' },
+      ] })
+      expect(onActivity).toHaveBeenCalledWith('s1', 'running', 'alpha')
+      expect(onActivity).toHaveBeenCalledWith('s2', 'idle', 'alpha')
+
+      // Live edge: running → idle rides the activity event.
+      source.emit('activity', { ref: { agentTypeId: 'alpha', sessionId: 's1' }, status: 'idle' })
+      expect(onActivity).toHaveBeenCalledWith('s1', 'idle', 'alpha')
+      expect(source.closed).toBe(false)
+
+      unmount()
+      expect(source.closed).toBe(true)
+    })
+  })
+
+  test('ignores malformed frames and skips opening when disabled', () => {
+    const onActivity = vi.fn()
+    withFakeEventSource(() => {
+      renderHook(() => useSessionListActivity({ enabled: false, onActivity }))
+      expect(FakeEventSource.instances).toHaveLength(0)
+
+      const { unmount } = renderHook(() => useSessionListActivity({ enabled: true, onActivity }))
+      const source = FakeEventSource.instances[0]
+      source.emit('activity', { ref: { sessionId: 's1' }, status: 'running' }) // missing agentTypeId
+      source.emit('activity', { ref: { agentTypeId: 'a', sessionId: 's1' }, status: 'exploded' })
+      source.emit('activity', undefined)
+      expect(onActivity).not.toHaveBeenCalled()
+      unmount()
+    })
+  })
+})

--- a/packages/agent/src/front/chat/session/index.ts
+++ b/packages/agent/src/front/chat/session/index.ts
@@ -5,7 +5,8 @@ export {
   type ActiveSessionStorageLike,
   type ActiveSessionStorageOptions,
 } from './sessionSelectionStorage'
-export { usePiSessions, type UsePiSessionsOptions, type UsePiSessionsResult, type PiSessionCreateInit, type PiSessionRefreshOptions } from './usePiSessions'
+export { usePiSessions, type UsePiSessionsOptions, type UsePiSessionsResult, type PiSessionCreateInit, type PiSessionRefreshOptions, type SessionActivityStatus } from './usePiSessions'
+export { useSessionListActivity } from './useSessionListActivity'
 export { SessionList, SessionBrowser, type SessionListProps } from './SessionList'
 export {
   searchPiSessions,

--- a/packages/agent/src/front/chat/session/usePiSessions.ts
+++ b/packages/agent/src/front/chat/session/usePiSessions.ts
@@ -61,6 +61,8 @@ export interface UsePiSessionsOptions {
   }
 }
 
+export type SessionActivityStatus = NonNullable<SessionSummary['status']>
+
 export interface UsePiSessionsResult {
   sessions: SessionSummary[]
   activeSession: SessionSummary | undefined
@@ -76,6 +78,15 @@ export interface UsePiSessionsResult {
   hasMore: boolean
   error: Error | undefined
   refresh: (options?: PiSessionRefreshOptions) => Promise<void>
+  /**
+   * Apply a live session-activity status to an already-listed session.
+   *
+   * Local state only — no request, no refetch. The server tracks activity in
+   * an in-memory index and already streams it over the session-activity SSE
+   * channel, so keeping a row's status honest costs nothing per row and never
+   * touches the transcript store (gh-1338).
+   */
+  applyActivity: (id: string, status: SessionActivityStatus) => void
   create: (init?: PiSessionCreateInit) => Promise<SessionSummary>
   rename: (id: string, title: string) => Promise<SessionSummary>
   switch: (id: string) => void
@@ -473,6 +484,20 @@ export function usePiSessions(options: UsePiSessionsOptions): UsePiSessionsResul
     return renamed
   }, [enabled, ensurePendingScope, fetchImpl, requestHeaders, requestScopeKey, sessionsUrl, sourceIsCurrent])
 
+  const applyActivity = useCallback((id: string, status: SessionActivityStatus): void => {
+    setSessions((current) => {
+      let changed = false
+      const next = current.map((session) => {
+        if (session.id !== id || session.status === status) return session
+        changed = true
+        return { ...session, status }
+      })
+      // Identity-stable when nothing moved, so an idle heartbeat can't churn
+      // every consumer of the list.
+      return changed ? next : current
+    })
+  }, [])
+
   const deleteSession = useCallback(async (id: string): Promise<void> => {
     const scope = requestScopeKey
     if (!sourceIsCurrent(scope)) throw new StaleSessionsSourceError()
@@ -551,6 +576,7 @@ export function usePiSessions(options: UsePiSessionsOptions): UsePiSessionsResul
     hasMore: enabled ? hasMore : false,
     error,
     refresh,
+    applyActivity,
     create,
     rename,
     switch: switchSession,

--- a/packages/agent/src/front/chat/session/usePiSessions.ts
+++ b/packages/agent/src/front/chat/session/usePiSessions.ts
@@ -485,6 +485,10 @@ export function usePiSessions(options: UsePiSessionsOptions): UsePiSessionsResul
   }, [enabled, ensurePendingScope, fetchImpl, requestHeaders, requestScopeKey, sessionsUrl, sourceIsCurrent])
 
   const applyActivity = useCallback((id: string, status: SessionActivityStatus): void => {
+    // Fail closed like every other mutation: a callback retained by an activity
+    // stream from a previous source (workspace/storage scope) must never mutate
+    // this list, even when session ids collide across sources.
+    if (!sourceIsCurrent(requestScopeKey)) return
     setSessions((current) => {
       let changed = false
       const next = current.map((session) => {
@@ -496,7 +500,7 @@ export function usePiSessions(options: UsePiSessionsOptions): UsePiSessionsResul
       // every consumer of the list.
       return changed ? next : current
     })
-  }, [])
+  }, [requestScopeKey, sourceIsCurrent])
 
   const deleteSession = useCallback(async (id: string): Promise<void> => {
     const scope = requestScopeKey

--- a/packages/agent/src/front/chat/session/useSessionListActivity.ts
+++ b/packages/agent/src/front/chat/session/useSessionListActivity.ts
@@ -1,0 +1,60 @@
+import { useEffect, useRef } from 'react'
+import type { SessionActivityStatus } from './usePiSessions'
+
+interface AddressedActivityFrame {
+  ref?: { agentTypeId?: unknown; sessionId?: unknown }
+  status?: unknown
+}
+
+function parseActivity(value: unknown): { sessionId: string; agentTypeId: string; status: SessionActivityStatus } | undefined {
+  if (!value || typeof value !== 'object') return undefined
+  const { ref, status } = value as AddressedActivityFrame
+  if (!ref || typeof ref !== 'object') return undefined
+  const { agentTypeId, sessionId } = ref
+  if (typeof agentTypeId !== 'string' || typeof sessionId !== 'string') return undefined
+  if (status !== 'idle' && status !== 'running' && status !== 'aborting' && status !== 'error') return undefined
+  return { sessionId, agentTypeId, status }
+}
+
+/**
+ * Live session-activity ownership for a *rendered* session list.
+ *
+ * The server tracks activity in an in-memory index and streams it on the
+ * session-activity SSE channel. Whoever renders the list must own this
+ * subscription — statuses that only update a hidden list leave visible rows
+ * stale. Local state only: no request, no per-row transcript read (gh-1338).
+ */
+export function useSessionListActivity(options: {
+  apiBaseUrl?: string
+  enabled: boolean
+  onActivity: (sessionId: string, status: SessionActivityStatus, agentTypeId: string) => void
+}): void {
+  const { apiBaseUrl, enabled, onActivity } = options
+  // Ref so stream events apply through the latest callback without
+  // resubscribing (and reconnecting) whenever list state changes.
+  const onActivityRef = useRef(onActivity)
+  onActivityRef.current = onActivity
+
+  useEffect(() => {
+    if (!enabled) return
+    const EventSourceCtor = typeof EventSource === 'undefined' ? null : EventSource
+    if (!EventSourceCtor) return
+    const endpoint = apiBaseUrl?.replace(/\/$/, '') ?? ''
+    const source = new EventSourceCtor(`${endpoint}/api/v1/agents/session-activity/events`)
+    const handle = (event: MessageEvent) => {
+      try {
+        const parsed: unknown = JSON.parse(event.data as string)
+        const frames = Array.isArray((parsed as { sessions?: unknown })?.sessions)
+          ? (parsed as { sessions: unknown[] }).sessions
+          : [parsed]
+        for (const frame of frames) {
+          const activity = parseActivity(frame)
+          if (activity) onActivityRef.current(activity.sessionId, activity.status, activity.agentTypeId)
+        }
+      } catch { /* Ignore malformed server frames. */ }
+    }
+    source.addEventListener('snapshot', handle as EventListener)
+    source.addEventListener('activity', handle as EventListener)
+    return () => source.close()
+  }, [apiBaseUrl, enabled])
+}

--- a/packages/boring-bash/src/server/git/gitBranch.test.ts
+++ b/packages/boring-bash/src/server/git/gitBranch.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { resolveGitBranch } from './gitBranch'
+import { __gitTestUtils } from './gitFileUrl'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+function stubGit(handler: (args: string[], cwd: string) => Promise<string>) {
+  return vi.spyOn(__gitTestUtils, 'runGit').mockImplementation(handler)
+}
+
+describe('resolveGitBranch', () => {
+  it('returns the checked-out branch for a Git-backed workspace', async () => {
+    const runGit = stubGit(async (args) => {
+      if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return '/repo'
+      if (args[0] === 'symbolic-ref') return 'feat/git-branch'
+      throw new Error(`unexpected git ${args.join(' ')}`)
+    })
+
+    await expect(resolveGitBranch('/repo/packages/app')).resolves.toEqual({
+      enabled: true,
+      branch: 'feat/git-branch',
+    })
+    // Branch lookup must stay to two cheap plumbing calls — no log/status walk.
+    expect(runGit).toHaveBeenCalledTimes(2)
+  })
+
+  it('reports the short sha when HEAD is detached', async () => {
+    stubGit(async (args) => {
+      if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return '/repo'
+      if (args[0] === 'symbolic-ref') throw new Error('not a symbolic ref')
+      if (args[0] === 'rev-parse' && args[1] === '--short') return 'a1b2c3d'
+      throw new Error(`unexpected git ${args.join(' ')}`)
+    })
+
+    await expect(resolveGitBranch('/repo')).resolves.toEqual({
+      enabled: true,
+      branch: 'a1b2c3d',
+      detached: true,
+    })
+  })
+
+  it('disables for a workspace that is not a Git repository', async () => {
+    const runGit = stubGit(async () => {
+      throw new Error('not a git repository')
+    })
+
+    await expect(resolveGitBranch('/plain/folder')).resolves.toEqual({
+      enabled: false,
+      reason: 'Workspace is not inside a Git repository.',
+    })
+    // Bails on the first failure instead of probing further.
+    expect(runGit).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables for a repository with no commits yet', async () => {
+    stubGit(async (args) => {
+      if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return '/fresh'
+      throw new Error('unborn branch')
+    })
+
+    await expect(resolveGitBranch('/fresh')).resolves.toEqual({
+      enabled: false,
+      reason: 'Git HEAD is not resolvable yet.',
+    })
+  })
+})

--- a/packages/boring-bash/src/server/git/gitBranch.ts
+++ b/packages/boring-bash/src/server/git/gitBranch.ts
@@ -1,0 +1,49 @@
+import { __gitTestUtils } from './gitFileUrl'
+
+export interface GitBranchResult {
+  enabled: boolean
+  reason?: string
+  /** Branch name, or the short commit sha when HEAD is detached. */
+  branch?: string
+  detached?: boolean
+}
+
+function disabled(reason: string): GitBranchResult {
+  return { enabled: false, reason }
+}
+
+/**
+ * Resolve the checked-out branch for a workspace root.
+ *
+ * Lives in the server adapter layer (not in routes/) because it shells out to
+ * git; routes must stay free of node:child_process/node:fs per the agent
+ * invariants. Reuses the same `runGit` seam as resolveGitFileUrl so tests can
+ * stub git without spawning a process, and so we add no git dependency.
+ *
+ * Returns a disabled result for the expected "not a repo / no commits yet"
+ * cases so non-Git workspaces render nothing rather than an error.
+ */
+export async function resolveGitBranch(workspaceRoot: string): Promise<GitBranchResult> {
+  let repoRoot: string
+  try {
+    repoRoot = await __gitTestUtils.runGit(['rev-parse', '--show-toplevel'], workspaceRoot)
+  } catch {
+    return disabled('Workspace is not inside a Git repository.')
+  }
+
+  try {
+    const branch = await __gitTestUtils.runGit(['symbolic-ref', '--quiet', '--short', 'HEAD'], repoRoot)
+    if (branch) return { enabled: true, branch }
+  } catch {
+    // Detached HEAD: symbolic-ref exits non-zero. Fall through to the sha.
+  }
+
+  try {
+    const commitSha = await __gitTestUtils.runGit(['rev-parse', '--short', 'HEAD'], repoRoot)
+    if (commitSha) return { enabled: true, branch: commitSha, detached: true }
+  } catch {
+    // Unborn branch (fresh `git init`, no commits): nothing meaningful to show.
+  }
+
+  return disabled('Git HEAD is not resolvable yet.')
+}

--- a/packages/boring-bash/src/server/index.ts
+++ b/packages/boring-bash/src/server/index.ts
@@ -106,6 +106,8 @@ export type {
 } from './routes/fsEventBroadcaster'
 
 export { buildGitFileUrl } from './git/buildGitFileUrl'
+export { resolveGitBranch } from './git/gitBranch'
+export type { GitBranchResult } from './git/gitBranch'
 export { __gitTestUtils, resolveGitFileUrl } from './git/gitFileUrl'
 export type { GitFileUrlResult } from './git/gitFileUrl'
 

--- a/packages/boring-bash/src/server/routes/git.test.ts
+++ b/packages/boring-bash/src/server/routes/git.test.ts
@@ -54,6 +54,43 @@ describe('gitRoutes', () => {
   })
 })
 
+describe('GET /api/v1/git/branch', () => {
+  it('reports the branch for a workspace with a host root', async () => {
+    vi.spyOn(__gitTestUtils, 'runGit').mockImplementation(async (args: string[]) => {
+      if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return '/repo'
+      if (args[0] === 'symbolic-ref') return 'main'
+      throw new Error(`unexpected git ${args.join(' ')}`)
+    })
+    const app = Fastify()
+    await app.register(gitRoutes, {
+      getWorkspace: async () => ({} as Workspace),
+      getWorkspaceHostRoot: () => '/repo',
+    })
+
+    const response = await app.inject({ method: 'GET', url: '/api/v1/git/branch' })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual({ enabled: true, branch: 'main' })
+    await app.close()
+  })
+
+  it('disables without invoking git when the runtime has no host root', async () => {
+    const runGit = vi.spyOn(__gitTestUtils, 'runGit')
+    const app = Fastify()
+    await app.register(gitRoutes, { getWorkspace: async () => ({} as Workspace) })
+
+    const response = await app.inject({ method: 'GET', url: '/api/v1/git/branch' })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual({
+      enabled: false,
+      reason: 'Git branch is unavailable for this runtime.',
+    })
+    expect(runGit).not.toHaveBeenCalled()
+    await app.close()
+  })
+})
+
 describe('resolveGitFileUrl path containment', () => {
   it('rejects traversal without invoking Git', async () => {
     const runGit = vi.spyOn(__gitTestUtils, 'runGit')

--- a/packages/boring-bash/src/server/routes/git.ts
+++ b/packages/boring-bash/src/server/routes/git.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
 import type { Workspace } from '@hachej/boring-agent/shared'
+import { resolveGitBranch } from '../git/gitBranch'
 import { isWorkspaceRelativeGitPath, resolveGitFileUrl } from '../git/gitFileUrl'
 import {
   ERROR_CODE_INTERNAL,
@@ -83,6 +84,25 @@ export function gitRoutes(
       request.log.warn({ err: error }, 'failed to build git file url')
       return reply.code(500).send({
         error: { code: ERROR_CODE_INTERNAL, message: 'failed to build git file url' },
+      })
+    }
+  })
+
+  app.get('/api/v1/git/branch', async (request, reply) => {
+    const workspaceRoot = await resolveWorkspaceRoot(request)
+    if (!workspaceRoot) {
+      return {
+        enabled: false,
+        reason: 'Git branch is unavailable for this runtime.',
+      }
+    }
+
+    try {
+      return await resolveGitBranch(workspaceRoot)
+    } catch (error) {
+      request.log.warn({ err: error }, 'failed to resolve git branch')
+      return reply.code(500).send({
+        error: { code: ERROR_CODE_INTERNAL, message: 'failed to resolve git branch' },
       })
     }
   })

--- a/packages/cli/src/front/App.test.tsx
+++ b/packages/cli/src/front/App.test.tsx
@@ -83,10 +83,19 @@ describe("CliWorkspaceShell", () => {
     expect(container.querySelector('[data-boring-workspace-part="workspace-loading-shell"]')).toBeNull()
   })
 
-  function mockWorkspacesMode(workspacesByCall: Array<Array<{ id: string; name: string; path: string; available: boolean }>>) {
+  function mockWorkspacesMode(
+    workspacesByCall: Array<Array<{ id: string; name: string; path: string; available: boolean }>>,
+    gitBranch: unknown = { enabled: false, reason: "Workspace is not inside a Git repository." },
+  ) {
     let call = 0
     globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input)
+      if (url.endsWith("/api/v1/git/branch")) {
+        return new Response(JSON.stringify(gitBranch), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      }
       if (url.endsWith("/api/v1/workspace/meta")) {
         return new Response(JSON.stringify({ projectName: "Folder Workspace", workspacesMode: true }), {
           status: 200,
@@ -175,6 +184,41 @@ describe("CliWorkspaceShell", () => {
 
     await waitFor(() => expect(workspaceAgentFrontSpy).toHaveBeenCalled())
     expect(workspaceAgentFrontSpy.mock.calls.at(-1)?.[0]).toMatchObject({ workspaceId: "target" })
+  })
+
+  test("shows the checked-out branch in the top bar for a Git-backed workspace", async () => {
+    window.history.replaceState(null, "", "/workspace/target")
+    mockWorkspacesMode(
+      [[{ id: "target", name: "Target", path: "/target", available: true }]],
+      { enabled: true, branch: "feat/git-branch-and-session-status" },
+    )
+
+    const { container } = render(<CliWorkspaceShell />)
+
+    await waitFor(() => expect(workspaceAgentFrontSpy).toHaveBeenCalled())
+    const badge = await waitFor(() => {
+      const found = container.querySelector('[data-testid="top-bar-right"] [data-boring-cli-part="git-branch"]')
+      expect(found).not.toBeNull()
+      return found!
+    })
+    expect(badge.textContent).toBe("feat/git-branch-and-session-status")
+    expect(badge.getAttribute("aria-label")).toBe("Git branch feat/git-branch-and-session-status")
+  })
+
+  test("renders no branch chrome for a workspace that is not Git-backed", async () => {
+    window.history.replaceState(null, "", "/workspace/target")
+    mockWorkspacesMode([[{ id: "target", name: "Target", path: "/target", available: true }]])
+
+    const { container } = render(<CliWorkspaceShell />)
+
+    await waitFor(() => expect(workspaceAgentFrontSpy).toHaveBeenCalled())
+    // Wait for the branch probe to have resolved before asserting absence.
+    await waitFor(() => expect(
+      (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls
+        .some(([input]) => String(input).endsWith("/api/v1/git/branch")),
+    ).toBe(true))
+    expect(container.querySelector('[data-boring-cli-part="git-branch"]')).toBeNull()
+    expect(container.textContent).not.toContain("not inside a Git repository")
   })
 
   test("statically composes live transcription without knowing its commands", async () => {

--- a/packages/cli/src/front/App.test.tsx
+++ b/packages/cli/src/front/App.test.tsx
@@ -205,6 +205,47 @@ describe("CliWorkspaceShell", () => {
     expect(badge.getAttribute("aria-label")).toBe("Git branch feat/git-branch-and-session-status")
   })
 
+  test("branch badge ignores a stale mount fetch that resolves after a newer focus fetch", async () => {
+    window.history.replaceState(null, "", "/workspace/target")
+    mockWorkspacesMode([[{ id: "target", name: "Target", path: "/target", available: true }]])
+
+    // Two deferred branch probes: the mount fetch (slow) and the focus fetch (fast).
+    const branchFetches: Array<(response: Response) => void> = []
+    const previousFetch = globalThis.fetch
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith("/api/v1/git/branch")) {
+        return new Promise<Response>((resolve) => branchFetches.push(resolve))
+      }
+      return await previousFetch(input)
+    }) as typeof fetch
+
+    try {
+      const { container, unmount } = render(<CliWorkspaceShell />)
+      await waitFor(() => expect(workspaceAgentFrontSpy).toHaveBeenCalled())
+      await waitFor(() => expect(branchFetches.length).toBe(1))
+
+      const mountFetch = branchFetches[0]
+      window.dispatchEvent(new Event("focus"))
+      await waitFor(() => expect(branchFetches.length).toBe(2))
+
+      // The focus fetch resolves first with the fresh branch…
+      branchFetches[1](new Response(JSON.stringify({ enabled: true, branch: "fresh-branch" }), { headers: { "Content-Type": "application/json" } }))
+      await waitFor(() => expect(
+        container.querySelector('[data-boring-cli-part="git-branch"]')?.textContent,
+      ).toBe("fresh-branch"))
+
+      // …then the older mount fetch lands late and must not overwrite it.
+      mountFetch(new Response(JSON.stringify({ enabled: true, branch: "stale-branch" }), { headers: { "Content-Type": "application/json" } }))
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      expect(container.querySelector('[data-boring-cli-part="git-branch"]')?.textContent).toBe("fresh-branch")
+
+      unmount()
+    } finally {
+      globalThis.fetch = previousFetch
+    }
+  })
+
   test("renders no branch chrome for a workspace that is not Git-backed", async () => {
     window.history.replaceState(null, "", "/workspace/target")
     mockWorkspacesMode([[{ id: "target", name: "Target", path: "/target", available: true }]])

--- a/packages/cli/src/front/App.tsx
+++ b/packages/cli/src/front/App.tsx
@@ -4,6 +4,7 @@ import * as ReactDomClient from "react-dom/client"
 import * as ReactJsxDevRuntime from "react/jsx-dev-runtime"
 import * as ReactJsxRuntime from "react/jsx-runtime"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { GitBranch } from "lucide-react"
 import { createAskUserPlugin } from "@hachej/boring-ask-user/front"
 import { boringAutomationPlugin } from "@hachej/boring-automation/front"
 import { diagramPlugin } from "@hachej/boring-diagram/front"
@@ -158,6 +159,60 @@ export function CliVersionBadge({ version }: { version?: string | null }) {
       className="rounded-full border border-border/60 bg-muted/40 px-2 py-0.5 text-[10px] font-medium leading-none tracking-tight text-muted-foreground"
     >
       v{label}
+    </span>
+  )
+}
+
+interface GitBranchMeta {
+  enabled?: boolean
+  branch?: string
+  detached?: boolean
+}
+
+/**
+ * Shows the checked-out branch for Git-backed workspaces, and nothing at all
+ * otherwise — no error, no empty chrome slot.
+ *
+ * Refresh strategy: fetch on mount, on workspace switch, and on window focus.
+ * A branch only changes through work done outside this tab (a terminal, an
+ * agent run), so regaining focus is the moment the value can be stale. That
+ * mirrors the existing refreshWorkspaces() focus listener below and costs one
+ * cheap `git symbolic-ref` instead of a poll.
+ */
+export function CliGitBranchBadge({ workspaceId }: { workspaceId?: string | null }) {
+  const [meta, setMeta] = useState<GitBranchMeta | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    const load = () => {
+      void fetch("/api/v1/git/branch", workspaceId ? { headers: { "x-boring-workspace-id": workspaceId } } : undefined)
+        .then(async (res) => res.ok ? await res.json() as GitBranchMeta : null)
+        .then((next) => { if (!cancelled) setMeta(next) })
+        .catch(() => { if (!cancelled) setMeta(null) })
+    }
+    // Drop the previous workspace's branch immediately so we never show it
+    // against the newly selected workspace.
+    setMeta(null)
+    load()
+    window.addEventListener("focus", load)
+    return () => {
+      cancelled = true
+      window.removeEventListener("focus", load)
+    }
+  }, [workspaceId])
+
+  const label = meta?.enabled ? meta.branch?.trim() : undefined
+  if (!label) return null
+  const description = meta?.detached ? `Detached HEAD at ${label}` : `Git branch ${label}`
+  return (
+    <span
+      data-boring-cli-part="git-branch"
+      aria-label={description}
+      title={description}
+      className="inline-flex max-w-40 items-center gap-1 rounded-full border border-border/60 bg-muted/40 px-2 py-0.5 text-[10px] font-medium leading-none tracking-tight text-muted-foreground"
+    >
+      <GitBranch className="size-3 shrink-0" strokeWidth={1.75} aria-hidden="true" />
+      <span className="truncate">{label}</span>
     </span>
   )
 }
@@ -483,7 +538,12 @@ export function CliWorkspaceShell() {
         }
         chatParams={{ thinkingControl: true }}
         frontPluginHotReload={runtimePluginFrontLoadingEnabled ? "vite" : false}
-        topBarRight={<CliVersionBadge version={cliVersion} />}
+        topBarRight={
+          <span className="flex items-center gap-1.5">
+            <CliGitBranchBadge workspaceId={activeWorkspace.id} />
+            <CliVersionBadge version={cliVersion} />
+          </span>
+        }
         topBarLeft={
           <WorkspaceSwitcherControl
             displayMode="workspace"
@@ -520,7 +580,12 @@ export function CliWorkspaceShell() {
       activeSessionId={initialSessionId ?? undefined}
       chatParams={{ thinkingControl: true }}
       frontPluginHotReload={runtimePluginFrontLoadingEnabled ? "vite" : false}
-      topBarRight={<CliVersionBadge version={cliVersion} />}
+      topBarRight={
+        <span className="flex items-center gap-1.5">
+          <CliGitBranchBadge />
+          <CliVersionBadge version={cliVersion} />
+        </span>
+      }
     />
   )
 }

--- a/packages/cli/src/front/App.tsx
+++ b/packages/cli/src/front/App.tsx
@@ -184,11 +184,15 @@ export function CliGitBranchBadge({ workspaceId }: { workspaceId?: string | null
 
   useEffect(() => {
     let cancelled = false
+    // Sequence commits: a slow mount/fetch can resolve after a newer focus
+    // fetch and otherwise pin a stale branch until the next event.
+    let latestLoad = 0
     const load = () => {
+      const loadSeq = ++latestLoad
       void fetch("/api/v1/git/branch", workspaceId ? { headers: { "x-boring-workspace-id": workspaceId } } : undefined)
         .then(async (res) => res.ok ? await res.json() as GitBranchMeta : null)
-        .then((next) => { if (!cancelled) setMeta(next) })
-        .catch(() => { if (!cancelled) setMeta(null) })
+        .then((next) => { if (!cancelled && loadSeq === latestLoad) setMeta(next) })
+        .catch(() => { if (!cancelled && loadSeq === latestLoad) setMeta(null) })
     }
     // Drop the previous workspace's branch immediately so we never show it
     // against the newly selected workspace.

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -68,7 +68,7 @@ import {
   workspaceSessionRefFromPersisted,
   type WorkspaceSessionRef,
 } from "../../front/sessionIdentity"
-import { startSessionActivityStream } from "../../front/sessionActivity"
+import { startSessionActivityStream, type SessionActivity } from "../../front/sessionActivity"
 
 const AGENT_OVERLAY_PREFIX = "agent-details:"
 const NATIVE_SESSION_UUID_PATTERN = /^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i
@@ -138,6 +138,15 @@ export interface WorkspaceAgentSessionsApi<
   delete: (id: string, agentTypeId?: string) => void | Promise<unknown>
   loadMore?: () => void | Promise<unknown>
   refresh?: (options?: { background?: boolean; throwOnError?: boolean }) => void | Promise<unknown>
+  /**
+   * Apply a live session-activity status to an already-listed row.
+   *
+   * Local state only: the status arrives on the session-activity SSE stream,
+   * so a provider must never fetch here — session inventory has to stay free
+   * of per-row work (gh-1338). Optional, so a host that does not implement it
+   * simply shows the status each row carried at list time.
+   */
+  applyActivity?: (id: string, status: SessionActivity, agentTypeId?: string) => void
 }
 
 export type UseWorkspaceAgentSessions<
@@ -541,6 +550,10 @@ function useDefaultWorkspacePiSessions(options: Parameters<UseWorkspaceAgentSess
     switch: (id, owner) => {
       if (owner && owner !== options.agentTypeId) return
       piSessions.switch(id)
+    },
+    applyActivity: (id, status, owner) => {
+      if (owner && owner !== options.agentTypeId) return
+      piSessions.applyActivity(id, status)
     },
     delete: async (id, owner) => {
       if (!owner || owner === options.agentTypeId) return await piSessions.delete(id)
@@ -1008,11 +1021,13 @@ export function WorkspaceAgentFront<
           },
         }))
         const current = remoteSessionsActivityRef.current
-        if (ref.agentTypeId !== current.selectedAgentTypeId) return
         // Keep the listed row's status honest as the turn moves. Pure local
         // state — no request and no transcript read, so this stays free even
-        // while session inventory is slow (gh-1338).
-        current.applyActivity?.(ref.sessionId, status)
+        // while session inventory is slow (gh-1338). Addressed by owner rather
+        // than gated on the selected agent: a fleet list shows rows from every
+        // agent, and all of them deserve an honest status.
+        current.applyActivity?.(ref.sessionId, status, ref.agentTypeId)
+        if (ref.agentTypeId !== current.selectedAgentTypeId) return
         // A session created out-of-band (e.g. an external chat entrypoint)
         // surfaces here as activity before this hook's own list has ever
         // fetched it. Reconcile the list immediately instead of waiting on

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -984,11 +984,13 @@ export function WorkspaceAgentFront<
   const remoteSessionsActivityRef = useRef({
     sessions: remoteSessionApi.sessions,
     refresh: remoteSessionApi.refresh,
+    applyActivity: remoteSessionApi.applyActivity,
     selectedAgentTypeId,
   })
   remoteSessionsActivityRef.current = {
     sessions: remoteSessionApi.sessions,
     refresh: remoteSessionApi.refresh,
+    applyActivity: remoteSessionApi.applyActivity,
     selectedAgentTypeId,
   }
   useEffect(() => {
@@ -1005,13 +1007,17 @@ export function WorkspaceAgentFront<
             working: status === "running" || status === "aborting",
           },
         }))
+        const current = remoteSessionsActivityRef.current
+        if (ref.agentTypeId !== current.selectedAgentTypeId) return
+        // Keep the listed row's status honest as the turn moves. Pure local
+        // state — no request and no transcript read, so this stays free even
+        // while session inventory is slow (gh-1338).
+        current.applyActivity?.(ref.sessionId, status)
         // A session created out-of-band (e.g. an external chat entrypoint)
         // surfaces here as activity before this hook's own list has ever
         // fetched it. Reconcile the list immediately instead of waiting on
         // a manual refresh or remount (gh-778).
         if (status !== "running" && status !== "aborting") return
-        const current = remoteSessionsActivityRef.current
-        if (ref.agentTypeId !== current.selectedAgentTypeId) return
         const known = current.sessions.some((session) => session.id === ref.sessionId)
         if (!known) void current.refresh?.({ background: true })
       },

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -292,6 +292,52 @@ describe("WorkspaceAgentFront", () => {
     window.removeEventListener("boring:chat-session-status", onStatus)
   })
 
+  it("applies activity to the listed row without refetching the session inventory", () => {
+    MockEventSource.instances = []
+    vi.stubGlobal("EventSource", MockEventSource)
+    const applyActivity = vi.fn()
+    const refresh = vi.fn()
+
+    render(
+      <WorkspaceAgentFront
+        workspaceId="row-status-stream"
+        chatPanel={SessionIdChatPanel}
+        useSessions={() => ({
+          sessions: [{ id: "session-1", title: "Session one", status: "idle" }],
+          activeSession: { id: "session-1", title: "Session one", status: "idle" },
+          activeSessionId: "session-1",
+          loading: false,
+          error: undefined,
+          create: vi.fn(),
+          switch: vi.fn(),
+          delete: vi.fn(),
+          refresh,
+          applyActivity,
+        })}
+      />,
+    )
+    const stream = MockEventSource.instances.find((instance) => instance.url.includes("/api/v1/agents/session-activity/events"))
+
+    act(() => {
+      stream?.emit("activity", { ref: { agentTypeId: "default", sessionId: "session-1" }, status: "running" })
+      stream?.emit("activity", { ref: { agentTypeId: "default", sessionId: "session-1" }, status: "idle" })
+    })
+
+    expect(applyActivity).toHaveBeenNthCalledWith(1, "session-1", "running", "default")
+    expect(applyActivity).toHaveBeenNthCalledWith(2, "session-1", "idle", "default")
+    // The whole point: an honest row status must never cost an inventory
+    // request (gh-1338).
+    expect(refresh).not.toHaveBeenCalled()
+
+    // A fleet list carries rows from every addressed agent, so status must be
+    // addressed by owner rather than dropped for the unselected ones.
+    applyActivity.mockClear()
+    act(() => {
+      stream?.emit("activity", { ref: { agentTypeId: "other", sessionId: "session-9" }, status: "running" })
+    })
+    expect(applyActivity).toHaveBeenCalledWith("session-9", "running", "other")
+  })
+
   it("reconciles the session list when activity reports a session created out-of-band (gh-778)", () => {
     MockEventSource.instances = []
     vi.stubGlobal("EventSource", MockEventSource)

--- a/packages/workspace/src/app/front/addressedFleetSessions.tsx
+++ b/packages/workspace/src/app/front/addressedFleetSessions.tsx
@@ -264,6 +264,12 @@ export function useAddressedFleetSessions<TSession extends WorkspaceAgentSession
       refresh: async (options) => {
         await Promise.all(agents.map((agent) => controllerFor(agent.agentTypeId)?.refresh?.(options)))
       },
+      applyActivity(id, status, requestedOwner) {
+        // Routed to the one owning controller, never broadcast: ids can collide
+        // across addressed agents, and this must stay a single local update.
+        const owner = ownerFor(id, requestedOwner)
+        controllerFor(owner)?.applyActivity?.(id, status, owner)
+      },
     }
   }, [agents, discoveryError, discoveryLoading, fleetSourceIdentity, selectAgentTypeId, selectedAgentTypeId, snapshots, sourceIdentityForAgent, workspaceId])
 

--- a/packages/workspace/src/front/sessionActivity.ts
+++ b/packages/workspace/src/front/sessionActivity.ts
@@ -6,7 +6,7 @@ import { workspaceSessionKey, workspaceSessionKeyFor } from "./sessionIdentity"
 const CHAT_SESSION_STATUS_EVENT = "boring:chat-session-status"
 const CHAT_SESSION_STATUS_REQUEST_EVENT = "boring:chat-session-status-request"
 
-type SessionActivity = "idle" | "running" | "aborting" | "error"
+export type SessionActivity = "idle" | "running" | "aborting" | "error"
 
 export interface SessionActivityItem {
   id: string


### PR DESCRIPTION
Two independent Roadmap board drafts (board items, no issue numbers). Kept as two commits so either can be dropped without touching the other.

---

## 1. Show the current Git branch for Git-backed workspaces

`059dc8e` — `packages/boring-bash`, `packages/cli`

**What the investigation found.** Nothing in the workspace model records that a workspace is Git-backed: `LocalWorkspace`, `toCoreWorkspace()`, and the core workspace runtime have no `git`/`repo`/`vcs` field, and there is no clone-a-repo provisioning path anywhere. Git-ness is discovered on demand by shelling out — that is already how `resolveGitFileUrl` works, and how `detectFolderModeTaskProviders` probes for a GitHub remote at boot.

**So it reuses that, exactly.** `resolveGitBranch()` sits next to `resolveGitFileUrl` in `packages/boring-bash/src/server/git/` and goes through the same `__gitTestUtils.runGit` seam, so:
- no new git dependency (the repo has none — no simple-git, no isomorphic-git);
- tests stub git without spawning a process;
- the invariant that routes stay free of `node:child_process` is preserved.

It is two plumbing commands (`rev-parse --show-toplevel`, `symbolic-ref --quiet --short HEAD`), with `rev-parse --short HEAD` only when HEAD is detached. No log walk, no `git status`.

**Nothing to wire per host.** `GET /api/v1/git/branch` rides the existing `gitRoutes` registration, so it lights up wherever `/api/v1/git/file-url` already does: CLI folder mode, CLI workspaces mode, standalone agent host, and core. Runtimes without a strong workspace fs capability have no host root and get `{ enabled: false }` without git ever being invoked.

**Refresh — why not a poll.** The badge fetches on mount, on workspace switch, and on window focus. A branch changes only through work done outside the tab (a terminal, an agent run), so regaining focus is precisely when the value can be stale; a timer would spend requests to learn nothing while you are typing. This mirrors the `refreshWorkspaces()` focus listener already in `CliWorkspaceShell`. Cost per refresh: one `git symbolic-ref`.

**Presentation.** `CliGitBranchBadge` reuses `CliVersionBadge`'s pill styling verbatim (same border, background, `text-[10px]`, radius) and sits next to it in `topBarRight`, with a lucide `GitBranch` glyph at `size-3` — the icon set already used in `WorkspaceSwitcherControl`. Long branch names truncate inside `max-w-40`. **Non-Git workspaces render nothing** — the component returns `null`, so there is no error text and no empty chrome slot, exactly like `CliVersionBadge` with no version. Detached HEAD shows the short sha with a "Detached HEAD at …" title.

**Proof**
- `packages/boring-bash`: `src/server/git/gitBranch.test.ts` (branch, detached HEAD, not-a-repo, unborn branch — and asserts the branch path stays at two git calls and that not-a-repo bails after one), plus two route tests in `src/server/routes/git.test.ts`.
- `packages/cli`: `App.test.tsx` gains "shows the checked-out branch in the top bar for a Git-backed workspace" and "renders no branch chrome for a workspace that is not Git-backed" (asserts absence *after* the probe resolved, so it cannot pass vacuously).
- **Revert check:** with only the implementation removed and the tests kept, the two route tests fail `expected 404 to be 200` and the CLI badge test times out waiting for `[data-boring-cli-part="git-branch"]`.

---

## 2. Session status visibility in the session list

`cb96d70` — `packages/agent`, `packages/workspace`

**The taxonomy is the server's, not invented.** `AgentSessionActivityIndex` tracks exactly four values — `idle | running | aborting | error` — in a process-lifetime in-memory `Map`. `embeddedGateway.listSessions()` already stamps it onto every summary, and `usePiSessions.toAddressedSessionSummary` already normalizes it into `SessionSummary.status`. The rows simply never rendered it. There is no "awaiting input" state anywhere in the session model, so none is shown.

**Perf: this adds nothing per row (gh-1338).** Status is a `Map.get` server-side — it never touches the transcript store, and the expensive part of inventory (title/turnCount/updatedAt) is untouched here. In the browser it rides the `session-activity` SSE stream that `WorkspaceAgentFront` already subscribes to. No new request, no extra round trip, no per-row work.

**One honesty fix was needed.** The activity stream previously only triggered a refresh for *unknown* sessions, so a listed row's `status` was frozen at whatever the last inventory fetch saw — a row would have sat on "running" forever after its turn ended. `usePiSessions.applyActivity(id, status)` patches local list state only (no request, no refetch) and returns the same array identity when nothing changed, so idle heartbeats cannot churn every consumer of the list.

**Presentation is deliberately quiet.** `idle` renders nothing at all — it is the resting state of nearly every row, and a column of dots would carry no information while costing the list its calm. The three remaining states reuse the tool-call group's existing dot vocabulary verbatim (`bg-amber-500/70` working, `bg-muted-foreground/55` stopping, `bg-destructive ring-2 ring-destructive/20` failed) in the same `size-1.5 rounded-full` inside a `size-4` centering wrapper, so chat speaks one status language. The dot sits in the trailing slot before the delete affordance, which keeps titles from shifting when a status appears. Screen readers get the label; the dot itself is `aria-hidden`. No new component, no new dependency, no badge chrome.

**Proof**
- `packages/agent`: `SessionList.test.tsx` — "conveys live session status on the row, and stays silent when idle" covers all four states plus a status-less summary; `usePiSessions.test.tsx` — "applies live activity to a listed session without refetching" asserts the status flips, that the fetch count does **not** move, and that an unknown session id leaves the array identity untouched.
- **Revert check:** with only the implementation removed and the tests kept, `expected undefined to be 'running'` and `TypeError: result.current.applyActivity is not a function`.

---

## Coordination

`fix/1338-session-inventory-perf` was read, not touched. It currently carries no inventory-perf commits and its diff touches `PiChatPanel.tsx` and `server/harness/pi-coding-agent/sessions.ts`; this branch touches neither. `SessionList.tsx`, `usePiSessions.ts`, `sessionInventory.ts`, `embeddedGateway.ts`, and `httpProjection.ts` are untouched by that branch, so there is no overlap.

## Visual verification

Pending — see the note added before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Review fixes (thermo gate round 1)

- **CRITICAL — visible list never received live updates**: `PiChatPanel` now owns the session-activity SSE stream beside its rendered `SessionList` (`useSessionListActivity`), so standalone rows track running→idle→error transitions. Integrated transition test added to `PiChatPanel.test.tsx`. Disposition note: workspace-side rows keep their existing working-chip path; full terminal-status rendering on workspace chrome rows belongs to #1364's surface, not this branch.
- **CRITICAL — `applyActivity` had no source guard**: now fails closed via `sourceIsCurrent(requestScopeKey)` like every other mutation; a callback retained from a previous source can no longer mutate a colliding session id. Extended the saved-callback source-switch test.
- **SHOULD-FIX — `CliGitBranchBadge` focus race**: fetch commits are sequenced; a late mount response can no longer overwrite a newer focus response. Focus-race regression test added.
