### PR TITLE
test(tasks): stop the task session link id assertion from flaking

### DIFF
--- a/plugins/tasks/src/server/taskSessionLinkStore.test.ts
+++ b/plugins/tasks/src/server/taskSessionLinkStore.test.ts
@@ -55,7 +55,10 @@ describe("FileTaskSessionLinkStore", () => {
     expect(firstReceipt).toMatchObject({ changed: true, snapshot: { adapterId: "github", taskId: "776", links: [first] } })
     expect(duplicate).toEqual({ ...firstReceipt, changed: false })
     expect(await store.list("github", "776")).toEqual([first])
-    expect(first.id).not.toContain("776")
+    // The link id must be opaque — never derived from the adapter/task pair.
+    // Asserting the UUID shape says that deterministically; a substring check
+    // against a random UUID flakes whenever the task id happens to appear in it.
+    expect(first.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
     expect(workspace.files.has(".pi/tasks/session-links.json")).toBe(true)
     expect(workspace.writes.every((path) => path.startsWith(".pi/tasks/session-links.json.tmp-"))).toBe(true)
   })


### PR DESCRIPTION
## What

`taskSessionLinkStore.test.ts` asserted `expect(first.id).not.toContain("776")` to express that a link id is **opaque** — not derived from the adapter/task pair.

The id is a random UUID and the task id is the 3-character string `"776"`, so the assertion fails whenever those three characters land anywhere in the UUID. It hit PR #1145: `f0f1259a-7765-483d-a606-56ddd027faea`.

## Fix

Assert the UUID shape. That states the actual invariant and cannot flake.

## Why it matters

This is a random-chance failure in a shared plugin suite, so it lands on unrelated PRs — it red-lit #1145 and cost a CI cycle there. Found while sweeping every open PR for tomorrow.

## Verification

`plugins/tasks` `taskSessionLinkStore.test.ts`: 11 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SqFadabn7hUwqfcs7AUbW