### PR TITLE
refactor(workspace): canonical ledger resolver + N+1 probe coverage

### DIFF
--- a/packages/agent/src/server/agent-host/__tests__/createAgentHost.test.ts
+++ b/packages/agent/src/server/agent-host/__tests__/createAgentHost.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs'
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -7,6 +8,7 @@ import { AgentGatewayError, AgentGatewayErrorCode, type AuthorizedAgentScope } f
 import { ErrorCode } from '../../../shared/error-codes'
 import type { AgentHarnessFactory } from '../../../shared/harness'
 import { createTestRuntimeModeAdapter } from '@agent-test-host'
+import { getEnv, restoreEnvForTest, setEnvForTest } from '../../config/env'
 import { createScriptedPiHarness } from '../../testing/scriptedPiHarness'
 import { InMemorySessionChangesTracker } from '../../http/sessionChangesTracker'
 import type { RuntimeFilesystemBinding } from '../../runtime/mode'
@@ -87,6 +89,39 @@ describe('createAgentHost', () => {
     const second = await createAgentHost(options(sessionRoot))
     expect(second.host.hostId).toBe(first.host.hostId)
     await second.host.close()
+  })
+
+  // The ledger path chain now has one canonical owner. These pin this host's
+  // effective default so delegating to it cannot move the file.
+  it('keeps its durable ledger default at <sessionRoot>/.agent-request-ledger.sqlite', async () => {
+    const originalSessionRootEnv = getEnv('BORING_AGENT_SESSION_ROOT')
+    const sessionRoot = await root()
+    const explicitRoot = await root()
+    const explicitPath = join(explicitRoot, 'nested', 'requests.sqlite')
+    try {
+      // This host never consults BORING_AGENT_SESSION_ROOT: outer hosts own that.
+      setEnvForTest('BORING_AGENT_SESSION_ROOT', await root())
+
+      const fromSessionRoot = await createAgentHost({ ...options(sessionRoot), hostId: 'ledger-default' })
+      await fromSessionRoot.host.close()
+      expect(existsSync(join(sessionRoot, '.agent-request-ledger.sqlite'))).toBe(true)
+
+      const explicit = await createAgentHost({
+        ...options(sessionRoot),
+        hostId: 'ledger-explicit',
+        requestLedgerPath: explicitPath,
+      })
+      await explicit.host.close()
+      expect(existsSync(explicitPath)).toBe(true)
+
+      await expect(createAgentHost({
+        ...options(sessionRoot),
+        hostId: 'ledger-fail-closed',
+        sessionRoot: undefined,
+      })).rejects.toThrow('requestLedgerPath or sessionRoot')
+    } finally {
+      restoreEnvForTest('BORING_AGENT_SESSION_ROOT', originalSessionRootEnv)
+    }
   })
 
   it('requires a stable host identity source and validates explicit IDs', async () => {

--- a/packages/agent/src/server/agent-host/__tests__/requestLedgerPath.test.ts
+++ b/packages/agent/src/server/agent-host/__tests__/requestLedgerPath.test.ts
@@ -1,0 +1,97 @@
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { getEnv, restoreEnvForTest, setEnvForTest } from '../../config/env'
+import { resolveRequestLedgerPath } from '../requestLedgerPath'
+
+const ORIGINAL_SESSION_ROOT = getEnv('BORING_AGENT_SESSION_ROOT')
+afterEach(() => restoreEnvForTest('BORING_AGENT_SESSION_ROOT', ORIGINAL_SESSION_ROOT))
+
+const WORKSPACE = '/srv/workspace'
+const SESSION = '/data/pi-sessions'
+const ENV_SESSION = '/data/env-sessions'
+
+/**
+ * Every host used to encode this chain itself. These cases pin the exact
+ * argument shape each host passes, so a change to the single canonical resolver
+ * cannot silently move any host's effective default.
+ */
+describe('resolveRequestLedgerPath', () => {
+  it('prefers an explicit path over every fallback', () => {
+    setEnvForTest('BORING_AGENT_SESSION_ROOT', ENV_SESSION)
+    expect(resolveRequestLedgerPath({
+      requestLedgerPath: '/explicit/ledger.sqlite',
+      sessionRoot: SESSION,
+      acceptSessionRootEnv: true,
+      legacy: { layout: 'workspace-boring-dir', workspaceRoot: WORKSPACE },
+    })).toBe('/explicit/ledger.sqlite')
+  })
+
+  it('treats a blank explicit path and a blank session root as absent', () => {
+    expect(resolveRequestLedgerPath({
+      requestLedgerPath: '   ',
+      sessionRoot: '\t',
+      legacy: { layout: 'workspace-boring-dir', workspaceRoot: WORKSPACE },
+    })).toBe(join(WORKSPACE, '.boring', 'agent-request-ledger.sqlite'))
+  })
+
+  it('prefers the caller session root over the environment', () => {
+    setEnvForTest('BORING_AGENT_SESSION_ROOT', ENV_SESSION)
+    expect(resolveRequestLedgerPath({ sessionRoot: SESSION, acceptSessionRootEnv: true }))
+      .toBe(join(SESSION, '.agent-request-ledger.sqlite'))
+  })
+
+  it('reads BORING_AGENT_SESSION_ROOT only when the host opts in', () => {
+    setEnvForTest('BORING_AGENT_SESSION_ROOT', ENV_SESSION)
+    expect(resolveRequestLedgerPath({ acceptSessionRootEnv: true }))
+      .toBe(join(ENV_SESSION, '.agent-request-ledger.sqlite'))
+    expect(resolveRequestLedgerPath({})).toBeUndefined()
+  })
+
+  it('fails closed for a host with no legacy location', () => {
+    setEnvForTest('BORING_AGENT_SESSION_ROOT', undefined)
+    expect(resolveRequestLedgerPath({})).toBeUndefined()
+  })
+
+  describe('per-host effective defaults', () => {
+    // Standalone + workspace agent hosts: explicit → sessionRoot → env →
+    // <workspaceRoot>/.boring/agent-request-ledger.sqlite.
+    const workspaceHost = (input: { requestLedgerPath?: string; sessionRoot?: string }) =>
+      resolveRequestLedgerPath({
+        ...input,
+        acceptSessionRootEnv: true,
+        legacy: { layout: 'workspace-boring-dir', workspaceRoot: WORKSPACE },
+      })
+
+    // Core workspace host: its own sessionRoot chain already folded in the env,
+    // and its legacy tail has no `.boring/` segment.
+    const coreHost = (sessionRoot?: string) =>
+      resolveRequestLedgerPath({
+        sessionRoot,
+        legacy: { layout: 'workspace-host-file', workspaceRoot: WORKSPACE },
+      })
+
+    it('keeps the standalone/workspace host default', () => {
+      setEnvForTest('BORING_AGENT_SESSION_ROOT', undefined)
+      expect(workspaceHost({})).toBe(join(WORKSPACE, '.boring', 'agent-request-ledger.sqlite'))
+      expect(workspaceHost({ sessionRoot: SESSION })).toBe(join(SESSION, '.agent-request-ledger.sqlite'))
+      expect(workspaceHost({ requestLedgerPath: '/x.sqlite' })).toBe('/x.sqlite')
+      setEnvForTest('BORING_AGENT_SESSION_ROOT', ENV_SESSION)
+      expect(workspaceHost({})).toBe(join(ENV_SESSION, '.agent-request-ledger.sqlite'))
+    })
+
+    it('keeps the core workspace host default, ignoring the environment', () => {
+      setEnvForTest('BORING_AGENT_SESSION_ROOT', ENV_SESSION)
+      expect(coreHost(SESSION)).toBe(join(SESSION, '.agent-request-ledger.sqlite'))
+      // Matches the pre-refactor `join(sessionRoot ?? workspaceRoot, '.agent-request-ledger.sqlite')`.
+      expect(coreHost(undefined)).toBe(join(WORKSPACE, '.agent-request-ledger.sqlite'))
+    })
+
+    it('keeps the createAgentHost default: session root only, never the environment', () => {
+      setEnvForTest('BORING_AGENT_SESSION_ROOT', ENV_SESSION)
+      expect(resolveRequestLedgerPath({ sessionRoot: SESSION }))
+        .toBe(join(SESSION, '.agent-request-ledger.sqlite'))
+      expect(resolveRequestLedgerPath({ sessionRoot: undefined })).toBeUndefined()
+    })
+  })
+})

--- a/packages/agent/src/server/agent-host/createAgentHost.ts
+++ b/packages/agent/src/server/agent-host/createAgentHost.ts
@@ -9,6 +9,7 @@ import { getOptionalRuntimeBundleStorageRoot } from '../runtime/mode'
 import { mergeRuntimeFilesystemBindings } from '../runtime/filesystemBindings'
 import { createAgentHostRoutes } from './httpProjection'
 import { InMemoryAgentRequestLedger } from './requestLedger'
+import { resolveRequestLedgerPath } from './requestLedgerPath'
 import { SqliteAgentRequestLedger } from './sqliteRequestLedger'
 import {
   createAgentHostRuntimeCapabilityProjection,
@@ -219,6 +220,20 @@ function validateEnvironmentScope(resolved: AgentHostEnvironmentScope): void {
   if (!resolved.workspaceRoot.trim()) throw new TypeError('resolved environment workspaceRoot must be non-empty')
 }
 
+/**
+ * Durable ledger file this host will open, or `undefined` when it was given
+ * neither an explicit path nor a session root.
+ *
+ * `createAgentHost` is the innermost host: its `requestLedgerPath` is a
+ * programmatic option taken verbatim (outer hosts normalize their user-facing
+ * option before passing it down), and it has no in-workspace fallback — a host
+ * with nothing host-owned to write to fails closed. The session-root tail is
+ * owned by {@link resolveRequestLedgerPath}, the single canonical chain.
+ */
+function resolveHostLedgerPath(options: CreateAgentHostOptions): string | undefined {
+  return options.requestLedgerPath ?? resolveRequestLedgerPath({ sessionRoot: options.sessionRoot })
+}
+
 function createRuntime(
   options: CreateAgentHostOptions,
   compiledAgents: readonly CompiledAgentHostAgentSpec[],
@@ -284,12 +299,11 @@ function createRuntime(
   let draining = false
   let drainPromise: Promise<void> | undefined
   let closePromise: Promise<void> | undefined
+  const durableLedgerPath = resolveHostLedgerPath(options)
   const ledger: import('./types').AgentRequestLedger = options.requestLedger
-    ?? (options.inMemoryRequestLedgerMode
+    ?? (options.inMemoryRequestLedgerMode || !durableLedgerPath
       ? new InMemoryAgentRequestLedger()
-      : options.requestLedgerPath || options.sessionRoot
-        ? new SqliteAgentRequestLedger(options.requestLedgerPath ?? join(options.sessionRoot!, '.agent-request-ledger.sqlite'))
-        : new InMemoryAgentRequestLedger())
+      : new SqliteAgentRequestLedger(durableLedgerPath))
 
   const disposeBinding = (binding: RuntimeBinding): Promise<void> => {
     let disposal = bindingDisposals.get(binding)
@@ -661,8 +675,7 @@ export async function createAgentHost(
   }
   const compiledAgents = await compileFleet(options)
   const hostId = await resolveHostId(options)
-  const durableLedgerPath = options.requestLedgerPath
-    ?? (options.sessionRoot ? join(options.sessionRoot, '.agent-request-ledger.sqlite') : undefined)
+  const durableLedgerPath = resolveHostLedgerPath(options)
   if (!options.requestLedger && !options.inMemoryRequestLedgerMode && !durableLedgerPath) {
     throw new TypeError(
       'createAgentHost requires requestLedgerPath or sessionRoot for its durable transactional ledger',

--- a/packages/agent/src/server/agent-host/requestLedgerPath.ts
+++ b/packages/agent/src/server/agent-host/requestLedgerPath.ts
@@ -5,19 +5,35 @@ import { getEnv } from '../config/env'
 /** Host-owned durable session root env var (AGENTS.md rule 9). */
 const SESSION_ROOT_ENV = 'BORING_AGENT_SESSION_ROOT'
 
-/** Ledger file name inside a host-owned root; matches `createCoreWorkspaceAgentServer`. */
+/** Ledger file name inside a host-owned root. */
 const HOST_LEDGER_FILENAME = '.agent-request-ledger.sqlite'
 
+/** Legacy in-workspace ledger location used by the standalone/workspace hosts. */
+const LEGACY_WORKSPACE_BORING_DIR_SEGMENTS = ['.boring', 'agent-request-ledger.sqlite'] as const
+
 /**
- * Legacy in-workspace ledger location. Kept as the documented compatibility
- * fallback for hosts that configure neither an explicit ledger path nor a
- * host-owned session root.
+ * Compatibility location a host falls back to when it has neither an explicit
+ * ledger path nor a host-owned session root.
+ *
+ * Hosts historically disagreed on this tail, so it is the *only* part of the
+ * chain that is parameterized. Everything before it is identical for every
+ * host and is owned solely by {@link resolveRequestLedgerPath}.
  */
-const LEGACY_WORKSPACE_LEDGER_SEGMENTS = ['.boring', 'agent-request-ledger.sqlite'] as const
+export type LegacyRequestLedgerLocation =
+  /** `<workspaceRoot>/.boring/agent-request-ledger.sqlite` (standalone + workspace hosts). */
+  | { readonly layout: 'workspace-boring-dir'; readonly workspaceRoot: string }
+  /** `<workspaceRoot>/.agent-request-ledger.sqlite` (core workspace host). */
+  | { readonly layout: 'workspace-host-file'; readonly workspaceRoot: string }
 
 function normalizeOptionalPath(value: string | undefined): string | undefined {
   const trimmed = value?.trim()
   return trimmed ? trimmed : undefined
+}
+
+function legacyPath(location: LegacyRequestLedgerLocation): string {
+  return location.layout === 'workspace-boring-dir'
+    ? join(location.workspaceRoot, ...LEGACY_WORKSPACE_BORING_DIR_SEGMENTS)
+    : join(location.workspaceRoot, HOST_LEDGER_FILENAME)
 }
 
 export interface ResolveRequestLedgerPathInput {
@@ -25,8 +41,17 @@ export interface ResolveRequestLedgerPathInput {
   readonly requestLedgerPath?: string
   /** Host-owned session root supplied by the caller, if any. */
   readonly sessionRoot?: string
-  /** User workspace root. Used only by the legacy compatibility fallback. */
-  readonly workspaceRoot: string
+  /**
+   * Also accept `BORING_AGENT_SESSION_ROOT` as a host-owned root when the
+   * caller supplied no `sessionRoot`. Hosts that already fold that env var
+   * into their own session-root chain omit this.
+   */
+  readonly acceptSessionRootEnv?: boolean
+  /**
+   * Last-resort compatibility location. Omit for hosts that must fail closed
+   * instead of inventing an in-workspace ledger; they get `undefined`.
+   */
+  readonly legacy?: LegacyRequestLedgerLocation
 }
 
 /**
@@ -34,14 +59,20 @@ export interface ResolveRequestLedgerPathInput {
  *
  * The request ledger is host application state, not workspace content, so the
  * chain prefers host-owned storage: explicit option, then the caller's
- * `sessionRoot` or `BORING_AGENT_SESSION_ROOT`, and only then the legacy
- * `<workspaceRoot>/.boring/agent-request-ledger.sqlite` location.
+ * `sessionRoot` (optionally `BORING_AGENT_SESSION_ROOT`), and only then the
+ * host's legacy in-workspace location.
+ *
+ * This is the sole owner of that chain: no host may re-encode any part of it.
  */
-export function resolveRequestLedgerPath(input: ResolveRequestLedgerPathInput): string {
+export function resolveRequestLedgerPath(
+  input: ResolveRequestLedgerPathInput & { readonly legacy: LegacyRequestLedgerLocation },
+): string
+export function resolveRequestLedgerPath(input: ResolveRequestLedgerPathInput): string | undefined
+export function resolveRequestLedgerPath(input: ResolveRequestLedgerPathInput): string | undefined {
   const explicit = normalizeOptionalPath(input.requestLedgerPath)
   if (explicit) return explicit
   const hostRoot = normalizeOptionalPath(input.sessionRoot)
-    ?? normalizeOptionalPath(getEnv(SESSION_ROOT_ENV))
+    ?? (input.acceptSessionRootEnv ? normalizeOptionalPath(getEnv(SESSION_ROOT_ENV)) : undefined)
   if (hostRoot) return join(hostRoot, HOST_LEDGER_FILENAME)
-  return join(input.workspaceRoot, ...LEGACY_WORKSPACE_LEDGER_SEGMENTS)
+  return input.legacy ? legacyPath(input.legacy) : undefined
 }

--- a/packages/agent/src/server/createStandaloneAgentHostApp.ts
+++ b/packages/agent/src/server/createStandaloneAgentHostApp.ts
@@ -210,7 +210,8 @@ export async function createStandaloneAgentHostApp(
       requestLedgerPath: resolveRequestLedgerPath({
         requestLedgerPath: options.requestLedgerPath,
         sessionRoot: options.sessionRoot,
-        workspaceRoot,
+        acceptSessionRootEnv: true,
+        legacy: { layout: 'workspace-boring-dir', workspaceRoot },
       }),
       telemetry: options.telemetry,
       metering: options.metering,

--- a/packages/agent/src/server/harness/pi-coding-agent/__tests__/createHarness.test.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/__tests__/createHarness.test.ts
@@ -202,9 +202,24 @@ describe("createPiCodingAgentHarness", () => {
       const before = await digestPiResourceInputs(input());
       expect(before).toMatch(/^sha256:/);
 
+      // Invariant: a skipped entry is never followed, opened or read, so its
+      // target's contents cannot reach the digest.
+      await writeFile(
+        join(outside, "linked-skill", "SKILL.md"),
+        "---\nname: linked-skill\ndescription: Rewritten out of band.\n---\nbody\n",
+        "utf8",
+      );
+      expect(await digestPiResourceInputs(input())).toBe(before);
+
       // The skip is recorded, so the digest still moves when the link goes away.
       await rm(join(ambientSkills, "linked-skill"));
-      expect(await digestPiResourceInputs(input())).not.toBe(before);
+      const withoutLink = await digestPiResourceInputs(input());
+      expect(withoutLink).not.toBe(before);
+
+      // ...and moves back when it reappears, so appearance is observable too.
+      await symlink(join(outside, "linked-skill"), join(ambientSkills, "linked-skill"));
+      expect(await digestPiResourceInputs(input())).not.toBe(withoutLink);
+      await rm(join(ambientSkills, "linked-skill"));
 
       // Invariant: a symlink the host declared itself is still rejected outright,
       // and the escaping link is never followed either way.

--- a/packages/agent/src/server/index.ts
+++ b/packages/agent/src/server/index.ts
@@ -167,7 +167,10 @@ export { createAuthMiddleware as createAgentAuthMiddleware } from './http/middle
 export { createAgentHost } from './agent-host/createAgentHost'
 export { SqliteAgentRequestLedger } from './agent-host/sqliteRequestLedger'
 export { resolveRequestLedgerPath } from './agent-host/requestLedgerPath'
-export type { ResolveRequestLedgerPathInput } from './agent-host/requestLedgerPath'
+export type {
+  LegacyRequestLedgerLocation,
+  ResolveRequestLedgerPathInput,
+} from './agent-host/requestLedgerPath'
 export {
   AgentFleetCompilationError,
   AgentFleetCompilationErrorCode,

--- a/packages/agent/src/server/piResourceDigest.ts
+++ b/packages/agent/src/server/piResourceDigest.ts
@@ -147,16 +147,18 @@ export async function digestPiResourceInputs(input: PiResourceDigestInput): Prom
       state.bytes += bytes
     }
   }
+  // Host-declared inputs: an unadmittable entry here is a host configuration
+  // defect, never a routine ambient symlink, so they all reject.
   await hashResourceCollection(state, piCwd, 'settings', [
     join(projectSettingsDir, 'settings.json'),
     join(piAgentDir, 'settings.json'),
-  ], false)
-  await hashResourceCollection(state, piCwd, 'skill', input.additionalSkillPaths ?? [], false)
+  ], false, 'reject')
+  await hashResourceCollection(state, piCwd, 'skill', input.additionalSkillPaths ?? [], false, 'reject')
   const localExtensionPaths = (input.extensionPaths ?? []).filter(isLocalPiResourceSource)
   for (const source of (input.extensionPaths ?? []).filter((value) => !isLocalPiResourceSource(value)).sort()) {
     frameString(hash, 'remote-extension-source', source)
   }
-  await hashResourceCollection(state, piCwd, 'extension', localExtensionPaths, true)
+  await hashResourceCollection(state, piCwd, 'extension', localExtensionPaths, true, 'reject')
 
   const settingsManager = createResourceSettingsManager(piCwd, piAgentDir, [...(input.packages ?? [])], {
     includePackage: (source) => isLocalPiResourceSource(typeof source === 'string' ? source : source.source),
@@ -176,7 +178,7 @@ export async function digestPiResourceInputs(input: PiResourceDigestInput): Prom
     frameString(hash, 'package-descriptor', packageDescriptor(source))
     const sourceValue = typeof source === 'string' ? source : source.source
     const localPath = localPiPackagePath(sourceValue, projectSettingsDir)
-    if (localPath) await hashLocalResource(state, localPath, '.', 0)
+    if (localPath) await hashLocalResource(state, localPath, '.', 0, 'reject')
   }
   return `sha256:${hash.digest('hex')}`
 }
@@ -251,22 +253,60 @@ function skippableResourceCode(error: unknown): string | undefined {
   return typeof code === 'string' && SKIPPABLE_RESOURCE_CODES.has(code) ? code : undefined
 }
 
+/** The entry whose admission was refused, and how this walk frames a skip of it. */
+interface RefusedPiEntry {
+  readonly state: WalkState
+  readonly policy: UnadmittedEntryPolicy
+  /** Hash tag used to frame a skip. Part of the digest format — do not change. */
+  readonly skipTag: string
+  /** Value framed next to the verdict code. Part of the digest format. */
+  readonly label: string
+}
+
+/**
+ * Why an entry was refused: either a caught resolver error, or a verdict this
+ * walk reached directly (a symlink, a target outside the authorized roots).
+ */
+type PiEntryRefusal =
+  | { readonly error: unknown }
+  | { readonly code: string; readonly message: string }
+
+/**
+ * The single admission gate for a refused Pi resource entry.
+ *
+ * Under `reject` — and for any refusal that is a resolver defect rather than an
+ * admission verdict (see {@link SKIPPABLE_RESOURCE_CODES}) — this throws. Under
+ * `skip` it frames the verdict and returns, and the caller must abandon the
+ * entry: a skipped entry is never realpath'd, opened, or mounted. The skip is
+ * still framed into the hash, so the digest moves when a skipped entry appears
+ * or disappears (gh-1196).
+ */
+function admitPiEntry(entry: RefusedPiEntry, refusal: PiEntryRefusal): void {
+  const refusedCode = 'error' in refusal ? skippableResourceCode(refusal.error) : refusal.code
+  if (entry.policy !== 'skip' || !refusedCode) {
+    if ('error' in refusal) throw refusal.error
+    throw stableError(refusal.code, 403, refusal.message)
+  }
+  frameString(entry.state.hash, entry.skipTag, `${refusedCode}:${entry.label}`)
+}
+
 async function hashResourceCollection(
   state: WalkState,
   baseDir: string,
   kind: string,
   paths: readonly string[],
   digestContainingArtifact: boolean,
-  unadmittedEntries: UnadmittedEntryPolicy = 'reject',
+  unadmittedEntries: UnadmittedEntryPolicy,
 ): Promise<void> {
   for (const path of [...new Set(paths)].sort()) {
     const absolutePath = resolvePiPath(path, baseDir)
     try {
       await assertContainedWithoutSymlinks(absolutePath, state.authorizedRoots)
     } catch (error) {
-      const code = unadmittedEntries === 'skip' ? skippableResourceCode(error) : undefined
-      if (!code) throw error
-      frameString(state.hash, `${kind}-skipped`, `${code}:${absolutePath}`)
+      admitPiEntry(
+        { state, policy: unadmittedEntries, skipTag: `${kind}-skipped`, label: absolutePath },
+        { error },
+      )
       continue
     }
     try {
@@ -370,18 +410,19 @@ async function hashLocalResource(
   path: string,
   logicalPath: string,
   depth: number,
-  unadmittedEntries: UnadmittedEntryPolicy = 'reject',
+  unadmittedEntries: UnadmittedEntryPolicy,
 ): Promise<void> {
   const absolutePath = resolve(path)
-  const skip = (code: string): void => {
-    frameString(state.hash, 'unadmitted-skipped', `${code}:${logicalPath}`)
+  const refused: RefusedPiEntry = {
+    state,
+    policy: unadmittedEntries,
+    skipTag: 'unadmitted-skipped',
+    label: logicalPath,
   }
   try {
     await assertContainedWithoutSymlinks(absolutePath, state.authorizedRoots)
   } catch (error) {
-    const code = unadmittedEntries === 'skip' ? skippableResourceCode(error) : undefined
-    if (!code) throw error
-    skip(code)
+    admitPiEntry(refused, { error })
     return
   }
   if (depth > state.limits.maxDepth) {
@@ -402,17 +443,19 @@ async function hashLocalResource(
     throw limitError(`Pi resource tree exceeds maximum node count ${state.limits.maxFiles}`)
   }
   if (stat.isSymbolicLink()) {
-    // Never resolved, never read — only recorded, so the digest still moves
-    // when the link appears or disappears.
-    if (unadmittedEntries === 'skip') return skip(ErrorCode.enum.PATH_SYMLINK_ESCAPE)
-    throw stableError(ErrorCode.enum.PATH_SYMLINK_ESCAPE, 403, `Pi resource symlinks are not allowed: ${absolutePath}`)
+    return admitPiEntry(refused, {
+      code: ErrorCode.enum.PATH_SYMLINK_ESCAPE,
+      message: `Pi resource symlinks are not allowed: ${absolutePath}`,
+    })
   }
   if (stat.isDirectory()) {
     frameString(state.hash, 'directory', logicalPath)
     const openedTarget = await realpath(absolutePath)
     if (!mostSpecificContainingRoot(openedTarget, state.authorizedRoots)) {
-      if (unadmittedEntries === 'skip') return skip(ErrorCode.enum.PATH_SYMLINK_ESCAPE)
-      throw stableError(ErrorCode.enum.PATH_SYMLINK_ESCAPE, 403, `Pi resource resolves outside authorized roots: ${absolutePath}`)
+      return admitPiEntry(refused, {
+        code: ErrorCode.enum.PATH_SYMLINK_ESCAPE,
+        message: `Pi resource resolves outside authorized roots: ${absolutePath}`,
+      })
     }
     assertSameFile(stat, await statPath(openedTarget), absolutePath)
     const entries: import('node:fs').Dirent[] = []

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.workspaceBridge.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.workspaceBridge.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import type { ExtensionAPI, ExtensionFactory, ToolDefinition } from '@mariozechner/pi-coding-agent'
 import Fastify from 'fastify'
 import { assertComposedAgentHostRouteTable } from '@hachej/boring-agent/server/agent-host/testing/compositionRouteProof'
@@ -5,6 +8,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const agentServerMock = vi.hoisted(() => ({
   registerOpts: [] as Array<Record<string, unknown>>,
+  requestLedgerPaths: [] as Array<string | undefined>,
 }))
 
 const workspaceServerMock = vi.hoisted(() => ({
@@ -28,6 +32,7 @@ vi.mock('@hachej/boring-agent/server', async (importOriginal) => {
       async compile({ agents }: { agents: readonly unknown[] }) { return agents },
     },
     createAgentHost: vi.fn(async (options: Parameters<typeof actual.createAgentHost>[0]) => {
+      agentServerMock.requestLedgerPaths.push(options.requestLedgerPath)
       const created = await actual.createAgentHost({
         ...options,
         requestLedgerPath: undefined,
@@ -315,6 +320,7 @@ const { createCoreWorkspaceAgentServer } = await import('../createCoreWorkspaceA
 
 afterEach(() => {
   agentServerMock.registerOpts.length = 0
+  agentServerMock.requestLedgerPaths.length = 0
   workspaceServerMock.browserAuthPolicyOptions.length = 0
   workspaceServerMock.runtimeEnvCalls.length = 0
   workspaceServerMock.httpRouteOpts.length = 0
@@ -867,5 +873,39 @@ describe('createCoreWorkspaceAgentServer workspace bridge wiring', () => {
       },
     })
     await app.close()
+  })
+
+  // The request-ledger path chain has a single canonical owner. This host's
+  // legacy tail has no `.boring/` segment, unlike the standalone/workspace
+  // hosts, so it is pinned here.
+  it('keeps its request ledger under the host session root, falling back to the workspace root', async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'core-ledger-ws-'))
+    const sessionRoot = await mkdtemp(join(tmpdir(), 'core-ledger-sessions-'))
+    const originalSessionRootEnv = process.env.BORING_AGENT_SESSION_ROOT
+    try {
+      delete process.env.BORING_AGENT_SESSION_ROOT
+
+      const withSessionRoot = await createCoreWorkspaceAgentServer({
+        serveFrontend: false,
+        workspaceRoot,
+        sessionRoot,
+      })
+      expect(agentServerMock.requestLedgerPaths.at(-1))
+        .toBe(join(sessionRoot, '.agent-request-ledger.sqlite'))
+      await withSessionRoot.close()
+
+      const withoutSessionRoot = await createCoreWorkspaceAgentServer({
+        serveFrontend: false,
+        workspaceRoot,
+      })
+      expect(agentServerMock.requestLedgerPaths.at(-1))
+        .toBe(join(workspaceRoot, '.agent-request-ledger.sqlite'))
+      await withoutSessionRoot.close()
+    } finally {
+      if (originalSessionRootEnv === undefined) delete process.env.BORING_AGENT_SESSION_ROOT
+      else process.env.BORING_AGENT_SESSION_ROOT = originalSessionRootEnv
+      await rm(workspaceRoot, { recursive: true, force: true })
+      await rm(sessionRoot, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -16,6 +16,7 @@ import {
   provisionWorkspaceRuntime,
   projectAuthorizedSessionRunDetails,
   resolveDefaultAgentFleet,
+  resolveRequestLedgerPath,
   withRuntimeEnvContributions,
   type AgentEffectAdmission,
   type AgentFleetCompiler,
@@ -1587,7 +1588,12 @@ export async function createCoreWorkspaceAgentServer(
       requireCompilerForModelPolicy: true,
     }),
     sessionRoot,
-    requestLedgerPath: path.join(sessionRoot ?? workspaceRoot, '.agent-request-ledger.sqlite'),
+    requestLedgerPath: resolveRequestLedgerPath({
+      // `sessionRoot` above already folds in BORING_AGENT_SESSION_ROOT and the
+      // per-mode inference, so the canonical chain must not re-read the env.
+      sessionRoot,
+      legacy: { layout: 'workspace-host-file', workspaceRoot },
+    }),
     hostId: options.agentHostId ?? (sessionRoot ? undefined : 'core-workspace-agent'),
     scopeVerifier: scopeAuthority.verifier,
     runtimeModeAdapter: hostRuntimeModeAdapter,

--- a/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
+++ b/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
@@ -1676,7 +1676,8 @@ export async function createWorkspaceAgentServer(
     requestLedgerPath: resolveRequestLedgerPath({
       requestLedgerPath: opts.requestLedgerPath,
       sessionRoot: opts.sessionRoot,
-      workspaceRoot,
+      acceptSessionRootEnv: true,
+      legacy: { layout: "workspace-boring-dir", workspaceRoot },
     }),
     telemetry: opts.telemetry,
     metering: opts.metering,

--- a/packages/workspace/src/server/index.ts
+++ b/packages/workspace/src/server/index.ts
@@ -173,7 +173,10 @@ export type {
   PackageResourceScanSource,
   ResolvedAgentManagedSkill,
   ResolvedAgentPackageSkill,
+  ResolveWorkspacePackageResourcesOptions,
   ResolvedWorkspacePackageResourceRegistry,
+  SharedSkillPath,
+  SkippedWorkspacePackageResource,
 } from "./plugins/packageResources"
 // Boring plugin asset manager + reload-pluggability helpers.
 export { buildBoringSystemPrompt } from "./boringSystemPrompt"

--- a/packages/workspace/src/server/plugins/__tests__/packageResources.singlePass.test.ts
+++ b/packages/workspace/src/server/plugins/__tests__/packageResources.singlePass.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// The resolver used to be run once per candidate as a probe and then again over
+// the survivors, so every admitted entry was resolved twice. Counting the reads
+// it performs is the only way to keep that from creeping back.
+const reads = vi.hoisted(() => ({ paths: [] as string[] }))
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>()
+  return {
+    ...actual,
+    default: actual,
+    readFile: (path: Parameters<typeof actual.readFile>[0], ...rest: unknown[]) => {
+      reads.paths.push(String(path))
+      return (actual.readFile as (...args: unknown[]) => unknown)(path, ...rest)
+    },
+  }
+})
+
+const { resolveWorkspacePackageResourceSnapshot } = await import('../packageResources')
+
+const roots: string[] = []
+
+async function tempRoot() {
+  const root = await mkdtemp(join(tmpdir(), 'boring-package-resources-single-pass-'))
+  roots.push(root)
+  return root
+}
+
+async function packageFixture(root: string, name: string) {
+  const packageRoot = join(root, name.replace(/[^a-z0-9]+/gi, '-'))
+  await mkdir(join(packageRoot, 'skills', 'authoring'), { recursive: true })
+  await writeFile(join(packageRoot, 'package.json'), JSON.stringify({
+    name,
+    pi: { skills: ['skills/authoring'] },
+  }), 'utf8')
+  await writeFile(
+    join(packageRoot, 'skills', 'authoring', 'SKILL.md'),
+    `---\nname: ${name.replace(/[^a-z0-9]+/gi, '-')}\ndescription: Example.\n---\n`,
+    'utf8',
+  )
+  return packageRoot
+}
+
+beforeEach(() => { reads.paths.length = 0 })
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('resolveWorkspacePackageResourceSnapshot', () => {
+  test('resolves every entry exactly once, with no probe pass', async () => {
+    const root = await tempRoot()
+    const declared = await packageFixture(root, '@example/declared')
+    const scannedGood = await packageFixture(root, '@example/scanned-good')
+    const scannedBad = join(root, 'scanned-bad')
+    await mkdir(scannedBad, { recursive: true })
+    await writeFile(join(scannedBad, 'package.json'), JSON.stringify({
+      name: '@example/scanned-bad',
+      pi: { skills: ['skills/missing'] },
+    }), 'utf8')
+
+    const sharedRoot = join(root, 'shared', 'shared-authoring')
+    await mkdir(sharedRoot, { recursive: true })
+    const sharedFile = join(sharedRoot, 'SKILL.md')
+    await writeFile(sharedFile, '---\nname: shared-authoring\ndescription: Shared.\n---\n', 'utf8')
+
+    const snapshot = await resolveWorkspacePackageResourceSnapshot({
+      declared: [{ pluginId: 'direct', packageName: '@example/declared', packageRoot: declared }],
+      scanned: [
+        { pluginId: 'scan:good', packageName: '@example/scanned-good', packageRoot: scannedGood },
+        { pluginId: 'scan:bad', packageName: '@example/scanned-bad', packageRoot: scannedBad },
+      ],
+      sharedSkillPaths: [{ id: 'shared-authoring', skillFile: sharedFile }],
+    })
+
+    // Behavior first: the good entries load, the bad one is skipped, not fatal.
+    expect(snapshot.registry.skills.map((skill) => skill.resource.path)).toEqual([
+      'packages/@example/declared/skills/authoring/SKILL.md',
+      'packages/@example/scanned-good/skills/authoring/SKILL.md',
+      'shared/pi-agent/shared-authoring/SKILL.md',
+    ])
+    expect(snapshot.diagnostics).toEqual([{
+      source: 'package-resource-scan',
+      message: 'scanned package skill resources were invalid',
+      pluginId: '@example/scanned-bad',
+    }])
+
+    const countOf = (path: string) => reads.paths.filter((value) => value === path).length
+    for (const manifest of [declared, scannedGood, scannedBad]) {
+      expect({ manifest, reads: countOf(join(manifest, 'package.json')) })
+        .toEqual({ manifest, reads: 1 })
+    }
+    for (const skillFile of [
+      join(declared, 'skills', 'authoring', 'SKILL.md'),
+      join(scannedGood, 'skills', 'authoring', 'SKILL.md'),
+      sharedFile,
+    ]) {
+      expect({ skillFile, reads: countOf(skillFile) }).toEqual({ skillFile, reads: 1 })
+    }
+  })
+})

--- a/packages/workspace/src/server/plugins/__tests__/packageResources.singlePass.test.ts
+++ b/packages/workspace/src/server/plugins/__tests__/packageResources.singlePass.test.ts
@@ -1,26 +1,9 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, describe, expect, test } from 'vitest'
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-// The resolver used to be run once per candidate as a probe and then again over
-// the survivors, so every admitted entry was resolved twice. Counting the reads
-// it performs is the only way to keep that from creeping back.
-const reads = vi.hoisted(() => ({ paths: [] as string[] }))
-
-vi.mock('node:fs/promises', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:fs/promises')>()
-  return {
-    ...actual,
-    default: actual,
-    readFile: (path: Parameters<typeof actual.readFile>[0], ...rest: unknown[]) => {
-      reads.paths.push(String(path))
-      return (actual.readFile as (...args: unknown[]) => unknown)(path, ...rest)
-    },
-  }
-})
-
-const { resolveWorkspacePackageResourceSnapshot } = await import('../packageResources')
+import { resolveWorkspacePackageResourceSnapshot } from '../packageResources'
 
 const roots: string[] = []
 
@@ -31,7 +14,8 @@ async function tempRoot() {
 }
 
 async function packageFixture(root: string, name: string) {
-  const packageRoot = join(root, name.replace(/[^a-z0-9]+/gi, '-'))
+  const dir = name.replace(/[^a-z0-9]+/gi, '-')
+  const packageRoot = join(root, dir)
   await mkdir(join(packageRoot, 'skills', 'authoring'), { recursive: true })
   await writeFile(join(packageRoot, 'package.json'), JSON.stringify({
     name,
@@ -39,66 +23,117 @@ async function packageFixture(root: string, name: string) {
   }), 'utf8')
   await writeFile(
     join(packageRoot, 'skills', 'authoring', 'SKILL.md'),
-    `---\nname: ${name.replace(/[^a-z0-9]+/gi, '-')}\ndescription: Example.\n---\n`,
+    `---\nname: ${dir}\ndescription: Example.\n---\n`,
     'utf8',
   )
   return packageRoot
 }
 
-beforeEach(() => { reads.paths.length = 0 })
+/**
+ * The resolver reads `packageRoot` exactly once per contribution it processes,
+ * so a counting getter is a direct measurement of how many times an entry was
+ * put through the resolver. Before this refactor the snapshot ran the whole
+ * resolver once per scanned candidate as a probe and then again over the
+ * survivors, so every scanned entry read 2.
+ */
+function countedContribution(pluginId: string, packageName: string, packageRoot: string) {
+  const counter = { reads: 0 }
+  return {
+    counter,
+    record: {
+      pluginId,
+      packageName,
+      get packageRoot() {
+        counter.reads += 1
+        return packageRoot
+      },
+    },
+  }
+}
+
+function countedSharedSkill(id: string, skillFile: string) {
+  const counter = { reads: 0 }
+  return {
+    counter,
+    record: {
+      id,
+      get skillFile() {
+        counter.reads += 1
+        return skillFile
+      },
+    },
+  }
+}
+
 afterEach(async () => {
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
 })
 
 describe('resolveWorkspacePackageResourceSnapshot', () => {
-  test('resolves every entry exactly once, with no probe pass', async () => {
+  test('puts every entry through the resolver exactly once, with no probe pass', async () => {
     const root = await tempRoot()
-    const declared = await packageFixture(root, '@example/declared')
-    const scannedGood = await packageFixture(root, '@example/scanned-good')
-    const scannedBad = join(root, 'scanned-bad')
-    await mkdir(scannedBad, { recursive: true })
-    await writeFile(join(scannedBad, 'package.json'), JSON.stringify({
+    const declared = countedContribution(
+      'direct',
+      '@example/declared',
+      await packageFixture(root, '@example/declared'),
+    )
+    const scannedGood = countedContribution(
+      'scan:good',
+      '@example/scanned-good',
+      await packageFixture(root, '@example/scanned-good'),
+    )
+
+    const badRoot = join(root, 'scanned-bad')
+    await mkdir(badRoot, { recursive: true })
+    await writeFile(join(badRoot, 'package.json'), JSON.stringify({
       name: '@example/scanned-bad',
       pi: { skills: ['skills/missing'] },
     }), 'utf8')
+    const scannedBad = countedContribution('scan:bad', '@example/scanned-bad', badRoot)
 
     const sharedRoot = join(root, 'shared', 'shared-authoring')
     await mkdir(sharedRoot, { recursive: true })
     const sharedFile = join(sharedRoot, 'SKILL.md')
     await writeFile(sharedFile, '---\nname: shared-authoring\ndescription: Shared.\n---\n', 'utf8')
+    const shared = countedSharedSkill('shared-authoring', sharedFile)
+
+    const danglingRoot = join(root, 'shared', 'dangling')
+    await mkdir(danglingRoot, { recursive: true })
+    const danglingFile = join(danglingRoot, 'SKILL.md')
+    const dangling = countedSharedSkill('dangling', danglingFile)
 
     const snapshot = await resolveWorkspacePackageResourceSnapshot({
-      declared: [{ pluginId: 'direct', packageName: '@example/declared', packageRoot: declared }],
-      scanned: [
-        { pluginId: 'scan:good', packageName: '@example/scanned-good', packageRoot: scannedGood },
-        { pluginId: 'scan:bad', packageName: '@example/scanned-bad', packageRoot: scannedBad },
-      ],
-      sharedSkillPaths: [{ id: 'shared-authoring', skillFile: sharedFile }],
+      declared: [declared.record],
+      scanned: [scannedGood.record, scannedBad.record],
+      sharedSkillPaths: [shared.record, dangling.record],
     })
 
-    // Behavior first: the good entries load, the bad one is skipped, not fatal.
+    // Behavior first: the good entries load, the bad ones are skipped, not fatal.
     expect(snapshot.registry.skills.map((skill) => skill.resource.path)).toEqual([
       'packages/@example/declared/skills/authoring/SKILL.md',
       'packages/@example/scanned-good/skills/authoring/SKILL.md',
       'shared/pi-agent/shared-authoring/SKILL.md',
     ])
-    expect(snapshot.diagnostics).toEqual([{
-      source: 'package-resource-scan',
-      message: 'scanned package skill resources were invalid',
-      pluginId: '@example/scanned-bad',
-    }])
+    expect(snapshot.diagnostics).toEqual([
+      {
+        source: 'package-resource-scan',
+        message: 'scanned package skill resources were invalid',
+        pluginId: '@example/scanned-bad',
+      },
+      {
+        source: 'shared-skill-scan',
+        message: 'shared skill "dangling" was not admissible and was skipped',
+        pluginId: 'shared/pi-agent',
+        code: 'PACKAGE_RESOURCE_INVALID',
+      },
+    ])
 
-    const countOf = (path: string) => reads.paths.filter((value) => value === path).length
-    for (const manifest of [declared, scannedGood, scannedBad]) {
-      expect({ manifest, reads: countOf(join(manifest, 'package.json')) })
-        .toEqual({ manifest, reads: 1 })
-    }
-    for (const skillFile of [
-      join(declared, 'skills', 'authoring', 'SKILL.md'),
-      join(scannedGood, 'skills', 'authoring', 'SKILL.md'),
-      sharedFile,
-    ]) {
-      expect({ skillFile, reads: countOf(skillFile) }).toEqual({ skillFile, reads: 1 })
-    }
+    expect({
+      declared: declared.counter.reads,
+      scannedGood: scannedGood.counter.reads,
+      scannedBad: scannedBad.counter.reads,
+      shared: shared.counter.reads,
+      dangling: dangling.counter.reads,
+    }).toEqual({ declared: 1, scannedGood: 1, scannedBad: 1, shared: 1, dangling: 1 })
   })
 })

--- a/packages/workspace/src/server/plugins/packageResources.ts
+++ b/packages/workspace/src/server/plugins/packageResources.ts
@@ -73,6 +73,8 @@ export interface AgentResourceReadonlyMount {
 
 export interface ResolvedWorkspacePackageResourceRegistry {
   readonly generation: string
+  /** Entries the caller marked skippable that this resolve declined to admit. */
+  readonly skipped: readonly SkippedWorkspacePackageResource[]
   readonly additionalSkillPaths: readonly string[]
   readonly skills: readonly ResolvedAgentPackageSkill[]
   readonly managedSkills: readonly ResolvedAgentManagedSkill[]
@@ -181,13 +183,19 @@ function normalizeDeclaration(packageName: string, declaration: unknown): string
   return declaration
 }
 
+/**
+ * A skill resolved from the filesystem, before it is attributed to the plugins
+ * that contributed its package. Attribution is a cross-entry concern, so it is
+ * applied once during assembly rather than repeated per contribution.
+ */
+type ResolvedSkillDraft = Omit<ResolvedAgentPackageSkill, 'pluginIds'>
+
 async function resolveSkillRecord(input: {
   packageName: string
-  pluginIds: readonly string[]
   sourceSkillFile: string
   logicalFile: string
   packageRoot?: string
-}): Promise<ResolvedAgentPackageSkill> {
+}): Promise<ResolvedSkillDraft> {
   if (!(await stat(input.sourceSkillFile).catch(() => null))?.isFile()) {
     throw invalid(input.packageName, 'declared skill has no SKILL.md file')
   }
@@ -206,7 +214,6 @@ async function resolveSkillRecord(input: {
   const { name, description } = parseSkillMetadataFrontmatter(content)
   return {
     packageName: input.packageName,
-    pluginIds: input.pluginIds,
     skillFile,
     mountRoot,
     resource: { filesystem: AGENT_RESOURCES_FILESYSTEM_ID, path: input.logicalFile },
@@ -219,8 +226,7 @@ async function resolveSkillDeclaration(
   packageName: string,
   canonicalPackageRoot: string,
   declaration: string,
-  pluginIds: readonly string[],
-): Promise<ResolvedAgentPackageSkill> {
+): Promise<ResolvedSkillDraft> {
   const declaredPath = resolve(canonicalPackageRoot, ...declaration.split('/'))
   if (!isInside(canonicalPackageRoot, declaredPath)) throw invalid(packageName, 'pi.skills entry escapes package root')
   const declaredStat = await stat(declaredPath).catch(() => null)
@@ -232,7 +238,6 @@ async function resolveSkillDeclaration(
   const relativeSkillFile = directFile ? declaration : `${declaration}/SKILL.md`
   return resolveSkillRecord({
     packageName,
-    pluginIds,
     sourceSkillFile: resolve(canonicalPackageRoot, ...relativeSkillFile.split('/')),
     logicalFile: `packages/${packageName}/${relativeSkillFile}`,
     packageRoot: canonicalPackageRoot,
@@ -243,44 +248,221 @@ function rootsOverlap(left: string, right: string): boolean {
   return left === right || left.startsWith(`${right}/`) || right.startsWith(`${left}/`)
 }
 
+export interface SharedSkillPath {
+  readonly id: string
+  readonly skillFile: string
+}
+
+/**
+ * One entry the resolver declined to admit. Only entries the caller marked
+ * skippable can appear here; a required entry still fails the whole resolve.
+ */
+export interface SkippedWorkspacePackageResource {
+  readonly kind: 'package-contribution' | 'shared-skill'
+  /** Package name for a contribution, shared skill id for a shared skill. */
+  readonly id: string
+  /** Admission verdict that caused the skip, when the refusal carried one. */
+  readonly code?: string
+}
+
+export interface ResolveWorkspacePackageResourcesOptions {
+  /** Host-declared shared skills. An inadmissible entry fails the resolve. */
+  sharedSkillPaths?: readonly SharedSkillPath[]
+  /**
+   * Speculatively scanned contributions. An entry that is not independently
+   * admissible is reported in `skipped` instead of failing the resolve, and is
+   * never mounted or exposed.
+   */
+  skippableContributions?: readonly WorkspacePackageResourceRecord[]
+  /**
+   * Ambient shared skills discovered in the user's tree (`~/.pi/agent/skills`
+   * is normally a tree of symlinks, so a stale entry is routine). Degrades the
+   * same way as `skippableContributions`, but only on an admission verdict —
+   * a resolver defect still propagates (gh-1196).
+   */
+  skippableSharedSkillPaths?: readonly SharedSkillPath[]
+}
+
+/** A contribution that passed independent admission: canonical root + manifest. */
+interface AdmittedContribution {
+  readonly contribution: WorkspacePackageResourceRecord
+  readonly canonicalRoot: string
+  readonly manifest: PackageManifest
+  readonly skippable: boolean
+  /** Position in the skippable input, used to report skips in input order. */
+  readonly order: number
+}
+
+function admissionCode(error: unknown): { code?: string } {
+  const code = (error as { code?: unknown })?.code
+  return typeof code === 'string' ? { code } : {}
+}
+
+function packageKey(packageName: string, canonicalRoot: string): string {
+  return `${packageName}\0${canonicalRoot}`
+}
+
+/**
+ * Independent admission of one contribution: everything that can be decided
+ * from the contribution alone, with no reference to its siblings. Cross-entry
+ * conflicts are deliberately *not* checked here — they are decided later, over
+ * the survivors only, so that a skipped entry cannot manufacture a conflict.
+ */
+async function admitContribution(
+  contribution: WorkspacePackageResourceRecord,
+): Promise<{ canonicalRoot: string; manifest: PackageManifest }> {
+  if (contribution.packageName === 'shared/pi-agent') {
+    throw invalid(contribution.packageName, 'package name is reserved for host-owned shared skills')
+  }
+  const requestedRoot = packageRootPath(contribution.packageRoot, contribution.packageName)
+  const canonicalRoot = await realpath(requestedRoot).catch(() => {
+    throw invalid(contribution.packageName, 'packageRoot is not readable')
+  })
+  const manifestBytes = await readFile(resolve(canonicalRoot, 'package.json'), 'utf8').catch(() => {
+    throw invalid(contribution.packageName, 'package manifest is not readable')
+  })
+  const manifest = parseManifest(contribution.packageName, manifestBytes)
+  if (manifest.name !== contribution.packageName) {
+    throw invalid(contribution.packageName, 'package manifest name does not match contribution')
+  }
+  return { canonicalRoot, manifest }
+}
+
+/** Resolve every skill a package declares, exactly once per package root. */
+async function resolvePackageSkills(
+  packageName: string,
+  canonicalRoot: string,
+  manifest: PackageManifest,
+): Promise<ResolvedSkillDraft[]> {
+  if (!Array.isArray(manifest.pi?.skills) || manifest.pi.skills.length === 0) {
+    throw invalid(packageName, 'package manifest must declare pi.skills')
+  }
+  const declarations = [...new Set(manifest.pi.skills.map((entry) => normalizeDeclaration(packageName, entry)))]
+  const drafts: ResolvedSkillDraft[] = []
+  for (const declaration of declarations.sort()) {
+    drafts.push(await resolveSkillDeclaration(packageName, canonicalRoot, declaration))
+  }
+  assertNoOverlappingLogicalRoots(drafts)
+  return drafts
+}
+
+/** Resolve one shared skill. Never called more than once per entry. */
+async function resolveSharedSkill(shared: SharedSkillPath): Promise<ResolvedSkillDraft & { sourceFile: string }> {
+  if (!shared.id || shared.id.includes('/') || shared.id.includes('\\') || shared.id === '.' || shared.id === '..') {
+    throw invalid('shared/pi-agent', 'shared skill id is invalid')
+  }
+  const sourceFile = resolve(shared.skillFile)
+  const skillFile = await realpath(sourceFile).catch(() => {
+    throw invalid('shared/pi-agent', 'shared skill is not readable')
+  })
+  if (posix.basename(skillFile.split(sep).join('/')) !== 'SKILL.md') {
+    throw invalid('shared/pi-agent', 'shared skill must name a SKILL.md file')
+  }
+  const skill = await resolveSkillRecord({
+    packageName: 'shared/pi-agent',
+    sourceSkillFile: skillFile,
+    logicalFile: `shared/pi-agent/${shared.id}/SKILL.md`,
+  })
+  return { ...skill, sourceFile }
+}
+
+function assertNoOverlappingLogicalRoots(drafts: readonly ResolvedSkillDraft[]): void {
+  const logicalRoots = drafts.map((skill) => posix.dirname(skill.resource.path))
+  for (let i = 0; i < logicalRoots.length; i++) {
+    for (let j = i + 1; j < logicalRoots.length; j++) {
+      if (rootsOverlap(logicalRoots[i], logicalRoots[j])) {
+        throw conflict(drafts[j].packageName, 'logical skill mounts overlap')
+      }
+    }
+  }
+}
+
 export async function resolveWorkspacePackageResources(
   contributions: readonly WorkspacePackageResourceRecord[],
-  options: {
-    sharedSkillPaths?: readonly { readonly id: string; readonly skillFile: string }[]
-  } = {},
+  options: ResolveWorkspacePackageResourcesOptions = {},
 ): Promise<ResolvedWorkspacePackageResourceRegistry> {
+  const skippableContributions = options.skippableContributions ?? []
+  // Package skips are reported in skippable-input order regardless of which
+  // phase rejected them, so callers see one stable diagnostic sequence.
+  const packageSkips: { order: number; entry: SkippedWorkspacePackageResource }[] = []
+  const sharedSkips: SkippedWorkspacePackageResource[] = []
+
+  // Phase 1 — independent admission. Required entries fail the resolve; a
+  // skippable entry is dropped here and never touched again.
+  const admitted: AdmittedContribution[] = []
+  const admitInto = async (records: readonly WorkspacePackageResourceRecord[], skippable: boolean) => {
+    for (const [order, contribution] of records.entries()) {
+      try {
+        const { canonicalRoot, manifest } = await admitContribution(contribution)
+        admitted.push({ contribution, canonicalRoot, manifest, skippable, order })
+      } catch (error) {
+        if (!skippable) throw error
+        packageSkips.push({
+          order,
+          entry: { kind: 'package-contribution', id: contribution.packageName, ...admissionCode(error) },
+        })
+      }
+    }
+  }
+  await admitInto(contributions, false)
+  await admitInto(skippableContributions, true)
+
+  // Phase 2 — resolve each distinct package root's skills exactly once. A root
+  // whose only claimants are skippable is dropped whole; one required claimant
+  // makes the failure fatal, as it is today.
+  const draftsByPackage = new Map<string, ResolvedSkillDraft[]>()
+  const surviving: AdmittedContribution[] = []
+  const droppedKeys = new Map<string, { code?: string }>()
+  const requiredKeys = new Set(admitted
+    .filter((entry) => !entry.skippable)
+    .map((entry) => packageKey(entry.contribution.packageName, entry.canonicalRoot)))
+  for (const entry of admitted) {
+    const key = packageKey(entry.contribution.packageName, entry.canonicalRoot)
+    const alreadyDropped = droppedKeys.get(key)
+    if (alreadyDropped) {
+      packageSkips.push({
+        order: entry.order,
+        entry: { kind: 'package-contribution', id: entry.contribution.packageName, ...alreadyDropped },
+      })
+      continue
+    }
+    if (!draftsByPackage.has(key)) {
+      try {
+        draftsByPackage.set(key, await resolvePackageSkills(
+          entry.contribution.packageName,
+          entry.canonicalRoot,
+          entry.manifest,
+        ))
+      } catch (error) {
+        if (requiredKeys.has(key)) throw error
+        const code = admissionCode(error)
+        droppedKeys.set(key, code)
+        packageSkips.push({
+          order: entry.order,
+          entry: { kind: 'package-contribution', id: entry.contribution.packageName, ...code },
+        })
+        continue
+      }
+    }
+    surviving.push(entry)
+  }
+
+  // Phase 3 — assemble. Cross-entry conflicts are decided here, over survivors
+  // only, in contribution order.
   const packageRecords = new Map<string, {
     root: string
     manifest: PackageManifest
     pluginIds: Set<string>
   }>()
-
-  for (const contribution of contributions) {
-    if (contribution.packageName === 'shared/pi-agent') {
-      throw invalid(contribution.packageName, 'package name is reserved for host-owned shared skills')
-    }
-    const requestedRoot = packageRootPath(contribution.packageRoot, contribution.packageName)
-    const canonicalRoot = await realpath(requestedRoot).catch(() => {
-      throw invalid(contribution.packageName, 'packageRoot is not readable')
-    })
+  for (const { contribution, canonicalRoot, manifest } of surviving) {
     const existingForName = packageRecords.get(contribution.packageName)?.root
     if (existingForName && existingForName !== canonicalRoot) {
       throw conflict(contribution.packageName, 'one package name resolved to multiple roots')
     }
-
-    const manifestBytes = await readFile(resolve(canonicalRoot, 'package.json'), 'utf8').catch(() => {
-      throw invalid(contribution.packageName, 'package manifest is not readable')
-    })
-    const manifest = parseManifest(contribution.packageName, manifestBytes)
-    if (manifest.name !== contribution.packageName) {
-      throw invalid(contribution.packageName, 'package manifest name does not match contribution')
-    }
-
     const existingAtRoot = [...packageRecords.entries()].find(([, record]) => record.root === canonicalRoot)
     if (existingAtRoot && existingAtRoot[0] !== contribution.packageName) {
       throw conflict(contribution.packageName, 'one package root was claimed by multiple names')
     }
-
     const record = packageRecords.get(contribution.packageName) ?? {
       root: canonicalRoot,
       manifest,
@@ -292,42 +474,33 @@ export async function resolveWorkspacePackageResources(
 
   const skills: ResolvedAgentPackageSkill[] = []
   for (const [packageName, record] of [...packageRecords.entries()].sort(([a], [b]) => a.localeCompare(b))) {
-    const manifest = record.manifest
-    if (!Array.isArray(manifest.pi?.skills) || manifest.pi.skills.length === 0) {
-      throw invalid(packageName, 'package manifest must declare pi.skills')
-    }
-    const declarations = [...new Set(manifest.pi.skills.map((entry) => normalizeDeclaration(packageName, entry)))]
-    for (const declaration of declarations.sort()) {
-      skills.push(await resolveSkillDeclaration(
-        packageName,
-        record.root,
-        declaration,
-        [...record.pluginIds].sort(),
-      ))
+    const pluginIds = [...record.pluginIds].sort()
+    for (const draft of draftsByPackage.get(packageKey(packageName, record.root)) ?? []) {
+      skills.push({ ...draft, pluginIds })
     }
   }
 
   const sharedLocatorAliases = new Map<string, AgentSkillResource>()
-  for (const shared of options.sharedSkillPaths ?? []) {
-    if (!shared.id || shared.id.includes('/') || shared.id.includes('\\') || shared.id === '.' || shared.id === '..') {
-      throw invalid('shared/pi-agent', 'shared skill id is invalid')
+  const admitShared = async (entries: readonly SharedSkillPath[], skippable: boolean) => {
+    for (const shared of entries) {
+      let resolved: Awaited<ReturnType<typeof resolveSharedSkill>>
+      try {
+        resolved = await resolveSharedSkill(shared)
+      } catch (error) {
+        // Only an admission verdict is routine. A resolver defect must surface,
+        // not masquerade as a stale symlink.
+        const code = skippable ? sharedSkillAdmissionCode(error) : undefined
+        if (!code) throw error
+        sharedSkips.push({ kind: 'shared-skill', id: shared.id, code })
+        continue
+      }
+      const { sourceFile, ...skill } = resolved
+      sharedLocatorAliases.set(sourceFile, skill.resource)
+      skills.push({ ...skill, pluginIds: ['host:shared-skill'] })
     }
-    const sourceFile = resolve(shared.skillFile)
-    const skillFile = await realpath(sourceFile).catch(() => {
-      throw invalid('shared/pi-agent', 'shared skill is not readable')
-    })
-    if (posix.basename(skillFile.split(sep).join('/')) !== 'SKILL.md') {
-      throw invalid('shared/pi-agent', 'shared skill must name a SKILL.md file')
-    }
-    const skill = await resolveSkillRecord({
-      packageName: 'shared/pi-agent',
-      pluginIds: ['host:shared-skill'],
-      sourceSkillFile: skillFile,
-      logicalFile: `shared/pi-agent/${shared.id}/SKILL.md`,
-    })
-    sharedLocatorAliases.set(sourceFile, skill.resource)
-    skills.push(skill)
   }
+  await admitShared(options.sharedSkillPaths ?? [], false)
+  await admitShared(options.skippableSharedSkillPaths ?? [], true)
 
   const logicalRoots = skills.map((skill) => posix.dirname(skill.resource.path))
   for (let i = 0; i < logicalRoots.length; i++) {
@@ -370,6 +543,10 @@ export async function resolveWorkspacePackageResources(
 
   return {
     generation: generationHash.digest('hex'),
+    skipped: [
+      ...packageSkips.sort((left, right) => left.order - right.order).map(({ entry }) => entry),
+      ...sharedSkips,
+    ],
     additionalSkillPaths: [...new Set(skills
       .filter((skill) => skill.packageName !== 'shared/pi-agent')
       .map((skill) => skill.mountRoot))],
@@ -502,47 +679,30 @@ export async function resolveWorkspacePackageResourceSnapshot<TBinding = never>(
   readonly binding?: TBinding
   readonly diagnostics: readonly PackageResourceDiagnostic[]
 }> {
-  const accepted: WorkspacePackageResourceRecord[] = []
-  const diagnostics: PackageResourceDiagnostic[] = []
-  for (const record of input.scanned) {
-    try {
-      await resolveWorkspacePackageResources([record])
-      accepted.push(record)
-    } catch {
-      diagnostics.push({
-        source: 'package-resource-scan',
-        message: 'scanned package skill resources were invalid',
-        pluginId: record.packageName,
-      })
-    }
-  }
-  // gh-1196: ~/.pi/agent/skills is normally a tree of symlinks into other
-  // roots, so one stale entry (a dangling link, or one whose target the host
-  // will not admit) is routine. Admit shared skills per entry the same way
-  // scanned packages are admitted above: an unadmittable entry is skipped with
-  // a diagnostic and is never resolved or exposed, and the rest still load.
-  // Failing the whole scan closed here used to 500 every agent-scoped route.
-  const acceptedSharedSkillPaths: { readonly id: string; readonly skillFile: string }[] = []
-  for (const shared of input.sharedSkillPaths ?? []) {
-    try {
-      await resolveWorkspacePackageResources([], { sharedSkillPaths: [shared] })
-      acceptedSharedSkillPaths.push(shared)
-    } catch (error) {
-      // Only an admission verdict is routine. A resolver defect must surface,
-      // not masquerade as a stale symlink.
-      const code = sharedSkillAdmissionCode(error)
-      if (!code) throw error
-      diagnostics.push({
-        source: 'shared-skill-scan',
-        message: `shared skill "${shared.id}" was not admissible and was skipped`,
-        pluginId: 'shared/pi-agent',
-        code,
-      })
-    }
-  }
-  const registry = await resolveWorkspacePackageResources([...input.declared, ...accepted], {
-    sharedSkillPaths: acceptedSharedSkillPaths,
+  // Scanned packages and ambient shared skills are speculative: an entry the
+  // resolver will not admit is skipped with a diagnostic and is never resolved,
+  // opened or exposed, while the rest still load. gh-1196: ~/.pi/agent/skills is
+  // normally a tree of symlinks into other roots, so one stale entry there is
+  // routine, and failing the whole scan closed used to 500 every agent-scoped
+  // route. The resolver reports these per entry in a single pass — do not
+  // reintroduce a probe that re-runs it once per candidate.
+  const registry = await resolveWorkspacePackageResources(input.declared, {
+    skippableContributions: input.scanned,
+    skippableSharedSkillPaths: input.sharedSkillPaths ?? [],
   })
+  const diagnostics: PackageResourceDiagnostic[] = registry.skipped.map((entry) =>
+    entry.kind === 'package-contribution'
+      ? {
+          source: 'package-resource-scan',
+          message: 'scanned package skill resources were invalid',
+          pluginId: entry.id,
+        }
+      : {
+          source: 'shared-skill-scan',
+          message: `shared skill "${entry.id}" was not admissible and was skipped`,
+          pluginId: 'shared/pi-agent',
+          ...(entry.code ? { code: entry.code } : {}),
+        })
   const binding = registry.readonlyMounts.length > 0 && input.createBinding
     ? await input.createBinding(registry.readonlyMounts)
     : undefined


### PR DESCRIPTION
## Summary
Stacked on #1358 (base = `fix/bugfix-sweep-2026-08-21`) so this diff contains only the 2 thermo-follow-up commits; retarget to `main` after #1358 merges.

- **One canonical request-ledger chain** (`requestLedgerPath.ts`, `createAgentHost.ts`, `createStandaloneAgentHostApp.ts`, server index): single shared implementation instead of per-entrypoint resolution drift.
- **One-pass package resource resolution** (`workspace/src/server/plugins/packageResources.ts`): removes the per-entry N+1 re-resolution pattern.
- **piResourceDigest** aligned to the canonical chain.

## Tests added
- `requestLedgerPath.test.ts` (new, 97 lines)
- `packageResources.singlePass.test.ts` (new, 139 lines) — counts resolver passes per entry without fs mocking, so a regression back to N+1 fails the test
- `createAgentHost.test.ts`, `createHarness.test.ts`, `createCoreWorkspaceAgentServer.workspaceBridge.test.ts` extended

## Proof
- `tsc --noEmit`: packages/agent + packages/workspace both clean
- requestLedgerPath + createAgentHost suites: 22 pass / 0 fail
- packageResources.singlePass + workspaceBridge: pass
- createHarness suite: 61 pass / 0 fail
- Wave-2 verification ran the touched workspace suites 9/9 twice (prior reds were parallel-fleet load contention)

Thermo follow-up from the overnight review sweep (canonical ledger resolver + N+1 probe).