### PR TITLE
fix(workspace): correct dark --accent fallback + dedupe theme palette (drift guard)

### DIFF
--- a/apps/agent-playground/src/front/App.tsx
+++ b/apps/agent-playground/src/front/App.tsx
@@ -41,6 +41,10 @@ export function App() {
   const [showSessions, setShowSessions] = useState(showSessionsParam === '1')
 
   useEffect(() => {
+    // data-theme is the palette selector used by ui-kit tokens.css and the
+    // agent front styles; the .dark class is kept for any consumer still
+    // keying on it. Setting only one of the two leaves the pane half-themed.
+    document.documentElement.setAttribute('data-theme', theme)
     document.documentElement.classList.toggle('dark', theme === 'dark')
     window.localStorage.setItem(THEME_STORAGE_KEY, theme)
   }, [theme])

--- a/apps/agent-playground/src/front/app.css
+++ b/apps/agent-playground/src/front/app.css
@@ -4,7 +4,12 @@
 /* Standard boring theme (light + dark --boring-* values + shadcn bridge). */
 @import '@hachej/boring-ui-kit/tokens.css' layer(base);
 
-@custom-variant dark (&:where(.dark, .dark *));
+/* Must match the selector the token palettes key on (ui-kit tokens.css and
+ * @boring/agent front styles both use [data-theme="dark"]). Keying the dark
+ * variant on .dark here while the palettes key on data-theme swaps utility
+ * colors without swapping the token surfaces — the class of mismatch that
+ * produced the white-on-white agent subtree in the past. */
+@custom-variant dark (&:is([data-theme="dark"], [data-theme="dark"] *));
 
 /* App-local Tailwind scan roots only. Agent classes ship precompiled via
  * @boring/agent/front/styles.css imported from main.tsx. */

--- a/packages/agent/src/__tests__/theme-token-parity.test.ts
+++ b/packages/agent/src/__tests__/theme-token-parity.test.ts
@@ -1,0 +1,226 @@
+// @vitest-environment node
+
+/**
+ * Drift guard for the boring theme palette.
+ *
+ * `@hachej/boring-ui-kit/tokens.css` is the canonical palette. The agent front
+ * styles cannot simply import it: the agent package deliberately scopes every
+ * token to `[data-boring-agent]` and never writes a `:root` palette, so that
+ * embedding hosts keep ownership of their own `--boring-*` values regardless of
+ * CSS import order. The agent therefore restates the canonical values as
+ * `var(--boring-x, <literal>)` fallbacks, which is what keeps a standalone
+ * agent pane (CLI front, agent playground) themed with no workspace CSS loaded.
+ *
+ * Those literals are a copy by construction, so they need a guard rather than a
+ * dedup. This test parses both palettes into token maps and compares them by
+ * value, so it survives reformatting and reports the exact token that drifted.
+ *
+ * Background: the dark `--accent` / `--accent-foreground` / `--ring` fallbacks
+ * sat one revision behind the canonical palette for ~3 months because commit
+ * 55070acb6 was never propagated here, rendering standalone dark panes with the
+ * wrong accent.
+ */
+
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, test } from 'vitest'
+
+const ROOT = resolve(__dirname, '..', '..', '..', '..')
+
+const UI_KIT_TOKENS = resolve(ROOT, 'packages/ui/src/tokens.css')
+const WORKSPACE_GLOBALS = resolve(ROOT, 'packages/workspace/src/globals.css')
+const AGENT_GLOBALS = resolve(ROOT, 'packages/agent/src/front/styles/globals.css')
+const PLAYGROUND_APP_CSS = resolve(ROOT, 'apps/agent-playground/src/front/app.css')
+const PLAYGROUND_APP_TSX = resolve(ROOT, 'apps/agent-playground/src/front/App.tsx')
+
+const read = (path: string) => readFileSync(path, 'utf8')
+
+/**
+ * Tokens excluded from parity, each with the reason it legitimately differs.
+ * An entry here must still actually diverge — see the "stays honest" test — so
+ * a drift that later gets fixed cannot hide behind a stale exemption.
+ */
+const INTENTIONAL_DIVERGENCES: Record<string, string> = {
+  popover:
+    "agent popovers sit lifted off the pane background (agent dark --popover matches its own --surface-chat). Authored alongside the workspace value in 3d81367ca9, not drifted from it.",
+}
+
+/** Non-color tokens whose values are structural, not palette. */
+const IGNORED_PREFIXES = /^(radius|font|boring-agent-)/
+
+/** Body of a top-level CSS rule, matched on an exact selector. */
+function ruleBody(css: string, selector: string): string {
+  const start = css.indexOf(`${selector} {`)
+  if (start < 0) throw new Error(`selector not found in CSS: ${selector}`)
+  const open = css.indexOf('{', start)
+  const close = css.indexOf('\n}', open)
+  if (close < 0) throw new Error(`unterminated rule for selector: ${selector}`)
+  return css.slice(open + 1, close)
+}
+
+/** Canonical form: `--boring-x: <value>;` */
+function parseCanonicalTokens(body: string): Map<string, string> {
+  const tokens = new Map<string, string>()
+  for (const match of body.matchAll(/^\s*--boring-([a-z0-9-]+):\s*([^;]+);/gm)) {
+    const [, name, value] = match
+    if (IGNORED_PREFIXES.test(name)) continue
+    tokens.set(name, value.trim())
+  }
+  return tokens
+}
+
+/** Agent fallback form: `--x: var(--boring-x, <value>);` */
+function parseFallbackTokens(body: string): Map<string, string> {
+  const tokens = new Map<string, string>()
+  for (const match of body.matchAll(
+    /^\s*--([a-z0-9-]+):\s*var\(--boring-\1,\s*([\s\S]*?)\);\s*$/gm,
+  )) {
+    const [, name, value] = match
+    if (IGNORED_PREFIXES.test(name)) continue
+    tokens.set(name, value.trim())
+  }
+  return tokens
+}
+
+/** Agent literal form: `--x: <value>;` */
+function parseLiteralTokens(body: string): Map<string, string> {
+  const tokens = new Map<string, string>()
+  for (const match of body.matchAll(/^\s*--([a-z0-9-]+):\s*([^;]+);/gm)) {
+    const [, name, value] = match
+    if (IGNORED_PREFIXES.test(name)) continue
+    if (value.trim().startsWith('var(')) continue
+    tokens.set(name, value.trim())
+  }
+  return tokens
+}
+
+/**
+ * Compare the tokens the two palettes have in common. The agent intentionally
+ * carries a subset (no --success*, no --surface-workbench*), so missing tokens
+ * are not drift; differing values are.
+ */
+function findDrift(canonical: Map<string, string>, actual: Map<string, string>) {
+  const drift: { token: string; canonical: string; actual: string }[] = []
+  for (const [token, canonicalValue] of canonical) {
+    if (token in INTENTIONAL_DIVERGENCES) continue
+    const actualValue = actual.get(token)
+    if (actualValue === undefined) continue
+    if (actualValue !== canonicalValue) {
+      drift.push({ token, canonical: canonicalValue, actual: actualValue })
+    }
+  }
+  return drift
+}
+
+function formatDrift(
+  label: string,
+  drift: { token: string; canonical: string; actual: string }[],
+) {
+  return [
+    `${drift.length} token(s) drifted from the canonical ui-kit palette in ${label}:`,
+    ...drift.map(
+      (d) =>
+        `  --${d.token}\n` +
+        `    canonical (packages/ui/src/tokens.css): ${d.canonical}\n` +
+        `    actual    (${label}):                   ${d.actual}`,
+    ),
+    '',
+    'Update the agent value to match packages/ui/src/tokens.css, or — if the',
+    'divergence is deliberate — add the token to INTENTIONAL_DIVERGENCES in',
+    'this file with the reason.',
+  ].join('\n')
+}
+
+describe('theme palette parity with ui-kit tokens.css', () => {
+  const uiKit = read(UI_KIT_TOKENS)
+  const agent = read(AGENT_GLOBALS)
+
+  const canonicalLight = parseCanonicalTokens(ruleBody(uiKit, ':root'))
+  const canonicalDark = parseCanonicalTokens(ruleBody(uiKit, '[data-theme="dark"]'))
+
+  test('the canonical palette parses to a non-trivial token set', () => {
+    // Guards the parser itself: a regex that silently matches nothing would
+    // make every parity assertion below vacuously pass.
+    expect(canonicalLight.size).toBeGreaterThan(15)
+    expect(canonicalDark.size).toBeGreaterThan(15)
+    expect(canonicalDark.get('accent')).toBe('oklch(0.72 0.13 65)')
+  })
+
+  test('workspace globals.css matches ui-kit tokens.css', () => {
+    const workspace = read(WORKSPACE_GLOBALS)
+    for (const [selector, canonical] of [
+      [':root', canonicalLight],
+      ['[data-theme="dark"]', canonicalDark],
+    ] as const) {
+      const actual = parseCanonicalTokens(ruleBody(workspace, selector))
+      const drift = findDrift(canonical, actual)
+      expect(drift, formatDrift(`workspace globals.css ${selector}`, drift)).toEqual([])
+    }
+  })
+
+  test('agent light fallbacks match the canonical light palette', () => {
+    const actual = parseFallbackTokens(ruleBody(agent, '[data-boring-agent]'))
+    expect(actual.size).toBeGreaterThan(15)
+    const drift = findDrift(canonicalLight, actual)
+    expect(drift, formatDrift('agent [data-boring-agent]', drift)).toEqual([])
+  })
+
+  test('agent dark fallbacks match the canonical dark palette', () => {
+    const actual = parseFallbackTokens(
+      ruleBody(agent, '[data-theme="dark"] [data-boring-agent]'),
+    )
+    expect(actual.size).toBeGreaterThan(15)
+    const drift = findDrift(canonicalDark, actual)
+    expect(
+      drift,
+      formatDrift('agent [data-theme="dark"] [data-boring-agent]', drift),
+    ).toEqual([])
+  })
+
+  test('agent standalone dark literals match the canonical dark palette', () => {
+    const actual = parseLiteralTokens(ruleBody(agent, '[data-theme="dark"]'))
+    expect(actual.size).toBeGreaterThan(15)
+    const drift = findDrift(canonicalDark, actual)
+    expect(drift, formatDrift('agent [data-theme="dark"]', drift)).toEqual([])
+  })
+
+  test('the INTENTIONAL_DIVERGENCES allowlist stays honest', () => {
+    const darkFallbacks = parseFallbackTokens(
+      ruleBody(agent, '[data-theme="dark"] [data-boring-agent]'),
+    )
+    for (const token of Object.keys(INTENTIONAL_DIVERGENCES)) {
+      const canonical = canonicalDark.get(token)
+      const actual = darkFallbacks.get(token)
+      expect(
+        canonical !== undefined && actual !== undefined && canonical !== actual,
+        `--${token} is listed in INTENTIONAL_DIVERGENCES but no longer diverges ` +
+          `from the canonical palette (canonical: ${canonical}, agent: ${actual}). ` +
+          `Remove the exemption so the token is covered by the parity guard.`,
+      ).toBe(true)
+    }
+  })
+})
+
+describe('dark-mode selector agreement', () => {
+  // The palettes all key on [data-theme="dark"]. A surface that keys its
+  // Tailwind dark variant on .dark, or that toggles only the .dark class,
+  // swaps utility colors without swapping token surfaces — the mismatch that
+  // produced the white-on-white agent subtree incident.
+  test('agent-playground keys its dark variant on data-theme, not .dark', () => {
+    const css = read(PLAYGROUND_APP_CSS)
+    const customVariant = css.match(/@custom-variant\s+dark\s*\(([^)]*\))\s*\)?/)
+    expect(customVariant?.[1]).toBeDefined()
+    expect(customVariant?.[1]).toContain('[data-theme="dark"]')
+    expect(customVariant?.[1]).not.toMatch(/\.dark\b/)
+  })
+
+  test('agent-playground sets data-theme when applying a theme', () => {
+    const tsx = read(PLAYGROUND_APP_TSX)
+    expect(
+      tsx,
+      'agent-playground must set data-theme on documentElement; the token ' +
+        'palettes it imports key on [data-theme="dark"], so toggling only the ' +
+        '.dark class leaves the pane half-themed.',
+    ).toMatch(/setAttribute\(\s*['"]data-theme['"]/)
+  })
+})

--- a/packages/agent/src/__tests__/theme-token-parity.test.ts
+++ b/packages/agent/src/__tests__/theme-token-parity.test.ts
@@ -37,13 +37,53 @@ const read = (path: string) => readFileSync(path, 'utf8')
 
 /**
  * Tokens excluded from parity, each with the reason it legitimately differs.
+ *
+ * Scope: these exemptions apply ONLY to the two agent-dark comparisons.
+ * The workspace palettes and the agent light palette must match the
+ * canonical values exactly — a divergence there is always drift.
  * An entry here must still actually diverge — see the "stays honest" test — so
  * a drift that later gets fixed cannot hide behind a stale exemption.
  */
-const INTENTIONAL_DIVERGENCES: Record<string, string> = {
+const AGENT_DARK_INTENTIONAL_DIVERGENCES: Record<string, string> = {
   popover:
     "agent popovers sit lifted off the pane background (agent dark --popover matches its own --surface-chat). Authored alongside the workspace value in 3d81367ca9, not drifted from it.",
 }
+
+/**
+ * Agent-local tokens with no canonical counterpart are always drift — there
+ * are none today, and any new one must join the canonical palette or be
+ * explicitly justified here. (Named empty set so call sites read clearly.)
+ */
+const AGENT_EXTRA_TOKENS = new Set<string>([])
+
+/**
+ * Canonical tokens each agent surface deliberately does NOT restate (the
+ * embedding host or unused semantic slots own them). Anything else missing
+ * from an agent palette is drift — this is what catches deletions/renames.
+ */
+const AGENT_LIGHT_ALLOWED_MISSING = new Set([
+  'success',
+  'success-foreground',
+  'success-soft',
+  'surface-workbench',
+  'surface-workbench-left',
+])
+
+const AGENT_DARK_ALLOWED_MISSING = new Set([
+  'destructive',
+  'destructive-foreground',
+  'success',
+  'success-foreground',
+  'success-soft',
+  'surface-workbench',
+  'surface-workbench-left',
+])
+
+// The standalone literal block additionally omits --surface-chat.
+const AGENT_DARK_LITERAL_ALLOWED_MISSING = new Set([
+  ...AGENT_DARK_ALLOWED_MISSING,
+  'surface-chat',
+])
 
 /** Non-color tokens whose values are structural, not palette. */
 const IGNORED_PREFIXES = /^(radius|font|boring-agent-)/
@@ -94,39 +134,79 @@ function parseLiteralTokens(body: string): Map<string, string> {
   return tokens
 }
 
+type DriftEntry =
+  | { kind: 'missing'; token: string; canonical: string }
+  | { kind: 'unexpected'; token: string; canonical: null; actual: string }
+  | { kind: 'mismatch'; token: string; canonical: string; actual: string }
+
+interface DriftOptions {
+  /** Canonical tokens this target may omit (none by default). */
+  allowedMissing?: ReadonlySet<string>
+  /** Actual tokens permitted despite having no canonical counterpart. */
+  allowUnexpected?: ReadonlySet<string>
+  /** Canonical tokens whose values may differ at this target. */
+  intentional?: ReadonlySet<string>
+}
+
 /**
- * Compare the tokens the two palettes have in common. The agent intentionally
- * carries a subset (no --success*, no --surface-workbench*), so missing tokens
- * are not drift; differing values are.
+ * Exact-set parity check. A token counts as drift when it is missing from the
+ * actual palette (deletion/rename), present without a canonical counterpart
+ * (unless explicitly allowed), or its value differs (unless the divergence is
+ * intentional AT THIS TARGET — see AGENT_DARK_INTENTIONAL_DIVERGENCES).
  */
-function findDrift(canonical: Map<string, string>, actual: Map<string, string>) {
-  const drift: { token: string; canonical: string; actual: string }[] = []
+function findDrift(
+  canonical: Map<string, string>,
+  actual: Map<string, string>,
+  options: DriftOptions = {},
+): DriftEntry[] {
+  const { allowedMissing, allowUnexpected, intentional } = options
+  const drift: DriftEntry[] = []
   for (const [token, canonicalValue] of canonical) {
-    if (token in INTENTIONAL_DIVERGENCES) continue
     const actualValue = actual.get(token)
-    if (actualValue === undefined) continue
-    if (actualValue !== canonicalValue) {
-      drift.push({ token, canonical: canonicalValue, actual: actualValue })
+    if (actualValue === undefined) {
+      if (!allowedMissing?.has(token)) {
+        drift.push({ kind: 'missing', token, canonical: canonicalValue })
+      }
+      continue
+    }
+    if (actualValue !== canonicalValue && !intentional?.has(token)) {
+      drift.push({ kind: 'mismatch', token, canonical: canonicalValue, actual: actualValue })
+    }
+  }
+  for (const [token, actualValue] of actual) {
+    if (!canonical.has(token) && !allowUnexpected?.has(token)) {
+      drift.push({ kind: 'unexpected', token, canonical: null, actual: actualValue })
     }
   }
   return drift
 }
 
-function formatDrift(
-  label: string,
-  drift: { token: string; canonical: string; actual: string }[],
-) {
+function formatDrift(label: string, drift: DriftEntry[]) {
   return [
     `${drift.length} token(s) drifted from the canonical ui-kit palette in ${label}:`,
-    ...drift.map(
-      (d) =>
+    ...drift.map((d) => {
+      if (d.kind === 'missing') {
+        return (
+          `  --${d.token} MISSING\n` +
+          `    expected (packages/ui/src/tokens.css): ${d.canonical}`
+        )
+      }
+      if (d.kind === 'unexpected') {
+        return (
+          `  --${d.token} UNEXPECTED (no canonical counterpart)\n` +
+          `    actual (${label}): ${d.actual}`
+        )
+      }
+      return (
         `  --${d.token}\n` +
         `    canonical (packages/ui/src/tokens.css): ${d.canonical}\n` +
-        `    actual    (${label}):                   ${d.actual}`,
-    ),
+        `    actual    (${label}):                   ${d.actual}`
+      )
+    }),
     '',
-    'Update the agent value to match packages/ui/src/tokens.css, or — if the',
-    'divergence is deliberate — add the token to INTENTIONAL_DIVERGENCES in',
+    'Update the value to match packages/ui/src/tokens.css, restore the missing',
+    'token, remove the stray one, or — if the divergence is deliberate — add',
+    'it to AGENT_DARK_INTENTIONAL_DIVERGENCES / the *_ALLOWED_MISSING sets in',
     'this file with the reason.',
   ].join('\n')
 }
@@ -146,13 +226,15 @@ describe('theme palette parity with ui-kit tokens.css', () => {
     expect(canonicalDark.get('accent')).toBe('oklch(0.72 0.13 65)')
   })
 
-  test('workspace globals.css matches ui-kit tokens.css', () => {
+  test('workspace globals.css matches ui-kit tokens.css exactly', () => {
     const workspace = read(WORKSPACE_GLOBALS)
     for (const [selector, canonical] of [
       [':root', canonicalLight],
       ['[data-theme="dark"]', canonicalDark],
     ] as const) {
       const actual = parseCanonicalTokens(ruleBody(workspace, selector))
+      // Strict: same keys AND same values — no exemptions apply here, so a
+      // deleted, renamed, added, or re-valued workspace token fails.
       const drift = findDrift(canonical, actual)
       expect(drift, formatDrift(`workspace globals.css ${selector}`, drift)).toEqual([])
     }
@@ -161,7 +243,12 @@ describe('theme palette parity with ui-kit tokens.css', () => {
   test('agent light fallbacks match the canonical light palette', () => {
     const actual = parseFallbackTokens(ruleBody(agent, '[data-boring-agent]'))
     expect(actual.size).toBeGreaterThan(15)
-    const drift = findDrift(canonicalLight, actual)
+    // Light carries NO intentional divergences: every restated token must
+    // equal the canon; omissions are limited to AGENT_LIGHT_ALLOWED_MISSING.
+    const drift = findDrift(canonicalLight, actual, {
+      allowedMissing: AGENT_LIGHT_ALLOWED_MISSING,
+      allowUnexpected: AGENT_EXTRA_TOKENS,
+    })
     expect(drift, formatDrift('agent [data-boring-agent]', drift)).toEqual([])
   })
 
@@ -170,7 +257,11 @@ describe('theme palette parity with ui-kit tokens.css', () => {
       ruleBody(agent, '[data-theme="dark"] [data-boring-agent]'),
     )
     expect(actual.size).toBeGreaterThan(15)
-    const drift = findDrift(canonicalDark, actual)
+    const drift = findDrift(canonicalDark, actual, {
+      intentional: new Set(Object.keys(AGENT_DARK_INTENTIONAL_DIVERGENCES)),
+      allowedMissing: AGENT_DARK_ALLOWED_MISSING,
+      allowUnexpected: AGENT_EXTRA_TOKENS,
+    })
     expect(
       drift,
       formatDrift('agent [data-theme="dark"] [data-boring-agent]', drift),
@@ -180,15 +271,93 @@ describe('theme palette parity with ui-kit tokens.css', () => {
   test('agent standalone dark literals match the canonical dark palette', () => {
     const actual = parseLiteralTokens(ruleBody(agent, '[data-theme="dark"]'))
     expect(actual.size).toBeGreaterThan(15)
-    const drift = findDrift(canonicalDark, actual)
+    const drift = findDrift(canonicalDark, actual, {
+      intentional: new Set(Object.keys(AGENT_DARK_INTENTIONAL_DIVERGENCES)),
+      allowedMissing: AGENT_DARK_LITERAL_ALLOWED_MISSING,
+      allowUnexpected: AGENT_EXTRA_TOKENS,
+    })
     expect(drift, formatDrift('agent [data-theme="dark"]', drift)).toEqual([])
   })
 
-  test('the INTENTIONAL_DIVERGENCES allowlist stays honest', () => {
+  describe('guard self-checks (negative cases)', () => {
+    // These pin the guard's own behavior: each mutation below MUST produce a
+    // finding, so a future weakening of findDrift cannot silently reintroduce
+    // the ~3-month undetected accent drift this file exists to prevent.
+    const darkExemptions = new Set(Object.keys(AGENT_DARK_INTENTIONAL_DIVERGENCES))
+
+    test('a deleted agent token is reported, not silently skipped', () => {
+      const actual = parseFallbackTokens(
+        ruleBody(agent, '[data-theme="dark"] [data-boring-agent]'),
+      )
+      actual.delete('accent')
+      const drift = findDrift(canonicalDark, actual, {
+        intentional: darkExemptions,
+        allowedMissing: AGENT_DARK_ALLOWED_MISSING,
+        allowUnexpected: AGENT_EXTRA_TOKENS,
+      })
+      expect(drift).toContainEqual({
+        kind: 'missing',
+        token: 'accent',
+        canonical: canonicalDark.get('accent'),
+      })
+    })
+
+    test('a renamed agent token surfaces as missing + unexpected', () => {
+      const actual = parseLiteralTokens(ruleBody(agent, '[data-theme="dark"]'))
+      const value = actual.get('accent-foreground')!
+      actual.delete('accent-foreground')
+      actual.set('accent-foreground-renamed', value)
+      const drift = findDrift(canonicalDark, actual, {
+        intentional: darkExemptions,
+        allowedMissing: AGENT_DARK_LITERAL_ALLOWED_MISSING,
+        allowUnexpected: AGENT_EXTRA_TOKENS,
+      })
+      expect(drift).toContainEqual({
+        kind: 'missing',
+        token: 'accent-foreground',
+        canonical: canonicalDark.get('accent-foreground'),
+      })
+      expect(drift).toContainEqual({
+        kind: 'unexpected',
+        token: 'accent-foreground-renamed',
+        canonical: null,
+        actual: value,
+      })
+    })
+
+    test('a workspace popover drift is NOT exempt (exemption is dark-agent-scoped)', () => {
+      const workspace = read(WORKSPACE_GLOBALS)
+      const actual = parseCanonicalTokens(ruleBody(workspace, '[data-theme="dark"]'))
+      actual.set('popover', 'oklch(0.99 0.004 285.823)')
+      const drift = findDrift(canonicalDark, actual)
+      expect(drift).toContainEqual({
+        kind: 'mismatch',
+        token: 'popover',
+        canonical: canonicalDark.get('popover'),
+        actual: 'oklch(0.99 0.004 285.823)',
+      })
+    })
+
+    test('an agent-light popover drift is NOT exempt either', () => {
+      const actual = parseFallbackTokens(ruleBody(agent, '[data-boring-agent]'))
+      actual.set('popover', 'oklch(0.5 0.1 65)')
+      const drift = findDrift(canonicalLight, actual, {
+        allowUnexpected: AGENT_EXTRA_TOKENS,
+      })
+      expect(drift).toContainEqual({
+        kind: 'mismatch',
+        token: 'popover',
+        canonical: canonicalLight.get('popover'),
+        actual: 'oklch(0.5 0.1 65)',
+      })
+    })
+  })
+
+  test('the AGENT_DARK_INTENTIONAL_DIVERGENCES allowlist stays honest', () => {
     const darkFallbacks = parseFallbackTokens(
       ruleBody(agent, '[data-theme="dark"] [data-boring-agent]'),
     )
-    for (const token of Object.keys(INTENTIONAL_DIVERGENCES)) {
+    for (const token of Object.keys(AGENT_DARK_INTENTIONAL_DIVERGENCES)) {
       const canonical = canonicalDark.get(token)
       const actual = darkFallbacks.get(token)
       expect(

--- a/packages/agent/src/front/styles/globals.css
+++ b/packages/agent/src/front/styles/globals.css
@@ -75,12 +75,12 @@
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.269 0.006 285.885);
   --muted-foreground: oklch(0.708 0.01 286.073);
-  --accent: oklch(0.62 0.14 65);
-  --accent-foreground: oklch(0.12 0.004 285.823);
+  --accent: oklch(0.72 0.13 65);
+  --accent-foreground: oklch(0.18 0.02 65);
   --accent-soft: oklch(0.28 0.04 65);
   --border: oklch(0.269 0.006 285.885);
   --input: oklch(0.269 0.006 285.885);
-  --ring: oklch(0.62 0.14 65);
+  --ring: oklch(0.72 0.13 65);
   --canvas: oklch(0.12 0.004 285.823);
 }
 
@@ -174,12 +174,12 @@
   --secondary-foreground: var(--boring-secondary-foreground, oklch(0.985 0 0));
   --muted: var(--boring-muted, oklch(0.269 0.006 285.885));
   --muted-foreground: var(--boring-muted-foreground, oklch(0.708 0.01 286.073));
-  --accent: var(--boring-accent, oklch(0.62 0.14 65));
-  --accent-foreground: var(--boring-accent-foreground, oklch(0.12 0.004 285.823));
+  --accent: var(--boring-accent, oklch(0.72 0.13 65));
+  --accent-foreground: var(--boring-accent-foreground, oklch(0.18 0.02 65));
   --accent-soft: var(--boring-accent-soft, oklch(0.28 0.04 65));
   --border: var(--boring-border, oklch(0.269 0.006 285.885));
   --input: var(--boring-input, oklch(0.269 0.006 285.885));
-  --ring: var(--boring-ring, oklch(0.62 0.14 65));
+  --ring: var(--boring-ring, oklch(0.72 0.13 65));
   --canvas: var(--boring-canvas, oklch(0.12 0.004 285.823));
   --surface-chat: var(--boring-surface-chat, oklch(0.165 0.004 285.823));
   --boring-agent-user-bg: oklch(from var(--accent) l c h / 0.16);

--- a/packages/agent/src/front/styles/globals.css
+++ b/packages/agent/src/front/styles/globals.css
@@ -11,6 +11,17 @@
  * pane and the shell it embeds into share one visual language — same warm
  * near-neutral surface ramp, same amber accent, same radius scale.
  * (See .impeccable.md in the repo root for design context and principles.)
+ *
+ * PALETTE SOURCE OF TRUTH: packages/ui/src/tokens.css.
+ * The literals in the blocks below are var() fallbacks, not an independent
+ * palette. They exist so a standalone agent pane (CLI front, agent playground)
+ * stays themed with no workspace/ui-kit :root palette loaded; the agent
+ * deliberately never writes :root itself, so hosts keep ownership of
+ * --boring-* regardless of CSS import order. Because they are a copy by
+ * construction, they are guarded rather than deduped — any value changed here
+ * must also change in tokens.css, and vice versa. Enforced by
+ * src/__tests__/theme-token-parity.test.ts, which compares parsed token sets
+ * and names the offending token on failure.
  */
 
 @layer theme, base, components, utilities;

--- a/packages/ui/src/tokens.css
+++ b/packages/ui/src/tokens.css
@@ -8,8 +8,15 @@
  *   @import '@hachej/boring-ui-kit/tokens.css';
  *   :root { --boring-accent: oklch(0.55 0.18 250); }
  *
- * Values mirror @hachej/boring-workspace/src/globals.css (the canonical
- * theme). This file is plain CSS — no Tailwind required; the utility-name
+ * This file is the palette source of truth. Two other places restate these
+ * values and must be kept in step:
+ *   - packages/workspace/src/globals.css (the workspace :root palette)
+ *   - packages/agent/src/front/styles/globals.css (var() fallbacks that keep
+ *     standalone agent panes themed with no workspace CSS loaded)
+ * Both are enforced against this file by
+ * packages/agent/src/__tests__/theme-token-parity.test.ts.
+ *
+ * This file is plain CSS — no Tailwind required; the utility-name
  * mapping lives in styles.css (@theme inline → --boring-*).
  */
 


### PR DESCRIPTION
## Problem

Standalone agent panes (CLI front, agent playground) rendered a stale warm-amber accent. The agent package's dark palette carried pre-2026-05-26 literals: `--accent: oklch(0.62 0.14 65)` vs the canonical `oklch(0.72 0.13 65)` set by #55070acb6 (workspace) and #66fba8bba (ui-kit tokens). The copy silently drifted for months.

## Change

1. **44129c5f** — correct the three stale tokens (`--accent`, `--accent-foreground`, `--ring`) in both dark blocks of `packages/agent/src/front/styles/globals.css`: the bare `[data-theme="dark"]` literals and the `[data-boring-agent]` var() fallbacks. Playground CSS updated to match.
2. **c443cc60** — add `theme-token-parity.test.ts`: parses both stylesheets and asserts every restated palette token matches `packages/ui/src/tokens.css`, so this class of drift cannot recur.

A full runtime dedup of the fallback block was considered and rejected in commit c443cc60's message: standalone panes must render with zero workspace/ui-kit CSS loaded, so the literals are load-bearing; the parity test is the guard instead of an import cycle.

## Proof

\`\`\`
vitest run src/__tests__/theme-token-parity.test.ts
# Test Files 1 passed (1), Tests 8 passed (8)
\`\`\`

CI green on all checks (poll loop, no skipped-required).

## Review fixes (thermo gate round 2)

**Finding (CRITICAL):** the drift guard only compared intersecting keys and applied the `popover` exemption globally — deleting/renaming an agent token passed, and workspace/light popover drift was silently exempt.

**Disposition: FIXED** (`78472bcb8`):
- `findDrift` now reports three distinct finding kinds: `missing` (deletion/rename), `unexpected` (non-canonical key), `mismatch` (value drift).
- The `popover` exemption is scoped to the two agent-dark comparisons only; workspace palettes and agent light must match canonical values exactly.
- Per-target `*_ALLOWED_MISSING` sets document which canonical tokens each agent surface deliberately omits; any other absence is drift.
- Four negative self-checks pin the guard itself: deleted token fails, renamed token fails (missing + unexpected), workspace popover drift fails, agent-light popover drift fails.
- Validation: 12/12 parity tests pass locally; package `tsc --noEmit` clean; full CI green after push.
