### PR TITLE
perf(agent): paginate session inventory so listing stays fast (#1338)

### DIFF
--- a/packages/agent/src/server/agent-host/__tests__/sessionInventoryPagination.test.ts
+++ b/packages/agent/src/server/agent-host/__tests__/sessionInventoryPagination.test.ts
@@ -1,0 +1,203 @@
+import { mkdir, mkdtemp, rm, utimes, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createTestRuntimeModeAdapter } from '@agent-test-host'
+import type { AuthorizedAgentScope } from '../../../shared/index'
+import type { SessionListOptions } from '../../../shared/session'
+import { PiSessionStore } from '../../harness/pi-coding-agent/sessions'
+import { createAgentHost } from '../createAgentHost'
+import { sessionNamespaceForAgent } from '../sessionInventory'
+import type { AgentHostAgentSpec } from '../types'
+
+const roots: string[] = []
+
+afterEach(async () => {
+  vi.restoreAllMocks()
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+async function temporaryRoot(): Promise<string> {
+  const value = await mkdtemp(join(tmpdir(), 'agent-session-inventory-'))
+  roots.push(value)
+  return value
+}
+
+const legacyDefaultAgent = { agentTypeId: 'default', legacyDefault: true } as const satisfies AgentHostAgentSpec
+
+function pathDerivedDirName(cwd: string): string {
+  return `--${cwd.replace(/^[/\\]/, '').replace(/[/\\:]/g, '-')}--`
+}
+
+function transcript(id: string, title: string, workspaceScopeId: string, timestamp: string): string {
+  return [
+    JSON.stringify({
+      type: 'session',
+      version: 1,
+      id,
+      timestamp,
+      cwd: '/workspace',
+      boringSessionCtx: { workspaceId: workspaceScopeId },
+    }),
+    JSON.stringify({ type: 'session_info', id: `info-${id}`, parentId: null, timestamp, name: title }),
+    JSON.stringify({
+      type: 'message',
+      id: `message-${id}`,
+      parentId: null,
+      timestamp,
+      message: { role: 'user', content: [{ type: 'text', text: 'hello' }], timestamp: 1 },
+    }),
+    '',
+  ].join('\n')
+}
+
+/** Plants an existing transcript with a deterministic mtime so listing order is stable. */
+async function plant(dir: string, id: string, title: string, workspaceScopeId: string, atMs: number): Promise<void> {
+  await mkdir(dir, { recursive: true })
+  const filepath = join(dir, `${id}.jsonl`)
+  await writeFile(filepath, transcript(id, title, workspaceScopeId, new Date(atMs).toISOString()))
+  await utimes(filepath, new Date(atMs), new Date(atMs))
+}
+
+async function startHost(input: {
+  readonly agents: readonly AgentHostAgentSpec[]
+  readonly sessionRoot: string
+  readonly workspaceRoot: string
+  readonly sessionNamespace: string
+}) {
+  const mode = createTestRuntimeModeAdapter('direct')
+  return await createAgentHost({
+    agents: input.agents,
+    fleetCompiler: { async compile({ agents }) { return agents } },
+    hostId: 'session-inventory-host',
+    scopeVerifier: {
+      async verify(candidate) {
+        return { workspaceScopeId: candidate.workspaceScopeId, authSubjectId: candidate.authSubjectId }
+      },
+    },
+    runtimeModeAdapter: mode,
+    sessionRoot: input.sessionRoot,
+    resolveAuthorizedEnvironmentScope: async () => ({
+      placementIdentity: 'direct-a',
+      workspaceRoot: input.workspaceRoot,
+      provisioningFingerprint: 'provision-a',
+    }),
+    resolveAuthorizedAgentRuntimeScope: async ({ agentTypeId }) => ({
+      identity: `${agentTypeId}:runtime`,
+      physicalBindingIdentity: `${agentTypeId}:runtime`,
+      resourceInputDigest: `${agentTypeId}:runtime`,
+      sessionNamespace: input.sessionNamespace,
+    }),
+    harnessFactory: async () => { throw new Error('listing must not create a harness') },
+  })
+}
+
+describe('legacyDefault seat storage placement', () => {
+  it('keeps an empty runtime namespace on the cwd-derived directory both sides already use', async () => {
+    const sessionRoot = await temporaryRoot()
+    const workspaceRoot = join(sessionRoot, 'workspace')
+
+    // The one function both `buildAgentComposition` (write) and
+    // `AgentSessionInventory` (read) consume. `undefined` is the deliberate
+    // answer, and it must keep resolving to the path-derived directory that
+    // already holds users' transcripts.
+    const namespace = sessionNamespaceForAgent(legacyDefaultAgent, 'workspace-a:storage-a', '')
+    expect(namespace).toBeUndefined()
+
+    const store = new PiSessionStore(workspaceRoot, {
+      sessionNamespace: namespace,
+      sessionRoot,
+      storageCwd: workspaceRoot,
+    })
+    expect(store.getSessionDir()).toBe(join(sessionRoot, pathDerivedDirName(workspaceRoot)))
+  })
+
+  it('honours a host-supplied namespace for the same seat', () => {
+    expect(sessionNamespaceForAgent(legacyDefaultAgent, 'workspace-a:storage-a', 'workspace-a'))
+      .toBe('workspace-a')
+  })
+
+  it('still lists transcripts that already live in the cwd-derived directory', async () => {
+    const sessionRoot = await temporaryRoot()
+    const workspaceRoot = join(sessionRoot, 'workspace')
+    const workspaceScopeId = 'workspace-a:storage-a'
+    const scope = { workspaceScopeId, authSubjectId: 'subject-a' } as AuthorizedAgentScope
+
+    await plant(
+      join(sessionRoot, pathDerivedDirName(workspaceRoot)),
+      'pre-existing-session',
+      'A session the user already had',
+      workspaceScopeId,
+      Date.UTC(2026, 6, 20),
+    )
+
+    const host = await startHost({
+      agents: [legacyDefaultAgent],
+      sessionRoot,
+      workspaceRoot,
+      sessionNamespace: '',
+    })
+    try {
+      const page = await host.gateway.listSessions({ scope, limit: 10 })
+      expect(page.sessions).toEqual([expect.objectContaining({
+        ref: { agentTypeId: 'default', sessionId: 'pre-existing-session' },
+        title: 'A session the user already had',
+      })])
+    } finally {
+      await host.host.close()
+    }
+  })
+})
+
+describe('seat session listing pagination', () => {
+  it('bounds every store read and pages without gaps or repeats', async () => {
+    const sessionRoot = await temporaryRoot()
+    const workspaceRoot = join(sessionRoot, 'workspace')
+    const workspaceScopeId = 'workspace-a:storage-a'
+    const scope = { workspaceScopeId, authSubjectId: 'subject-a' } as AuthorizedAgentScope
+    const dir = join(sessionRoot, pathDerivedDirName(workspaceRoot))
+    const total = 7
+    for (let index = 0; index < total; index += 1) {
+      await plant(dir, `session-${index}`, `Session ${index}`, workspaceScopeId, Date.UTC(2026, 6, 20) + index * 60_000)
+    }
+
+    const listOptions: (SessionListOptions | undefined)[] = []
+    const originalList = PiSessionStore.prototype.list
+    vi.spyOn(PiSessionStore.prototype, 'list').mockImplementation(async function (this: PiSessionStore, ctx, options) {
+      listOptions.push(options)
+      return await originalList.call(this, ctx, options)
+    })
+
+    const host = await startHost({
+      agents: [legacyDefaultAgent],
+      sessionRoot,
+      workspaceRoot,
+      sessionNamespace: '',
+    })
+    try {
+      const seen: string[] = []
+      let cursor: string | undefined
+      let pages = 0
+      do {
+        const page = await host.gateway.listSessions({ scope, agentTypeId: 'default', limit: 2, cursor })
+        pages += 1
+        seen.push(...page.sessions.map((summary) => summary.ref.sessionId))
+        cursor = page.nextCursor
+        expect(page.sessions.length).toBeLessThanOrEqual(2)
+      } while (cursor && pages < 10)
+
+      // Newest first, every session exactly once.
+      expect(seen).toEqual(
+        Array.from({ length: total }, (_unused, index) => `session-${total - 1 - index}`),
+      )
+
+      // The listing NEVER asks the store for the whole directory: each read is
+      // bounded, and the bound only grows by the page size as paging deepens.
+      expect(listOptions.length).toBe(pages)
+      expect(listOptions.every((options) => typeof options?.limit === 'number')).toBe(true)
+      expect(listOptions.map((options) => options!.limit)).toEqual([3, 5, 7, 9])
+    } finally {
+      await host.host.close()
+    }
+  })
+})

--- a/packages/agent/src/server/agent-host/__tests__/sessionInventoryPagination.test.ts
+++ b/packages/agent/src/server/agent-host/__tests__/sessionInventoryPagination.test.ts
@@ -351,4 +351,77 @@ describe('equal-updatedAt tiebreak (sessions must never disappear)', () => {
       await host.host.close()
     }
   })
+
+  it('sorts readable wrapper transcripts by header id, not filename (limit-1)', async () => {
+    // A wrapper transcript is not timestamp-named, so its FILENAME stem is
+    // free to disagree with the canonical summary id in its readable header.
+    // With filenames mapped REVERSE to header ids and limit 1, an ordering
+    // keyed on stems leads its bounded prefix with the WRONG row: the
+    // gateway emits it, advances the cursor past ids that sort earlier, and
+    // every smaller-header-id session vanishes from all later pages.
+    const sessionRoot = await temporaryRoot()
+    const workspaceRoot = join(sessionRoot, 'workspace')
+    const workspaceScopeId = 'workspace-w:storage-w'
+    const scope = { workspaceScopeId, authSubjectId: 'subject-a' } as AuthorizedAgentScope
+    const dir = join(sessionRoot, pathDerivedDirName(workspaceRoot))
+    await mkdir(dir, { recursive: true })
+    const wrappers = [
+      { file: 'a.jsonl', headerId: 'wrap-c' },
+      { file: 'b.jsonl', headerId: 'wrap-b' },
+      { file: 'c.jsonl', headerId: 'wrap-a' },
+    ]
+    for (const { file, headerId } of wrappers) {
+      const iso = new Date(SHARED_MS).toISOString()
+      const lines = [
+        JSON.stringify({
+          type: 'session',
+          version: 1,
+          id: headerId,
+          timestamp: iso,
+          cwd: '/workspace',
+          boringSessionCtx: { workspaceId: workspaceScopeId },
+        }),
+        JSON.stringify({
+          type: 'message',
+          id: `message-${headerId}`,
+          parentId: null,
+          timestamp: iso,
+          message: { role: 'user', content: [{ type: 'text', text: `hello ${headerId}` }], timestamp: 1 },
+        }),
+      ]
+      await writeFile(join(dir, file), `${lines.join('\n')}\n`)
+    }
+    // Equalize file mtimes so recency ties and the id tiebreak decides —
+    // that tiebreak is the whole point of this regression.
+    const sharedTime = new Date(SHARED_MS)
+    for (const { file } of wrappers) {
+      await utimes(join(dir, file), sharedTime, sharedTime)
+    }
+
+    const host = await startHost({
+      agents: [legacyDefaultAgent],
+      sessionRoot,
+      workspaceRoot,
+      sessionNamespace: '',
+    })
+    try {
+      const seen: string[] = []
+      let cursor: string | undefined
+      let pages = 0
+      do {
+        const page = await host.gateway.listSessions({ scope, agentTypeId: 'default', limit: 1, cursor })
+        pages += 1
+        seen.push(...page.sessions.map((summary) => summary.ref.sessionId))
+        cursor = page.nextCursor
+        expect(page.sessions.length).toBeLessThanOrEqual(1)
+      } while (cursor && pages < 10)
+
+      // Exact gateway total order over header ids. Under filename-stem
+      // ordering the store's prefix led with a.jsonl (wrap-c), so wrap-a and
+      // wrap-b fell outside the bounded prefix and vanished.
+      expect(seen).toEqual(['wrap-a', 'wrap-b', 'wrap-c'])
+    } finally {
+      await host.host.close()
+    }
+  })
 })

--- a/packages/agent/src/server/agent-host/__tests__/sessionInventoryPagination.test.ts
+++ b/packages/agent/src/server/agent-host/__tests__/sessionInventoryPagination.test.ts
@@ -2,6 +2,23 @@ import { mkdir, mkdtemp, rm, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// Deterministic worst-case directory order (reverse-alphabetical): a store
+// that breaks recency ties by readdir order instead of session id truncates
+// away exactly the sessions the merge order ranks first. Without this mock
+// the regression below depends on the host filesystem's hash order.
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>()
+  return {
+    ...actual,
+    readdir: ((path: Parameters<typeof actual.readdir>[0], options?: Parameters<typeof actual.readdir>[1]) =>
+      Promise.resolve(actual.readdir(path, options as never)).then((entries: unknown) =>
+        Array.isArray(entries)
+          ? (entries as string[]).slice().sort().reverse()
+          : entries,
+      )) as typeof actual.readdir,
+  }
+})
 import { createTestRuntimeModeAdapter } from '@agent-test-host'
 import type { AuthorizedAgentScope } from '../../../shared/index'
 import type { SessionListOptions } from '../../../shared/session'
@@ -199,5 +216,94 @@ describe('seat session listing pagination', () => {
     } finally {
       await host.host.close()
     }
+  })
+})
+
+describe('equal-updatedAt tiebreak (sessions must never disappear)', () => {
+  // The gateway's bounded merge only sees each store's top prefix, so the
+  // store MUST break recency ties by session id — exactly like the gateway's
+  // total order. These transcripts all share one latest-message timestamp and
+  // are CREATED in reverse id order, so readdir order among the ties is the
+  // opposite of the required order: a store that truncates before breaking
+  // ties drops low-id sessions from every page, forever.
+  const SHARED_MS = Date.UTC(2026, 6, 20, 12, 0, 0)
+  const IDS = ['zeta', 'yankee', 'xray', 'beta', 'alpha']
+
+  async function plantNativeTie(dir: string, id: string, workspaceScopeId: string): Promise<void> {
+    await mkdir(dir, { recursive: true })
+    const iso = new Date(SHARED_MS).toISOString()
+    const lines = [
+      JSON.stringify({
+        type: 'session',
+        version: 1,
+        id,
+        timestamp: iso,
+        cwd: '/workspace',
+        boringSessionCtx: { workspaceId: workspaceScopeId },
+      }),
+      JSON.stringify({
+        type: 'message',
+        id: `message-${id}`,
+        parentId: null,
+        timestamp: iso,
+        message: { role: 'user', content: [{ type: 'text', text: `hello ${id}` }], timestamp: 1 },
+      }),
+    ]
+    await writeFile(join(dir, `${iso.replace(/[:.]/g, '-')}_${id}.jsonl`), `${lines.join('\n')}\n`)
+  }
+
+  it('pages every equal-timestamp native session exactly once through the gateway', async () => {
+    const sessionRoot = await temporaryRoot()
+    const workspaceRoot = join(sessionRoot, 'workspace')
+    const workspaceScopeId = 'workspace-a:storage-a'
+    const scope = { workspaceScopeId, authSubjectId: 'subject-a' } as AuthorizedAgentScope
+    const dir = join(sessionRoot, pathDerivedDirName(workspaceRoot))
+    for (const id of IDS) {
+      await plantNativeTie(dir, id, workspaceScopeId)
+    }
+
+    const host = await startHost({
+      agents: [legacyDefaultAgent],
+      sessionRoot,
+      workspaceRoot,
+      sessionNamespace: '',
+    })
+    try {
+      const seen: string[] = []
+      let cursor: string | undefined
+      let pages = 0
+      do {
+        const page = await host.gateway.listSessions({ scope, agentTypeId: 'default', limit: 2, cursor })
+        pages += 1
+        seen.push(...page.sessions.map((summary) => summary.ref.sessionId))
+        cursor = page.nextCursor
+      } while (cursor && pages < 10)
+
+      expect(seen).toEqual(['alpha', 'beta', 'xray', 'yankee', 'zeta'])
+      expect(new Set(seen).size).toBe(IDS.length)
+    } finally {
+      await host.host.close()
+    }
+  })
+
+  it('orders tied sessions by id inside the store itself, before any truncation', async () => {
+    const { PiSessionStore: Store } = await import('../../harness/pi-coding-agent/sessions')
+    const sessionRoot = await temporaryRoot()
+    const cwd = join(sessionRoot, 'workspace')
+    const dir = join(sessionRoot, pathDerivedDirName(cwd))
+    for (const id of IDS) {
+      await plantNativeTie(dir, id, 'tie-workspace')
+    }
+    const store = new Store(cwd, { sessionRoot, storageCwd: cwd })
+    const ctx = { workspaceId: 'tie-workspace' }
+
+    // The first page of a bounded listing must already be the total-order
+    // prefix; deeper offsets must complete it with zero gaps or repeats.
+    const paged: string[] = []
+    for (let offset = 0; offset < IDS.length; offset += 2) {
+      paged.push(...(await store.list(ctx, { limit: 2, offset })).map((summary) => summary.id))
+    }
+    expect(paged).toEqual(['alpha', 'beta', 'xray', 'yankee', 'zeta'])
+    expect(new Set(paged).size).toBe(IDS.length)
   })
 })

--- a/packages/agent/src/server/agent-host/__tests__/sessionInventoryPagination.test.ts
+++ b/packages/agent/src/server/agent-host/__tests__/sessionInventoryPagination.test.ts
@@ -306,4 +306,49 @@ describe('equal-updatedAt tiebreak (sessions must never disappear)', () => {
     expect(paged).toEqual(['alpha', 'beta', 'xray', 'yankee', 'zeta'])
     expect(new Set(paged).size).toBe(IDS.length)
   })
+
+  it('tiebreaks on the FULL header id even when it contains underscores (limit-1)', async () => {
+    // SAFE_NATIVE_SESSION_ID allows `_`, but splitting a timestamp-named
+    // filename at its LAST underscore truncates 'a_z' to 'z' and 'b_a' to
+    // 'a'. A store tiebreak on those truncated keys disagrees with the
+    // gateway's total order over full ids, so equal-timestamp sessions can
+    // fall outside a bounded prefix and vanish from every page. With limit 1
+    // every page is a single row, so any prefix/order disagreement surfaces
+    // immediately as a gap, a repeat, or a wrong first row.
+    const UNDERSCORE_IDS = ['b_a', 'a_z', 'aa', 'zz_9']
+    // localeCompare over full ids: 'a_z' < 'aa' ('_' < 'a'), then 'b_a', 'zz_9'.
+    const EXPECTED = ['a_z', 'aa', 'b_a', 'zz_9']
+
+    const sessionRoot = await temporaryRoot()
+    const workspaceRoot = join(sessionRoot, 'workspace')
+    const workspaceScopeId = 'workspace-u:storage-u'
+    const scope = { workspaceScopeId, authSubjectId: 'subject-a' } as AuthorizedAgentScope
+    const dir = join(sessionRoot, pathDerivedDirName(workspaceRoot))
+    for (const id of UNDERSCORE_IDS) {
+      await plantNativeTie(dir, id, workspaceScopeId)
+    }
+
+    const host = await startHost({
+      agents: [legacyDefaultAgent],
+      sessionRoot,
+      workspaceRoot,
+      sessionNamespace: '',
+    })
+    try {
+      const seen: string[] = []
+      let cursor: string | undefined
+      let pages = 0
+      do {
+        const page = await host.gateway.listSessions({ scope, agentTypeId: 'default', limit: 1, cursor })
+        pages += 1
+        seen.push(...page.sessions.map((summary) => summary.ref.sessionId))
+        cursor = page.nextCursor
+        expect(page.sessions.length).toBeLessThanOrEqual(1)
+      } while (cursor && pages < 10)
+
+      expect(seen).toEqual(EXPECTED)
+    } finally {
+      await host.host.close()
+    }
+  })
 })

--- a/packages/agent/src/server/agent-host/createAgentHost.ts
+++ b/packages/agent/src/server/agent-host/createAgentHost.ts
@@ -63,6 +63,7 @@ export interface AgentHostRuntime {
     agentTypeId: string,
     scope: AuthorizedAgentScope,
     claim: VerifiedAgentScopeClaim,
+    options?: import('../../shared/session').SessionListOptions,
   ): Promise<readonly import('../../shared/session').SessionSummary[]>
   isDraining(): boolean
   assertOpen(): void
@@ -319,9 +320,9 @@ function createRuntime(
     },
     activity,
     shutdownGraceMs: graceMs,
-    listSessionSummaries(agentTypeId, scope, claim) {
+    listSessionSummaries(agentTypeId, scope, claim, options) {
       runtime.assertOpen()
-      return inventory.list(agentTypeId, scope, claim)
+      return inventory.list(agentTypeId, scope, claim, options)
     },
     isDraining: () => draining,
     assertOpen() {

--- a/packages/agent/src/server/agent-host/embeddedGateway.ts
+++ b/packages/agent/src/server/agent-host/embeddedGateway.ts
@@ -259,23 +259,37 @@ export class EmbeddedAgentGateway implements AgentGateway {
     }
     const cursor = input.cursor
       ? this.decodeCursor(input.cursor, claim.workspaceScopeId, input.agentTypeId, normalizedLimit)
-      : undefined
+      : { depth: 0, after: undefined }
     const agents = input.agentTypeId
       ? [input.agentTypeId]
       : [...this.runtime.compiledById.keys()]
+    // Bounded fan-out. Every seat's store orders by the same recency key this
+    // gateway sorts by, so a row that lands at merged rank `r` sits at rank
+    // <= r inside its own seat's listing. The page covers merged ranks
+    // [depth, depth + limit), and one extra row decides `nextCursor` — so
+    // `depth + limit + 1` rows per seat is exactly sufficient and never reads
+    // the rest of the store (#1338: an unbounded listing parsed every
+    // transcript on every request).
+    const perAgentLimit = cursor.depth + normalizedLimit + 1
     const rows: AgentSessionSummary[] = []
     for (const agentTypeId of agents) {
-      const listed = await this.runtime.listSessionSummaries(agentTypeId, input.scope, claim)
+      const listed = await this.runtime.listSessionSummaries(agentTypeId, input.scope, claim, { limit: perAgentLimit })
       for (const item of listed) {
         const ref = { agentTypeId, sessionId: item.id }
         rows.push(summaryFromLegacy(ref, item, this.runtime.activity.get(claim.workspaceScopeId, ref)))
       }
     }
     rows.sort(compareSessions)
-    const eligible = cursor ? rows.filter((row) => isAfterCursor(row, cursor)) : rows
+    const eligible = cursor.after ? rows.filter((row) => isAfterCursor(row, cursor.after!)) : rows
     const sessions = eligible.slice(0, normalizedLimit)
     const nextCursor = eligible.length > sessions.length && sessions.length > 0
-      ? this.encodeCursor(claim.workspaceScopeId, input.agentTypeId, normalizedLimit, sessions.at(-1)!)
+      ? this.encodeCursor(
+          claim.workspaceScopeId,
+          input.agentTypeId,
+          normalizedLimit,
+          cursor.depth + sessions.length,
+          sessions.at(-1)!,
+        )
       : undefined
     return { sessions, ...(nextCursor ? { nextCursor } : {}) }
   }
@@ -895,12 +909,14 @@ export class EmbeddedAgentGateway implements AgentGateway {
     workspaceScopeId: string,
     agentTypeId: string | undefined,
     limit: number,
+    depth: number,
     last: AgentSessionSummary,
   ): string {
     const payload = JSON.stringify({
       workspaceScopeId,
       agentTypeId: agentTypeId ?? null,
       limit,
+      depth,
       updatedAt: last.updatedAt,
       lastAgentTypeId: last.ref.agentTypeId,
       sessionId: last.ref.sessionId,
@@ -915,7 +931,7 @@ export class EmbeddedAgentGateway implements AgentGateway {
     workspaceScopeId: string,
     agentTypeId: string | undefined,
     limit: number,
-  ): { updatedAt: number; agentTypeId: string; sessionId: string } {
+  ): { depth: number; after: { updatedAt: number; agentTypeId: string; sessionId: string } } {
     try {
       const [encoded, signature, extra] = cursor.split('.')
       if (!encoded || !signature || extra) throw new Error('malformed')
@@ -926,14 +942,20 @@ export class EmbeddedAgentGateway implements AgentGateway {
         decoded.workspaceScopeId !== workspaceScopeId
         || decoded.agentTypeId !== (agentTypeId ?? null)
         || decoded.limit !== limit
+        || typeof decoded.depth !== 'number'
+        || !Number.isInteger(decoded.depth)
+        || decoded.depth < 0
         || typeof decoded.updatedAt !== 'number'
         || typeof decoded.lastAgentTypeId !== 'string'
         || typeof decoded.sessionId !== 'string'
       ) throw new Error('binding')
       return {
-        updatedAt: decoded.updatedAt,
-        agentTypeId: decoded.lastAgentTypeId,
-        sessionId: decoded.sessionId,
+        depth: decoded.depth,
+        after: {
+          updatedAt: decoded.updatedAt,
+          agentTypeId: decoded.lastAgentTypeId,
+          sessionId: decoded.sessionId,
+        },
       }
     } catch {
       throw new AgentGatewayError(AgentGatewayErrorCode.AGENT_SESSION_CURSOR_INVALID, 'session cursor is invalid')

--- a/packages/agent/src/server/agent-host/sessionInventory.ts
+++ b/packages/agent/src/server/agent-host/sessionInventory.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto'
 import type { PiChatEvent } from '../../shared/chat'
 import type { AgentSessionActivity, AgentSessionRef, AuthorizedAgentScope, VerifiedAgentScopeClaim } from '../../shared/index'
-import type { SessionSummary } from '../../shared/session'
+import type { SessionListOptions, SessionSummary } from '../../shared/session'
 import { PiSessionStore } from '../harness/pi-coding-agent/sessions'
 import { agentSessionKey } from './agentSessionKey'
 import type { CompiledAgentHostAgentSpec, ResolvedAgentRuntimeScope } from './types'
@@ -10,6 +10,27 @@ function safeScopeSegment(scope: string): string {
   return createHash('sha256').update(scope).digest('hex').slice(0, 20)
 }
 
+/**
+ * Storage namespace for a seat, or `undefined` to keep the store's cwd-derived
+ * default directory.
+ *
+ * `undefined` is a DELIBERATE result, not a gap. It happens for the
+ * `legacyDefault` seat on hosts that resolve an empty runtime
+ * `sessionNamespace` (the CLI hub and the workspace app both pass `""`), and it
+ * routes that seat to {@link PiSessionStore}'s path-derived directory
+ * (`<sessionRoot>/--<workspaceRoot with separators flattened>--`). That
+ * directory is the trusted-local store terminal `pi` writes for the same cwd,
+ * and `PiSessionStore.pathDerivedLegacyAccess` exists precisely so the local
+ * app and terminal `pi` can read each other's unpinned transcripts there.
+ *
+ * Naming that seat would relocate its lookup and orphan every session a user
+ * already has, so this function MUST stay the single source of truth for both
+ * sides: `buildAgentComposition` uses it to place the writing harness and
+ * `AgentSessionInventory` uses it to place the reading store. Read and write
+ * therefore always resolve the same directory. Hosts that do want an isolated
+ * per-workspace store (core passes `ctx.workspaceId`) get one from the same
+ * branch, because a non-empty namespace is honoured as-is.
+ */
 export function sessionNamespaceForAgent(
   agent: CompiledAgentHostAgentSpec,
   workspaceScopeId: string,
@@ -39,14 +60,22 @@ export class AgentSessionInventory {
     ) => Promise<ResolvedAgentRuntimeScope>,
   ) {}
 
+  /**
+   * Lists a seat's sessions. `options` is threaded straight into the store so a
+   * bounded page reads a bounded number of transcripts: an unbounded call makes
+   * the store stream and parse EVERY native transcript it holds (see
+   * `summarizeNativeTranscript`, whose result is intentionally never cached),
+   * which is what made a per-seat boot listing cost tens of seconds (#1338).
+   */
   async list(
     agentTypeId: string,
     scope: AuthorizedAgentScope,
     claim: VerifiedAgentScopeClaim,
+    options?: SessionListOptions,
   ): Promise<SessionSummary[]> {
     const resolved = await this.resolveStore(agentTypeId, scope, claim)
     if (!resolved) return []
-    return await resolved.store.list({ workspaceId: claim.workspaceScopeId })
+    return await resolved.store.list({ workspaceId: claim.workspaceScopeId }, options)
   }
 
   async resolveSessionRuntime(

--- a/packages/agent/src/server/harness/pi-coding-agent/__tests__/sessionListPagination.perf.test.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/__tests__/sessionListPagination.perf.test.ts
@@ -1,0 +1,86 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { PiSessionStore } from "../sessions.js";
+
+/**
+ * Reproduces issue #1338's shape: one session store holding hundreds of native
+ * Pi transcripts. `summarizeNativeTranscript` streams and JSON-parses a whole
+ * transcript per session and its result is deliberately never cached, so an
+ * unbounded `list()` pays the entire store on every request. A bounded page must
+ * pay only for the page.
+ *
+ * Off by default (it writes ~100 MB of fixtures); run with `BENCH_1338=1`.
+ */
+const enabled = process.env.BENCH_1338 === "1";
+const SESSIONS = Number(process.env.BENCH_SESSIONS ?? 600);
+const MESSAGES = Number(process.env.BENCH_MESSAGES ?? 120);
+
+function buildStore(): { root: string; cwd: string } {
+  const root = mkdtempSync(join(tmpdir(), "pi-sessions-perf-"));
+  const cwd = join(root, "workspace");
+  const dir = join(root, `--${cwd.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--`);
+  mkdirSync(dir, { recursive: true });
+  const body = "x".repeat(1200);
+  for (let index = 0; index < SESSIONS; index += 1) {
+    const id = `00000000-0000-4000-8000-${index.toString(16).padStart(12, "0")}`;
+    const base = Date.UTC(2026, 7, 1) + index * 60_000;
+    const iso = new Date(base).toISOString();
+    const lines = [JSON.stringify({ type: "session", version: 1, id, timestamp: iso, cwd })];
+    for (let message = 0; message < MESSAGES; message += 1) {
+      lines.push(JSON.stringify({
+        type: "message",
+        id: `${id}-m${message}`,
+        parentId: null,
+        timestamp: new Date(base + message * 1000).toISOString(),
+        message: {
+          role: message % 2 === 0 ? "user" : "assistant",
+          content: [{ type: "text", text: `message ${message} ${body}` }],
+        },
+      }));
+    }
+    writeFileSync(join(dir, `${iso.replace(/[:.]/g, "-")}_${id}.jsonl`), `${lines.join("\n")}\n`);
+  }
+  return { root, cwd };
+}
+
+describe.skipIf(!enabled)("PiSessionStore.list pagination cost", () => {
+  it("pays for the page, not the store", async () => {
+    const { root, cwd } = buildStore();
+    const ctx = { workspaceId: "perf-workspace" };
+    const measure = async (options?: { limit: number }) => {
+      // Fresh store per case: cold caches, exactly like a fresh host boot.
+      const store = new PiSessionStore(cwd, { sessionRoot: root, storageCwd: cwd });
+      const started = performance.now();
+      const rows = await store.list(ctx, options);
+      return { ms: performance.now() - started, rows: rows.length };
+    };
+
+    // Warm re-list on the SAME store instance: the shape a live host serves
+    // after boot, where the prefix cache is already populated.
+    const warm = async () => {
+      const store = new PiSessionStore(cwd, { sessionRoot: root, storageCwd: cwd });
+      await store.list(ctx, { limit: 50 });
+      const started = performance.now();
+      const rows = await store.list(ctx, { limit: 50 });
+      return { ms: performance.now() - started, rows: rows.length };
+    };
+
+    const unbounded = await measure();
+    const paged = await measure({ limit: 50 });
+    const warmed = await warm();
+    process.stdout.write(
+      `[#1338] sessions=${SESSIONS} messages=${MESSAGES}`
+      + ` unbounded=${unbounded.ms.toFixed(0)}ms (${unbounded.rows} rows)`
+      + ` cold-limit50=${paged.ms.toFixed(0)}ms (${paged.rows} rows)`
+      + ` warm-limit50=${warmed.ms.toFixed(0)}ms (${warmed.rows} rows)\n`,
+    );
+
+    expect(unbounded.rows).toBe(SESSIONS);
+    expect(paged.rows).toBe(50);
+    expect(warmed.rows).toBe(50);
+    expect(paged.ms).toBeLessThan(unbounded.ms / 2);
+    expect(warmed.ms).toBeLessThan(paged.ms);
+  }, 600_000);
+});

--- a/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
@@ -730,10 +730,18 @@ export class PiSessionStore implements SessionStore {
         const linkedStat = await fsStat(linkedPiFile);
         sortMtimeMs = Math.max(sortMtimeMs, linkedStat.mtime.getTime());
       }
-      if (!cached.headerId || !isTimestampNamedPiSessionFile(filepath, cached.headerId)) {
-        // Wrapper transcript (or headerless native file): the stem is the id
-        // `resolveSessionFile` accepts — never a last-underscore truncation.
+      if (!cached.headerId) {
+        // Headerless file: the stem is the id `resolveSessionFile` accepts —
+        // never a last-underscore truncation.
         return { sortMtimeMs, sortId: wrapperSessionId(filepath) };
+      }
+      if (!isTimestampNamedPiSessionFile(filepath, cached.headerId)) {
+        // Readable header in a non-timestamp-named (wrapper) transcript: the
+        // header id is canonical — it is exactly what `summary.id` emits — so
+        // the gateway's full-id total order and this store's prefix agree.
+        // Sorting by the filename here would order by a different key than
+        // the id we report for the row (#1338 review round 2).
+        return { sortMtimeMs, sortId: cached.headerId };
       }
       if (cached.nativeSortMtimeMs !== undefined) {
         return { sortMtimeMs: cached.nativeSortMtimeMs, sortId: cached.headerId };

--- a/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
@@ -245,7 +245,18 @@ export class PiSessionStore implements SessionStore {
         ...file,
         sortMtimeMs: await this.sessionSortMtimeMs(file),
       })));
-    visibleFiles.sort((a, b) => b.sortMtimeMs - a.sortMtimeMs);
+    // The gateway merge (embeddedGateway.listSessions) orders rows by the
+    // total order `updatedAt desc, then session id asc`, and its bounded
+    // fan-out assumes every store truncates under that SAME order: a row at
+    // merged rank r must sit at rank <= r inside its own store's listing.
+    // Sorting on recency alone left equal-updatedAt sessions in readdir
+    // order, so one could fall outside the requested prefix and then fail
+    // the gateway's cursor filter forever — a session that never appears.
+    visibleFiles.sort((a, b) =>
+      b.sortMtimeMs - a.sortMtimeMs
+      || sessionIdFromFilename(basename(a.filepath)).localeCompare(
+        sessionIdFromFilename(basename(b.filepath)),
+      ));
 
     const { offset, limit } = options;
     const includeId = options.includeId;
@@ -1210,6 +1221,20 @@ function extractSessionHeaderId(entries: (SessionHeader | SessionEntry)[]): stri
  */
 function nativeSessionFilename(sessionId: string, isoTimestamp: string): string {
   return `${isoTimestamp.replace(/[:.]/g, "-")}_${sessionId}.jsonl`;
+}
+
+/**
+ * Cheap session-id extraction for sort tiebreaks. Session files are either
+ * wrapper-named `${sessionId}.jsonl` or pi-native `${timestamp}_${id}.jsonl`
+ * (timestamps use `-` separators, ids are UUIDs — neither contains `_`), so
+ * the text after the last underscore is the id in both forms. Matches what
+ * `resolveSessionFile` accepts and, for timestamp-named native files,
+ * `isTimestampNamedPiSessionFile` enforces about the header id.
+ */
+function sessionIdFromFilename(filename: string): string {
+  const base = filename.endsWith(".jsonl") ? filename.slice(0, -".jsonl".length) : filename;
+  const underscore = base.lastIndexOf("_");
+  return underscore === -1 ? base : base.slice(underscore + 1);
 }
 
 function isTimestampNamedPiSessionFile(filepath: string, sessionId: string): boolean {

--- a/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
@@ -718,6 +718,14 @@ export class PiSessionStore implements SessionStore {
     { filepath, stat }: SessionFileStat,
   ): Promise<{ sortMtimeMs: number; sortId: string }> {
     let sortMtimeMs = stat.mtime.getTime();
+    // Once a readable header supplies an id, it stays canonical even if a
+    // later step (linked-file stat, native timestamp scan) throws — the
+    // filename stem is only for files with no readable header at all.
+    let headerId: string | undefined = undefined;
+    const stemFallback = (): { sortMtimeMs: number; sortId: string } => ({
+      sortMtimeMs,
+      sortId: wrapperSessionId(filepath),
+    });
     try {
       // One prefix read per file per listing: `referencedPiFiles` already
       // populated this cache entry. Its header id supplies BOTH the native-
@@ -725,37 +733,40 @@ export class PiSessionStore implements SessionStore {
       // re-reading and re-parsing the prefix here was a second full-store
       // pass on every request (#1338).
       const cached = await this.readPrefixCache(filepath, stat);
+      headerId = cached.headerId ?? undefined;
       const linkedPiFile = cached.referencedPiFile;
       if (linkedPiFile && resolve(linkedPiFile) !== resolve(filepath)) {
         const linkedStat = await fsStat(linkedPiFile);
         sortMtimeMs = Math.max(sortMtimeMs, linkedStat.mtime.getTime());
       }
-      if (!cached.headerId) {
+      if (!headerId) {
         // Headerless file: the stem is the id `resolveSessionFile` accepts —
         // never a last-underscore truncation.
-        return { sortMtimeMs, sortId: wrapperSessionId(filepath) };
+        return stemFallback();
       }
-      if (!isTimestampNamedPiSessionFile(filepath, cached.headerId)) {
+      if (!isTimestampNamedPiSessionFile(filepath, headerId)) {
         // Readable header in a non-timestamp-named (wrapper) transcript: the
         // header id is canonical — it is exactly what `summary.id` emits — so
         // the gateway's full-id total order and this store's prefix agree.
         // Sorting by the filename here would order by a different key than
         // the id we report for the row (#1338 review round 2).
-        return { sortMtimeMs, sortId: cached.headerId };
+        return { sortMtimeMs, sortId: headerId };
       }
       if (cached.nativeSortMtimeMs !== undefined) {
-        return { sortMtimeMs: cached.nativeSortMtimeMs, sortId: cached.headerId };
+        return { sortMtimeMs: cached.nativeSortMtimeMs, sortId: headerId };
       }
       const latest = await latestNativeMessageTimestamp(filepath, Number(stat.size));
-      if (latest === undefined) return { sortMtimeMs, sortId: cached.headerId };
+      if (latest === undefined) return { sortMtimeMs, sortId: headerId };
       // Only a value derived purely from this file's own bytes is cacheable:
       // the (mtime, size) key does not invalidate on a linked file's change.
       this.prefixCache.set(filepath, { ...cached, nativeSortMtimeMs: latest });
-      return { sortMtimeMs: latest, sortId: cached.headerId };
+      return { sortMtimeMs: latest, sortId: headerId };
     } catch {
-      // Fall back to the wrapper/native file mtime for unreadable links.
+      // Unreadable linked file / failed timestamp scan: keep the file's own
+      // mtime. If a header was already read, its id remains the tiebreak key;
+      // only a file with no readable header falls back to the stem.
+      return headerId ? { sortMtimeMs, sortId: headerId } : stemFallback();
     }
-    return { sortMtimeMs, sortId: wrapperSessionId(filepath) };
   }
 
   private async summarizeFile(
@@ -1244,15 +1255,16 @@ function nativeSessionFilename(sessionId: string, isoTimestamp: string): string 
  */
 interface SessionSortKey {
   sortMtimeMs: number;
-  /** Canonical session id: header id for timestamp-named natives, stem for wrappers. */
+  /** Canonical session id: header id whenever a readable header exists (wrapper or native); stem only for headerless files. */
   sortId: string;
 }
 
 /**
- * Session id of a WRAPPER-named transcript: `resolveSessionFile` looks these up
- * as `${sessionId}.jsonl`, so the stem is authoritative. Never split on `_`:
- * SAFE_NATIVE_SESSION_ID allows it (`a_z.jsonl` wraps the id `a_z`).
- * Timestamp-named pi-native files take their id from the transcript header
+ * Session id of a HEADERLESS transcript: `resolveSessionFile` looks wrapper
+ * files up as `${sessionId}.jsonl`, so for those the stem is the only id
+ * available. Never split on `_`: SAFE_NATIVE_SESSION_ID allows it
+ * (`a_z.jsonl` wraps the id `a_z`). Used ONLY as a last resort — any file
+ * with a readable header takes its id (and sort key) from that header
  * instead (see {@link PiSessionStore.sessionSortKey}).
  */
 function wrapperSessionId(filepath: string): string {

--- a/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
@@ -110,6 +110,15 @@ interface PrefixCacheEntry {
   mtimeMs: number;
   size: number;
   referencedPiFile: string | null;
+  /** Header id of this transcript, so listing never re-reads a prefix to learn it. */
+  headerId?: string | null;
+  /**
+   * Recency key of a native transcript, derived from its own bytes by
+   * {@link latestNativeMessageTimestamp}. Cached because it is a pure function
+   * of this file at this (mtime, size), and recomputing it for every file on
+   * every listing was a per-request full-store tail scan (#1338).
+   */
+  nativeSortMtimeMs?: number;
   sessionCtx?: StoredSessionCtx;
   linkedMtimeMs?: number;
   linkedSize?: number;
@@ -699,17 +708,24 @@ export class PiSessionStore implements SessionStore {
   private async sessionSortMtimeMs({ filepath, stat }: SessionFileStat): Promise<number> {
     let sortMtimeMs = stat.mtime.getTime();
     try {
-      const linkedPiFile = (await this.readPrefixCache(filepath, stat)).referencedPiFile;
+      // One prefix read per file per listing: `referencedPiFiles` already
+      // populated this cache entry, and the header id it carries is all the
+      // native-file test needs. Re-reading and re-parsing the prefix here was a
+      // second full-store pass on every request (#1338).
+      const cached = await this.readPrefixCache(filepath, stat);
+      const linkedPiFile = cached.referencedPiFile;
       if (linkedPiFile && resolve(linkedPiFile) !== resolve(filepath)) {
         const linkedStat = await fsStat(linkedPiFile);
         sortMtimeMs = Math.max(sortMtimeMs, linkedStat.mtime.getTime());
       }
-      const header = parseJsonlPrefixEntries(await readJsonlPrefix(filepath))
-        .find((entry): entry is SessionHeader => entry.type === "session");
-      if (header && isTimestampNamedPiSessionFile(filepath, header.id)) {
-        sortMtimeMs = await latestNativeMessageTimestamp(filepath, Number(stat.size))
-          ?? sortMtimeMs;
-      }
+      if (!cached.headerId || !isTimestampNamedPiSessionFile(filepath, cached.headerId)) return sortMtimeMs;
+      if (cached.nativeSortMtimeMs !== undefined) return cached.nativeSortMtimeMs;
+      const latest = await latestNativeMessageTimestamp(filepath, Number(stat.size));
+      if (latest === undefined) return sortMtimeMs;
+      // Only a value derived purely from this file's own bytes is cacheable:
+      // the (mtime, size) key does not invalidate on a linked file's change.
+      this.prefixCache.set(filepath, { ...cached, nativeSortMtimeMs: latest });
+      return latest;
     } catch {
       // Fall back to the wrapper/native file mtime for unreadable links.
     }
@@ -798,6 +814,10 @@ export class PiSessionStore implements SessionStore {
         mtimeMs: fileStat.mtime.getTime(),
         size: Number(fileStat.size),
         referencedPiFile: linkedPiFile,
+        // Carried so a later `sessionSortMtimeMs` on this same entry still
+        // recognises a native transcript instead of falling back to mtime.
+        headerId: header.id,
+        ...(cached?.nativeSortMtimeMs !== undefined ? { nativeSortMtimeMs: cached.nativeSortMtimeMs } : {}),
         sessionCtx,
         ...(linked ? { linkedMtimeMs: linked.mtime.getTime(), linkedSize: linked.size } : {}),
         ...(!nativeSummary ? { summary } : {}),
@@ -838,11 +858,13 @@ export class PiSessionStore implements SessionStore {
 
     const content = await readJsonlPrefix(filepath);
     const entries = parseJsonlPrefixEntries(content);
+    const header = entries.find((item): item is SessionHeader => item.type === "session");
     const entry: PrefixCacheEntry = {
       mtimeMs: fileStat.mtime.getTime(),
       size: Number(fileStat.size),
       referencedPiFile: extractPiSessionFilePath(entries),
-      sessionCtx: readHeaderSessionCtx(entries.find((item): item is SessionHeader => item.type === "session")),
+      headerId: header?.id ?? null,
+      sessionCtx: readHeaderSessionCtx(header),
     };
     this.prefixCache.set(filepath, entry);
     return entry;

--- a/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
@@ -241,22 +241,20 @@ export class PiSessionStore implements SessionStore {
     const referencedPiFiles = await this.referencedPiFiles(existingFiles);
     const visibleFiles = await Promise.all(existingFiles
       .filter(({ filepath }) => !referencedPiFiles.has(resolve(filepath)))
-      .map(async (file) => ({
-        ...file,
-        sortMtimeMs: await this.sessionSortMtimeMs(file),
-      })));
+      .map(async (file) => ({ ...file, ...(await this.sessionSortKey(file)) })));
     // The gateway merge (embeddedGateway.listSessions) orders rows by the
     // total order `updatedAt desc, then session id asc`, and its bounded
     // fan-out assumes every store truncates under that SAME order: a row at
     // merged rank r must sit at rank <= r inside its own store's listing.
+    // The tiebreak must therefore use each row's CANONICAL id — the header id
+    // already parsed into the prefix cache — not a filename-derived guess:
+    // ids may legally contain `_`, which a last-underscore split truncates.
     // Sorting on recency alone left equal-updatedAt sessions in readdir
     // order, so one could fall outside the requested prefix and then fail
     // the gateway's cursor filter forever — a session that never appears.
     visibleFiles.sort((a, b) =>
       b.sortMtimeMs - a.sortMtimeMs
-      || sessionIdFromFilename(basename(a.filepath)).localeCompare(
-        sessionIdFromFilename(basename(b.filepath)),
-      ));
+      || a.sortId.localeCompare(b.sortId));
 
     const { offset, limit } = options;
     const includeId = options.includeId;
@@ -716,31 +714,40 @@ export class PiSessionStore implements SessionStore {
     return referenced;
   }
 
-  private async sessionSortMtimeMs({ filepath, stat }: SessionFileStat): Promise<number> {
+  private async sessionSortKey(
+    { filepath, stat }: SessionFileStat,
+  ): Promise<{ sortMtimeMs: number; sortId: string }> {
     let sortMtimeMs = stat.mtime.getTime();
     try {
       // One prefix read per file per listing: `referencedPiFiles` already
-      // populated this cache entry, and the header id it carries is all the
-      // native-file test needs. Re-reading and re-parsing the prefix here was a
-      // second full-store pass on every request (#1338).
+      // populated this cache entry. Its header id supplies BOTH the native-
+      // file test and the canonical tiebreak id (the row's `summary.id`);
+      // re-reading and re-parsing the prefix here was a second full-store
+      // pass on every request (#1338).
       const cached = await this.readPrefixCache(filepath, stat);
       const linkedPiFile = cached.referencedPiFile;
       if (linkedPiFile && resolve(linkedPiFile) !== resolve(filepath)) {
         const linkedStat = await fsStat(linkedPiFile);
         sortMtimeMs = Math.max(sortMtimeMs, linkedStat.mtime.getTime());
       }
-      if (!cached.headerId || !isTimestampNamedPiSessionFile(filepath, cached.headerId)) return sortMtimeMs;
-      if (cached.nativeSortMtimeMs !== undefined) return cached.nativeSortMtimeMs;
+      if (!cached.headerId || !isTimestampNamedPiSessionFile(filepath, cached.headerId)) {
+        // Wrapper transcript (or headerless native file): the stem is the id
+        // `resolveSessionFile` accepts — never a last-underscore truncation.
+        return { sortMtimeMs, sortId: wrapperSessionId(filepath) };
+      }
+      if (cached.nativeSortMtimeMs !== undefined) {
+        return { sortMtimeMs: cached.nativeSortMtimeMs, sortId: cached.headerId };
+      }
       const latest = await latestNativeMessageTimestamp(filepath, Number(stat.size));
-      if (latest === undefined) return sortMtimeMs;
+      if (latest === undefined) return { sortMtimeMs, sortId: cached.headerId };
       // Only a value derived purely from this file's own bytes is cacheable:
       // the (mtime, size) key does not invalidate on a linked file's change.
       this.prefixCache.set(filepath, { ...cached, nativeSortMtimeMs: latest });
-      return latest;
+      return { sortMtimeMs: latest, sortId: cached.headerId };
     } catch {
       // Fall back to the wrapper/native file mtime for unreadable links.
     }
-    return sortMtimeMs;
+    return { sortMtimeMs, sortId: wrapperSessionId(filepath) };
   }
 
   private async summarizeFile(
@@ -1224,17 +1231,25 @@ function nativeSessionFilename(sessionId: string, isoTimestamp: string): string 
 }
 
 /**
- * Cheap session-id extraction for sort tiebreaks. Session files are either
- * wrapper-named `${sessionId}.jsonl` or pi-native `${timestamp}_${id}.jsonl`
- * (timestamps use `-` separators, ids are UUIDs — neither contains `_`), so
- * the text after the last underscore is the id in both forms. Matches what
- * `resolveSessionFile` accepts and, for timestamp-named native files,
- * `isTimestampNamedPiSessionFile` enforces about the header id.
+ * Recency-plus-tiebreak key implementing the gateway's store-side order.
+ * See {@link PiSessionStore.sessionSortKey} for how `sortId` is derived.
  */
-function sessionIdFromFilename(filename: string): string {
-  const base = filename.endsWith(".jsonl") ? filename.slice(0, -".jsonl".length) : filename;
-  const underscore = base.lastIndexOf("_");
-  return underscore === -1 ? base : base.slice(underscore + 1);
+interface SessionSortKey {
+  sortMtimeMs: number;
+  /** Canonical session id: header id for timestamp-named natives, stem for wrappers. */
+  sortId: string;
+}
+
+/**
+ * Session id of a WRAPPER-named transcript: `resolveSessionFile` looks these up
+ * as `${sessionId}.jsonl`, so the stem is authoritative. Never split on `_`:
+ * SAFE_NATIVE_SESSION_ID allows it (`a_z.jsonl` wraps the id `a_z`).
+ * Timestamp-named pi-native files take their id from the transcript header
+ * instead (see {@link PiSessionStore.sessionSortKey}).
+ */
+function wrapperSessionId(filepath: string): string {
+  const base = basename(filepath);
+  return base.endsWith(".jsonl") ? base.slice(0, -".jsonl".length) : base;
 }
 
 function isTimestampNamedPiSessionFile(filepath: string, sessionId: string): boolean {


### PR DESCRIPTION
## Problem

`listSessions` on the embedded gateway listed **every seat's store unbounded** on every call. Each unbounded `PiSessionStore.list()` then:
1. re-read + re-parsed the jsonl prefix of every file just to recover a header id it had already cached,
2. re-ran `latestNativeMessageTimestamp` (full stream + JSON parse of every native transcript, deliberately uncached) per file per request.

With hundreds of native transcripts this made a listing cost tens of seconds (issue #1338: 16s session inventory).

## Change

**Bounded fan-out (gateway/inventory/runtime):**
- Thread `SessionListOptions` through `AgentHostRuntime.listSessionSummaries` → `AgentSessionInventory.list` → `PiSessionStore.list`.
- Give the merged-rank cursor a `depth`. Every seat's store orders by the same recency key the gateway sorts by, so a row at merged rank `r` sits at rank `<= r` in its own seat's listing. A page covering merged ranks `[depth, depth+limit)` therefore needs exactly `depth + limit + 1` rows per seat (the +1 decides `nextCursor`) — provably sufficient, never reads the rest of the store.

**Store cost per listing (sessions.ts):**
- `PrefixCacheEntry` now carries `headerId`, so `sessionSortMtimeMs` stops re-reading prefixes it already parsed.
- `latestNativeMessageTimestamp` is cached as `nativeSortMtimeMs` keyed on (mtime, size) — a pure function of the file's own bytes. Linked-file mtime stays deliberately uncached: the key cannot invalidate on a linked file's change.

## Guardrail honored: sessions never disappear

Pagination is strictly additive: the store's existing `summarizeVisiblePage` already honors `limit/offset/includeId`; the gateway pages via cursor with a per-page bound that only grows by the page size as paging deepens. The new test walks a 7-session store with `limit: 2` and asserts **every session appears exactly once, newest-first, across pages** (`[3, 5, 7, 9]` per-seat bounds).

Also documents why `sessionNamespaceForAgent` returning `undefined` for the `legacyDefault` seat is load-bearing: relocating that seat's directory would orphan existing transcripts (covered by a regression test that lists a pre-existing cwd-derived transcript through the full host).

## Proof

- `tsc --noEmit`: clean
- New `sessionInventoryPagination.test.ts`: 3 tests (seat placement, namespace honor, gapless paging with bounded reads)
- New `sessionListPagination.perf.test.ts`: opt-in bench (`BENCH_1338=1`, ~100 MB fixtures — not run here to protect /tmp; asserts cold-limit50 < unbounded/2 and warm < cold)
- Neighbor suites: httpProjection, noBootSessionListing, sessionIsolation, legacyTranscriptCompatibility, sessionMapping.conformance, sessions.load — 32/32 pass

Closes #1338

## Review fixes (thermo gate round 1)

- **CRITICAL fixed** — store-side listing now breaks recency ties by session id (the exact per-seat total order the gateway merge assumes) *before* truncation. Previously equal-`updatedAt` sessions were ordered by readdir order; one could fall outside a bounded prefix and fail the cursor filter permanently, so sessions could disappear from listings. Reproduced at gateway level (`xray, yankee, zeta` returned; `alpha`, `beta` gone) and fixed.
- Regression tests added under an adversarial reverse-alphabetical `readdir` mock (both store-level and gateway-level); negative-controlled to fail against the unfixed store.
- Commit: b3f8428


## Review fixes (thermo gate follow-up)

**Blocker fixed:** the bounded merge assumed every store used the gateway's complete ordering, but stores truncated on recency alone before the gateway's session-ID tiebreak could apply. Sessions with equal `updatedAt` could fall outside a bounded prefix and then fail the cursor filter permanently — five-session reproduction dropped `alpha`/`beta` from the listing.

- `b3f8428b9` — apply the exact per-seat total order (recency descending, then session ID ascending) **before** store truncation, so bounded prefixes are now stable under ties.
- Added a native-transcript regression test with equal latest timestamps and creation/filename order opposite to session-ID order, asserting every session appears exactly once across pages.
- Full CI re-run settled green after the fix (E2E, Typecheck, Unit Tests + Changed, Invariants, Reference Images, Lint, P8 — 0 failures).


## Review fixes (round 2 — verifier follow-up)

- **CRITICAL resolved** — the equal-updatedAt tiebreak now sorts on the canonical **header id** from the prefix cache (the exact value returned as `summary.id`), not the filename-derived guess. `sessionIdFromFilename` truncated valid ids containing `_` (`a_z` → `z`), letting a store's prefix disagree with the gateway's full-id total order and permanently omit equal-timestamp sessions. The filename split remains only as a fallback for unreadable headers (`703332f`).
- **New regression:** limit-1 gateway paging with adversarial underscore ids (`a_z`, `aa`, `b_a`, `zz_9`) — asserts every session appears exactly once in full-id order; this test fails on the previous filename-derived tiebreak.
- Validation: agent `tsc --noEmit` clean; `sessionInventoryPagination` 7/7 (incl. new case); full `pi-coding-agent` harness suite 131 pass / 1 skip.
