### PR TITLE
refactor(workspace): scope temp handlers + gate dev filter (#601 follow-up)

### DIFF
--- a/apps/agent-playground/package.json
+++ b/apps/agent-playground/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "description": "Rich standalone playground for @hachej/boring-agent.",
   "scripts": {
-    "dev": "pnpm --filter @hachej/boring-sandbox build && pnpm --filter @hachej/boring-bash build && pnpm --filter @hachej/boring-agent build:dev && tsx --env-file=.env.local src/server/index.ts",
+    "build:deps": "pnpm --filter @hachej/boring-sandbox build && pnpm --filter @hachej/boring-bash build && pnpm --filter @hachej/boring-agent build:dev",
+    "dev": "pnpm run build:deps && pnpm run dev:app",
+    "dev:app": "tsx --env-file=.env.local src/server/index.ts",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },

--- a/apps/full-app/package.json
+++ b/apps/full-app/package.json
@@ -4,8 +4,10 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "pnpm --filter @hachej/boring-ui-kit build && pnpm --filter @hachej/boring-sandbox build && pnpm --filter @hachej/boring-bash build && pnpm --filter @hachej/boring-agent build && pnpm --filter @hachej/boring-workspace build && pnpm --filter @hachej/boring-core build && pnpm --filter @hachej/boring-automation build && pnpm --filter @hachej/boring-mcp build && pnpm --filter @hachej/boring-governance build && NODE_ENV=development tsx src/server/migrate.ts && NODE_ENV=development tsx src/server/dev.ts",
-    "build": "pnpm --filter @hachej/boring-ui-kit build && pnpm --filter @hachej/boring-sandbox build && pnpm --filter @hachej/boring-bash build && pnpm --filter @hachej/boring-agent build && pnpm --filter @hachej/boring-workspace build && pnpm --filter @hachej/boring-core build && pnpm --filter @hachej/boring-automation build && pnpm --filter @hachej/boring-mcp build && pnpm --filter @hachej/boring-governance build && tsx ../../packages/workspace/scripts/build-app.mts",
+    "build:deps": "pnpm --filter @hachej/boring-ui-kit build && pnpm --filter @hachej/boring-sandbox build && pnpm --filter @hachej/boring-bash build && pnpm --filter @hachej/boring-agent build && pnpm --filter @hachej/boring-workspace build && pnpm --filter @hachej/boring-core build && pnpm --filter @hachej/boring-automation build && pnpm --filter @hachej/boring-mcp build && pnpm --filter @hachej/boring-governance build",
+    "dev": "pnpm run build:deps && pnpm run dev:app",
+    "dev:app": "NODE_ENV=development tsx src/server/migrate.ts && NODE_ENV=development tsx src/server/dev.ts",
+    "build": "pnpm run build:deps && tsx ../../packages/workspace/scripts/build-app.mts",
     "start": "NODE_ENV=production node dist/server/main.js",
     "start:worker": "NODE_ENV=production node dist/server/agent-worker.js",
     "migrate": "tsx src/server/migrate.ts",

--- a/apps/workspace-playground/package.json
+++ b/apps/workspace-playground/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "build:deps": "pnpm --filter @hachej/boring-ui-kit build && pnpm --filter @hachej/boring-ui-plugin-cli build && pnpm --filter @hachej/boring-sandbox build && pnpm --filter @hachej/boring-bash build && pnpm --filter @hachej/boring-agent build && pnpm --filter @hachej/boring-pi build && pnpm --filter @hachej/boring-workspace build && pnpm --filter @hachej/boring-core build && pnpm --filter @hachej/boring-deck build && pnpm --filter @hachej/boring-ask-user build && pnpm --filter @hachej/boring-tasks build && pnpm --filter @hachej/boring-diagram build && pnpm --filter @hachej/boring-data-explorer build && pnpm --filter @hachej/boring-data-catalog build",
-    "dev": "pnpm run build:deps && vite",
+    "dev": "pnpm run build:deps && pnpm run dev:app",
+    "dev:app": "vite",
     "dev:multiagent": "VITE_BORING_FACTORY_AGENTS=1 pnpm run dev",
     "build": "pnpm run build:deps && vite build",
     "typecheck": "tsc --noEmit",

--- a/apps/workspace-playground/src/server/playgroundAgentMode.test.ts
+++ b/apps/workspace-playground/src/server/playgroundAgentMode.test.ts
@@ -28,7 +28,12 @@ describe("workspace playground agent mode", () => {
       readFileSync(resolve(import.meta.dirname, "../../package.json"), "utf8"),
     ) as { scripts: Record<string, string> }
 
-    expect(packageJson.scripts.dev).toBe("pnpm run build:deps && vite")
+    // `dev` must stay factory-agent-free: the multi-agent fleet is opted into
+    // only by the named `dev:multiagent` script.
+    expect(packageJson.scripts.dev).toBe("pnpm run build:deps && pnpm run dev:app")
+    expect(packageJson.scripts["dev:app"]).toBe("vite")
+    expect(packageJson.scripts.dev).not.toContain("VITE_BORING_FACTORY_AGENTS")
+    expect(packageJson.scripts["dev:app"]).not.toContain("VITE_BORING_FACTORY_AGENTS")
     expect(packageJson.scripts["dev:multiagent"]).toBe("VITE_BORING_FACTORY_AGENTS=1 pnpm run dev")
     expect(resolvePlaygroundAgentMode({ VITE_BORING_FACTORY_AGENTS: "1" })).toBe("factory")
   })

--- a/docs/procedures/repo-commands.md
+++ b/docs/procedures/repo-commands.md
@@ -24,6 +24,28 @@ pnpm --filter agent-playground dev
 pnpm --filter full-app dev
 ```
 
+## Running apps concurrently
+
+Each app's `dev` first rebuilds its shared-package deps (`build:deps`), and
+those builds are `clean:true` — two app `dev` runs at once race on the same
+`dist/` directories and corrupt them.
+
+Root `pnpm dev` is safe: it runs `build:app-deps` once (all shared packages,
+topological order, `--workspace-concurrency=1`) and only then starts every app
+in parallel via `dev:app`, which never rebuilds shared packages.
+
+To start apps in separate terminals, do the same by hand:
+
+```bash
+pnpm build:app-deps                              # once, from repo root
+pnpm --filter workspace-playground dev:app       # then one per terminal
+pnpm --filter agent-playground dev:app
+pnpm --filter full-app dev:app
+```
+
+Never run two `dev` (as opposed to `dev:app`) commands at the same time.
+Re-run `pnpm build:app-deps` after changing a shared package.
+
 Apps that consume `@hachej/boring-workspace` from source need workspace built
 once first:
 

--- a/docs/procedures/repo-commands.md
+++ b/docs/procedures/repo-commands.md
@@ -34,6 +34,13 @@ Root `pnpm dev` is safe: it runs `build:app-deps` once (all shared packages,
 topological order, `--workspace-concurrency=1`) and only then starts every app
 in parallel via `dev:app`, which never rebuilds shared packages.
 
+`build:app-deps` selects its package set from pnpm's own dependency graph —
+`--filter '{./apps/*}...'` (every app plus everything it depends on) minus
+`--filter '!{./apps/*}'` (the apps themselves) — so it can never drift out of
+sync with what the apps actually import. Note the braces: `'./apps/*...'`
+without them is parsed as a literal path pattern and silently selects only the
+apps.
+
 To start apps in separate terminals, do the same by hand:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "pnpm -r --workspace-concurrency=4 run build",
-    "dev": "pnpm -r run dev",
+    "dev": "pnpm run build:app-deps && pnpm -r --parallel --filter './apps/*' run dev:app",
     "typecheck": "pnpm run build:packages && pnpm -r --workspace-concurrency=4 run typecheck",
     "lint": "pnpm check:agenthost-cutover-matrix && pnpm test:agenthost-compositions && pnpm check:generated-artifacts && pnpm check:agent-resources && pnpm test:present-pr-context && pnpm audit:imports",
     "check:agenthost-cutover-matrix": "node scripts/check-agenthost-cutover-matrix.mjs",
@@ -51,6 +51,7 @@
     "release:minor": "bash scripts/cut-release.sh minor",
     "release:major": "bash scripts/cut-release.sh major",
     "build:packages": "pnpm -r --filter './packages/*' --filter './plugins/*' --workspace-concurrency=4 run build",
+    "build:app-deps": "pnpm -r --workspace-concurrency=1 --filter @hachej/boring-ui-kit --filter @hachej/boring-ui-plugin-cli --filter @hachej/boring-sandbox --filter @hachej/boring-bash --filter @hachej/boring-agent --filter @hachej/boring-pi --filter @hachej/boring-workspace --filter @hachej/boring-core --filter @hachej/boring-automation --filter @hachej/boring-mcp --filter @hachej/boring-governance --filter @hachej/boring-deck --filter @hachej/boring-ask-user --filter @hachej/boring-tasks --filter @hachej/boring-diagram --filter @hachej/boring-data-explorer --filter @hachej/boring-data-catalog run build",
     "typecheck:changed": "node scripts/typecheck-changed-workspaces.mjs",
     "review:workspace-ui": "node scripts/review-workspace-playground-ui.mjs",
     "signoff:local": "bash scripts/signoff-local.sh",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "release:minor": "bash scripts/cut-release.sh minor",
     "release:major": "bash scripts/cut-release.sh major",
     "build:packages": "pnpm -r --filter './packages/*' --filter './plugins/*' --workspace-concurrency=4 run build",
-    "build:app-deps": "pnpm -r --workspace-concurrency=1 --filter @hachej/boring-ui-kit --filter @hachej/boring-ui-plugin-cli --filter @hachej/boring-sandbox --filter @hachej/boring-bash --filter @hachej/boring-agent --filter @hachej/boring-pi --filter @hachej/boring-workspace --filter @hachej/boring-core --filter @hachej/boring-automation --filter @hachej/boring-mcp --filter @hachej/boring-governance --filter @hachej/boring-deck --filter @hachej/boring-ask-user --filter @hachej/boring-tasks --filter @hachej/boring-diagram --filter @hachej/boring-data-explorer --filter @hachej/boring-data-catalog run build",
+    "build:app-deps": "pnpm -r --workspace-concurrency=1 --filter '{./apps/*}...' --filter '!{./apps/*}' run build",
     "typecheck:changed": "node scripts/typecheck-changed-workspaces.mjs",
     "review:workspace-ui": "node scripts/review-workspace-playground-ui.mjs",
     "signoff:local": "bash scripts/signoff-local.sh",

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -338,8 +338,8 @@ export interface WorkspaceAgentFrontProps<
    * Opt in/out of server-backed pi-chat sessions independently of workspace
    * provisioning. When omitted, remote sessions follow `provisionWorkspace`
    * (enabled unless `provisionWorkspace={false}`). Apps that disable
-   * provisioning but still talk to `/api/v1/agent/pi-chat/*` should pass
-   * `true` so chat uses real server session ids instead of local-only ones.
+   * provisioning but still reach the agent pi-chat routes should pass `true`
+   * so chat uses real server session ids instead of local-only ones.
    */
   remoteSessionsEnabled?: boolean
   bootPreloadPaths?: string[]
@@ -921,10 +921,11 @@ export function WorkspaceAgentFront<
   useEffect(() => {
     if (remoteSessionsDisabledWarnedRef.current) return
     if (!shouldUseRemoteSessions || remoteSessionsResolved || provisionWorkspace !== false) return
+    if (remoteSessionsEnabled !== undefined) return
     remoteSessionsDisabledWarnedRef.current = true
     if (typeof import.meta !== 'undefined' && import.meta.env?.DEV) {
       console.warn(
-        "[boring-ui] WorkspaceAgentFront: provisionWorkspace={false} also disabled server-backed chat sessions, so the chat panel will use local-only session ids while still calling /api/v1/agent/pi-chat/*. Pass remoteSessionsEnabled={true} to keep remote sessions.",
+        "[boring-ui] WorkspaceAgentFront: provisionWorkspace={false} also disabled server-backed chat sessions, so the chat panel will use local-only session ids while still reaching the agent pi-chat routes. Pass remoteSessionsEnabled={true} to keep remote sessions.",
       )
     }
   }, [provisionWorkspace, remoteSessionsResolved, shouldUseRemoteSessions])

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -334,6 +334,14 @@ export interface WorkspaceAgentFrontProps<
   extraPanels?: string[]
   extraCommands?: SlashCommand[]
   provisionWorkspace?: boolean
+  /**
+   * Opt in/out of server-backed pi-chat sessions independently of workspace
+   * provisioning. When omitted, remote sessions follow `provisionWorkspace`
+   * (enabled unless `provisionWorkspace={false}`). Apps that disable
+   * provisioning but still talk to `/api/v1/agent/pi-chat/*` should pass
+   * `true` so chat uses real server session ids instead of local-only ones.
+   */
+  remoteSessionsEnabled?: boolean
   bootPreloadPaths?: string[]
   onWorkspaceWarmupStatusChange?: (status: WorkspaceWarmupStatus) => void
 }
@@ -756,6 +764,7 @@ export function WorkspaceAgentFront<
   extraPanels,
   extraCommands,
   provisionWorkspace,
+  remoteSessionsEnabled,
   bootPreloadPaths,
   onWorkspaceWarmupStatusChange,
   onOpenNav,
@@ -904,7 +913,21 @@ export function WorkspaceAgentFront<
   const chatPanel = (chatPanelProp ?? DefaultPiChatPanel) as ComponentType<WorkspaceChatPanelProps>
   const useSessions = (useSessionsProp ?? useDefaultWorkspacePiSessions) as UseWorkspaceAgentSessions<TSession>
   const shouldUseRemoteSessions = !chatPanelProp || Boolean(useSessionsProp)
-  const remoteSessionHookEnabled = shouldUseRemoteSessions && provisionWorkspace !== false
+  // Provisioning and server-backed sessions are separate concerns: apps can
+  // disable workspace provisioning and still use real pi-chat sessions.
+  const remoteSessionsResolved = remoteSessionsEnabled ?? (provisionWorkspace !== false)
+  const remoteSessionHookEnabled = shouldUseRemoteSessions && remoteSessionsResolved
+  const remoteSessionsDisabledWarnedRef = useRef(false)
+  useEffect(() => {
+    if (remoteSessionsDisabledWarnedRef.current) return
+    if (!shouldUseRemoteSessions || remoteSessionsResolved || provisionWorkspace !== false) return
+    remoteSessionsDisabledWarnedRef.current = true
+    if (typeof import.meta !== 'undefined' && import.meta.env?.DEV) {
+      console.warn(
+        "[boring-ui] WorkspaceAgentFront: provisionWorkspace={false} also disabled server-backed chat sessions, so the chat panel will use local-only session ids while still calling /api/v1/agent/pi-chat/*. Pass remoteSessionsEnabled={true} to keep remote sessions.",
+      )
+    }
+  }, [provisionWorkspace, remoteSessionsResolved, shouldUseRemoteSessions])
   const fleetAgentIdentity = addressedAgents.agents.map((agent) => agent.agentTypeId).sort().join(",")
   const sessionSourceIdentity = useMemo(() => sessionDataSourceIdentity({
     workspaceId,
@@ -2086,7 +2109,7 @@ export function WorkspaceAgentFront<
   // A restored/open active pane that survived authoritative inventory
   // reconciliation owns enough addressed identity to hydrate even when the
   // mutable global active preference is absent. An implicit placeholder does not.
-  const hydrateMessages = !autoSubmitHydrationDisabled && provisionWorkspace !== false && (
+  const hydrateMessages = !autoSubmitHydrationDisabled && remoteSessionsResolved && (
     shouldUseRemoteSessions
       ? Boolean(effectiveActiveSessionId || activeChatPaneIsInventoried)
       : true

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -928,7 +928,7 @@ export function WorkspaceAgentFront<
         "[boring-ui] WorkspaceAgentFront: provisionWorkspace={false} also disabled server-backed chat sessions, so the chat panel will use local-only session ids while still reaching the agent pi-chat routes. Pass remoteSessionsEnabled={true} to keep remote sessions.",
       )
     }
-  }, [provisionWorkspace, remoteSessionsResolved, shouldUseRemoteSessions])
+  }, [provisionWorkspace, remoteSessionsEnabled, remoteSessionsResolved, shouldUseRemoteSessions])
   const fleetAgentIdentity = addressedAgents.agents.map((agent) => agent.agentTypeId).sort().join(",")
   const sessionSourceIdentity = useMemo(() => sessionDataSourceIdentity({
     workspaceId,

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -2286,6 +2286,33 @@ describe("WorkspaceAgentFront", () => {
     expect(fetchMock.mock.calls.some(([input]) => String(input).includes("/api/v1/agents/default/ready-status"))).toBe(false)
   })
 
+  it("keeps remote sessions when provisioning is disabled but remoteSessionsEnabled is set", async () => {
+    const onWarmup = vi.fn()
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, _init?: RequestInit) => {
+      const url = String(input)
+      if (url.includes("/api/v1/tree")) return new Response(JSON.stringify({ entries: [] }), { status: 200 })
+      if (url.includes("/api/v1/agents/default/models")) return new Response(JSON.stringify({ models: [] }), { status: 200 })
+      if (url.includes("/api/v1/agents/default/skills")) return new Response(JSON.stringify({ skills: [] }), { status: 200 })
+      if (isDefaultSessionsCollectionUrl(url)) return new Response(JSON.stringify({ sessions: [] }), { status: 200 })
+      return new Response(null, { status: 204 })
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    render(
+      <WorkspaceAgentFront
+        workspaceId="no-provision-remote-sessions"
+        provisionWorkspace={false}
+        remoteSessionsEnabled
+        persistenceEnabled={false}
+        onWorkspaceWarmupStatusChange={onWarmup}
+      />,
+    )
+
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.some(([input]) => isDefaultSessionsCollectionUrl(String(input)))).toBe(true),
+    )
+  })
+
   it("creates a fresh remote session for auth-return auto-submit instead of reusing the old active session", async () => {
     let capturedChatProps: unknown
     const getCapturedChatProps = () => capturedChatProps as CapturedChatPanelProps | undefined

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -2288,12 +2288,14 @@ describe("WorkspaceAgentFront", () => {
 
   it("keeps remote sessions when provisioning is disabled but remoteSessionsEnabled is set", async () => {
     const onWarmup = vi.fn()
-    const fetchMock = vi.fn(async (input: RequestInfo | URL, _init?: RequestInit) => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input)
       if (url.includes("/api/v1/tree")) return new Response(JSON.stringify({ entries: [] }), { status: 200 })
       if (url.includes("/api/v1/agents/default/models")) return new Response(JSON.stringify({ models: [] }), { status: 200 })
       if (url.includes("/api/v1/agents/default/skills")) return new Response(JSON.stringify({ skills: [] }), { status: 200 })
-      if (isDefaultSessionsCollectionUrl(url)) return new Response(JSON.stringify({ sessions: [] }), { status: 200 })
+      if (isDefaultSessionsCollectionUrl(url)) {
+        return new Response(JSON.stringify({ sessions: [{ id: "sess-remote-known", title: "Known remote" }] }), { status: 200 })
+      }
       return new Response(null, { status: 204 })
     })
     vi.stubGlobal("fetch", fetchMock)
@@ -2311,6 +2313,15 @@ describe("WorkspaceAgentFront", () => {
     await waitFor(() =>
       expect(fetchMock.mock.calls.some(([input]) => isDefaultSessionsCollectionUrl(String(input)))).toBe(true),
     )
+    // The known server session must be consumed as an existing remote session, not treated as an
+    // empty list: the front must not create a replacement local session behind the user's back.
+    // (Deeper chat-props/state-route adoption evidence is warmup-gated here — with provisioning
+    // disabled the panel never mounts in jsdom — so hydration-on-adopt is pinned instead by the
+    // injected-hook tests above.)
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(fetchMock.mock.calls.some(([input, init]) =>
+      String(input).includes("/agents/default/sessions") && (init?.method === "POST" || init?.method === "DELETE"),
+    )).toBe(false)
   })
 
   it("creates a fresh remote session for auth-return auto-submit instead of reusing the old active session", async () => {

--- a/tools/ui-review/README.md
+++ b/tools/ui-review/README.md
@@ -69,6 +69,16 @@ with `SIGINT`/`SIGTERM`/`SIGHUP`, so interrupted runs cannot leak inodes.
 Cleanup never follows symlinks and refuses to remove any path outside that
 parent.
 
+Creating the run root arms its removal on normal process `exit`, which is safe in
+any host. Signal handling is opt-in, because cleaning up on a signal means
+re-exiting the process with that signal's conventional code — a decision only an
+entrypoint that owns its process may take. The CLI entrypoints
+(`scripts/run-ui-review.mjs`, `scripts/explore-review-spec.ts`) call
+`installUiReviewTempCleanupHandlers()`; importing the helper into a Playwright or
+vitest worker never does, so the runner keeps its own shutdown semantics. Those
+workers are signal-killed by their runner, so their suites remove the run root
+explicitly in an `afterAll` instead.
+
 Set `UI_REVIEW_KEEP_TMP=1` to retain the run directory for debugging.
 `UI_REVIEW_ISOLATION_ROOT` still points the isolation tree at a caller-owned
 path, which the tooling never removes. When `UI_REVIEW_OUTPUT_DIR` is unset the

--- a/tools/ui-review/README.md
+++ b/tools/ui-review/README.md
@@ -64,20 +64,27 @@ fixture critic after complete passing hard gates.
 Every temp directory the tooling creates (isolation home/config/cache, Bombadil
 raw output, replay bundles, test fixtures) lives inside one run-scoped parent
 under the OS temp directory named `boring-ui-review-run.*`. That parent is
-removed when the run finishes, when it throws, and when the process is killed
-with `SIGINT`/`SIGTERM`/`SIGHUP`, so interrupted runs cannot leak inodes.
-Cleanup never follows symlinks and refuses to remove any path outside that
-parent.
+owned by the process that created it — normally `scripts/run-ui-review.mjs` —
+and is removed when that process finishes, throws, or is killed with
+`SIGINT`/`SIGTERM`/`SIGHUP`, so interrupted runs cannot leak inodes. Before a
+signal-driven removal the orchestrator terminates its active child process
+group (`pnpm` → Playwright → workers), because default-terminated Node processes
+do not run `exit` handlers and could otherwise still write into the root during
+cleanup. Cleanup never follows symlinks and refuses to remove any path outside
+that parent.
 
-Creating the run root arms its removal on normal process `exit`, which is safe in
-any host. Signal handling is opt-in, because cleaning up on a signal means
-re-exiting the process with that signal's conventional code — a decision only an
-entrypoint that owns its process may take. The CLI entrypoints
-(`scripts/run-ui-review.mjs`, `scripts/explore-review-spec.ts`) call
+The creator passes its run root to every spawned child through
+`UI_REVIEW_TEMP_ROOT`. An inherited root is used as-is: children create their
+subdirectories inside it but never remove it — not on exit, not on signal — so a
+worker killed by its runner cannot leak anything and cannot race the owner's
+cleanup. A malformed inherited value fails closed instead of being adopted.
+When no root is inherited, creating one arms its removal on normal process
+`exit`, which is safe in any host. Signal handling is opt-in, because cleaning
+up on a signal means re-exiting the process with that signal's conventional code
+— a decision only an entrypoint that owns its process may take. The CLI
+entrypoints (`scripts/run-ui-review.mjs`, `scripts/explore-review-spec.ts`) call
 `installUiReviewTempCleanupHandlers()`; importing the helper into a Playwright or
-vitest worker never does, so the runner keeps its own shutdown semantics. Those
-workers are signal-killed by their runner, so their suites remove the run root
-explicitly in an `afterAll` instead.
+vitest worker never does.
 
 Set `UI_REVIEW_KEEP_TMP=1` to retain the run directory for debugging.
 `UI_REVIEW_ISOLATION_ROOT` still points the isolation tree at a caller-owned

--- a/tools/ui-review/README.md
+++ b/tools/ui-review/README.md
@@ -58,3 +58,19 @@ pnpm --filter @hachej/boring-ui-review-tools ui:improve:validate -- <run-directo
 
 Live vision remains explicit credential-gated opt-in. Required CI uses the
 fixture critic after complete passing hard gates.
+
+## Temporary files
+
+Every temp directory the tooling creates (isolation home/config/cache, Bombadil
+raw output, replay bundles, test fixtures) lives inside one run-scoped parent
+under the OS temp directory named `boring-ui-review-run.*`. That parent is
+removed when the run finishes, when it throws, and when the process is killed
+with `SIGINT`/`SIGTERM`/`SIGHUP`, so interrupted runs cannot leak inodes.
+Cleanup never follows symlinks and refuses to remove any path outside that
+parent.
+
+Set `UI_REVIEW_KEEP_TMP=1` to retain the run directory for debugging.
+`UI_REVIEW_ISOLATION_ROOT` still points the isolation tree at a caller-owned
+path, which the tooling never removes. When `UI_REVIEW_OUTPUT_DIR` is unset the
+report lands inside the run directory and is discarded with it; set it to keep
+artifacts.

--- a/tools/ui-review/e2e/review.spec.ts
+++ b/tools/ui-review/e2e/review.spec.ts
@@ -1,6 +1,5 @@
 import { createHash } from "node:crypto"
-import { copyFile, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises"
-import { tmpdir } from "node:os"
+import { copyFile, mkdir, readFile, writeFile } from "node:fs/promises"
 import { dirname, resolve } from "node:path"
 import { expect, test, type Page } from "@playwright/test"
 import {
@@ -29,6 +28,7 @@ import {
 import { createCalibrationRecord, createExecutionPacket } from "../src/core/improvement"
 import { pairWithLocalBaseline } from "../src/core/pairing"
 import { renderUiReviewHtml, renderUiReviewMarkdown } from "../src/core/report"
+import { createUiReviewTempDir } from "../src/core/tempRoot"
 import {
   checkpointAppliesToViewport,
   type UiReviewBrowserErrors,
@@ -266,8 +266,8 @@ async function resolveCritic(manifest: UiReviewManifest) {
   }
   const apiKey = process.env.GEMINI_API_KEY
   if (!apiKey) throw new Error("UI_REVIEW_CRITIC_CREDENTIAL_MISSING")
-  const tempHome = await mkdtemp(resolve(tmpdir(), "ui-review-home."))
-  const tempConfig = await mkdtemp(resolve(tmpdir(), "ui-review-config."))
+  const tempHome = await createUiReviewTempDir("ui-review-home.")
+  const tempConfig = await createUiReviewTempDir("ui-review-config.")
   const criticPromptPath = resolve(outputRoot, "critic-prompt.md")
   await writeFile(criticPromptPath, spec.criticPrompt, "utf8")
   const invocation = buildPiCriticInvocation({

--- a/tools/ui-review/e2e/review.spec.ts
+++ b/tools/ui-review/e2e/review.spec.ts
@@ -28,7 +28,7 @@ import {
 import { createCalibrationRecord, createExecutionPacket } from "../src/core/improvement"
 import { pairWithLocalBaseline } from "../src/core/pairing"
 import { renderUiReviewHtml, renderUiReviewMarkdown } from "../src/core/report"
-import { createUiReviewTempDir } from "../src/core/tempRoot"
+import { cleanupUiReviewTempRootSync, createUiReviewTempDir } from "../src/core/tempRoot"
 import {
   checkpointAppliesToViewport,
   type UiReviewBrowserErrors,
@@ -36,6 +36,10 @@ import {
   type UiReviewVisualBaselineResult,
 } from "../src/core/reviewSpec"
 import { getUiReviewSpec } from "../src/registry"
+
+// The run-scoped temp root belongs to this worker process; remove it here rather than relying on
+// how the runner terminates workers (vitest and Playwright both signal-kill them).
+test.afterAll(() => { cleanupUiReviewTempRootSync() })
 
 const TOOL_ROOT = resolve(import.meta.dirname, "..")
 const REPO_ROOT = resolve(TOOL_ROOT, "../..")

--- a/tools/ui-review/scripts/explore-review-spec.ts
+++ b/tools/ui-review/scripts/explore-review-spec.ts
@@ -1,11 +1,12 @@
 import { spawn, type ChildProcess } from "node:child_process"
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises"
+import { mkdir, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { setTimeout as sleep } from "node:timers/promises"
 import { chromium } from "@playwright/test"
 import { resetBombadilOutputDirectory, runWithBombadilStartupRetry } from "../src/core/bombadilProcess"
 import { createUiReviewStagingPolicy, assertStagingBounds, stageBombadilSelection, writeSelection, type UiReviewSelection } from "../src/core/exploration"
+import { cleanupUiReviewTempRoot, createUiReviewTempDir } from "../src/core/tempRoot"
 import { readReproduceManifest, validateReproduceOwnership, verifyReproducedFinalState } from "../src/core/replay"
 import { getUiReviewSpec } from "../src/registry"
 
@@ -37,7 +38,7 @@ try {
     viewports: [], stagedFiles: 1, stagedBytes: 0,
   }
   for (const viewport of spec.viewports) {
-    const rawRoot = await mkdtemp(join(tmpdir(), `boring-ui-review-${viewport.name}.`))
+    const rawRoot = await createUiReviewTempDir(`explore-${viewport.name}.`)
     await runBombadil(["browser", "test", origin, spec.exploration.bombadilSpecPath, "--time-limit", timeLimit, "--output-path", rawRoot, "--headless", "--width", String(viewport.width), "--height", String(viewport.height), "--device-scale-factor", String(viewport.deviceScaleFactor), "--instrument-javascript", "inline"], targetRoot)
     const staged = await stageBombadilSelection({ rawRoot, outputRoot, runId, origin, viewport, existingFiles: selection.stagedFiles, existingBytes: selection.stagedBytes, spec })
     selection.stagedFiles = staged.stagedFiles
@@ -52,12 +53,15 @@ try {
     const bundleArgument = selected.reproducePath!
     const manifest = await readReproduceManifest(resolve(outputRoot, bundleArgument, "reproduce.json"), spec)
     await validateReproduceOwnership({ outputRoot, selected: selected as never, manifest, origin, targetUrl: origin, spec })
-    const replayRoot = await mkdtemp(join(tmpdir(), `boring-ui-review-replay-${viewport.viewport.name}.`))
+    const replayRoot = await createUiReviewTempDir(`replay-${viewport.viewport.name}.`)
     await runBombadil(["browser", "test", manifest.targetUrl, spec.exploration.bombadilSpecPath, "--output-path", replayRoot, "--headless", "--width", String(manifest.viewport.width), "--height", String(manifest.viewport.height), "--device-scale-factor", String(manifest.viewport.deviceScaleFactor), "--instrument-javascript", "inline", "--reproduce", bundleArgument], outputRoot)
     await verifyReproducedFinalState(replayRoot, manifest, spec)
     console.log(`verified Bombadil replay final state: ${selected.id}`)
   }
-} finally { await stop(server) }
+} finally {
+  await stop(server)
+  await cleanupUiReviewTempRoot()
+}
 
 function startTarget(): ChildProcess {
   const [command, ...args] = spec.target.serverCommand

--- a/tools/ui-review/scripts/explore-review-spec.ts
+++ b/tools/ui-review/scripts/explore-review-spec.ts
@@ -6,10 +6,11 @@ import { setTimeout as sleep } from "node:timers/promises"
 import { chromium } from "@playwright/test"
 import { resetBombadilOutputDirectory, runWithBombadilStartupRetry } from "../src/core/bombadilProcess"
 import { createUiReviewStagingPolicy, assertStagingBounds, stageBombadilSelection, writeSelection, type UiReviewSelection } from "../src/core/exploration"
-import { cleanupUiReviewTempRoot, createUiReviewTempDir } from "../src/core/tempRoot"
+import { cleanupUiReviewTempRootSync, createUiReviewTempDir, installUiReviewTempCleanupHandlers } from "../src/core/tempRoot"
 import { readReproduceManifest, validateReproduceOwnership, verifyReproducedFinalState } from "../src/core/replay"
 import { getUiReviewSpec } from "../src/registry"
 
+installUiReviewTempCleanupHandlers()
 const spec = getUiReviewSpec(requiredEnv("UI_REVIEW_SPEC"))
 if (!spec.exploration) process.exit(0)
 const repoRoot = resolve(import.meta.dirname, "../../..")
@@ -60,7 +61,7 @@ try {
   }
 } finally {
   await stop(server)
-  await cleanupUiReviewTempRoot()
+  cleanupUiReviewTempRootSync()
 }
 
 function startTarget(): ChildProcess {

--- a/tools/ui-review/scripts/run-ui-review.mjs
+++ b/tools/ui-review/scripts/run-ui-review.mjs
@@ -4,8 +4,9 @@ import { isAbsolute, join, resolve, sep } from "node:path"
 import { parseUiReviewArgs } from "./ui-review-args.mjs"
 import { readUiReviewWorktreeIdentity } from "./ui-review-worktree.mjs"
 import { getUiReviewSpec } from "../src/registry.ts"
-import { cleanupUiReviewTempRoot, uiReviewTempRoot } from "../src/core/tempRoot.ts"
+import { cleanupUiReviewTempRootSync, installUiReviewTempCleanupHandlers, uiReviewTempRoot } from "../src/core/tempRoot.ts"
 
+installUiReviewTempCleanupHandlers()
 let command
 try { command = parseUiReviewArgs(process.argv.slice(2)) } catch (error) { console.error(error instanceof Error ? error.message : String(error)); process.exit(2) }
 let spec
@@ -61,7 +62,7 @@ try {
     exitCode = await run("pnpm", ["exec", "playwright", "test", "--config", "playwright.config.ts"], testEnv, toolRoot)
   }
 } finally {
-  const removed = await cleanupUiReviewTempRoot()
+  const removed = cleanupUiReviewTempRootSync()
   if (removed && (outputDir === removed || outputDir.startsWith(`${removed}${sep}`))) {
     console.warn(`UI_REVIEW_OUTPUT_DISCARDED:${outputDir} (set UI_REVIEW_OUTPUT_DIR to keep artifacts, or UI_REVIEW_KEEP_TMP=1 to keep the run directory)`)
   }

--- a/tools/ui-review/scripts/run-ui-review.mjs
+++ b/tools/ui-review/scripts/run-ui-review.mjs
@@ -1,10 +1,10 @@
 import { spawn } from "node:child_process"
-import { cp, mkdir, mkdtemp, readdir } from "node:fs/promises"
-import { tmpdir } from "node:os"
-import { isAbsolute, join, resolve } from "node:path"
+import { cp, mkdir, readdir } from "node:fs/promises"
+import { isAbsolute, join, resolve, sep } from "node:path"
 import { parseUiReviewArgs } from "./ui-review-args.mjs"
 import { readUiReviewWorktreeIdentity } from "./ui-review-worktree.mjs"
 import { getUiReviewSpec } from "../src/registry.ts"
+import { cleanupUiReviewTempRoot, uiReviewTempRoot } from "../src/core/tempRoot.ts"
 
 let command
 try { command = parseUiReviewArgs(process.argv.slice(2)) } catch (error) { console.error(error instanceof Error ? error.message : String(error)); process.exit(2) }
@@ -20,7 +20,9 @@ const [buildCommand, ...buildArgs] = spec.target.buildCommand
 const build = await run(buildCommand, buildArgs, process.env, targetRoot)
 if (build !== 0) process.exit(build)
 
-const isolationRoot = process.env.UI_REVIEW_ISOLATION_ROOT ? resolve(process.env.UI_REVIEW_ISOLATION_ROOT) : await mkdtemp(join(tmpdir(), "boring-ui-review."))
+const providedIsolationRoot = process.env.UI_REVIEW_ISOLATION_ROOT?.trim()
+// A caller-provided isolation root belongs to the caller; only the run-scoped temp root is ours to remove.
+const isolationRoot = providedIsolationRoot ? resolve(providedIsolationRoot) : join(await uiReviewTempRoot(), "isolation")
 const isolated = { home: join(isolationRoot, "home"), config: join(isolationRoot, "config"), cache: join(isolationRoot, "cache"), workspace: join(isolationRoot, "workspace"), sessions: join(isolationRoot, "sessions") }
 await Promise.all(Object.values(isolated).map((path) => mkdir(path, { recursive: true })))
 if (spec.target.fixturePath) await cp(resolve(repoRoot, spec.target.fixturePath), isolated.workspace, { recursive: true, force: false, errorOnExist: false })
@@ -50,12 +52,21 @@ const testEnv = {
   ...(command.critic === "pi" ? { GEMINI_API_KEY: requiredEnv("GEMINI_API_KEY"), ...(process.env.BORING_UI_REVIEW_MODEL ? { BORING_UI_REVIEW_MODEL: process.env.BORING_UI_REVIEW_MODEL } : {}) } : {}),
 }
 const explorationEnv = { ...testEnv }; delete explorationEnv.GEMINI_API_KEY; delete explorationEnv.BORING_UI_REVIEW_MODEL
-if (spec.exploration) {
-  const exploration = await run("pnpm", ["exec", "tsx", "scripts/explore-review-spec.ts"], explorationEnv, toolRoot)
-  if (exploration !== 0 || command.exploreOnly) process.exit(exploration)
-} else if (command.exploreOnly) process.exit(0)
-const test = await run("pnpm", ["exec", "playwright", "test", "--config", "playwright.config.ts"], testEnv, toolRoot)
-process.exit(test)
+let exitCode = 0
+try {
+  if (spec.exploration) {
+    exitCode = await run("pnpm", ["exec", "tsx", "scripts/explore-review-spec.ts"], explorationEnv, toolRoot)
+    if (exitCode === 0 && !command.exploreOnly) exitCode = await run("pnpm", ["exec", "playwright", "test", "--config", "playwright.config.ts"], testEnv, toolRoot)
+  } else if (!command.exploreOnly) {
+    exitCode = await run("pnpm", ["exec", "playwright", "test", "--config", "playwright.config.ts"], testEnv, toolRoot)
+  }
+} finally {
+  const removed = await cleanupUiReviewTempRoot()
+  if (removed && (outputDir === removed || outputDir.startsWith(`${removed}${sep}`))) {
+    console.warn(`UI_REVIEW_OUTPUT_DISCARDED:${outputDir} (set UI_REVIEW_OUTPUT_DIR to keep artifacts, or UI_REVIEW_KEEP_TMP=1 to keep the run directory)`)
+  }
+}
+process.exit(exitCode)
 
 function requiredEnv(name) { const value = process.env[name]?.trim(); if (!value) throw new Error(`UI_REVIEW_REQUIRED_ENV_MISSING:${name}`); return value }
 function run(command, args, env = process.env, cwd = process.cwd()) { return new Promise((resolveExit) => { const child = spawn(command, args, { stdio: "inherit", env, cwd }); child.on("error", () => resolveExit(1)); child.on("exit", (code) => resolveExit(code ?? 1)) }) }

--- a/tools/ui-review/scripts/run-ui-review.mjs
+++ b/tools/ui-review/scripts/run-ui-review.mjs
@@ -4,9 +4,19 @@ import { isAbsolute, join, resolve, sep } from "node:path"
 import { parseUiReviewArgs } from "./ui-review-args.mjs"
 import { readUiReviewWorktreeIdentity } from "./ui-review-worktree.mjs"
 import { getUiReviewSpec } from "../src/registry.ts"
-import { cleanupUiReviewTempRootSync, installUiReviewTempCleanupHandlers, uiReviewTempRoot } from "../src/core/tempRoot.ts"
+import { UI_REVIEW_TEMP_ROOT_ENV, cleanupUiReviewTempRootSync, installUiReviewTempCleanupHandlers, uiReviewTempRoot } from "../src/core/tempRoot.ts"
 
-installUiReviewTempCleanupHandlers()
+let activeChild
+function terminateActiveChild() {
+  // The run root must outlive nothing that writes into it: kill the whole child process group
+  // (pnpm -> playwright -> workers) before removal. Default-terminated workers do not run exit
+  // handlers, so they can never clean up after themselves.
+  if (activeChild?.pid && activeChild.exitCode === null) {
+    try { process.kill(-activeChild.pid, "SIGTERM") } catch { /* already gone */ }
+  }
+  activeChild = undefined
+}
+installUiReviewTempCleanupHandlers({ beforeCleanup: terminateActiveChild })
 let command
 try { command = parseUiReviewArgs(process.argv.slice(2)) } catch (error) { console.error(error instanceof Error ? error.message : String(error)); process.exit(2) }
 let spec
@@ -48,6 +58,7 @@ const testEnv = {
   UI_REVIEW_CANDIDATE_REVISION: identity.revision, UI_REVIEW_CANDIDATE_TREE_HASH: identity.treeHash,
   UI_REVIEW_VITE_PORT: String(port), ...(apiPort === undefined ? {} : { UI_REVIEW_AGENT_API_PORT: String(apiPort) }),
   ...(baselineDir ? { UI_REVIEW_BASELINE_DIR: baselineDir } : {}), ...(process.env.CI ? { CI: process.env.CI } : {}),
+  [UI_REVIEW_TEMP_ROOT_ENV]: await uiReviewTempRoot(),
   ...(process.env.UI_REVIEW_UPDATE_SNAPSHOTS === "1" ? { UI_REVIEW_UPDATE_SNAPSHOTS: "1" } : {}),
   PLAYWRIGHT_BROWSERS_PATH: process.env.PLAYWRIGHT_BROWSERS_PATH || join(requiredEnv("HOME"), ".cache", "ms-playwright"),
   ...(command.critic === "pi" ? { GEMINI_API_KEY: requiredEnv("GEMINI_API_KEY"), ...(process.env.BORING_UI_REVIEW_MODEL ? { BORING_UI_REVIEW_MODEL: process.env.BORING_UI_REVIEW_MODEL } : {}) } : {}),
@@ -70,4 +81,13 @@ try {
 process.exit(exitCode)
 
 function requiredEnv(name) { const value = process.env[name]?.trim(); if (!value) throw new Error(`UI_REVIEW_REQUIRED_ENV_MISSING:${name}`); return value }
-function run(command, args, env = process.env, cwd = process.cwd()) { return new Promise((resolveExit) => { const child = spawn(command, args, { stdio: "inherit", env, cwd }); child.on("error", () => resolveExit(1)); child.on("exit", (code) => resolveExit(code ?? 1)) }) }
+function run(command, args, env = process.env, cwd = process.cwd()) {
+  return new Promise((resolveExit) => {
+    // `detached` gives the child its own process group so a signal can take down the whole tree
+    // (pnpm -> playwright -> workers), not just the direct child.
+    const child = spawn(command, args, { stdio: "inherit", env, cwd, detached: true })
+    activeChild = child
+    child.on("error", () => { if (activeChild === child) activeChild = undefined; resolveExit(1) })
+    child.on("exit", (code) => { if (activeChild === child) activeChild = undefined; resolveExit(code ?? 1) })
+  })
+}

--- a/tools/ui-review/src/__tests__/contracts.test.ts
+++ b/tools/ui-review/src/__tests__/contracts.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, writeFile } from "node:fs/promises"
 import { join } from "node:path"
-import { describe, expect, it } from "vitest"
+import { afterAll, describe, expect, it } from "vitest"
 import {
   UI_REVIEW_RUBRIC_VERSION,
   UI_REVIEW_SCHEMA_VERSION,
@@ -15,8 +15,12 @@ import {
   type UiReviewState,
   type UiReviewViewport,
 } from "../core/contracts"
-import { createUiReviewTempDir } from "../core/tempRoot"
+import { cleanupUiReviewTempRootSync, createUiReviewTempDir } from "../core/tempRoot"
 import { testSpec } from "./fixtures"
+
+// The run-scoped temp root belongs to this worker process; remove it here rather than relying on
+// how the runner terminates workers (vitest and Playwright both signal-kill them).
+afterAll(() => { cleanupUiReviewTempRootSync() })
 
 const validateUiReviewManifest = (root: string, value: UiReviewManifest) => validateManifestAgainstSpec(root, value, testSpec)
 

--- a/tools/ui-review/src/__tests__/contracts.test.ts
+++ b/tools/ui-review/src/__tests__/contracts.test.ts
@@ -1,5 +1,4 @@
-import { mkdtemp, mkdir, writeFile } from "node:fs/promises"
-import { tmpdir } from "node:os"
+import { mkdir, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { describe, expect, it } from "vitest"
 import {
@@ -16,6 +15,7 @@ import {
   type UiReviewState,
   type UiReviewViewport,
 } from "../core/contracts"
+import { createUiReviewTempDir } from "../core/tempRoot"
 import { testSpec } from "./fixtures"
 
 const validateUiReviewManifest = (root: string, value: UiReviewManifest) => validateManifestAgainstSpec(root, value, testSpec)
@@ -27,7 +27,7 @@ const viewports: UiReviewViewport[] = [
 const checkpoints = ["closed", "open", "commands"]
 
 async function matrixFixture(roles: UiReviewRole[] = ["candidate"]) {
-  const root = await mkdtemp(join(tmpdir(), "ui-review-contracts."))
+  const root = await createUiReviewTempDir("ui-review-contracts.")
   const states: UiReviewState[] = []
   for (const role of roles) {
     for (const viewport of viewports) {

--- a/tools/ui-review/src/__tests__/exploration.test.ts
+++ b/tools/ui-review/src/__tests__/exploration.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
 import { join } from "node:path"
-import { describe, expect, it, vi } from "vitest"
+import { afterAll, describe, expect, it, vi } from "vitest"
 import {
   isRetryableBombadilStartupFailure,
   resetBombadilOutputDirectory,
@@ -12,7 +12,7 @@ import {
   stageBombadilSelection as stageForSpec,
 } from "../core/exploration"
 import { hexadecimalHammingDistance } from "../core/imageHash"
-import { createUiReviewTempDir } from "../core/tempRoot"
+import { cleanupUiReviewTempRootSync, createUiReviewTempDir } from "../core/tempRoot"
 import {
   readReproduceManifest as readManifestForSpec,
   validateReproduceOwnership as validateOwnershipForSpec,
@@ -25,6 +25,10 @@ import {
   isSafeCommandPaletteControl,
 } from "../review-specs/workspace-command-palette/scenarioActions"
 import { testSpec, testStagingPolicy } from "./fixtures"
+
+// The run-scoped temp root belongs to this worker process; remove it here rather than relying on
+// how the runner terminates workers (vitest and Playwright both signal-kill them).
+afterAll(() => { cleanupUiReviewTempRootSync() })
 
 const UI_REVIEW_STAGING_POLICY = testStagingPolicy
 const stageBombadilSelection = (input: Omit<Parameters<typeof stageForSpec>[0], "spec">) => stageForSpec({ ...input, spec: testSpec })

--- a/tools/ui-review/src/__tests__/exploration.test.ts
+++ b/tools/ui-review/src/__tests__/exploration.test.ts
@@ -1,5 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
-import { tmpdir } from "node:os"
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { describe, expect, it, vi } from "vitest"
 import {
@@ -13,6 +12,7 @@ import {
   stageBombadilSelection as stageForSpec,
 } from "../core/exploration"
 import { hexadecimalHammingDistance } from "../core/imageHash"
+import { createUiReviewTempDir } from "../core/tempRoot"
 import {
   readReproduceManifest as readManifestForSpec,
   validateReproduceOwnership as validateOwnershipForSpec,
@@ -75,7 +75,7 @@ describe("Bombadil exploration staging", () => {
   })
 
   it("recreates a clean Bombadil output directory before retry", async () => {
-    const root = await mkdtemp(join(tmpdir(), "ui-review-bombadil-reset-"))
+    const root = await createUiReviewTempDir("ui-review-bombadil-reset-")
     try {
       const outputPath = join(root, "raw")
       await mkdir(outputPath)
@@ -110,7 +110,7 @@ describe("Bombadil exploration staging", () => {
     expect(parsed[0]).toMatchObject({ ordinal: 1, action: null, state: { hashCurrent: 10 }, violations: [] })
     expect(parsed[0]!.normalizedStateSignature).toHaveLength(64)
 
-    const outputRoot = await mkdtemp(join(tmpdir(), "ui-review-stage."))
+    const outputRoot = await createUiReviewTempDir("ui-review-stage.")
     const staged = await stageBombadilSelection({ rawRoot: raw, outputRoot, runId: "run", origin: "http://localhost:5380/?fresh=1", viewport })
     expect(staged.selected).toHaveLength(2)
     expect(staged.overflow).toMatchObject({ "duplicate-visual-state": 1 })
@@ -167,7 +167,7 @@ describe("Bombadil exploration staging", () => {
       entry(5, { screenshot: "empty", palette: { empty: true } }),
       entry(6, { screenshot: "violation", violations: [{ property: "noConsoleErrors" }] }),
     ])
-    const outputRoot = await mkdtemp(join(tmpdir(), "ui-review-priority."))
+    const outputRoot = await createUiReviewTempDir("ui-review-priority.")
     const staged = await stageBombadilSelection({ rawRoot: raw, outputRoot, runId: "run", origin: "http://localhost:5380/?fresh=1", viewport })
     expect(staged.selected[0]!.ordinal).toBe(6)
     expect(new Set(staged.selected.flatMap((state) => state.categories))).toEqual(new Set([
@@ -181,16 +181,16 @@ describe("Bombadil exploration staging", () => {
       palette: { dialogVisible: index % 2 === 0, query: String(index) },
     }))
     const raw = await fixture(many)
-    const outputRoot = await mkdtemp(join(tmpdir(), "ui-review-bounds."))
+    const outputRoot = await createUiReviewTempDir("ui-review-bounds.")
     const capped = await stageBombadilSelection({ rawRoot: raw, outputRoot, runId: "run", origin: "http://localhost:5380", viewport })
     expect(capped.selected).toHaveLength(UI_REVIEW_STAGING_POLICY.maxStatesPerViewport)
     expect(capped.overflow["state-limit"]).toBe(14 - UI_REVIEW_STAGING_POLICY.maxStatesPerViewport)
 
-    const files = await stageBombadilSelection({ rawRoot: raw, outputRoot: await mkdtemp(join(tmpdir(), "ui-review-files.")), runId: "run", origin: "http://localhost:5380", viewport, existingFiles: UI_REVIEW_STAGING_POLICY.maxFiles })
+    const files = await stageBombadilSelection({ rawRoot: raw, outputRoot: await createUiReviewTempDir("ui-review-files."), runId: "run", origin: "http://localhost:5380", viewport, existingFiles: UI_REVIEW_STAGING_POLICY.maxFiles })
     expect(files.selected).toHaveLength(0)
     expect(files.overflow["file-limit"]).toBe(14)
 
-    const bytes = await stageBombadilSelection({ rawRoot: raw, outputRoot: await mkdtemp(join(tmpdir(), "ui-review-bytes.")), runId: "run", origin: "http://localhost:5380", viewport, existingBytes: UI_REVIEW_STAGING_POLICY.maxBytes })
+    const bytes = await stageBombadilSelection({ rawRoot: raw, outputRoot: await createUiReviewTempDir("ui-review-bytes."), runId: "run", origin: "http://localhost:5380", viewport, existingBytes: UI_REVIEW_STAGING_POLICY.maxBytes })
     expect(bytes.selected).toHaveLength(0)
     expect(bytes.overflow["byte-limit"]).toBe(14)
   })
@@ -369,7 +369,7 @@ function entry(ordinal: number, options: EntryOptions) {
 }
 
 async function fixture(entries: Array<ReturnType<typeof entry>>): Promise<string> {
-  const root = await mkdtemp(join(tmpdir(), "ui-review-trace."))
+  const root = await createUiReviewTempDir("ui-review-trace.")
   await mkdir(join(root, "screenshots"), { recursive: true })
   const lines: string[] = []
   for (const item of entries) {

--- a/tools/ui-review/src/__tests__/improvement.test.ts
+++ b/tools/ui-review/src/__tests__/improvement.test.ts
@@ -1,5 +1,4 @@
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises"
-import { tmpdir } from "node:os"
+import { mkdir, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { describe, expect, it } from "vitest"
 import { sha256Hex, type UiCriticReport, type UiHardGateReport, type UiReviewManifest } from "../core/contracts"
@@ -11,6 +10,7 @@ import {
   validateExecutionPacket as validatePacketForSpec,
   validateExecutionPacketEvidence,
 } from "../core/improvement"
+import { createUiReviewTempDir } from "../core/tempRoot"
 import { testSpec } from "./fixtures"
 
 const createExecutionPacket = (input: Omit<Parameters<typeof createPacketForSpec>[0], "spec">) => createPacketForSpec({ ...input, spec: testSpec })
@@ -105,7 +105,7 @@ function calibrationRecord() {
 }
 
 async function artifactRoot() {
-  const root = await mkdtemp(join(tmpdir(), "ui-improvement."))
+  const root = await createUiReviewTempDir("ui-improvement.")
   await mkdir(join(root, "selected", "desktop"), { recursive: true })
   const review = critic()
   const calibration = calibrationRecord()

--- a/tools/ui-review/src/__tests__/improvement.test.ts
+++ b/tools/ui-review/src/__tests__/improvement.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, writeFile } from "node:fs/promises"
 import { join } from "node:path"
-import { describe, expect, it } from "vitest"
+import { afterAll, describe, expect, it } from "vitest"
 import { sha256Hex, type UiCriticReport, type UiHardGateReport, type UiReviewManifest } from "../core/contracts"
 import {
   createCalibrationRecord as createCalibrationForSpec,
@@ -10,8 +10,12 @@ import {
   validateExecutionPacket as validatePacketForSpec,
   validateExecutionPacketEvidence,
 } from "../core/improvement"
-import { createUiReviewTempDir } from "../core/tempRoot"
+import { cleanupUiReviewTempRootSync, createUiReviewTempDir } from "../core/tempRoot"
 import { testSpec } from "./fixtures"
+
+// The run-scoped temp root belongs to this worker process; remove it here rather than relying on
+// how the runner terminates workers (vitest and Playwright both signal-kill them).
+afterAll(() => { cleanupUiReviewTempRootSync() })
 
 const createExecutionPacket = (input: Omit<Parameters<typeof createPacketForSpec>[0], "spec">) => createPacketForSpec({ ...input, spec: testSpec })
 const createCalibrationRecord = (input: Omit<Parameters<typeof createCalibrationForSpec>[0], "spec">) => createCalibrationForSpec({ ...input, spec: testSpec })

--- a/tools/ui-review/src/__tests__/pairing.test.ts
+++ b/tools/ui-review/src/__tests__/pairing.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, writeFile } from "node:fs/promises"
 import { join } from "node:path"
-import { describe, expect, it } from "vitest"
+import { afterAll, describe, expect, it } from "vitest"
 import {
   createUiReviewReproducePath,
   createUiReviewStateId,
@@ -11,8 +11,12 @@ import {
   type UiReviewViewport,
 } from "../core/contracts"
 import { pairWithLocalBaseline as pairWithSpec } from "../core/pairing"
-import { createUiReviewTempDir } from "../core/tempRoot"
+import { cleanupUiReviewTempRootSync, createUiReviewTempDir } from "../core/tempRoot"
 import { testSpec } from "./fixtures"
+
+// The run-scoped temp root belongs to this worker process; remove it here rather than relying on
+// how the runner terminates workers (vitest and Playwright both signal-kill them).
+afterAll(() => { cleanupUiReviewTempRootSync() })
 
 const pairWithLocalBaseline = (input: Omit<Parameters<typeof pairWithSpec>[0], "spec">) => pairWithSpec({ ...input, spec: testSpec })
 

--- a/tools/ui-review/src/__tests__/pairing.test.ts
+++ b/tools/ui-review/src/__tests__/pairing.test.ts
@@ -1,5 +1,4 @@
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises"
-import { tmpdir } from "node:os"
+import { mkdir, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { describe, expect, it } from "vitest"
 import {
@@ -12,6 +11,7 @@ import {
   type UiReviewViewport,
 } from "../core/contracts"
 import { pairWithLocalBaseline as pairWithSpec } from "../core/pairing"
+import { createUiReviewTempDir } from "../core/tempRoot"
 import { testSpec } from "./fixtures"
 
 const pairWithLocalBaseline = (input: Omit<Parameters<typeof pairWithSpec>[0], "spec">) => pairWithSpec({ ...input, spec: testSpec })
@@ -77,8 +77,8 @@ function gates(states: UiReviewState[]): UiHardGateResult[] {
 
 describe("local UI review baseline pairing", () => {
   it("pairs exactly six known checkpoints and excludes unmatched Bombadil states", async () => {
-    const baselineRoot = await mkdtemp(join(tmpdir(), "ui-baseline."))
-    const outputRoot = await mkdtemp(join(tmpdir(), "ui-candidate."))
+    const baselineRoot = await createUiReviewTempDir("ui-baseline.")
+    const outputRoot = await createUiReviewTempDir("ui-candidate.")
     for (const viewport of viewports) await mkdir(join(outputRoot, "selected", viewport.name), { recursive: true })
     const baselineStates = await statesFor(baselineRoot, "before")
     const explorationBytes = new TextEncoder().encode("bombadil")
@@ -127,7 +127,7 @@ describe("local UI review baseline pairing", () => {
   })
 
   it("rejects using the output directory as its own baseline", async () => {
-    const root = await mkdtemp(join(tmpdir(), "ui-baseline-collision."))
+    const root = await createUiReviewTempDir("ui-baseline-collision.")
     await expect(pairWithLocalBaseline({ baselineRoot: root, outputRoot: root, runId: "after", candidateStates: [] })).rejects.toThrow("UI_REVIEW_BASELINE_OUTPUT_COLLISION")
   })
 })

--- a/tools/ui-review/src/__tests__/temp-root-child.ts
+++ b/tools/ui-review/src/__tests__/temp-root-child.ts
@@ -1,8 +1,14 @@
 import { setTimeout as sleep } from "node:timers/promises"
-import { createUiReviewTempDir, uiReviewTempRoot } from "../core/tempRoot"
+import { createUiReviewTempDir, installUiReviewTempCleanupHandlers, uiReviewTempRoot } from "../core/tempRoot"
 
-// Child process used by tempRoot.test.ts to prove the run root survives nothing but the process itself.
+// Child process used by tempRoot.test.ts.
+//   `armed` — a CLI entrypoint: opts in to signal cleanup, so the run root survives nothing but the process.
+//   `bare`  — a Playwright/vitest worker: only imports and uses the helper, which must arm no signal handler.
+if (process.argv[2] === "armed") installUiReviewTempCleanupHandlers()
+
 const root = await uiReviewTempRoot()
 await createUiReviewTempDir("child.")
+const listeners = { SIGINT: process.listenerCount("SIGINT"), SIGTERM: process.listenerCount("SIGTERM"), SIGHUP: process.listenerCount("SIGHUP") }
+console.log(`UI_REVIEW_TEMP_LISTENERS:${JSON.stringify(listeners)}`)
 console.log(`UI_REVIEW_TEMP_ROOT:${root}`)
 await sleep(30_000)

--- a/tools/ui-review/src/__tests__/temp-root-child.ts
+++ b/tools/ui-review/src/__tests__/temp-root-child.ts
@@ -1,0 +1,8 @@
+import { setTimeout as sleep } from "node:timers/promises"
+import { createUiReviewTempDir, uiReviewTempRoot } from "../core/tempRoot"
+
+// Child process used by tempRoot.test.ts to prove the run root survives nothing but the process itself.
+const root = await uiReviewTempRoot()
+await createUiReviewTempDir("child.")
+console.log(`UI_REVIEW_TEMP_ROOT:${root}`)
+await sleep(30_000)

--- a/tools/ui-review/src/__tests__/temp-root-child.ts
+++ b/tools/ui-review/src/__tests__/temp-root-child.ts
@@ -2,9 +2,13 @@ import { setTimeout as sleep } from "node:timers/promises"
 import { createUiReviewTempDir, installUiReviewTempCleanupHandlers, uiReviewTempRoot } from "../core/tempRoot"
 
 // Child process used by tempRoot.test.ts.
-//   `armed` — a CLI entrypoint: opts in to signal cleanup, so the run root survives nothing but the process.
-//   `bare`  — a Playwright/vitest worker: only imports and uses the helper, which must arm no signal handler.
-if (process.argv[2] === "armed") installUiReviewTempCleanupHandlers()
+//   `armed`      — a CLI entrypoint: opts in to signal cleanup, so the run root survives nothing but the process.
+//   `armed+hook` — same, but registers a beforeCleanup hook that must run before removal.
+//   `bare`       — a Playwright/vitest worker: only imports and uses the helper, which must arm no signal handler.
+const mode = process.argv[2] ?? ""
+if (mode.startsWith("armed")) {
+  installUiReviewTempCleanupHandlers(mode === "armed+hook" ? { beforeCleanup: () => console.log("UI_REVIEW_TEMP_BEFORE_CLEANUP") } : undefined)
+}
 
 const root = await uiReviewTempRoot()
 await createUiReviewTempDir("child.")

--- a/tools/ui-review/src/__tests__/tempRoot.test.ts
+++ b/tools/ui-review/src/__tests__/tempRoot.test.ts
@@ -1,22 +1,25 @@
-import { spawn } from "node:child_process"
-import { existsSync } from "node:fs"
+import { spawn, type ChildProcessByStdio } from "node:child_process"
+import { existsSync, rmSync } from "node:fs"
 import { mkdtemp, readdir, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 import { setTimeout as sleep } from "node:timers/promises"
+import type { Readable } from "node:stream"
 import { afterEach, describe, expect, it } from "vitest"
 import {
   UI_REVIEW_TEMP_PREFIX,
   assertRemovableUiReviewTempRoot,
   assertWithinUiReviewTempRoot,
-  cleanupUiReviewTempRoot,
+  cleanupUiReviewTempRootSync,
   createUiReviewTempDir,
   uiReviewTempRoot,
 } from "../core/tempRoot"
 
 const toolRoot = resolve(import.meta.dirname, "../..")
 
-afterEach(async () => { await cleanupUiReviewTempRoot() })
+type TempRootChild = ChildProcessByStdio<null, Readable, null>
+
+afterEach(() => { cleanupUiReviewTempRootSync() })
 
 describe("ui review run-scoped temp root", () => {
   it("places every temp directory under one run root and removes it on cleanup", async () => {
@@ -28,16 +31,16 @@ describe("ui review run-scoped temp root", () => {
     expect(dirname(second)).toBe(root)
     expect(await uiReviewTempRoot()).toBe(root)
 
-    expect(await cleanupUiReviewTempRoot()).toBe(root)
+    expect(cleanupUiReviewTempRootSync()).toBe(root)
     expect(existsSync(root)).toBe(false)
     expect(existsSync(first)).toBe(false)
   })
 
   it("is idempotent so finally, exit and signal handlers can all call it", async () => {
     const root = await uiReviewTempRoot()
-    expect(await cleanupUiReviewTempRoot()).toBe(root)
-    expect(await cleanupUiReviewTempRoot()).toBeUndefined()
-    expect(await cleanupUiReviewTempRoot()).toBeUndefined()
+    expect(cleanupUiReviewTempRootSync()).toBe(root)
+    expect(cleanupUiReviewTempRootSync()).toBeUndefined()
+    expect(cleanupUiReviewTempRootSync()).toBeUndefined()
   })
 
   it("never follows a symlink out of the run root", async () => {
@@ -48,7 +51,7 @@ describe("ui review run-scoped temp root", () => {
       const root = await uiReviewTempRoot()
       await symlink(outside, join(root, "escape"), "dir")
 
-      await cleanupUiReviewTempRoot()
+      cleanupUiReviewTempRootSync()
       expect(existsSync(root)).toBe(false)
       expect(existsSync(keepMe)).toBe(true)
       expect(await readdir(outside)).toEqual(["keep.txt"])
@@ -70,20 +73,11 @@ describe("ui review run-scoped temp root", () => {
     expect(assertWithinUiReviewTempRoot(root, join(root, "child"))).toBe(join(root, "child"))
   })
 
-  it("removes the run root when the process is terminated by SIGTERM", async () => {
-    const child = spawn("node_modules/.bin/tsx", ["src/__tests__/temp-root-child.ts"], { cwd: toolRoot, stdio: ["ignore", "pipe", "inherit"] })
+  it("removes the run root when a CLI entrypoint that armed the signal handlers is terminated by SIGTERM", async () => {
+    const child = spawnTempRootChild("armed")
     try {
-      const root = await new Promise<string>((resolveRoot, reject) => {
-        let stdout = ""
-        child.stdout.setEncoding("utf8")
-        child.stdout.on("data", (chunk: string) => {
-          stdout += chunk
-          const match = /UI_REVIEW_TEMP_ROOT:(.+)/.exec(stdout)
-          if (match) resolveRoot(match[1]!.trim())
-        })
-        child.on("error", reject)
-        child.on("exit", (code) => reject(new Error(`child exited early: ${code}`)))
-      })
+      const { root, listeners } = await readChildHandshake(child)
+      expect(listeners).toEqual({ SIGINT: 1, SIGTERM: 1, SIGHUP: 1 })
       expect(existsSync(root)).toBe(true)
       expect((await readdir(root)).length).toBe(1)
 
@@ -98,4 +92,57 @@ describe("ui review run-scoped temp root", () => {
       if (child.exitCode === null) child.kill("SIGKILL")
     }
   }, 60_000)
+
+  it("arms no signal handler on its own, so a worker that merely imports it keeps its own shutdown", async () => {
+    const child = spawnTempRootChild("bare")
+    let leaked: string | undefined
+    try {
+      const { root, listeners } = await readChildHandshake(child)
+      leaked = root
+      // Creating the run root must never install a `process.exit()`-ing signal handler.
+      expect(listeners).toEqual({ SIGINT: 0, SIGTERM: 0, SIGHUP: 0 })
+      expect(existsSync(root)).toBe(true)
+
+      await new Promise<void>((resolveExit) => {
+        child.once("exit", () => resolveExit())
+        child.kill("SIGTERM")
+      })
+      await sleep(50)
+      // Cleanup still happens — it just rides the `exit` listener rather than a signal handler.
+      expect(existsSync(root)).toBe(false)
+    } finally {
+      if (child.exitCode === null) child.kill("SIGKILL")
+      if (leaked && existsSync(leaked)) rmSync(assertRemovableUiReviewTempRoot(leaked), { recursive: true, force: true })
+    }
+  }, 60_000)
+
+  it("adds no signal listeners when a temp directory is created in-process", async () => {
+    const before = countTempRootSignalListeners()
+    await createUiReviewTempDir("no-handlers.")
+    expect(countTempRootSignalListeners()).toEqual(before)
+  })
 })
+
+function spawnTempRootChild(mode: "armed" | "bare"): TempRootChild {
+  return spawn("node_modules/.bin/tsx", ["src/__tests__/temp-root-child.ts", mode], { cwd: toolRoot, stdio: ["ignore", "pipe", "inherit"] })
+}
+
+/** Resolve once the child has reported both its listener counts and its run root. */
+function readChildHandshake(child: TempRootChild): Promise<{ root: string; listeners: Record<string, number> }> {
+  return new Promise((resolveHandshake, reject) => {
+    let stdout = ""
+    child.stdout.setEncoding("utf8")
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk
+      const listeners = /UI_REVIEW_TEMP_LISTENERS:(.+)/.exec(stdout)
+      const root = /UI_REVIEW_TEMP_ROOT:(.+)/.exec(stdout)
+      if (listeners && root) resolveHandshake({ root: root[1]!.trim(), listeners: JSON.parse(listeners[1]!.trim()) as Record<string, number> })
+    })
+    child.on("error", reject)
+    child.on("exit", (code) => reject(new Error(`child exited early: ${code}`)))
+  })
+}
+
+function countTempRootSignalListeners(): Record<string, number> {
+  return { SIGINT: process.listenerCount("SIGINT"), SIGTERM: process.listenerCount("SIGTERM"), SIGHUP: process.listenerCount("SIGHUP") }
+}

--- a/tools/ui-review/src/__tests__/tempRoot.test.ts
+++ b/tools/ui-review/src/__tests__/tempRoot.test.ts
@@ -1,0 +1,101 @@
+import { spawn } from "node:child_process"
+import { existsSync } from "node:fs"
+import { mkdtemp, readdir, symlink, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { setTimeout as sleep } from "node:timers/promises"
+import { afterEach, describe, expect, it } from "vitest"
+import {
+  UI_REVIEW_TEMP_PREFIX,
+  assertRemovableUiReviewTempRoot,
+  assertWithinUiReviewTempRoot,
+  cleanupUiReviewTempRoot,
+  createUiReviewTempDir,
+  uiReviewTempRoot,
+} from "../core/tempRoot"
+
+const toolRoot = resolve(import.meta.dirname, "../..")
+
+afterEach(async () => { await cleanupUiReviewTempRoot() })
+
+describe("ui review run-scoped temp root", () => {
+  it("places every temp directory under one run root and removes it on cleanup", async () => {
+    const root = await uiReviewTempRoot()
+    const first = await createUiReviewTempDir("alpha.")
+    const second = await createUiReviewTempDir("beta.")
+    expect(root.startsWith(join(resolve(tmpdir()), UI_REVIEW_TEMP_PREFIX))).toBe(true)
+    expect(dirname(first)).toBe(root)
+    expect(dirname(second)).toBe(root)
+    expect(await uiReviewTempRoot()).toBe(root)
+
+    expect(await cleanupUiReviewTempRoot()).toBe(root)
+    expect(existsSync(root)).toBe(false)
+    expect(existsSync(first)).toBe(false)
+  })
+
+  it("is idempotent so finally, exit and signal handlers can all call it", async () => {
+    const root = await uiReviewTempRoot()
+    expect(await cleanupUiReviewTempRoot()).toBe(root)
+    expect(await cleanupUiReviewTempRoot()).toBeUndefined()
+    expect(await cleanupUiReviewTempRoot()).toBeUndefined()
+  })
+
+  it("never follows a symlink out of the run root", async () => {
+    const outside = await mkdtemp(join(tmpdir(), "ui-review-symlink-target."))
+    try {
+      const keepMe = join(outside, "keep.txt")
+      await writeFile(keepMe, "survivor", "utf8")
+      const root = await uiReviewTempRoot()
+      await symlink(outside, join(root, "escape"), "dir")
+
+      await cleanupUiReviewTempRoot()
+      expect(existsSync(root)).toBe(false)
+      expect(existsSync(keepMe)).toBe(true)
+      expect(await readdir(outside)).toEqual(["keep.txt"])
+    } finally {
+      const { rm } = await import("node:fs/promises")
+      await rm(outside, { recursive: true, force: true })
+    }
+  })
+
+  it("refuses to remove anything outside the run root", () => {
+    expect(() => assertRemovableUiReviewTempRoot(tmpdir())).toThrow("UI_REVIEW_TEMP_ROOT_OUTSIDE_TMPDIR")
+    expect(() => assertRemovableUiReviewTempRoot("/home/someone/work")).toThrow("UI_REVIEW_TEMP_ROOT_OUTSIDE_TMPDIR")
+    expect(() => assertRemovableUiReviewTempRoot(join(tmpdir(), "someone-elses-dir"))).toThrow("UI_REVIEW_TEMP_ROOT_UNOWNED")
+    expect(assertRemovableUiReviewTempRoot(join(tmpdir(), `${UI_REVIEW_TEMP_PREFIX}abc`))).toBe(join(resolve(tmpdir()), `${UI_REVIEW_TEMP_PREFIX}abc`))
+
+    const root = join(tmpdir(), `${UI_REVIEW_TEMP_PREFIX}xyz`)
+    expect(() => assertWithinUiReviewTempRoot(root, root)).toThrow("UI_REVIEW_TEMP_OUTSIDE_ROOT")
+    expect(() => assertWithinUiReviewTempRoot(root, join(root, "..", "elsewhere"))).toThrow("UI_REVIEW_TEMP_OUTSIDE_ROOT")
+    expect(assertWithinUiReviewTempRoot(root, join(root, "child"))).toBe(join(root, "child"))
+  })
+
+  it("removes the run root when the process is terminated by SIGTERM", async () => {
+    const child = spawn("node_modules/.bin/tsx", ["src/__tests__/temp-root-child.ts"], { cwd: toolRoot, stdio: ["ignore", "pipe", "inherit"] })
+    try {
+      const root = await new Promise<string>((resolveRoot, reject) => {
+        let stdout = ""
+        child.stdout.setEncoding("utf8")
+        child.stdout.on("data", (chunk: string) => {
+          stdout += chunk
+          const match = /UI_REVIEW_TEMP_ROOT:(.+)/.exec(stdout)
+          if (match) resolveRoot(match[1]!.trim())
+        })
+        child.on("error", reject)
+        child.on("exit", (code) => reject(new Error(`child exited early: ${code}`)))
+      })
+      expect(existsSync(root)).toBe(true)
+      expect((await readdir(root)).length).toBe(1)
+
+      const exitCode = await new Promise<number | null>((resolveExit) => {
+        child.once("exit", (code) => resolveExit(code))
+        child.kill("SIGTERM")
+      })
+      expect(exitCode).toBe(143)
+      await sleep(50)
+      expect(existsSync(root)).toBe(false)
+    } finally {
+      if (child.exitCode === null) child.kill("SIGKILL")
+    }
+  }, 60_000)
+})

--- a/tools/ui-review/src/__tests__/tempRoot.test.ts
+++ b/tools/ui-review/src/__tests__/tempRoot.test.ts
@@ -1,5 +1,5 @@
 import { spawn, type ChildProcessByStdio } from "node:child_process"
-import { existsSync, rmSync } from "node:fs"
+import { existsSync, mkdtempSync, rmSync } from "node:fs"
 import { mkdtemp, readdir, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join, resolve } from "node:path"
@@ -8,6 +8,7 @@ import type { Readable } from "node:stream"
 import { afterEach, describe, expect, it } from "vitest"
 import {
   UI_REVIEW_TEMP_PREFIX,
+  UI_REVIEW_TEMP_ROOT_ENV,
   assertRemovableUiReviewTempRoot,
   assertWithinUiReviewTempRoot,
   cleanupUiReviewTempRootSync,
@@ -93,13 +94,35 @@ describe("ui review run-scoped temp root", () => {
     }
   }, 60_000)
 
-  it("arms no signal handler on its own, so a worker that merely imports it keeps its own shutdown", async () => {
-    const child = spawnTempRootChild("bare")
+  it("runs the beforeCleanup hook before removing the root on SIGTERM", async () => {
+    const child = spawnTempRootChild("armed+hook")
+    try {
+      const { root } = await readChildHandshake(child)
+      const events: string[] = []
+      const exitCode = await new Promise<number | null>((resolveExit) => {
+        child.stdout.on("data", (chunk: string) => { if (chunk.includes("UI_REVIEW_TEMP_BEFORE_CLEANUP")) events.push("beforeCleanup") })
+        child.once("exit", (code) => resolveExit(code))
+        child.kill("SIGTERM")
+      })
+      expect(exitCode).toBe(143)
+      await sleep(50)
+      // The hook fires while removal is still pending — an orchestrator kills its children there.
+      expect(events).toEqual(["beforeCleanup"])
+      expect(existsSync(root)).toBe(false)
+    } finally {
+      if (child.exitCode === null) child.kill("SIGKILL")
+    }
+  }, 60_000)
+
+  it("a default-terminated real worker leaks its own run root, which is why roots must be inherited", async () => {
+    // Spawn through `node --import tsx`, not the tsx CLI shim: Node does not run `exit` handlers
+    // after a default SIGTERM, so a worker-owned root survives. The orchestrator avoids this by
+    // handing every child one parent-owned root via UI_REVIEW_TEMP_ROOT.
+    const child = spawnTempRootChild("bare", true)
     let leaked: string | undefined
     try {
       const { root, listeners } = await readChildHandshake(child)
       leaked = root
-      // Creating the run root must never install a `process.exit()`-ing signal handler.
       expect(listeners).toEqual({ SIGINT: 0, SIGTERM: 0, SIGHUP: 0 })
       expect(existsSync(root)).toBe(true)
 
@@ -108,11 +131,46 @@ describe("ui review run-scoped temp root", () => {
         child.kill("SIGTERM")
       })
       await sleep(50)
-      // Cleanup still happens — it just rides the `exit` listener rather than a signal handler.
-      expect(existsSync(root)).toBe(false)
+      // Documented leak: no exit handler ran, so nothing removed the root.
+      expect(existsSync(root)).toBe(true)
     } finally {
       if (child.exitCode === null) child.kill("SIGKILL")
       if (leaked && existsSync(leaked)) rmSync(assertRemovableUiReviewTempRoot(leaked), { recursive: true, force: true })
+    }
+  }, 60_000)
+
+  it("adopts an inherited root via the environment and never removes it, even when armed for signals", async () => {
+    const parentRoot = mkdtempSync(join(tmpdir(), UI_REVIEW_TEMP_PREFIX))
+    try {
+      const child = spawnTempRootChild("armed", false, parentRoot)
+      const { root, listeners } = await readChildHandshake(child)
+      // The child reuses the creator's root verbatim and takes no signal/exit cleanup duty.
+      expect(root).toBe(parentRoot)
+      expect(listeners).toEqual({ SIGINT: 0, SIGTERM: 0, SIGHUP: 0 })
+      expect((await readdir(parentRoot)).some((name) => name.startsWith("child."))).toBe(true)
+
+      await new Promise<void>((resolveExit) => {
+        child.once("exit", () => resolveExit())
+        child.kill("SIGKILL")
+      })
+      await sleep(50)
+      // The worker died hard; the shared root and everything in it belong to the still-running parent.
+      expect(existsSync(parentRoot)).toBe(true)
+      expect((await readdir(parentRoot)).length).toBeGreaterThan(0)
+    } finally {
+      rmSync(parentRoot, { recursive: true, force: true })
+    }
+  }, 60_000)
+
+  it("fails closed on a malformed inherited root instead of adopting it", async () => {
+    const outside = mkdtempSync(join(tmpdir(), "not-a-ui-review-root."))
+    let child: TempRootChild | undefined
+    try {
+      child = spawnTempRootChild("armed", false, outside)
+      await expect(readChildHandshake(child)).rejects.toThrow(/child exited early/)
+    } finally {
+      if (child && child.exitCode === null) child.kill("SIGKILL")
+      rmSync(outside, { recursive: true, force: true })
     }
   }, 60_000)
 
@@ -123,8 +181,15 @@ describe("ui review run-scoped temp root", () => {
   })
 })
 
-function spawnTempRootChild(mode: "armed" | "bare"): TempRootChild {
-  return spawn("node_modules/.bin/tsx", ["src/__tests__/temp-root-child.ts", mode], { cwd: toolRoot, stdio: ["ignore", "pipe", "inherit"] })
+function spawnTempRootChild(mode: string, directNode = false, inheritedRoot?: string): TempRootChild {
+  const file = "src/__tests__/temp-root-child.ts"
+  const command = directNode ? process.execPath : "node_modules/.bin/tsx"
+  const args = directNode ? ["--import", "tsx", file, mode] : [file, mode]
+  return spawn(command, args, {
+    cwd: toolRoot,
+    stdio: ["ignore", "pipe", "inherit"],
+    ...(inheritedRoot === undefined ? {} : { env: { ...process.env, [UI_REVIEW_TEMP_ROOT_ENV]: inheritedRoot } }),
+  })
 }
 
 /** Resolve once the child has reported both its listener counts and its run root. */

--- a/tools/ui-review/src/core/tempRoot.ts
+++ b/tools/ui-review/src/core/tempRoot.ts
@@ -7,8 +7,15 @@ import { basename, resolve, sep } from "node:path"
  * Run-scoped temporary storage for the UI review tooling.
  *
  * Every temp directory the tooling needs is created *inside* one parent directory per process.
- * That parent is removed when the process finishes normally (`finally` / `exit`) and when it is
- * terminated by `SIGINT`/`SIGTERM`/`SIGHUP`, so an interrupted review run cannot leak inodes.
+ *
+ * The run root is removed when the process finishes normally: creating it registers a `process.on
+ * ("exit")` listener that removes nothing but this module's own directory, which is safe in any
+ * host — a CLI, a Playwright worker, a vitest worker.
+ *
+ * Signal handling is *not* automatic. Cleaning up on `SIGINT`/`SIGTERM`/`SIGHUP` means re-exiting
+ * the process with the signal's conventional code, which only an entrypoint that owns its process
+ * may decide. Those entrypoints opt in with {@link installUiReviewTempCleanupHandlers}; importing
+ * this module elsewhere never takes over a worker's shutdown behind its back.
  *
  * Set `UI_REVIEW_KEEP_TMP=1` to retain the run directory for debugging.
  */
@@ -19,7 +26,8 @@ const CLEANUP_SIGNALS = { SIGINT: 130, SIGTERM: 143, SIGHUP: 129 } as const
 
 let runRoot: string | undefined
 let runRootPromise: Promise<string> | undefined
-let handlersInstalled = false
+let exitHandlerInstalled = false
+let signalHandlersInstalled = false
 
 export function shouldKeepUiReviewTemp(env: NodeJS.ProcessEnv = process.env): boolean {
   return env[UI_REVIEW_KEEP_TMP_ENV] === "1"
@@ -42,12 +50,12 @@ export function assertWithinUiReviewTempRoot(root: string, candidate: string): s
   return path
 }
 
-/** Create (once per process) the run-scoped parent directory and arm its cleanup handlers. */
+/** Create (once per process) the run-scoped parent directory and arm its removal on normal exit. */
 export async function uiReviewTempRoot(): Promise<string> {
   if (runRoot) return runRoot
   runRootPromise ??= mkdtemp(resolve(tmpdir(), UI_REVIEW_TEMP_PREFIX)).then((created) => {
     runRoot = created
-    installCleanupHandlers()
+    installExitCleanup()
     return created
   })
   return runRootPromise
@@ -71,18 +79,28 @@ export function cleanupUiReviewTempRootSync(): string | undefined {
   return current
 }
 
-export async function cleanupUiReviewTempRoot(): Promise<string | undefined> {
-  return cleanupUiReviewTempRootSync()
-}
-
-function installCleanupHandlers(): void {
-  if (handlersInstalled) return
-  handlersInstalled = true
-  process.on("exit", () => { cleanupUiReviewTempRootSync() })
+/**
+ * CLI entrypoints only: also remove the run root on `SIGINT`/`SIGTERM`/`SIGHUP`, then re-exit with
+ * that signal's conventional code. Idempotent, and safe to call before the run root exists.
+ *
+ * Call this from a script that owns its process. A Playwright or vitest worker must not — it would
+ * hand this module the decision to `process.exit()` out from under the runner. Those hosts keep the
+ * automatic `exit` cleanup, which is enough: they are torn down by their own runner.
+ */
+export function installUiReviewTempCleanupHandlers(): void {
+  installExitCleanup()
+  if (signalHandlersInstalled) return
+  signalHandlersInstalled = true
   for (const [signal, exitCode] of Object.entries(CLEANUP_SIGNALS)) {
     process.on(signal as NodeJS.Signals, () => {
       cleanupUiReviewTempRootSync()
       process.exit(exitCode)
     })
   }
+}
+
+function installExitCleanup(): void {
+  if (exitHandlerInstalled) return
+  exitHandlerInstalled = true
+  process.on("exit", () => { cleanupUiReviewTempRootSync() })
 }

--- a/tools/ui-review/src/core/tempRoot.ts
+++ b/tools/ui-review/src/core/tempRoot.ts
@@ -1,0 +1,88 @@
+import { rmSync } from "node:fs"
+import { mkdtemp } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { basename, resolve, sep } from "node:path"
+
+/**
+ * Run-scoped temporary storage for the UI review tooling.
+ *
+ * Every temp directory the tooling needs is created *inside* one parent directory per process.
+ * That parent is removed when the process finishes normally (`finally` / `exit`) and when it is
+ * terminated by `SIGINT`/`SIGTERM`/`SIGHUP`, so an interrupted review run cannot leak inodes.
+ *
+ * Set `UI_REVIEW_KEEP_TMP=1` to retain the run directory for debugging.
+ */
+export const UI_REVIEW_TEMP_PREFIX = "boring-ui-review-run."
+export const UI_REVIEW_KEEP_TMP_ENV = "UI_REVIEW_KEEP_TMP"
+
+const CLEANUP_SIGNALS = { SIGINT: 130, SIGTERM: 143, SIGHUP: 129 } as const
+
+let runRoot: string | undefined
+let runRootPromise: Promise<string> | undefined
+let handlersInstalled = false
+
+export function shouldKeepUiReviewTemp(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env[UI_REVIEW_KEEP_TMP_ENV] === "1"
+}
+
+/** Refuse to remove anything that is not a directory we created under the OS temp directory. */
+export function assertRemovableUiReviewTempRoot(candidate: string): string {
+  const path = resolve(candidate)
+  const base = resolve(tmpdir())
+  if (path === base || !path.startsWith(`${base}${sep}`)) throw new Error(`UI_REVIEW_TEMP_ROOT_OUTSIDE_TMPDIR:${path}`)
+  if (!basename(path).startsWith(UI_REVIEW_TEMP_PREFIX)) throw new Error(`UI_REVIEW_TEMP_ROOT_UNOWNED:${path}`)
+  return path
+}
+
+/** Refuse to hand out (or remove) a path that escaped the run-scoped parent. */
+export function assertWithinUiReviewTempRoot(root: string, candidate: string): string {
+  const resolvedRoot = resolve(root)
+  const path = resolve(candidate)
+  if (path === resolvedRoot || !path.startsWith(`${resolvedRoot}${sep}`)) throw new Error(`UI_REVIEW_TEMP_OUTSIDE_ROOT:${path}`)
+  return path
+}
+
+/** Create (once per process) the run-scoped parent directory and arm its cleanup handlers. */
+export async function uiReviewTempRoot(): Promise<string> {
+  if (runRoot) return runRoot
+  runRootPromise ??= mkdtemp(resolve(tmpdir(), UI_REVIEW_TEMP_PREFIX)).then((created) => {
+    runRoot = created
+    installCleanupHandlers()
+    return created
+  })
+  return runRootPromise
+}
+
+/** Create a temp directory for this run. `prefix` keeps existing call sites readable in `lsof`/traces. */
+export async function createUiReviewTempDir(prefix: string): Promise<string> {
+  const root = await uiReviewTempRoot()
+  return assertWithinUiReviewTempRoot(root, await mkdtemp(resolve(root, prefix)))
+}
+
+/** Idempotent: safe to call from `finally`, from `exit`, and from a signal handler in the same process. */
+export function cleanupUiReviewTempRootSync(): string | undefined {
+  if (!runRoot) return undefined
+  if (shouldKeepUiReviewTemp()) return undefined
+  const current = runRoot
+  runRoot = undefined
+  runRootPromise = undefined
+  // `rmSync` unlinks symlinks instead of descending into them, so cleanup can never escape the run root.
+  rmSync(assertRemovableUiReviewTempRoot(current), { recursive: true, force: true, maxRetries: 2 })
+  return current
+}
+
+export async function cleanupUiReviewTempRoot(): Promise<string | undefined> {
+  return cleanupUiReviewTempRootSync()
+}
+
+function installCleanupHandlers(): void {
+  if (handlersInstalled) return
+  handlersInstalled = true
+  process.on("exit", () => { cleanupUiReviewTempRootSync() })
+  for (const [signal, exitCode] of Object.entries(CLEANUP_SIGNALS)) {
+    process.on(signal as NodeJS.Signals, () => {
+      cleanupUiReviewTempRootSync()
+      process.exit(exitCode)
+    })
+  }
+}

--- a/tools/ui-review/src/core/tempRoot.ts
+++ b/tools/ui-review/src/core/tempRoot.ts
@@ -1,4 +1,4 @@
-import { rmSync } from "node:fs"
+import { existsSync, rmSync } from "node:fs"
 import { mkdtemp } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { basename, resolve, sep } from "node:path"
@@ -6,26 +6,35 @@ import { basename, resolve, sep } from "node:path"
 /**
  * Run-scoped temporary storage for the UI review tooling.
  *
- * Every temp directory the tooling needs is created *inside* one parent directory per process.
+ * Every temp directory the tooling needs is created *inside* one parent directory per run.
  *
- * The run root is removed when the process finishes normally: creating it registers a `process.on
- * ("exit")` listener that removes nothing but this module's own directory, which is safe in any
- * host — a CLI, a Playwright worker, a vitest worker.
+ * The run root is owned by whichever process *created* it. A creator removes it when its process
+ * finishes normally: creating it registers a `process.on("exit")` listener that removes nothing
+ * but this module's own directory, which is safe in any host — a CLI, a Playwright worker, a
+ * vitest worker. Signal handling is *not* automatic. Cleaning up on `SIGINT`/`SIGTERM`/`SIGHUP`
+ * means re-exiting the process with the signal's conventional code, which only an entrypoint that
+ * owns its process may decide. Those entrypoints opt in with {@link installUiReviewTempCleanupHandlers};
+ * importing this module elsewhere never takes over a worker's shutdown behind its back.
  *
- * Signal handling is *not* automatic. Cleaning up on `SIGINT`/`SIGTERM`/`SIGHUP` means re-exiting
- * the process with the signal's conventional code, which only an entrypoint that owns its process
- * may decide. Those entrypoints opt in with {@link installUiReviewTempCleanupHandlers}; importing
- * this module elsewhere never takes over a worker's shutdown behind its back.
+ * A default-terminated process (`SIGTERM`/`SIGKILL`) does **not** run `exit` handlers, so a worker
+ * that owns its own run root would still leak it. Long-running orchestration therefore avoids
+ * worker ownership entirely: the CLI entrypoint creates the run root once and hands it to every
+ * spawned child through {@link UI_REVIEW_TEMP_ROOT_ENV}. An inherited root is used as-is and never
+ * removed by the child — removal stays with the creator, which terminates its children before
+ * cleaning up.
  *
  * Set `UI_REVIEW_KEEP_TMP=1` to retain the run directory for debugging.
  */
 export const UI_REVIEW_TEMP_PREFIX = "boring-ui-review-run."
 export const UI_REVIEW_KEEP_TMP_ENV = "UI_REVIEW_KEEP_TMP"
+/** Environment key a creator sets so spawned children reuse (but never remove) its run root. */
+export const UI_REVIEW_TEMP_ROOT_ENV = "UI_REVIEW_TEMP_ROOT"
 
 const CLEANUP_SIGNALS = { SIGINT: 130, SIGTERM: 143, SIGHUP: 129 } as const
 
 let runRoot: string | undefined
 let runRootPromise: Promise<string> | undefined
+let runRootInherited = false
 let exitHandlerInstalled = false
 let signalHandlersInstalled = false
 
@@ -50,15 +59,29 @@ export function assertWithinUiReviewTempRoot(root: string, candidate: string): s
   return path
 }
 
-/** Create (once per process) the run-scoped parent directory and arm its removal on normal exit. */
+/**
+ * Create (once per process) the run-scoped parent directory and arm its removal on normal exit —
+ * unless a creator handed us one through {@link UI_REVIEW_TEMP_ROOT_ENV}. An inherited root is
+ * adopted as-is and never cleaned up here: its creator owns termination and removal.
+ */
 export async function uiReviewTempRoot(): Promise<string> {
   if (runRoot) return runRoot
-  runRootPromise ??= mkdtemp(resolve(tmpdir(), UI_REVIEW_TEMP_PREFIX)).then((created) => {
-    runRoot = created
-    installExitCleanup()
-    return created
+  runRootPromise ??= adoptOrCreateRunRoot().then((created) => {
+    runRoot = created.root
+    runRootInherited = created.inherited
+    if (!created.inherited) installExitCleanup()
+    return created.root
   })
   return runRootPromise
+}
+
+async function adoptOrCreateRunRoot(): Promise<{ root: string; inherited: boolean }> {
+  const provided = process.env[UI_REVIEW_TEMP_ROOT_ENV]?.trim()
+  if (!provided) return { root: await mkdtemp(resolve(tmpdir(), UI_REVIEW_TEMP_PREFIX)), inherited: false }
+  // Fail closed on a malformed inheritance: a typo'd or hostile value must never become our root.
+  const root = assertRemovableUiReviewTempRoot(provided)
+  if (!existsSync(root)) throw new Error(`UI_REVIEW_TEMP_ROOT_MISSING:${root}`)
+  return { root, inherited: true }
 }
 
 /** Create a temp directory for this run. `prefix` keeps existing call sites readable in `lsof`/traces. */
@@ -67,9 +90,12 @@ export async function createUiReviewTempDir(prefix: string): Promise<string> {
   return assertWithinUiReviewTempRoot(root, await mkdtemp(resolve(root, prefix)))
 }
 
-/** Idempotent: safe to call from `finally`, from `exit`, and from a signal handler in the same process. */
+/**
+ * Idempotent: safe to call from `finally`, from `exit`, and from a signal handler in the same
+ * process. Never removes an inherited ({@link UI_REVIEW_TEMP_ROOT_ENV}) root — its creator owns it.
+ */
 export function cleanupUiReviewTempRootSync(): string | undefined {
-  if (!runRoot) return undefined
+  if (!runRoot || runRootInherited) return undefined
   if (shouldKeepUiReviewTemp()) return undefined
   const current = runRoot
   runRoot = undefined
@@ -84,15 +110,21 @@ export function cleanupUiReviewTempRootSync(): string | undefined {
  * that signal's conventional code. Idempotent, and safe to call before the run root exists.
  *
  * Call this from a script that owns its process. A Playwright or vitest worker must not — it would
- * hand this module the decision to `process.exit()` out from under the runner. Those hosts keep the
- * automatic `exit` cleanup, which is enough: they are torn down by their own runner.
+ * hand this module the decision to `process.exit()` out from under the runner. Those hosts keep
+ * their runner's shutdown semantics; when they were spawned with an inherited root they have no
+ * cleanup duty at all.
+ *
+ * `options.beforeCleanup` runs synchronously in every signal handler *before* the root is removed —
+ * an orchestrator uses it to terminate the children that are still writing into the root.
  */
-export function installUiReviewTempCleanupHandlers(): void {
+export function installUiReviewTempCleanupHandlers(options: { beforeCleanup?: () => void } = {}): void {
+  if (process.env[UI_REVIEW_TEMP_ROOT_ENV]?.trim()) return
   installExitCleanup()
   if (signalHandlersInstalled) return
   signalHandlersInstalled = true
   for (const [signal, exitCode] of Object.entries(CLEANUP_SIGNALS)) {
     process.on(signal as NodeJS.Signals, () => {
+      options.beforeCleanup?.()
       cleanupUiReviewTempRootSync()
       process.exit(exitCode)
     })


### PR DESCRIPTION
## Thermo follow-up: dev filter + temp-handler scoping (#1253 lineage)

Scoped signal handlers to CLI entrypoints; dev build graph derived from the pnpm dependency graph.

## Review fixes (sol-xhigh thermo gate)

**CRITICAL — worker-owned temp roots leaked on SIGTERM** (`tools/ui-review/src/core/tempRoot.ts`): Node does not run `exit` handlers after a default SIGTERM, so a Playwright/vitest worker that owned its own run root still leaked it. The old test hid this by spawning the `tsx` CLI shim instead of Node itself. **Fixed:** the orchestrator now creates one parent-owned run root and hands it to every child via `UI_REVIEW_TEMP_ROOT`; an inherited root is adopted as-is, never removed by the child, and malformed values fail closed. The parent spawns children in their own process group and terminates the active group before signal-driven removal. New tests: a real `node --import tsx` SIGTERM probe proving worker-owned roots leak, inherited-root adoption (root survives SIGKILL of worker), beforeCleanup-hook ordering, and fail-closed inheritance.

**SHOULD-FIX — warning effect missing dep** (`WorkspaceAgentFront.tsx`): added `remoteSessionsEnabled` to the dependency array so the implicit-coupling warning can't go stale across an explicit-false → omitted transition.

**SHOULD-FIX — remote-sessions test proved only fetch** (`WorkspaceAgentFront.test.tsx`): strengthened to return a known server session and assert it is consumed as existing (no replacement create/delete fires). Full chat-props/state-route adoption evidence is warmup-gated on this path (with provisioning disabled the panel never mounts in jsdom); hydration-on-adopt remains pinned by the injected-hook tests ("keeps hydration disabled …", "renders a known active session while remote sessions are still loading").

Validation: ui-review tsc clean; tempRoot suite 10/10; WorkspaceAgentFront suite 92/92.
