### PR TITLE
fix(agent): factory generic seat for dispatched agents (#1296)

### DIFF
--- a/packages/agent/docs/AGENT_GATEWAY_V0.md
+++ b/packages/agent/docs/AGENT_GATEWAY_V0.md
@@ -72,12 +72,12 @@ Note `listAgents` takes `ListAgentsInput`, not a bare `AuthorizedAgentScope`.
 
 ### Output DTOs
 
-`AgentSummary` (`agentTypeId`, `label`, `description?`, `legacy?`,
-`definition?{version,digest}`), `AgentSessionSummary` (`ref`, `title`,
-`status`, `createdAt`, `updatedAt`), `AgentSessionPage` (`sessions`,
+`AgentSummary` (`agentTypeId`, `label`, `description?`, `pluginIds?`,
+`legacy?`, `definition?{version,digest}`), `AgentSessionSummary` (`ref`,
+`title`, `status`, `createdAt`, `updatedAt`), `AgentSessionPage` (`sessions`,
 `nextCursor?`), and the receipts (`CommandReceipt`, `AgentSendReceipt`,
 `QueueClearReceipt`, `StopReceipt`) are unchanged from §6, field for field,
-apart from `AgentSummary.legacy`.
+apart from `AgentSummary.pluginIds` and `AgentSummary.legacy`.
 
 `legacy: true` marks the `default` fallback identity, listed beside a
 configured fleet so sessions bound to it stay addressable (gh-1296). It is not

--- a/packages/agent/docs/AGENT_GATEWAY_V0.md
+++ b/packages/agent/docs/AGENT_GATEWAY_V0.md
@@ -80,16 +80,16 @@ Note `listAgents` takes `ListAgentsInput`, not a bare `AuthorizedAgentScope`.
 apart from `AgentSummary.legacy`.
 
 `legacy: true` marks the `default` fallback identity, listed beside a
-configured fleet only so the sessions bound to it stay addressable (gh-1296).
-It is not an authored seat: with configured Agents in the fleet it is labelled
-`default` rather than `Agent`, and clients keep listing and routing its
-sessions while leaving it out of seat chrome unless it owns chats or its
-history source fails. Decision 28
-retains that history compatibility, while Decision 29 makes the Gateway the
-canonical enforcement point: `createSession` rejects this history-only target
-when an authored Agent shares the fleet. A fleet that is nothing but the
-fallback is the legacy single-agent boot and remains creation-capable — label
-`Agent`, no `legacy` flag.
+configured fleet so sessions bound to it stay addressable (gh-1296). It is not
+an authored seat: with configured Agents in the fleet it is labelled `default`
+rather than `Agent`, and clients keep listing and routing its sessions while
+leaving it out of authored-seat chrome unless it owns chats or its history
+source fails. The marker is presentation metadata, not a creation policy:
+`createSession` remains valid for `default` in mixed fleets, just as it is for
+the legacy single-agent boot. This keeps the same explicit or persisted owner
+consistent across Gateway, UI, CLI, MCP, and dispatcher callers under Decisions
+28 and 29. In a fallback-only fleet the entry keeps its original presentation —
+label `Agent`, no `legacy` flag.
 
 Session activity is the extracted alias `AgentSessionActivity`:
 `'idle' | 'running' | 'aborting' | 'error'`.

--- a/packages/agent/docs/AGENT_GATEWAY_V0.md
+++ b/packages/agent/docs/AGENT_GATEWAY_V0.md
@@ -72,11 +72,20 @@ Note `listAgents` takes `ListAgentsInput`, not a bare `AuthorizedAgentScope`.
 
 ### Output DTOs
 
-`AgentSummary` (`agentTypeId`, `label`, `description?`, `definition?{version,digest}`),
-`AgentSessionSummary` (`ref`, `title`, `status`, `createdAt`, `updatedAt`),
-`AgentSessionPage` (`sessions`, `nextCursor?`), and the receipts
-(`CommandReceipt`, `AgentSendReceipt`, `QueueClearReceipt`, `StopReceipt`) are
-unchanged from §6, field for field.
+`AgentSummary` (`agentTypeId`, `label`, `description?`, `legacy?`,
+`definition?{version,digest}`), `AgentSessionSummary` (`ref`, `title`,
+`status`, `createdAt`, `updatedAt`), `AgentSessionPage` (`sessions`,
+`nextCursor?`), and the receipts (`CommandReceipt`, `AgentSendReceipt`,
+`QueueClearReceipt`, `StopReceipt`) are unchanged from §6, field for field,
+apart from `AgentSummary.legacy`.
+
+`legacy: true` marks the `default` fallback identity, listed beside a
+configured fleet only so the sessions bound to it stay addressable (gh-1296).
+It is not an authored seat: with configured Agents in the fleet it is labelled
+`default` rather than `Agent`, and clients keep listing and routing its
+sessions while leaving it out of seat chrome unless it owns chats. A fleet that
+is nothing but the fallback is the legacy single-agent boot and is unchanged —
+label `Agent`, no `legacy` flag.
 
 Session activity is the extracted alias `AgentSessionActivity`:
 `'idle' | 'running' | 'aborting' | 'error'`.

--- a/packages/agent/docs/AGENT_GATEWAY_V0.md
+++ b/packages/agent/docs/AGENT_GATEWAY_V0.md
@@ -83,9 +83,13 @@ apart from `AgentSummary.legacy`.
 configured fleet only so the sessions bound to it stay addressable (gh-1296).
 It is not an authored seat: with configured Agents in the fleet it is labelled
 `default` rather than `Agent`, and clients keep listing and routing its
-sessions while leaving it out of seat chrome unless it owns chats. A fleet that
-is nothing but the fallback is the legacy single-agent boot and is unchanged —
-label `Agent`, no `legacy` flag.
+sessions while leaving it out of seat chrome unless it owns chats or its
+history source fails. Decision 28
+retains that history compatibility, while Decision 29 makes the Gateway the
+canonical enforcement point: `createSession` rejects this history-only target
+when an authored Agent shares the fleet. A fleet that is nothing but the
+fallback is the legacy single-agent boot and remains creation-capable — label
+`Agent`, no `legacy` flag.
 
 Session activity is the extracted alias `AgentSessionActivity`:
 `'idle' | 'running' | 'aborting' | 'error'`.

--- a/packages/agent/src/front/chat/__tests__/useAddressedAgentSelection.test.tsx
+++ b/packages/agent/src/front/chat/__tests__/useAddressedAgentSelection.test.tsx
@@ -45,10 +45,8 @@ describe('useAddressedAgentSelection', () => {
     expect(result.current.selectedAgentTypeId).toBe('review/agent')
   })
 
-  // gh-1296: the host lists its legacy `default` fallback so existing sessions
-  // stay addressable — it is still selectable and still owns its chats, but it
-  // is not what an unaddressed workspace should start talking to.
-  test('opens on an authored seat rather than the legacy fallback', async () => {
+  // gh-1296: `legacy` changes presentation, not the host's default owner.
+  test('keeps the first default entry selected beside an authored fleet', async () => {
     const fetchMock = vi.fn(async () => jsonResponse([
       { agentTypeId: 'default', label: 'default', legacy: true },
       { agentTypeId: 'alpha', label: 'Alpha' },
@@ -63,10 +61,9 @@ describe('useAddressedAgentSelection', () => {
       { agentTypeId: 'default', label: 'default', legacy: true },
       { agentTypeId: 'alpha', label: 'Alpha' },
     ])
-    expect(result.current.selectedAgentTypeId).toBe('alpha')
-    // Still addressable: a chat bound to `default` can be selected as before.
-    act(() => result.current.selectAgentTypeId('default'))
     expect(result.current.selectedAgentTypeId).toBe('default')
+    act(() => result.current.selectAgentTypeId('alpha'))
+    expect(result.current.selectedAgentTypeId).toBe('alpha')
   })
 
   test('selects the legacy fallback when it is the whole fleet', async () => {

--- a/packages/agent/src/front/chat/__tests__/useAddressedAgentSelection.test.tsx
+++ b/packages/agent/src/front/chat/__tests__/useAddressedAgentSelection.test.tsx
@@ -45,6 +45,41 @@ describe('useAddressedAgentSelection', () => {
     expect(result.current.selectedAgentTypeId).toBe('review/agent')
   })
 
+  // gh-1296: the host lists its legacy `default` fallback so existing sessions
+  // stay addressable — it is still selectable and still owns its chats, but it
+  // is not what an unaddressed workspace should start talking to.
+  test('opens on an authored seat rather than the legacy fallback', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse([
+      { agentTypeId: 'default', label: 'default', legacy: true },
+      { agentTypeId: 'alpha', label: 'Alpha' },
+    ]))
+    const { result } = renderHook(() => useAddressedAgentSelection({
+      fetch: fetchMock as unknown as typeof fetch,
+      enabled: true,
+    }))
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.agents).toEqual([
+      { agentTypeId: 'default', label: 'default', legacy: true },
+      { agentTypeId: 'alpha', label: 'Alpha' },
+    ])
+    expect(result.current.selectedAgentTypeId).toBe('alpha')
+    // Still addressable: a chat bound to `default` can be selected as before.
+    act(() => result.current.selectAgentTypeId('default'))
+    expect(result.current.selectedAgentTypeId).toBe('default')
+  })
+
+  test('selects the legacy fallback when it is the whole fleet', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse([{ agentTypeId: 'default', label: 'Agent' }]))
+    const { result } = renderHook(() => useAddressedAgentSelection({
+      fetch: fetchMock as unknown as typeof fetch,
+      enabled: true,
+    }))
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.selectedAgentTypeId).toBe('default')
+  })
+
   test('does not discover agents without the explicit opt-in', async () => {
     const fetchMock = vi.fn()
     const { result } = renderHook(() => useAddressedAgentSelection({

--- a/packages/agent/src/front/chat/useAddressedAgentSelection.ts
+++ b/packages/agent/src/front/chat/useAddressedAgentSelection.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { AgentSummary } from '../../shared/gateway/types'
 import { gatewayResponseError } from './gatewayResponseError'
 
-export type AddressedAgentOption = Pick<AgentSummary, 'agentTypeId' | 'label' | 'description' | 'pluginIds'>
+export type AddressedAgentOption = Pick<AgentSummary, 'agentTypeId' | 'label' | 'description' | 'pluginIds' | 'legacy'>
 
 export interface UseAddressedAgentSelectionOptions {
   apiBaseUrl?: string
@@ -87,7 +87,7 @@ export function useAddressedAgentSelection({
         agents,
         selectedAgentTypeId: agents.some((agent) => agent.agentTypeId === previous.selectedAgentTypeId)
           ? previous.selectedAgentTypeId
-          : agents[0]?.agentTypeId,
+          : defaultSelection(agents),
         loading: false,
         error: undefined,
       }))
@@ -152,6 +152,15 @@ function discoverAgents(
   return request
 }
 
+/**
+ * Nothing picked yet addresses an authored seat, never the `legacy` fallback
+ * the host lists only to keep its existing sessions addressable (gh-1296).
+ * A fleet that is nothing but the fallback still selects it.
+ */
+function defaultSelection(agents: readonly AddressedAgentOption[]): string | undefined {
+  return (agents.find((agent) => !agent.legacy) ?? agents[0])?.agentTypeId
+}
+
 function parseAgentOptions(value: unknown): AddressedAgentOption[] {
   if (!Array.isArray(value)) throw new Error('Failed to load agents: invalid response')
   return value.map((item) => {
@@ -167,6 +176,7 @@ function parseAgentOptions(value: unknown): AddressedAgentOption[] {
       ...(Array.isArray(record.pluginIds)
         ? { pluginIds: record.pluginIds.filter((pluginId): pluginId is string => typeof pluginId === 'string' && pluginId.length > 0) }
         : {}),
+      ...(record.legacy === true ? { legacy: true } : {}),
     }
   })
 }

--- a/packages/agent/src/front/chat/useAddressedAgentSelection.ts
+++ b/packages/agent/src/front/chat/useAddressedAgentSelection.ts
@@ -152,13 +152,9 @@ function discoverAgents(
   return request
 }
 
-/**
- * Nothing picked yet addresses an authored seat, never the `legacy` fallback
- * the host lists only to keep its existing sessions addressable (gh-1296).
- * A fleet that is nothing but the fallback still selects it.
- */
+/** Nothing picked yet addresses the host's first (default) fleet entry. */
 function defaultSelection(agents: readonly AddressedAgentOption[]): string | undefined {
-  return (agents.find((agent) => !agent.legacy) ?? agents[0])?.agentTypeId
+  return agents[0]?.agentTypeId
 }
 
 function parseAgentOptions(value: unknown): AddressedAgentOption[] {

--- a/packages/agent/src/server/__tests__/workspaceAgentDispatcher.test.ts
+++ b/packages/agent/src/server/__tests__/workspaceAgentDispatcher.test.ts
@@ -38,7 +38,12 @@ function createFakeGateway(): AgentGateway & {
     sends,
     createSession,
     connectSession,
-    async listAgents() { return [] },
+    async listAgents() {
+      return [
+        { agentTypeId: 'default', label: 'default', legacy: true },
+        { agentTypeId: 'alpha', label: 'Alpha' },
+      ]
+    },
     async listSessions() { return { sessions: [] } },
     async readSessionState() { throw new Error('not implemented') },
     async renameSession() { throw new Error('not implemented') },
@@ -48,7 +53,7 @@ function createFakeGateway(): AgentGateway & {
 }
 
 describe('workspace agent dispatcher', () => {
-  it('uses addressed Gateway operations and returns the durable dispatch receipt before events', async () => {
+  it('preserves default creation in a mixed fleet and returns the durable dispatch receipt before events', async () => {
     const gateway = createFakeGateway()
     const dispatcher = createBoundWorkspaceAgentDispatcher({ gateway, scope, agentTypeId: 'default' }, CTX)
 

--- a/packages/agent/src/server/agent-host/__tests__/createAgentHost.test.ts
+++ b/packages/agent/src/server/agent-host/__tests__/createAgentHost.test.ts
@@ -48,6 +48,28 @@ function options(sessionRoot: string) {
 }
 
 describe('createAgentHost', () => {
+  it('keeps the legacy marker on the Gateway catalog instead of leaking it through host.describe()', async () => {
+    const sessionRoot = await root()
+    const created = await createAgentHost({
+      ...options(sessionRoot),
+      agents: [
+        { agentTypeId: 'default', legacyDefault: true },
+        { agentTypeId: 'alpha', definition: { instructions: 'alpha', label: 'Alpha' } },
+      ],
+    })
+
+    expect((await created.gateway.listAgents({ scope }))[0]).toEqual({
+      agentTypeId: 'default',
+      label: 'default',
+      legacy: true,
+    })
+    expect((await created.host.describe()).agents[0]).toEqual({
+      agentTypeId: 'default',
+      label: 'default',
+    })
+    await created.host.close()
+  })
+
   it('requires durable transactional ledger ownership for the direct projection unless test/dev in-memory mode is explicit', async () => {
     await expect(createAgentHost({
       ...options(await root()),

--- a/packages/agent/src/server/agent-host/__tests__/embeddedGatewayFixture.ts
+++ b/packages/agent/src/server/agent-host/__tests__/embeddedGatewayFixture.ts
@@ -186,7 +186,9 @@ class FakeService implements PiChatSessionService {
   })
 }
 
-export async function createEmbeddedGatewayFixture(): Promise<EmbeddedGatewayFixture> {
+export async function createEmbeddedGatewayFixture(
+  options: { readonly agents?: readonly AgentHostAgentSpec[] } = {},
+): Promise<EmbeddedGatewayFixture> {
   const issued = new WeakSet<object>()
   const revoked = new WeakSet<object>()
   const services = new Map<string, FakeService>()
@@ -195,7 +197,7 @@ export async function createEmbeddedGatewayFixture(): Promise<EmbeddedGatewayFix
     wait: Promise<void>
   }
   const admission = new Map<AgentGatewayEffect, AdmissionDisposition[]>()
-  const agents: readonly AgentHostAgentSpec[] = [
+  const agents: readonly AgentHostAgentSpec[] = options.agents ?? [
     { agentTypeId: 'alpha', definition: { instructions: 'alpha', label: 'Alpha' } },
     { agentTypeId: 'beta', definition: { instructions: 'beta', label: 'Beta' } },
   ]

--- a/packages/agent/src/server/agent-host/__tests__/embeddedGatewayFixture.ts
+++ b/packages/agent/src/server/agent-host/__tests__/embeddedGatewayFixture.ts
@@ -14,6 +14,11 @@ import type { AgentGatewayEffect, AgentHostAgentSpec } from '../types'
 import type { GatewayConformanceFixture } from '../testing/gatewayConformance'
 
 interface EmbeddedGatewayFixture extends GatewayConformanceFixture {
+  seedSession(input: {
+    workspaceScopeId: string
+    agentTypeId: string
+    title: string
+  }): Promise<AgentSessionRef>
   modelLoopStarts(ref: AgentSessionRef): number
   blockAdmission(operation: AgentGatewayEffect): {
     entered: Promise<void>
@@ -291,6 +296,13 @@ export async function createEmbeddedGatewayFixture(
   return {
     gateway: embedded,
     issueScope,
+    async seedSession({ workspaceScopeId, agentTypeId, title }) {
+      const created = await serviceFor(workspaceScopeId, agentTypeId).createSession({
+        workspaceId: workspaceScopeId,
+        requestId: 'fixture-history-seed',
+      }, { title })
+      return { agentTypeId, sessionId: created.id }
+    },
     revoke(scope) { revoked.add(scope as object) },
     setActivity(ref: AgentSessionRef, activity: AgentSessionActivity) {
       for (const [key, service] of services) {

--- a/packages/agent/src/server/agent-host/__tests__/embeddedGatewayFixture.ts
+++ b/packages/agent/src/server/agent-host/__tests__/embeddedGatewayFixture.ts
@@ -14,11 +14,6 @@ import type { AgentGatewayEffect, AgentHostAgentSpec } from '../types'
 import type { GatewayConformanceFixture } from '../testing/gatewayConformance'
 
 interface EmbeddedGatewayFixture extends GatewayConformanceFixture {
-  seedSession(input: {
-    workspaceScopeId: string
-    agentTypeId: string
-    title: string
-  }): Promise<AgentSessionRef>
   modelLoopStarts(ref: AgentSessionRef): number
   blockAdmission(operation: AgentGatewayEffect): {
     entered: Promise<void>
@@ -296,13 +291,6 @@ export async function createEmbeddedGatewayFixture(
   return {
     gateway: embedded,
     issueScope,
-    async seedSession({ workspaceScopeId, agentTypeId, title }) {
-      const created = await serviceFor(workspaceScopeId, agentTypeId).createSession({
-        workspaceId: workspaceScopeId,
-        requestId: 'fixture-history-seed',
-      }, { title })
-      return { agentTypeId, sessionId: created.id }
-    },
     revoke(scope) { revoked.add(scope as object) },
     setActivity(ref: AgentSessionRef, activity: AgentSessionActivity) {
       for (const [key, service] of services) {

--- a/packages/agent/src/server/agent-host/__tests__/legacyDefaultPresentation.test.ts
+++ b/packages/agent/src/server/agent-host/__tests__/legacyDefaultPresentation.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from 'vitest'
-import { AgentGatewayErrorCode } from '../../../shared/index'
 import type { AgentHostAgentSpec } from '../types'
 import { createEmbeddedGatewayFixture } from './embeddedGatewayFixture'
 
@@ -34,30 +33,29 @@ describe('legacy default presentation (gh-1296)', () => {
     })).resolves.toMatchObject({ agentTypeId: 'default' })
   })
 
-  it('rejects direct creation on the history-only fallback beside an authored fleet', async () => {
+  it('keeps direct default creation compatible beside an authored fleet', async () => {
     const fixture = await createEmbeddedGatewayFixture({ agents: CONFIGURED_FLEET })
     const scope = fixture.issueScope({ workspaceScopeId: 'workspace-a', authSubjectId: 'subject-a' })
 
-    await expect(fixture.gateway.createSession({
+    const created = await fixture.gateway.createSession({
       scope,
       agentTypeId: 'default',
-      requestId: 'forbidden-legacy-create',
-    })).rejects.toMatchObject({
-      code: AgentGatewayErrorCode.AGENT_COMMAND_INVALID_STATE,
-      message: 'legacy default agent is available for history only',
+      requestId: 'mixed-fleet-default-create',
+      title: 'Default-owned chat',
     })
+
+    expect(created.agentTypeId).toBe('default')
     await expect(fixture.gateway.listSessions({ scope, agentTypeId: 'default' }))
-      .resolves.toEqual({ sessions: [] })
+      .resolves.toMatchObject({ sessions: [{ ref: created, title: 'Default-owned chat' }] })
   })
 
   it('keeps sessions bound to `default` addressable, listed and readable beside a fleet', async () => {
     const fixture = await createEmbeddedGatewayFixture({ agents: CONFIGURED_FLEET })
     const scope = fixture.issueScope({ workspaceScopeId: 'workspace-a', authSubjectId: 'subject-a' })
-    // Seed a chat created before the authored fleet existed without using the
-    // now-forbidden public creation path.
-    const legacyRef = await fixture.seedSession({
-      workspaceScopeId: 'workspace-a',
+    const legacyRef = await fixture.gateway.createSession({
+      scope,
       agentTypeId: 'default',
+      requestId: 'legacy-chat',
       title: 'Legacy chat',
     })
     const seatRef = await fixture.gateway.createSession({

--- a/packages/agent/src/server/agent-host/__tests__/legacyDefaultPresentation.test.ts
+++ b/packages/agent/src/server/agent-host/__tests__/legacyDefaultPresentation.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import type { AgentHostAgentSpec } from '../types'
+import { createEmbeddedGatewayFixture } from './embeddedGatewayFixture'
+
+const LEGACY_DEFAULT = { agentTypeId: 'default', legacyDefault: true } as const
+const CONFIGURED_FLEET: readonly AgentHostAgentSpec[] = [
+  LEGACY_DEFAULT,
+  { agentTypeId: 'alpha', definition: { instructions: 'alpha', label: 'Alpha' } },
+  { agentTypeId: 'beta', definition: { instructions: 'beta', label: 'Beta' } },
+]
+
+describe('legacy default presentation (gh-1296)', () => {
+  it('labels the legacy default as the fallback, not as an authored seat', async () => {
+    const fixture = await createEmbeddedGatewayFixture({ agents: CONFIGURED_FLEET })
+    const scope = fixture.issueScope({ workspaceScopeId: 'workspace-a', authSubjectId: 'subject-a' })
+
+    expect(await fixture.gateway.listAgents({ scope })).toEqual([
+      { agentTypeId: 'default', label: 'default', legacy: true },
+      { agentTypeId: 'alpha', label: 'Alpha' },
+      { agentTypeId: 'beta', label: 'Beta' },
+    ])
+  })
+
+  it('keeps the single-agent boot byte-identical: one default agent still reads "Agent"', async () => {
+    const fixture = await createEmbeddedGatewayFixture({ agents: [LEGACY_DEFAULT] })
+    const scope = fixture.issueScope({ workspaceScopeId: 'workspace-a', authSubjectId: 'subject-a' })
+
+    expect(await fixture.gateway.listAgents({ scope })).toEqual([{ agentTypeId: 'default', label: 'Agent' }])
+  })
+
+  it('keeps sessions bound to `default` addressable, listed and readable beside a fleet', async () => {
+    const fixture = await createEmbeddedGatewayFixture({ agents: CONFIGURED_FLEET })
+    const scope = fixture.issueScope({ workspaceScopeId: 'workspace-a', authSubjectId: 'subject-a' })
+    // A chat someone started before the fleet existed.
+    const legacyRef = await fixture.gateway.createSession({
+      scope,
+      agentTypeId: 'default',
+      requestId: 'legacy-chat',
+      title: 'Legacy chat',
+    })
+    const seatRef = await fixture.gateway.createSession({
+      scope,
+      agentTypeId: 'alpha',
+      requestId: 'seat-chat',
+      title: 'Seat chat',
+    })
+
+    // The presentation change must not touch reachability: the legacy chat is
+    // still enumerated fleet-wide, still enumerated under its own agent, and
+    // still opens.
+    const all = await fixture.gateway.listSessions({ scope })
+    expect(all.sessions.map((row) => row.ref)).toEqual(expect.arrayContaining([legacyRef, seatRef]))
+    const addressed = await fixture.gateway.listSessions({ scope, agentTypeId: 'default' })
+    expect(addressed.sessions.map((row) => row.ref)).toEqual([legacyRef])
+    await expect(fixture.gateway.readSessionState({ scope, ref: legacyRef })).resolves.toMatchObject({
+      ref: legacyRef,
+    })
+  })
+})

--- a/packages/agent/src/server/agent-host/__tests__/legacyDefaultPresentation.test.ts
+++ b/packages/agent/src/server/agent-host/__tests__/legacyDefaultPresentation.test.ts
@@ -21,21 +21,42 @@ describe('legacy default presentation (gh-1296)', () => {
     ])
   })
 
-  it('keeps the single-agent boot byte-identical: one default agent still reads "Agent"', async () => {
+  it('keeps the single-agent boot byte-identical and creation-capable', async () => {
     const fixture = await createEmbeddedGatewayFixture({ agents: [LEGACY_DEFAULT] })
     const scope = fixture.issueScope({ workspaceScopeId: 'workspace-a', authSubjectId: 'subject-a' })
 
     expect(await fixture.gateway.listAgents({ scope })).toEqual([{ agentTypeId: 'default', label: 'Agent' }])
+    await expect(fixture.gateway.createSession({
+      scope,
+      agentTypeId: 'default',
+      requestId: 'fallback-only-create',
+    })).resolves.toMatchObject({ agentTypeId: 'default' })
+  })
+
+  it('rejects direct creation on the history-only fallback beside an authored fleet', async () => {
+    const fixture = await createEmbeddedGatewayFixture({ agents: CONFIGURED_FLEET })
+    const scope = fixture.issueScope({ workspaceScopeId: 'workspace-a', authSubjectId: 'subject-a' })
+
+    await expect(fixture.gateway.createSession({
+      scope,
+      agentTypeId: 'default',
+      requestId: 'forbidden-legacy-create',
+    })).rejects.toMatchObject({
+      code: 'AGENT_COMMAND_INVALID_STATE',
+      message: 'legacy default agent is available for history only',
+    })
+    await expect(fixture.gateway.listSessions({ scope, agentTypeId: 'default' }))
+      .resolves.toEqual({ sessions: [] })
   })
 
   it('keeps sessions bound to `default` addressable, listed and readable beside a fleet', async () => {
     const fixture = await createEmbeddedGatewayFixture({ agents: CONFIGURED_FLEET })
     const scope = fixture.issueScope({ workspaceScopeId: 'workspace-a', authSubjectId: 'subject-a' })
-    // A chat someone started before the fleet existed.
-    const legacyRef = await fixture.gateway.createSession({
-      scope,
+    // Seed a chat created before the authored fleet existed without using the
+    // now-forbidden public creation path.
+    const legacyRef = await fixture.seedSession({
+      workspaceScopeId: 'workspace-a',
       agentTypeId: 'default',
-      requestId: 'legacy-chat',
       title: 'Legacy chat',
     })
     const seatRef = await fixture.gateway.createSession({

--- a/packages/agent/src/server/agent-host/__tests__/legacyDefaultPresentation.test.ts
+++ b/packages/agent/src/server/agent-host/__tests__/legacyDefaultPresentation.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { AgentGatewayErrorCode } from '../../../shared/index'
 import type { AgentHostAgentSpec } from '../types'
 import { createEmbeddedGatewayFixture } from './embeddedGatewayFixture'
 
@@ -42,7 +43,7 @@ describe('legacy default presentation (gh-1296)', () => {
       agentTypeId: 'default',
       requestId: 'forbidden-legacy-create',
     })).rejects.toMatchObject({
-      code: 'AGENT_COMMAND_INVALID_STATE',
+      code: AgentGatewayErrorCode.AGENT_COMMAND_INVALID_STATE,
       message: 'legacy default agent is available for history only',
     })
     await expect(fixture.gateway.listSessions({ scope, agentTypeId: 'default' }))

--- a/packages/agent/src/server/agent-host/createAgentHost.ts
+++ b/packages/agent/src/server/agent-host/createAgentHost.ts
@@ -702,9 +702,9 @@ export async function createAgentHost(
         hostId,
         agents: compiledAgents.map((agent) => ({
           agentTypeId: agent.agentTypeId,
-          ...('legacyDefault' in agent
-            ? legacyDefaultPresentation(configuredFleet)
-            : { label: agent.definition.label }),
+          label: 'legacyDefault' in agent
+            ? legacyDefaultPresentation(configuredFleet).label
+            : agent.definition.label,
           ...('legacyDefault' in agent || agent.definition.digest === undefined
             ? {}
             : { definitionDigest: agent.definition.digest }),

--- a/packages/agent/src/server/agent-host/createAgentHost.ts
+++ b/packages/agent/src/server/agent-host/createAgentHost.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path'
 import { AgentGatewayError, AgentGatewayErrorCode, type AuthorizedAgentScope, type VerifiedAgentScopeClaim } from '../../shared/index'
 import { buildAgentComposition, type BuiltAgentComposition } from './buildAgentComposition'
 import { EmbeddedAgentGateway } from './embeddedGateway'
+import { fleetHasConfiguredAgents, legacyDefaultPresentation } from './fleetPresentation'
 import { EnvironmentLeaseManager, type EnvironmentLease } from './environmentLease'
 import { getOptionalRuntimeBundleStorageRoot } from '../runtime/mode'
 import { mergeRuntimeFilesystemBindings } from '../runtime/filesystemBindings'
@@ -680,6 +681,7 @@ export async function createAgentHost(
     )
   }
   const gateway = new EmbeddedAgentGateway(runtime)
+  const configuredFleet = fleetHasConfiguredAgents(compiledAgents)
   const assertStrongLedger = () => {
     if (
       runtime.ledger.durability !== 'durable-transactional'
@@ -700,7 +702,9 @@ export async function createAgentHost(
         hostId,
         agents: compiledAgents.map((agent) => ({
           agentTypeId: agent.agentTypeId,
-          label: 'legacyDefault' in agent ? 'Agent' : agent.definition.label,
+          ...('legacyDefault' in agent
+            ? legacyDefaultPresentation(configuredFleet)
+            : { label: agent.definition.label }),
           ...('legacyDefault' in agent || agent.definition.digest === undefined
             ? {}
             : { definitionDigest: agent.definition.digest }),

--- a/packages/agent/src/server/agent-host/embeddedGateway.ts
+++ b/packages/agent/src/server/agent-host/embeddedGateway.ts
@@ -288,8 +288,18 @@ export class EmbeddedAgentGateway implements AgentGateway {
 
   async createSession(input: Parameters<AgentGateway['createSession']>[0]) {
     const claim = await this.verify(input.scope)
-    if (!this.runtime.compiledById.has(input.agentTypeId)) {
+    const agent = this.runtime.compiledById.get(input.agentTypeId)
+    if (!agent) {
       throw new AgentGatewayError(AgentGatewayErrorCode.AGENT_TYPE_UNKNOWN, 'agent type is not available')
+    }
+    // Decision 28 keeps the legacy default only for session/history
+    // compatibility beside an authored fleet. Enforce that at the Gateway so
+    // HTTP, MCP, dispatcher, and embedded callers share one creation rule.
+    if ('legacyDefault' in agent && fleetHasConfiguredAgents(this.runtime.compiledAgents)) {
+      throw new AgentGatewayError(
+        AgentGatewayErrorCode.AGENT_COMMAND_INVALID_STATE,
+        'legacy default agent is available for history only',
+      )
     }
     const target: AgentRequestTarget = { kind: 'agent', agentTypeId: input.agentTypeId }
     let binding: Awaited<ReturnType<AgentHostRuntime['resolveBinding']>> | undefined

--- a/packages/agent/src/server/agent-host/embeddedGateway.ts
+++ b/packages/agent/src/server/agent-host/embeddedGateway.ts
@@ -23,6 +23,7 @@ import {
 import { AgentSessionEventQueue } from './agentSessionEventQueue'
 import { agentSessionKey } from './agentSessionKey'
 import { canonicalDigest } from './canonical'
+import { fleetHasConfiguredAgents, legacyDefaultPresentation } from './fleetPresentation'
 import { stableServiceActionFailure } from './stableServiceError'
 import type { AgentHostRuntime } from './createAgentHost'
 import type {
@@ -239,9 +240,14 @@ export class EmbeddedAgentGateway implements AgentGateway {
 
   async listAgents(input: { readonly scope: AuthorizedAgentScope }) {
     await this.verify(input.scope)
+    // The legacy `default` entry stays listed so its sessions remain
+    // addressable; it is marked and labelled as the fallback it is (gh-1296).
+    const configuredFleet = fleetHasConfiguredAgents(this.runtime.compiledAgents)
     return this.runtime.compiledAgents.map((agent) => ({
       agentTypeId: agent.agentTypeId,
-      label: 'legacyDefault' in agent ? 'Agent' : agent.definition.label,
+      ...('legacyDefault' in agent
+        ? legacyDefaultPresentation(configuredFleet)
+        : { label: agent.definition.label }),
       ...('legacyDefault' in agent || !agent.plugins?.length
         ? {}
         : { pluginIds: agent.plugins.map((plugin) => plugin.name) }),

--- a/packages/agent/src/server/agent-host/embeddedGateway.ts
+++ b/packages/agent/src/server/agent-host/embeddedGateway.ts
@@ -288,18 +288,8 @@ export class EmbeddedAgentGateway implements AgentGateway {
 
   async createSession(input: Parameters<AgentGateway['createSession']>[0]) {
     const claim = await this.verify(input.scope)
-    const agent = this.runtime.compiledById.get(input.agentTypeId)
-    if (!agent) {
+    if (!this.runtime.compiledById.has(input.agentTypeId)) {
       throw new AgentGatewayError(AgentGatewayErrorCode.AGENT_TYPE_UNKNOWN, 'agent type is not available')
-    }
-    // Decision 28 keeps the legacy default only for session/history
-    // compatibility beside an authored fleet. Enforce that at the Gateway so
-    // HTTP, MCP, dispatcher, and embedded callers share one creation rule.
-    if ('legacyDefault' in agent && fleetHasConfiguredAgents(this.runtime.compiledAgents)) {
-      throw new AgentGatewayError(
-        AgentGatewayErrorCode.AGENT_COMMAND_INVALID_STATE,
-        'legacy default agent is available for history only',
-      )
     }
     const target: AgentRequestTarget = { kind: 'agent', agentTypeId: input.agentTypeId }
     let binding: Awaited<ReturnType<AgentHostRuntime['resolveBinding']>> | undefined

--- a/packages/agent/src/server/agent-host/fleetPresentation.ts
+++ b/packages/agent/src/server/agent-host/fleetPresentation.ts
@@ -2,8 +2,8 @@
  * How the legacy `default` runtime presents itself in agent listings.
  *
  * The `default` agentTypeId is never removed from a composed fleet: existing
- * sessions are bound to it and hosts normalize `default → primary` (DECISIONS,
- * Decision 30), so dropping it from the compiled fleet would strand chat
+ * sessions are bound to it and Decision 28 retains session/history
+ * compatibility, so dropping it from the compiled fleet would strand chat
  * history. What gh-1296 fixes is the *presentation*: alongside a configured
  * fleet the fallback used to advertise itself as an authored seat labelled
  * `Agent`, sitting above the real seats.

--- a/packages/agent/src/server/agent-host/fleetPresentation.ts
+++ b/packages/agent/src/server/agent-host/fleetPresentation.ts
@@ -2,16 +2,16 @@
  * How the legacy `default` runtime presents itself in agent listings.
  *
  * The `default` agentTypeId is never removed from a composed fleet: existing
- * sessions are bound to it and Decision 28 retains session/history
- * compatibility, so dropping it from the compiled fleet would strand chat
- * history. What gh-1296 fixes is the *presentation*: alongside a configured
+ * sessions are bound to it, so dropping it from the compiled fleet would strand
+ * chat history. What gh-1296 fixes is the *presentation*: alongside a configured
  * fleet the fallback used to advertise itself as an authored seat labelled
  * `Agent`, sitting above the real seats.
  *
- * So listings keep the entry — every caller can still address it, and clients
- * still enumerate its sessions — but mark it `legacy` and label it `default`,
- * which is what it is. Clients hide a legacy entry that owns no sessions from
- * seat chrome; one that owns sessions stays visible so its chats are reachable.
+ * So listings keep the entry — every caller can still address it for creation
+ * and history, and clients still enumerate its sessions — but mark it `legacy`
+ * and label it `default`, which is what it is. Clients hide a legacy entry that
+ * owns no sessions from authored-seat chrome; one that owns sessions stays
+ * visible so its chats are reachable.
  *
  * With no configured fleet (the legacy single-agent boot) nothing changes: the
  * lone default agent is the workspace's agent and keeps the `Agent` label.

--- a/packages/agent/src/server/agent-host/fleetPresentation.ts
+++ b/packages/agent/src/server/agent-host/fleetPresentation.ts
@@ -1,0 +1,30 @@
+/**
+ * How the legacy `default` runtime presents itself in agent listings.
+ *
+ * The `default` agentTypeId is never removed from a composed fleet: existing
+ * sessions are bound to it and hosts normalize `default → primary` (DECISIONS,
+ * Decision 30), so dropping it from the compiled fleet would strand chat
+ * history. What gh-1296 fixes is the *presentation*: alongside a configured
+ * fleet the fallback used to advertise itself as an authored seat labelled
+ * `Agent`, sitting above the real seats.
+ *
+ * So listings keep the entry — every caller can still address it, and clients
+ * still enumerate its sessions — but mark it `legacy` and label it `default`,
+ * which is what it is. Clients hide a legacy entry that owns no sessions from
+ * seat chrome; one that owns sessions stays visible so its chats are reachable.
+ *
+ * With no configured fleet (the legacy single-agent boot) nothing changes: the
+ * lone default agent is the workspace's agent and keeps the `Agent` label.
+ */
+
+/** True once at least one configured (authored) Agent shares the fleet. */
+export function fleetHasConfiguredAgents(agents: readonly object[]): boolean {
+  return agents.some((agent) => !('legacyDefault' in agent))
+}
+
+/** Listing identity of the legacy default entry for a fleet of either shape. */
+export function legacyDefaultPresentation(
+  configuredFleet: boolean,
+): { readonly label: string; readonly legacy?: true } {
+  return configuredFleet ? { label: 'default', legacy: true } : { label: 'Agent' }
+}

--- a/packages/agent/src/server/mcp/__tests__/managedAgentDelegate.test.ts
+++ b/packages/agent/src/server/mcp/__tests__/managedAgentDelegate.test.ts
@@ -4,7 +4,7 @@ import type { AddressInfo } from 'node:net'
 
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
   MANAGED_AGENT_MCP_DELIVERY_RULE,
@@ -89,6 +89,24 @@ describe('ManagedAgentMcpDelegateController', () => {
     expect(first).not.toHaveProperty('shareLink')
     expect(JSON.stringify(first)).not.toMatch(/\/share\//i)
     expect(progressMessages).toContain('Agent turn started.')
+  })
+
+  it('preserves an explicitly configured default owner at the MCP Gateway seam', async () => {
+    const agent = new FakeAgent()
+    const gateway = legacyAgentGateway(agent)
+    gateway.listAgents = async () => [
+      { agentTypeId: 'default', label: 'default', legacy: true },
+      { agentTypeId: 'alpha', label: 'Alpha' },
+    ]
+    const createSession = vi.spyOn(gateway, 'createSession')
+    const controller = createManagedAgentMcpDelegateController(options(agent, { gateway }))
+
+    await controller.delegateTask({ brief: 'keep the configured owner' })
+
+    expect(createSession).toHaveBeenCalledWith(expect.objectContaining({
+      agentTypeId: 'default',
+      title: 'keep the configured owner',
+    }))
   })
 
   it('accepts a Markdown artifact at exactly 256 KiB and reports byte digest metadata', async () => {

--- a/packages/agent/src/shared/gateway/types.ts
+++ b/packages/agent/src/shared/gateway/types.ts
@@ -64,10 +64,10 @@ export interface AgentSummary {
   readonly pluginIds?: readonly string[]
   /**
    * The legacy `default` fallback identity, listed alongside a configured
-   * fleet purely so the sessions bound to it stay addressable (Decision 28's
-   * session/history compatibility). It is NOT an authored seat: clients keep
-   * loading and routing its sessions, but must not present it as a peer of the seats
-   * someone actually wrote (gh-1296).
+   * fleet so sessions bound to it stay addressable. It is NOT an authored seat:
+   * clients keep loading and routing its sessions, but must not present it as a
+   * peer of the seats someone actually wrote (gh-1296). This presentation
+   * marker does not restrict explicit creation for that identity.
    */
   readonly legacy?: boolean
   readonly definition?: {

--- a/packages/agent/src/shared/gateway/types.ts
+++ b/packages/agent/src/shared/gateway/types.ts
@@ -64,9 +64,9 @@ export interface AgentSummary {
   readonly pluginIds?: readonly string[]
   /**
    * The legacy `default` fallback identity, listed alongside a configured
-   * fleet purely so the sessions bound to it stay addressable (DECISIONS,
-   * Decision 30). It is NOT an authored seat: clients keep loading and
-   * routing its sessions, but must not present it as a peer of the seats
+   * fleet purely so the sessions bound to it stay addressable (Decision 28's
+   * session/history compatibility). It is NOT an authored seat: clients keep
+   * loading and routing its sessions, but must not present it as a peer of the seats
    * someone actually wrote (gh-1296).
    */
   readonly legacy?: boolean

--- a/packages/agent/src/shared/gateway/types.ts
+++ b/packages/agent/src/shared/gateway/types.ts
@@ -62,6 +62,14 @@ export interface AgentSummary {
   readonly description?: string
   /** Runtime plugins explicitly bound to this Agent definition. */
   readonly pluginIds?: readonly string[]
+  /**
+   * The legacy `default` fallback identity, listed alongside a configured
+   * fleet purely so the sessions bound to it stay addressable (DECISIONS,
+   * Decision 30). It is NOT an authored seat: clients keep loading and
+   * routing its sessions, but must not present it as a peer of the seats
+   * someone actually wrote (gh-1296).
+   */
+  readonly legacy?: boolean
   readonly definition?: {
     readonly version: string
     readonly digest: string

--- a/packages/cli/src/server/__tests__/modeApps.agentHost.test.ts
+++ b/packages/cli/src/server/__tests__/modeApps.agentHost.test.ts
@@ -325,6 +325,16 @@ describe.sequential("CLI Agent Host composition", () => {
       expect(workerTools.statusCode, workerTools.body).toBe(200)
       expect(defaultTools.json().tools.map((tool: { name: string }) => tool.name)).toContain("workspace_seat_tool")
       expect(workerTools.json().tools.map((tool: { name: string }) => tool.name)).toContain("workspace_seat_tool")
+
+      // The marked default and authored worker form a mixed fleet. CLI's HTTP
+      // edge must preserve direct default creation just like embedded callers.
+      const createdDefault = await app.inject({
+        method: "POST",
+        url: "/api/v1/agents/default/sessions",
+        payload: { requestId: "cli-mixed-fleet-default-create", title: "CLI default chat" },
+      })
+      expect(createdDefault.statusCode, createdDefault.body).toBe(201)
+      expect(createdDefault.json()).toMatchObject({ agentTypeId: "default" })
     } finally {
       if (app) await app.close()
       process.chdir(previousCwd)

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -821,24 +821,10 @@ export function WorkspaceAgentFront<
       setNewChatAgentTypeIdOverride(undefined)
     }
   }, [addressedAgentOptions, newChatAgentTypeIdOverride])
-  // gh-1296 review fix: the legacy `default` fallback stays listable,
-  // switchable and readable, but it is never a CREATION target — opening a
-  // default-bound chat retargets the addressed selection at the fallback, and
-  // letting that flow into New chat would manufacture more fallback-bound
-  // sessions with every click. Creation derives from authored seats; a fleet
-  // that is nothing but the fallback still selects it (matches the discovery
-  // default in useAddressedAgentSelection).
-  const newChatAgentTypeId = useMemo(() => {
-    if (newChatAgentTypeIdOverride) return newChatAgentTypeIdOverride
-    if (!fleetModeEnabled) return effectiveAgentTypeId
-    const effectiveIsLegacy = addressedAgentOptions.find(
-      (agent) => agent.agentTypeId === effectiveAgentTypeId,
-    )?.legacy === true
-    // Only divert when creation would otherwise land on the fallback; a normal
-    // configured default keeps its role as the pre-selection target.
-    if (!effectiveIsLegacy) return effectiveAgentTypeId
-    return addressedAgentOptions.find((agent) => !agent.legacy)?.agentTypeId ?? effectiveAgentTypeId
-  }, [addressedAgentOptions, effectiveAgentTypeId, fleetModeEnabled, newChatAgentTypeIdOverride])
+  // Creation follows the explicit picker target or the currently addressed
+  // owner exactly. The `legacy` catalog marker is presentation-only and must
+  // not silently rewrite a persisted or explicitly selected `default` owner.
+  const newChatAgentTypeId = newChatAgentTypeIdOverride ?? effectiveAgentTypeId
   const localSessionStore = useMemo(
     () => createLocalStorageSessions({ storageKey: resolvedSessionStorageKey }),
     [resolvedSessionStorageKey],

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -821,7 +821,24 @@ export function WorkspaceAgentFront<
       setNewChatAgentTypeIdOverride(undefined)
     }
   }, [addressedAgentOptions, newChatAgentTypeIdOverride])
-  const newChatAgentTypeId = newChatAgentTypeIdOverride ?? effectiveAgentTypeId
+  // gh-1296 review fix: the legacy `default` fallback stays listable,
+  // switchable and readable, but it is never a CREATION target — opening a
+  // default-bound chat retargets the addressed selection at the fallback, and
+  // letting that flow into New chat would manufacture more fallback-bound
+  // sessions with every click. Creation derives from authored seats; a fleet
+  // that is nothing but the fallback still selects it (matches the discovery
+  // default in useAddressedAgentSelection).
+  const newChatAgentTypeId = useMemo(() => {
+    if (newChatAgentTypeIdOverride) return newChatAgentTypeIdOverride
+    if (!fleetModeEnabled) return effectiveAgentTypeId
+    const effectiveIsLegacy = addressedAgentOptions.find(
+      (agent) => agent.agentTypeId === effectiveAgentTypeId,
+    )?.legacy === true
+    // Only divert when creation would otherwise land on the fallback; a normal
+    // configured default keeps its role as the pre-selection target.
+    if (!effectiveIsLegacy) return effectiveAgentTypeId
+    return addressedAgentOptions.find((agent) => !agent.legacy)?.agentTypeId ?? effectiveAgentTypeId
+  }, [addressedAgentOptions, effectiveAgentTypeId, fleetModeEnabled, newChatAgentTypeIdOverride])
   const localSessionStore = useMemo(
     () => createLocalStorageSessions({ storageKey: resolvedSessionStorageKey }),
     [resolvedSessionStorageKey],

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -707,12 +707,61 @@ describe("WorkspaceAgentFront", () => {
     expect(document.querySelector('[data-boring-workspace-part="app-left-agents-count"]')).toHaveTextContent("2 seats")
   })
 
+  it("keeps fallback history error chrome visible when authored session sources still load", async () => {
+    const user = userEvent.setup()
+    const agents = [
+      { agentTypeId: "default", label: "default", legacy: true },
+      { agentTypeId: "alpha", label: "Alpha" },
+      { agentTypeId: "beta", label: "Beta" },
+    ]
+    const useAgentSelection = () => ({
+      agents,
+      selectedAgentTypeId: "alpha",
+      loading: false,
+      error: undefined,
+      selectAgentTypeId: vi.fn(),
+    })
+    const legacyHistoryError = new Error("legacy history unavailable")
+    const useFleetSessions: AttestedWorkspaceAgentFrontProps<WorkspaceAgentSession>["useSessions"] = (options) => ({
+      sessions: options.agentTypeId === "alpha"
+        ? [{ id: "alpha-one", agentTypeId: "alpha", title: "Alpha one", updatedAt: 2 }]
+        : [],
+      loading: false,
+      error: options.agentTypeId === "default" ? legacyHistoryError : undefined,
+      activeSessionId: undefined,
+      activeSessionAgentTypeId: options.agentTypeId,
+      activeSession: undefined,
+      workspaceId: options.workspaceId,
+      switch: vi.fn(),
+      create: vi.fn(),
+      delete: vi.fn(),
+    })
+
+    render(
+      <WorkspaceAgentFront
+        workspaceId="fleet-partial-error"
+        workspaceLayout="plugin-tabs"
+        chatPanel={SessionIdChatPanel}
+        addressedAgentSelection
+        useAddressedAgentSelection={useAgentSelection}
+        useSessions={useFleetSessions}
+        persistenceEnabled={false}
+      />,
+    )
+
+    await waitFor(() => expect(screen.getAllByText("Alpha one").length).toBeGreaterThan(0))
+    expect(document.querySelector('[data-boring-workspace-part="app-left-agents-count"]')).toHaveTextContent("2 seats")
+    await user.click(screen.getByRole("button", { name: "Expand default; chats unavailable" }))
+    expect(screen.getByText("Chats unavailable.")).toHaveAttribute("role", "alert")
+  })
+
   // gh-1296 review fix: opening a default-bound chat switches the addressed
   // owner to the legacy fallback, but creation must never follow it there —
   // otherwise reading history retargets New chat at `default` and manufactures
   // more fallback-bound sessions.
-  it("does not retarget new chats at the legacy fallback after opening a legacy chat", async () => {
+  it("keeps implicit new chats authored and never retargets an explicit legacy split", async () => {
     const user = userEvent.setup()
+    const createAttempts = vi.fn()
     const createdBy = vi.fn()
     const agents = [
       { agentTypeId: "default", label: "default", legacy: true },
@@ -745,6 +794,8 @@ describe("WorkspaceAgentFront", () => {
         workspaceId: options.workspaceId,
         switch: vi.fn(),
         create: async () => {
+          createAttempts(owner)
+          if (owner === "default") throw new Error("legacy default agent is available for history only")
           createdBy(owner)
           return { id: `${owner}-new`, agentTypeId: owner, title: `${owner} new`, updatedAt: 9 }
         },
@@ -776,8 +827,16 @@ describe("WorkspaceAgentFront", () => {
       expect(screen.getByTestId("chat-pane")).toHaveAttribute("data-session-id", "legacy-one")
     })
 
-    // Creation does NOT follow: the primary picker target derives from an
-    // authored seat and the menu never offers `default`.
+    // A split is explicitly owned by the pane being split. Preserve that
+    // legacy owner through the session controller so the Gateway rejection is
+    // honest; never turn it into an Alpha session behind the user's back.
+    await user.click(screen.getByRole("button", { name: /^Split .* chat vertically$/ }))
+    await waitFor(() => expect(createAttempts).toHaveBeenCalledWith("default"))
+    expect(createdBy).not.toHaveBeenCalled()
+    expect(screen.getAllByTestId("chat-pane")).toHaveLength(1)
+
+    // Implicit New chat does NOT follow history selection: the primary picker
+    // target derives from an authored seat and never offers `default`.
     const primary = screen.getByRole("button", { name: /^Start new chat with / })
     expect(primary).not.toHaveAttribute("aria-label", "Start new chat with default")
     await user.click(screen.getByRole("button", { name: "Choose Agent for new chat" }))
@@ -792,6 +851,7 @@ describe("WorkspaceAgentFront", () => {
       expect(createdBy).toHaveBeenCalledWith("alpha")
     })
     expect(createdBy).not.toHaveBeenCalledWith("default")
+    expect(createAttempts).toHaveBeenCalledWith("default")
   })
 
   it("discovers an addressed fleet, groups its chats, and creates through the chosen owner", async () => {

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react"
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react"
 import { useEffect, useState } from "react"
 import userEvent from "@testing-library/user-event"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
@@ -612,6 +612,99 @@ describe("WorkspaceAgentFront", () => {
       expect(screen.getByRole("button", { name: "Start new chat with Beta" })).toBeInTheDocument()
     })
     expect(screen.queryByRole("button", { name: "Start new chat with Alpha" })).not.toBeInTheDocument()
+  })
+
+  // gh-1296. The host keeps listing its legacy `default` fallback beside a
+  // configured fleet, flagged `legacy`, so chats bound to it stay addressable.
+  // Two guarantees, one test: the fleet ALWAYS mounts a session source for it
+  // (never filtered — that is the continuity guarantee), while the seat chrome
+  // shows its card only while it owns chats.
+  it("keeps loading the legacy fallback's sessions while hiding an empty fallback seat", async () => {
+    const user = userEvent.setup()
+    const sessionScopes = new Map<string, string | undefined>()
+    const agents = [
+      { agentTypeId: "default", label: "default", legacy: true },
+      { agentTypeId: "alpha", label: "Alpha" },
+      { agentTypeId: "beta", label: "Beta" },
+    ]
+    const useAgentSelection = () => ({
+      agents,
+      selectedAgentTypeId: "alpha",
+      loading: false,
+      error: undefined,
+      selectAgentTypeId: vi.fn(),
+    })
+    const legacyChats = new Map<string, { id: string; agentTypeId: string; title: string; updatedAt: number }[]>([
+      ["default", [{ id: "legacy-one", agentTypeId: "default", title: "Chat from before the fleet", updatedAt: 5 }]],
+      ["alpha", [{ id: "alpha-one", agentTypeId: "alpha", title: "Alpha one", updatedAt: 2 }]],
+      ["beta", []],
+    ])
+    const useFleetSessions: AttestedWorkspaceAgentFrontProps<WorkspaceAgentSession>["useSessions"] = (options) => {
+      const owner = options.agentTypeId
+      if (options.enabled !== false) sessionScopes.set(owner ?? "", options.sessionStorageScope)
+      return {
+        sessions: legacyChats.get(owner ?? "") ?? [],
+        loading: false,
+        activeSessionId: undefined,
+        activeSessionAgentTypeId: owner,
+        activeSession: undefined,
+        workspaceId: options.workspaceId,
+        switch: vi.fn(),
+        create: vi.fn(),
+        delete: vi.fn(),
+      }
+    }
+
+    render(
+      <WorkspaceAgentFront
+        workspaceId="fleet-legacy"
+        workspaceLayout="plugin-tabs"
+        chatPanel={SessionIdChatPanel}
+        addressedAgentSelection
+        useAddressedAgentSelection={useAgentSelection}
+        useSessions={useFleetSessions}
+        persistenceEnabled={false}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "New chat with Alpha" })).toBeInTheDocument()
+    })
+    // Continuity: the legacy identity keeps its own session source, on its own
+    // storage scope, exactly like an authored seat.
+    expect(sessionScopes.get("default")).toBe("fleet-legacy:default")
+    // …and because it owns a chat, it keeps a card, and that chat opens. The
+    // card starts expanded (the pane opens seats that own chats), so collapse
+    // and re-expand to prove the disclosure actually drives the region.
+    await user.click(screen.getByRole("button", { name: "Collapse default; 1 chat" }))
+    expect(screen.queryByRole("region", { name: "default sessions" })).not.toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: "Expand default; 1 chat" }))
+    const defaultRegion = screen.getByRole("region", { name: "default sessions" })
+    expect(within(defaultRegion).getByText("Chat from before the fleet")).toBeInTheDocument()
+    // Beta owns nothing and is still a seat; only the legacy fallback is
+    // presentation-gated, and only while empty.
+    expect(screen.getByRole("button", { name: /Beta;/ })).toBeInTheDocument()
+
+    // Same fleet, nothing bound to the fallback: three listed agents, two seats.
+    legacyChats.set("default", [])
+    cleanup()
+    render(
+      <WorkspaceAgentFront
+        workspaceId="fleet-legacy-empty"
+        workspaceLayout="plugin-tabs"
+        chatPanel={SessionIdChatPanel}
+        addressedAgentSelection
+        useAddressedAgentSelection={useAgentSelection}
+        useSessions={useFleetSessions}
+        persistenceEnabled={false}
+      />,
+    )
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "New chat with Alpha" })).toBeInTheDocument()
+    })
+    expect(sessionScopes.get("default")).toBe("fleet-legacy-empty:default")
+    expect(document.querySelector('[data-boring-agent-type-id="default"]')).toBeNull()
+    expect(document.querySelector('[data-boring-workspace-part="app-left-agents-count"]')).toHaveTextContent("2 seats")
   })
 
   it("discovers an addressed fleet, groups its chats, and creates through the chosen owner", async () => {

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -705,7 +705,7 @@ describe("WorkspaceAgentFront", () => {
     expect(sessionScopes.get("default")).toBe("fleet-legacy-empty:default")
     expect(document.querySelector('[data-boring-agent-type-id="default"]')).toBeNull()
     expect(document.querySelector('[data-boring-workspace-part="app-left-agents-count"]')).toHaveTextContent("2 seats")
-  })
+  }, 10_000)
 
   it("keeps fallback history error chrome visible when authored session sources still load", async () => {
     const user = userEvent.setup()
@@ -755,14 +755,13 @@ describe("WorkspaceAgentFront", () => {
     expect(screen.getByText("Chats unavailable.")).toHaveAttribute("role", "alert")
   })
 
-  // gh-1296 review fix: opening a default-bound chat switches the addressed
-  // owner to the legacy fallback, but creation must never follow it there —
-  // otherwise reading history retargets New chat at `default` and manufactures
-  // more fallback-bound sessions.
-  it("keeps implicit new chats authored and never retargets an explicit legacy split", async () => {
+  // Owner-ratified option B: `legacy` is presentation metadata. Persisted and
+  // explicit `default` owners remain creation-capable beside authored seats.
+  it("creates for the addressed default and preserves explicit split ownership", async () => {
     const user = userEvent.setup()
     const createAttempts = vi.fn()
     const createdBy = vi.fn()
+    let created = 0
     const agents = [
       { agentTypeId: "default", label: "default", legacy: true },
       { agentTypeId: "alpha", label: "Alpha" },
@@ -795,9 +794,9 @@ describe("WorkspaceAgentFront", () => {
         switch: vi.fn(),
         create: async () => {
           createAttempts(owner)
-          if (owner === "default") throw new Error("legacy default agent is available for history only")
           createdBy(owner)
-          return { id: `${owner}-new`, agentTypeId: owner, title: `${owner} new`, updatedAt: 9 }
+          created += 1
+          return { id: `${owner}-new-${created}`, agentTypeId: owner, title: `${owner} new`, updatedAt: 9 }
         },
         delete: vi.fn(),
       }
@@ -827,32 +826,27 @@ describe("WorkspaceAgentFront", () => {
       expect(screen.getByTestId("chat-pane")).toHaveAttribute("data-session-id", "legacy-one")
     })
 
-    // A split is explicitly owned by the pane being split. Preserve that
-    // legacy owner through the session controller so the Gateway rejection is
-    // honest; never turn it into an Alpha session behind the user's back.
+    // A split is explicitly owned by the pane being split. Preserve `default`
+    // through the fleet controller rather than silently retargeting Alpha.
     await user.click(screen.getByRole("button", { name: /^Split .* chat vertically$/ }))
-    await waitFor(() => expect(createAttempts).toHaveBeenCalledWith("default"))
-    expect(createdBy).not.toHaveBeenCalled()
-    expect(screen.getAllByTestId("chat-pane")).toHaveLength(1)
+    await waitFor(() => expect(createdBy).toHaveBeenCalledWith("default"))
+    expect(screen.getAllByTestId("chat-pane")).toHaveLength(2)
 
-    // Implicit New chat does NOT follow history selection: the primary picker
-    // target derives from an authored seat and never offers `default`.
-    const primary = screen.getByRole("button", { name: /^Start new chat with / })
-    expect(primary).not.toHaveAttribute("aria-label", "Start new chat with default")
+    // Implicit New chat follows the currently addressed default, and the full
+    // catalog keeps default available as an explicit picker choice.
+    const primary = screen.getByRole("button", { name: "Start new chat with default" })
     await user.click(screen.getByRole("button", { name: "Choose Agent for new chat" }))
     const menu = screen.getByRole("menu")
-    expect(within(menu).queryByText("default")).not.toBeInTheDocument()
-
-    // Retarget through the picker's authored seats, then create — landing must
-    // be Alpha even though the addressed owner is still the legacy fallback.
-    await user.click(within(menu).getByText("Alpha"))
-    await user.click(await screen.findByRole("button", { name: "Start new chat with Alpha" }))
-    await waitFor(() => {
-      expect(createdBy).toHaveBeenCalledWith("alpha")
-    })
-    expect(createdBy).not.toHaveBeenCalledWith("default")
-    expect(createAttempts).toHaveBeenCalledWith("default")
-  })
+    expect(within(menu).getByText("default")).toBeInTheDocument()
+    expect(within(menu).getByText("Alpha")).toBeInTheDocument()
+    await user.keyboard("{Escape}")
+    fireEvent.click(primary)
+    await waitFor(() => expect(createdBy).toHaveBeenCalledTimes(2))
+    expect(createdBy).toHaveBeenNthCalledWith(1, "default")
+    expect(createdBy).toHaveBeenNthCalledWith(2, "default")
+    expect(createAttempts).toHaveBeenNthCalledWith(1, "default")
+    expect(createAttempts).toHaveBeenNthCalledWith(2, "default")
+  }, 10_000)
 
   it("discovers an addressed fleet, groups its chats, and creates through the chosen owner", async () => {
     const user = userEvent.setup()

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -707,6 +707,93 @@ describe("WorkspaceAgentFront", () => {
     expect(document.querySelector('[data-boring-workspace-part="app-left-agents-count"]')).toHaveTextContent("2 seats")
   })
 
+  // gh-1296 review fix: opening a default-bound chat switches the addressed
+  // owner to the legacy fallback, but creation must never follow it there —
+  // otherwise reading history retargets New chat at `default` and manufactures
+  // more fallback-bound sessions.
+  it("does not retarget new chats at the legacy fallback after opening a legacy chat", async () => {
+    const user = userEvent.setup()
+    const createdBy = vi.fn()
+    const agents = [
+      { agentTypeId: "default", label: "default", legacy: true },
+      { agentTypeId: "alpha", label: "Alpha" },
+      { agentTypeId: "beta", label: "Beta" },
+    ]
+    const useAgentSelection = () => {
+      const [selectedAgentTypeId, setSelectedAgentTypeId] = useState("alpha")
+      return {
+        agents,
+        selectedAgentTypeId,
+        loading: false,
+        error: undefined,
+        selectAgentTypeId: (agentTypeId: string) => setSelectedAgentTypeId(agentTypeId),
+      }
+    }
+    const legacyChats = new Map<string, { id: string; agentTypeId: string; title: string; updatedAt: number }[]>([
+      ["default", [{ id: "legacy-one", agentTypeId: "default", title: "Chat from before the fleet", updatedAt: 5 }]],
+      ["alpha", [{ id: "alpha-one", agentTypeId: "alpha", title: "Alpha one", updatedAt: 2 }]],
+      ["beta", []],
+    ])
+    const useFleetSessions: AttestedWorkspaceAgentFrontProps<WorkspaceAgentSession>["useSessions"] = (options) => {
+      const owner = options.agentTypeId
+      return {
+        sessions: legacyChats.get(owner ?? []) ?? [],
+        loading: false,
+        activeSessionId: undefined,
+        activeSessionAgentTypeId: owner,
+        activeSession: undefined,
+        workspaceId: options.workspaceId,
+        switch: vi.fn(),
+        create: async () => {
+          createdBy(owner)
+          return { id: `${owner}-new`, agentTypeId: owner, title: `${owner} new`, updatedAt: 9 }
+        },
+        delete: vi.fn(),
+      }
+    }
+
+    render(
+      <WorkspaceAgentFront
+        workspaceId="fleet-legacy-retarget"
+        workspaceLayout="plugin-tabs"
+        chatPanel={SessionIdChatPanel}
+        addressedAgentSelection
+        useAddressedAgentSelection={useAgentSelection}
+        useSessions={useFleetSessions}
+        persistenceEnabled={false}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Chat from before the fleet").length).toBeGreaterThan(0)
+    })
+
+    // Open the old default-bound chat: this legitimately switches the
+    // addressed owner to the legacy fallback.
+    const defaultRegion = screen.getByRole("region", { name: "default sessions" })
+    await user.click(within(defaultRegion).getByText("Chat from before the fleet").closest("button")!)
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-pane")).toHaveAttribute("data-session-id", "legacy-one")
+    })
+
+    // Creation does NOT follow: the primary picker target derives from an
+    // authored seat and the menu never offers `default`.
+    const primary = screen.getByRole("button", { name: /^Start new chat with / })
+    expect(primary).not.toHaveAttribute("aria-label", "Start new chat with default")
+    await user.click(screen.getByRole("button", { name: "Choose Agent for new chat" }))
+    const menu = screen.getByRole("menu")
+    expect(within(menu).queryByText("default")).not.toBeInTheDocument()
+
+    // Retarget through the picker's authored seats, then create — landing must
+    // be Alpha even though the addressed owner is still the legacy fallback.
+    await user.click(within(menu).getByText("Alpha"))
+    await user.click(await screen.findByRole("button", { name: "Start new chat with Alpha" }))
+    await waitFor(() => {
+      expect(createdBy).toHaveBeenCalledWith("alpha")
+    })
+    expect(createdBy).not.toHaveBeenCalledWith("default")
+  })
+
   it("discovers an addressed fleet, groups its chats, and creates through the chosen owner", async () => {
     const user = userEvent.setup()
     const createdBy = vi.fn()

--- a/packages/workspace/src/app/front/addressedFleetSessions.tsx
+++ b/packages/workspace/src/app/front/addressedFleetSessions.tsx
@@ -251,9 +251,9 @@ export function useAddressedFleetSessions<TSession extends WorkspaceAgentSession
         controllerFor(owner)?.switch(id, owner)
       },
       create(input) {
-        // Preserve explicit ownership exactly. In particular, a split of a
-        // legacy history pane must reach the canonical Gateway as `default`
-        // and be rejected there, never silently become the first authored seat.
+        // Preserve explicit ownership exactly. In particular, a split or MCP-
+        // style caller addressed to `default` must never silently become the
+        // first authored seat merely because the catalog marks it `legacy`.
         const owner = input?.agentTypeId ?? selectedAgentTypeId
         const controller = controllerFor(owner)
         if (!owner || !controller) return Promise.reject(new Error("Agent sessions are not ready"))

--- a/packages/workspace/src/app/front/addressedFleetSessions.tsx
+++ b/packages/workspace/src/app/front/addressedFleetSessions.tsx
@@ -251,7 +251,17 @@ export function useAddressedFleetSessions<TSession extends WorkspaceAgentSession
         controllerFor(owner)?.switch(id, owner)
       },
       create(input) {
-        const owner = input?.agentTypeId ?? selectedAgentTypeId
+        // gh-1296 review fix: the legacy fallback is reachable for list/switch/
+        // read, but never a creation target — retarget a legacy request to the
+        // first authored seat so opening old default chats cannot multiply
+        // fallback-bound sessions. A fleet that is only the fallback keeps it.
+        const requested = input?.agentTypeId ?? selectedAgentTypeId
+        const requestedIsLegacy = requested != null && agents.find(
+          (agent) => agent.agentTypeId === requested,
+        )?.legacy === true
+        const owner = requestedIsLegacy
+          ? agents.find((agent) => !agent.legacy)?.agentTypeId ?? requested
+          : requested
         const controller = controllerFor(owner)
         if (!owner || !controller) return Promise.reject(new Error("Agent sessions are not ready"))
         const { agentTypeId: _agentTypeId, ...createInput } = input ?? {}

--- a/packages/workspace/src/app/front/addressedFleetSessions.tsx
+++ b/packages/workspace/src/app/front/addressedFleetSessions.tsx
@@ -11,6 +11,13 @@ export interface WorkspaceAddressedAgentOption {
   label: string
   description?: string
   pluginIds?: readonly string[]
+  /**
+   * The host's legacy `default` fallback, listed beside a configured fleet only
+   * so the sessions bound to it stay reachable (gh-1296). Seat CHROME hides an
+   * empty one; session sourcing below deliberately does not, so its chats keep
+   * loading, listing and routing exactly as before.
+   */
+  legacy?: boolean
 }
 
 interface FleetSnapshot<TSession extends WorkspaceAgentSession> {
@@ -164,6 +171,9 @@ export function useAddressedFleetSessions<TSession extends WorkspaceAgentSession
     })
   }, [])
 
+  // Every listed agent gets a session source, `legacy` fallback included: the
+  // pane may hide an empty fallback seat, but its inventory must never stop
+  // loading or a chat bound to `default` would drop out of the sidebar.
   const sources = enabled ? agents.map((agent) => {
     const expectedSourceIdentity = sourceIdentityForAgent(agent.agentTypeId)
     return (

--- a/packages/workspace/src/app/front/addressedFleetSessions.tsx
+++ b/packages/workspace/src/app/front/addressedFleetSessions.tsx
@@ -251,17 +251,10 @@ export function useAddressedFleetSessions<TSession extends WorkspaceAgentSession
         controllerFor(owner)?.switch(id, owner)
       },
       create(input) {
-        // gh-1296 review fix: the legacy fallback is reachable for list/switch/
-        // read, but never a creation target — retarget a legacy request to the
-        // first authored seat so opening old default chats cannot multiply
-        // fallback-bound sessions. A fleet that is only the fallback keeps it.
-        const requested = input?.agentTypeId ?? selectedAgentTypeId
-        const requestedIsLegacy = requested != null && agents.find(
-          (agent) => agent.agentTypeId === requested,
-        )?.legacy === true
-        const owner = requestedIsLegacy
-          ? agents.find((agent) => !agent.legacy)?.agentTypeId ?? requested
-          : requested
+        // Preserve explicit ownership exactly. In particular, a split of a
+        // legacy history pane must reach the canonical Gateway as `default`
+        // and be rejected there, never silently become the first authored seat.
+        const owner = input?.agentTypeId ?? selectedAgentTypeId
         const controller = controllerFor(owner)
         if (!owner || !controller) return Promise.reject(new Error("Agent sessions are not ready"))
         const { agentTypeId: _agentTypeId, ...createInput } = input ?? {}

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -33,8 +33,9 @@ export interface AppLeftPaneAgent {
   sessionsStatus?: "loading" | "loaded" | "error"
   /**
    * The host's legacy `default` fallback rather than an authored seat. It is
-   * not fleet chrome material — but it keeps its card for as long as it owns
-   * chats, because that card is how those chats are reached (gh-1296).
+   * not fleet chrome material — but it keeps its card while it owns chats or
+   * its history source failed, because that card carries route/error chrome
+   * for the fallback history (gh-1296).
    */
   legacy?: boolean
 }
@@ -308,8 +309,16 @@ export function AppLeftPane({
     return owned
   }, [listedAgents, sessions])
   const agents = useMemo(
-    () => listedAgents.filter((agent) => !agent.legacy || legacyAgentsWithChats.has(agent.agentTypeId)),
+    () => listedAgents.filter((agent) => (
+      !agent.legacy
+      || legacyAgentsWithChats.has(agent.agentTypeId)
+      || agent.sessionsStatus === "error"
+    )),
     [legacyAgentsWithChats, listedAgents],
+  )
+  const factorySeatCount = useMemo(
+    () => agents.filter((agent) => !agent.legacy).length,
+    [agents],
   )
   // Fleet row idiom (accent dot, compact rows, owner labels): any addressed
   // fleet gets it, including a fleet of one, so chat cards look identical in
@@ -580,22 +589,28 @@ export function AppLeftPane({
               ? agentSessions.map((session) => renderSession(session, pinnedSet.has(workspaceSessionKeyFor(session)), activeProjectId ?? undefined, false, true))
               : (agent.sessionsStatus ?? "loading") === "loading"
                 ? renderChatsLoading()
-                : (
-                  <div className="flex min-h-[26px] items-center gap-1.5 pl-6 pr-1.5 text-[12px] text-muted-foreground/80">
-                    <span>No chats yet.</span>
-                    <button
-                      type="button"
-                      data-boring-mobile-dismiss="true"
-                      onClick={() => {
-                        onSelectAgent?.(agent.agentTypeId)
-                        onCreateSession(agent.agentTypeId)
-                      }}
-                      className="app-left-empty-start rounded-sm text-[12px] font-medium text-[color:var(--accent)] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-                    >
-                      Start one
-                    </button>
-                  </div>
-                )}
+                : agent.sessionsStatus === "error"
+                  ? (
+                    <div role="alert" className="flex min-h-[26px] items-center pl-6 pr-1.5 text-[12px] text-destructive">
+                      Chats unavailable.
+                    </div>
+                  )
+                  : (
+                    <div className="flex min-h-[26px] items-center gap-1.5 pl-6 pr-1.5 text-[12px] text-muted-foreground/80">
+                      <span>No chats yet.</span>
+                      <button
+                        type="button"
+                        data-boring-mobile-dismiss="true"
+                        onClick={() => {
+                          onSelectAgent?.(agent.agentTypeId)
+                          onCreateSession(agent.agentTypeId)
+                        }}
+                        className="app-left-empty-start rounded-sm text-[12px] font-medium text-[color:var(--accent)] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+                      >
+                        Start one
+                      </button>
+                    </div>
+                  )}
           </div>
         ) : null}
       </div>
@@ -655,7 +670,7 @@ export function AppLeftPane({
             {/* Lowercased against the row's uppercase: "5 SEATS" in the title's
                 tracking shouts louder than the title. */}
             <span data-boring-workspace-part="app-left-agents-count" className="shrink-0 normal-case font-normal tabular-nums tracking-normal text-muted-foreground">
-              {agents.length} {agents.length === 1 ? "seat" : "seats"}
+              {factorySeatCount} {factorySeatCount === 1 ? "seat" : "seats"}
             </span>
             <button
               type="button"

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -31,6 +31,12 @@ export interface AppLeftPaneAgent {
   label: string
   description?: string
   sessionsStatus?: "loading" | "loaded" | "error"
+  /**
+   * The host's legacy `default` fallback rather than an authored seat. It is
+   * not fleet chrome material — but it keeps its card for as long as it owns
+   * chats, because that card is how those chats are reached (gh-1296).
+   */
+  legacy?: boolean
 }
 
 export interface AppLeftPaneProjectSession {
@@ -242,7 +248,7 @@ export function AppLeftPane({
   bottomSlot,
   headerMode = "full",
   sessions,
-  agents = [],
+  agents: listedAgents = [],
   selectedAgentTypeId,
   addressedAgentTypeId: addressedAgentTypeIdProp,
   onSelectAgent,
@@ -287,6 +293,24 @@ export function AppLeftPane({
   const openSet = useMemo(() => new Set(normalizedOpenSessionIds), [normalizedOpenSessionIds])
   const pinnedSet = useMemo(() => new Set(normalizedPinnedSessionIds), [normalizedPinnedSessionIds])
   const workingSessionIds = useWorkingSessionIds(sessions)
+  // gh-1296: the host lists its legacy `default` fallback beside the authored
+  // seats so chats bound to it stay addressable. It is not a seat someone
+  // wrote, so it earns a card only while it actually owns chats — otherwise a
+  // factory fleet of three would read as four, the extra one unnamed. The scan
+  // is skipped entirely for the usual fleet, which has no legacy entry.
+  const legacyAgentsWithChats = useMemo(() => {
+    const owned = new Set<string>()
+    const legacyIds = new Set(listedAgents.filter((agent) => agent.legacy).map((agent) => agent.agentTypeId))
+    if (legacyIds.size === 0) return owned
+    for (const session of sessions) {
+      if (session.agentTypeId && legacyIds.has(session.agentTypeId)) owned.add(session.agentTypeId)
+    }
+    return owned
+  }, [listedAgents, sessions])
+  const agents = useMemo(
+    () => listedAgents.filter((agent) => !agent.legacy || legacyAgentsWithChats.has(agent.agentTypeId)),
+    [legacyAgentsWithChats, listedAgents],
+  )
   // Fleet row idiom (accent dot, compact rows, owner labels): any addressed
   // fleet gets it, including a fleet of one, so chat cards look identical in
   // both cardinalities. Hosts wanting the plain shell omit `agents` entirely.

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -325,10 +325,11 @@ export function AppLeftPane({
   // both cardinalities. Hosts wanting the plain shell omit `agents` entirely.
   const agentRowsEnabled = agents.length > 0
   // Fleet CHROME — per-Agent sections and the New chat Agent picker — only
-  // earns its keep once there is more than one Agent to choose between. With a
-  // single Agent (the default seat) the pane is a flat "Chats" list, owner
-  // spec; the fleet hub (many seats) keeps the full tree.
-  const fleetChromeEnabled = agents.length > 1
+  // earns its keep once there is more than one creation target in the complete
+  // catalog. With a single Agent the pane is a flat "Chats" list, owner spec;
+  // a hidden legacy fallback still counts as a choice because Option B keeps
+  // explicit `default` creation available even when it has no card.
+  const fleetChromeEnabled = listedAgents.length > 1
   // Ratified layout: each Agent's chats nest under its card in single-project
   // mode; multi-project keeps chats inside the project tree instead.
   const nestedAgentChats = fleetChromeEnabled && layoutMode !== "multi-project"

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -549,6 +549,11 @@ export function AppLeftPane({
         // The per-Agent lens only exists where a shared list remains to
         // filter (the multi-project tree); nesting replaces it elsewhere.
         onToggleFilter={nestedAgentChats ? undefined : () => toggleChatsAgentLens(agent.agentTypeId)}
+        // gh-1296 review fix: the legacy fallback card exists only so its old
+        // chats stay reachable — it is read-only chrome, never a creation
+        // surface, or clicking around history would manufacture more
+        // fallback-bound sessions.
+        readOnly={agent.legacy === true}
         onCreateSession={createForAgent(onCreateSession)}
         onCreateSplitSession={onCreateSplitSession ? createForAgent(onCreateSplitSession) : undefined}
         onCreatePopoverSession={onCreatePopoverSession ? createForAgent(onCreatePopoverSession) : undefined}
@@ -678,10 +683,17 @@ export function AppLeftPane({
   // Item 6: one global new-chat entry point for both layouts, targeting the
   // Agent the pane is currently addressing (the host resolves that to the
   // default Agent until one is explicitly picked).
+  // gh-1296 review fix: the legacy fallback is not a seat someone wrote — the
+  // picker never offers it as a creation target. If nothing authored exists,
+  // the fallback stays selectable (it is then the only home for new chats).
+  const creatableAgents = useMemo(() => {
+    const authored = agents.filter((agent) => !agent.legacy)
+    return authored.length > 0 ? authored : agents
+  }, [agents])
   const renderFleetNewChat = () => (
     <div className="px-0">
       <FleetNewChatAction
-        agents={agents}
+        agents={creatableAgents}
         selectedAgentTypeId={selectedAgentTypeId}
         onSelectAgent={onSelectAgent}
         onCreateSession={(agentTypeId) => {

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -558,11 +558,6 @@ export function AppLeftPane({
         // The per-Agent lens only exists where a shared list remains to
         // filter (the multi-project tree); nesting replaces it elsewhere.
         onToggleFilter={nestedAgentChats ? undefined : () => toggleChatsAgentLens(agent.agentTypeId)}
-        // gh-1296 review fix: the legacy fallback card exists only so its old
-        // chats stay reachable — it is read-only chrome, never a creation
-        // surface, or clicking around history would manufacture more
-        // fallback-bound sessions.
-        readOnly={agent.legacy === true}
         onCreateSession={createForAgent(onCreateSession)}
         onCreateSplitSession={onCreateSplitSession ? createForAgent(onCreateSplitSession) : undefined}
         onCreatePopoverSession={onCreatePopoverSession ? createForAgent(onCreatePopoverSession) : undefined}
@@ -697,18 +692,13 @@ export function AppLeftPane({
 
   // Item 6: one global new-chat entry point for both layouts, targeting the
   // Agent the pane is currently addressing (the host resolves that to the
-  // default Agent until one is explicitly picked).
-  // gh-1296 review fix: the legacy fallback is not a seat someone wrote — the
-  // picker never offers it as a creation target. If nothing authored exists,
-  // the fallback stays selectable (it is then the only home for new chats).
-  const creatableAgents = useMemo(() => {
-    const authored = agents.filter((agent) => !agent.legacy)
-    return authored.length > 0 ? authored : agents
-  }, [agents])
+  // default Agent until one is explicitly picked). Use the complete catalog:
+  // an empty legacy fallback is hidden only from authored-seat chrome, not from
+  // explicit creation choices.
   const renderFleetNewChat = () => (
     <div className="px-0">
       <FleetNewChatAction
-        agents={creatableAgents}
+        agents={listedAgents}
         selectedAgentTypeId={selectedAgentTypeId}
         onSelectAgent={onSelectAgent}
         onCreateSession={(agentTypeId) => {

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneAgentCards.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneAgentCards.tsx
@@ -41,6 +41,12 @@ export interface AppLeftPaneAgentCardProps {
   onToggle?: () => void
   /** Omitted in nested mode: the disclosure replaces the per-Agent lens. */
   onToggleFilter?: () => void
+  /**
+   * gh-1296: the legacy fallback card is reachability chrome, not a seat —
+   * read-only hides every creation affordance so browsing old chats cannot
+   * manufacture more fallback-bound sessions.
+   */
+  readOnly?: boolean
   onCreateSession: () => void
   onCreateSplitSession?: () => void
   onCreatePopoverSession?: () => void
@@ -65,6 +71,7 @@ export function AppLeftPaneAgentCard({
   expanded = false,
   onToggle,
   onToggleFilter,
+  readOnly = false,
   onCreateSession,
   onCreateSplitSession,
   onCreatePopoverSession,
@@ -186,7 +193,7 @@ export function AppLeftPaneAgentCard({
             <Settings className="size-3.5" strokeWidth={1.75} aria-hidden="true" />
           </button>
         ) : null}
-        {onCreateSplitSession || onCreatePopoverSession ? (
+        {onCreateSplitSession || onCreatePopoverSession ? !readOnly && (
           // One "+" creates the default chat; this caret is the single place
           // for the placement variants (owner: three placement icons were too
           // many — compact into one affordance, keep the options).
@@ -223,7 +230,10 @@ export function AppLeftPaneAgentCard({
           </DropdownMenu>
         ) : null}
       </span>
-      {/* The "+" is the card's primary affordance, so it never hides. */}
+      {/* The "+" is the card's primary affordance, so it never hides —
+          except on a read-only legacy fallback, whose only job is reaching
+          its existing chats. */}
+      {!readOnly && (
       <button
         type="button"
         aria-label={`New chat with ${label}`}
@@ -234,6 +244,7 @@ export function AppLeftPaneAgentCard({
       >
         <Plus className="size-4" strokeWidth={2} aria-hidden="true" />
       </button>
+      )}
     </div>
   )
 }

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneAgentCards.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneAgentCards.tsx
@@ -41,12 +41,6 @@ export interface AppLeftPaneAgentCardProps {
   onToggle?: () => void
   /** Omitted in nested mode: the disclosure replaces the per-Agent lens. */
   onToggleFilter?: () => void
-  /**
-   * gh-1296: the legacy fallback card is reachability chrome, not a seat —
-   * read-only hides every creation affordance so browsing old chats cannot
-   * manufacture more fallback-bound sessions.
-   */
-  readOnly?: boolean
   onCreateSession: () => void
   onCreateSplitSession?: () => void
   onCreatePopoverSession?: () => void
@@ -71,7 +65,6 @@ export function AppLeftPaneAgentCard({
   expanded = false,
   onToggle,
   onToggleFilter,
-  readOnly = false,
   onCreateSession,
   onCreateSplitSession,
   onCreatePopoverSession,
@@ -193,7 +186,7 @@ export function AppLeftPaneAgentCard({
             <Settings className="size-3.5" strokeWidth={1.75} aria-hidden="true" />
           </button>
         ) : null}
-        {onCreateSplitSession || onCreatePopoverSession ? !readOnly && (
+        {onCreateSplitSession || onCreatePopoverSession ? (
           // One "+" creates the default chat; this caret is the single place
           // for the placement variants (owner: three placement icons were too
           // many — compact into one affordance, keep the options).
@@ -230,10 +223,7 @@ export function AppLeftPaneAgentCard({
           </DropdownMenu>
         ) : null}
       </span>
-      {/* The "+" is the card's primary affordance, so it never hides —
-          except on a read-only legacy fallback, whose only job is reaching
-          its existing chats. */}
-      {!readOnly && (
+      {/* The "+" is the card's primary affordance, so it never hides. */}
       <button
         type="button"
         aria-label={`New chat with ${label}`}
@@ -244,7 +234,6 @@ export function AppLeftPaneAgentCard({
       >
         <Plus className="size-4" strokeWidth={2} aria-hidden="true" />
       </button>
-      )}
     </div>
   )
 }

--- a/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
@@ -485,11 +485,28 @@ describe("AppLeftPane", () => {
       pinnedSessionRefs: [],
     })
 
-    expect(document.querySelector('[data-boring-workspace-part="app-left-agents-count"]')).toHaveTextContent("3 seats")
+    expect(document.querySelector('[data-boring-workspace-part="app-left-agents-count"]')).toHaveTextContent("2 seats")
     expect(document.querySelector('[data-boring-agent-type-id="default"]')).not.toBeNull()
     expect(screen.getByRole("region", { name: "default sessions" })).toContainElement(
       screen.getByText("Chat from before the fleet"),
     )
+  })
+
+  it("keeps fallback route and error chrome visible when only its history source fails", () => {
+    renderFleetPane({
+      agents: [
+        { agentTypeId: "default", label: "default", legacy: true, sessionsStatus: "error" },
+        { agentTypeId: "alpha", label: "Boring Alpha", sessionsStatus: "loaded" },
+        { agentTypeId: "beta", label: "Boring Beta", sessionsStatus: "loaded" },
+      ],
+      addressedAgentTypeId: "default",
+      sessions: [{ id: "alpha-one", agentTypeId: "alpha", title: "Alpha session" }],
+      pinnedSessionRefs: [],
+    })
+
+    expect(document.querySelector('[data-boring-workspace-part="app-left-agents-count"]')).toHaveTextContent("2 seats")
+    expect(screen.getByRole("button", { name: "Collapse default; chats unavailable" })).toBeInTheDocument()
+    expect(screen.getByRole("alert")).toHaveTextContent("Chats unavailable.")
   })
 
   // gh-1296 review fix: the fallback card is reachability chrome, not a seat.

--- a/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
@@ -473,6 +473,35 @@ describe("AppLeftPane", () => {
     expect(within(screen.getByRole("menu")).getByText("default")).toBeInTheDocument()
   })
 
+  it("keeps fleet creation choices when an empty fallback leaves one authored seat", async () => {
+    const user = userEvent.setup()
+    const handlers = renderFleetPane({
+      agents: [
+        { agentTypeId: "default", label: "default", legacy: true, sessionsStatus: "loaded" },
+        { agentTypeId: "alpha", label: "Boring Alpha", sessionsStatus: "loaded" },
+      ],
+      selectedAgentTypeId: "default",
+      sessions: [{ id: "alpha-one", agentTypeId: "alpha", title: "Alpha session" }],
+      pinnedSessionRefs: [],
+    })
+
+    expect(document.querySelector('[data-boring-workspace-part="app-left-agents-count"]')).toHaveTextContent("1 seat")
+    expect(document.querySelector('[data-boring-agent-type-id="default"]')).toBeNull()
+    expect(document.querySelector('[data-boring-agent-type-id="alpha"]')).not.toBeNull()
+    expect(screen.queryByRole("button", { name: /^default;/ })).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /Boring Alpha;/ })).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Choose Agent for new chat" }))
+    const menu = screen.getByRole("menu")
+    expect(within(menu).getByRole("menuitem", { name: "default" })).toBeInTheDocument()
+    expect(within(menu).getByRole("menuitem", { name: "Alpha" })).toBeInTheDocument()
+    await user.click(within(menu).getByRole("menuitem", { name: "default" }))
+    expect(handlers.onSelectAgent).toHaveBeenCalledWith("default")
+
+    await user.click(screen.getByRole("button", { name: "Start new chat with default" }))
+    expect(handlers.onCreateSession).toHaveBeenCalledWith("default")
+  })
+
   it("keeps a legacy fallback that owns chats listed, so those chats stay reachable", () => {
     renderFleetPane({
       agents: [

--- a/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
@@ -451,6 +451,47 @@ describe("AppLeftPane", () => {
     expect(screen.queryByRole("heading", { name: "Chats" })).not.toBeInTheDocument()
   })
 
+  // gh-1296: the host lists its legacy `default` fallback next to the authored
+  // seats so chats bound to it stay addressable. It is not an authored seat,
+  // so an empty one is not fleet chrome — but the moment it owns a chat its
+  // card comes back, because in the nested tree that card IS the route to it.
+  it("hides an empty legacy fallback from the seat list", () => {
+    renderFleetPane({
+      agents: [
+        { agentTypeId: "default", label: "default", legacy: true, sessionsStatus: "loaded" },
+        { agentTypeId: "alpha", label: "Boring Alpha", sessionsStatus: "loaded" },
+        { agentTypeId: "beta", label: "Boring Beta", sessionsStatus: "loaded" },
+      ],
+    })
+
+    expect(document.querySelector('[data-boring-workspace-part="app-left-agents-count"]')).toHaveTextContent("2 seats")
+    expect(document.querySelector('[data-boring-agent-type-id="default"]')).toBeNull()
+    expect(screen.queryByRole("button", { name: /^default;/ })).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /Boring Alpha;/ })).toBeInTheDocument()
+  })
+
+  it("keeps a legacy fallback that owns chats listed, so those chats stay reachable", () => {
+    renderFleetPane({
+      agents: [
+        { agentTypeId: "default", label: "default", legacy: true, sessionsStatus: "loaded" },
+        { agentTypeId: "alpha", label: "Boring Alpha", sessionsStatus: "loaded" },
+        { agentTypeId: "beta", label: "Boring Beta", sessionsStatus: "loaded" },
+      ],
+      addressedAgentTypeId: "default",
+      sessions: [
+        { id: "legacy-one", agentTypeId: "default", title: "Chat from before the fleet" },
+        { id: "alpha-one", agentTypeId: "alpha", title: "Alpha session" },
+      ],
+      pinnedSessionRefs: [],
+    })
+
+    expect(document.querySelector('[data-boring-workspace-part="app-left-agents-count"]')).toHaveTextContent("3 seats")
+    expect(document.querySelector('[data-boring-agent-type-id="default"]')).not.toBeNull()
+    expect(screen.getByRole("region", { name: "default sessions" })).toContainElement(
+      screen.getByText("Chat from before the fleet"),
+    )
+  })
+
   it("unifies the multi-project fleet: labeled project rows, a lens that filters them, and a global new chat", async () => {
     const user = userEvent.setup()
     const onCreateSession = vi.fn()

--- a/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
@@ -492,6 +492,41 @@ describe("AppLeftPane", () => {
     )
   })
 
+  // gh-1296 review fix: the fallback card is reachability chrome, not a seat.
+  // It must expose no creation affordance, and the New chat picker must never
+  // offer the fallback — browsing old chats must not manufacture more
+  // fallback-bound sessions.
+  it("keeps the legacy fallback card read-only and out of the new-chat picker", async () => {
+    const user = userEvent.setup()
+    renderFleetPane({
+      agents: [
+        { agentTypeId: "default", label: "default", legacy: true, sessionsStatus: "loaded" },
+        { agentTypeId: "alpha", label: "Boring Alpha", sessionsStatus: "loaded" },
+        { agentTypeId: "beta", label: "Boring Beta", sessionsStatus: "loaded" },
+      ],
+      addressedAgentTypeId: "default",
+      sessions: [
+        { id: "legacy-one", agentTypeId: "default", title: "Chat from before the fleet" },
+        { id: "alpha-one", agentTypeId: "alpha", title: "Alpha session" },
+      ],
+      pinnedSessionRefs: [],
+    })
+
+    // The card exists (its chat is listed beneath it), but it has no "+" and
+    // no placement-variants menu.
+    expect(screen.getByText("Chat from before the fleet")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "New chat with default" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "New chat options for default" })).not.toBeInTheDocument()
+    // The picker's primary target derives from authored seats — never the
+    // fallback — regardless of which owner the pane is addressing.
+    expect(screen.getByRole("button", { name: "Start new chat with Boring Alpha" })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Start new chat with default" })).not.toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: "Choose Agent for new chat" }))
+    const menu = screen.getByRole("menu")
+    expect(within(menu).getByText("Alpha")).toBeInTheDocument()
+    expect(within(menu).queryByText("default")).not.toBeInTheDocument()
+  })
+
   it("unifies the multi-project fleet: labeled project rows, a lens that filters them, and a global new chat", async () => {
     const user = userEvent.setup()
     const onCreateSession = vi.fn()

--- a/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
@@ -455,7 +455,8 @@ describe("AppLeftPane", () => {
   // seats so chats bound to it stay addressable. It is not an authored seat,
   // so an empty one is not fleet chrome — but the moment it owns a chat its
   // card comes back, because in the nested tree that card IS the route to it.
-  it("hides an empty legacy fallback from the seat list", () => {
+  it("hides an empty legacy fallback only from the authored-seat list", async () => {
+    const user = userEvent.setup()
     renderFleetPane({
       agents: [
         { agentTypeId: "default", label: "default", legacy: true, sessionsStatus: "loaded" },
@@ -468,6 +469,8 @@ describe("AppLeftPane", () => {
     expect(document.querySelector('[data-boring-agent-type-id="default"]')).toBeNull()
     expect(screen.queryByRole("button", { name: /^default;/ })).not.toBeInTheDocument()
     expect(screen.getByRole("button", { name: /Boring Alpha;/ })).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: "Choose Agent for new chat" }))
+    expect(within(screen.getByRole("menu")).getByText("default")).toBeInTheDocument()
   })
 
   it("keeps a legacy fallback that owns chats listed, so those chats stay reachable", () => {
@@ -509,13 +512,12 @@ describe("AppLeftPane", () => {
     expect(screen.getByRole("alert")).toHaveTextContent("Chats unavailable.")
   })
 
-  // gh-1296 review fix: the fallback card is reachability chrome, not a seat.
-  // It must expose no creation affordance, and the New chat picker must never
-  // offer the fallback — browsing old chats must not manufacture more
-  // fallback-bound sessions.
-  it("keeps the legacy fallback card read-only and out of the new-chat picker", async () => {
+  // Owner-ratified option B: the fallback is excluded from authored-seat
+  // counting, not from creation. Its visible history card and the complete
+  // catalog picker preserve an explicit `default` owner.
+  it("keeps default creation available without counting the fallback as a seat", async () => {
     const user = userEvent.setup()
-    renderFleetPane({
+    const handlers = renderFleetPane({
       agents: [
         { agentTypeId: "default", label: "default", legacy: true, sessionsStatus: "loaded" },
         { agentTypeId: "alpha", label: "Boring Alpha", sessionsStatus: "loaded" },
@@ -529,19 +531,18 @@ describe("AppLeftPane", () => {
       pinnedSessionRefs: [],
     })
 
-    // The card exists (its chat is listed beneath it), but it has no "+" and
-    // no placement-variants menu.
     expect(screen.getByText("Chat from before the fleet")).toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: "New chat with default" })).not.toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: "New chat options for default" })).not.toBeInTheDocument()
-    // The picker's primary target derives from authored seats — never the
-    // fallback — regardless of which owner the pane is addressing.
-    expect(screen.getByRole("button", { name: "Start new chat with Boring Alpha" })).toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: "Start new chat with default" })).not.toBeInTheDocument()
+    expect(document.querySelector('[data-boring-workspace-part="app-left-agents-count"]')).toHaveTextContent("2 seats")
+    await user.click(screen.getByRole("button", { name: "New chat with default" }))
+    expect(handlers.onCreateSession).toHaveBeenCalledWith("default")
+    await user.click(screen.getByRole("button", { name: "New chat options for default" }))
+    await user.click(screen.getByText("New chat in split pane"))
+    expect(handlers.onCreateSplitSession).toHaveBeenCalledWith("default")
+
     await user.click(screen.getByRole("button", { name: "Choose Agent for new chat" }))
     const menu = screen.getByRole("menu")
+    expect(within(menu).getByText("default")).toBeInTheDocument()
     expect(within(menu).getByText("Alpha")).toBeInTheDocument()
-    expect(within(menu).queryByText("default")).not.toBeInTheDocument()
   })
 
   it("unifies the multi-project fleet: labeled project rows, a lens that filters them, and a global new chat", async () => {


### PR DESCRIPTION
## Problem

A factory fleet of configured agents still showed a fourth entry: the legacy `default` fallback, labelled `Agent`, sitting above the seats someone actually wrote. Nothing distinguished an authored seat from the compatibility identity, while removing `default` would strand sessions already bound to it.

## Change

**Host (`packages/agent`)**
- `listAgents` marks the legacy fallback `legacy: true` and labels it `default` whenever at least one configured agent shares the runtime.
- The legacy single-agent boot remains unchanged: the lone default keeps the `Agent` label and no `legacy` marker.
- `host.describe()` remains within its declared schema; the presentation marker is exposed only by the Gateway catalog.

**Clients (`agent front` + `workspace`)**
- The marker is presentation-only, not a creation policy.
- Empty legacy fallback entries are hidden only from authored-seat chrome and are never counted as authored seats.
- The complete catalog remains available to explicit New chat selection. If the fallback owns chats, or its session source fails, its route/card stays visible.
- Fleet session sourcing keeps a source for every listed agent, including `default`, so old sessions remain listed, scoped, and addressable.
- Explicit owners are preserved exactly; split creation is not silently retargeted to another agent.

## Owner-ratified Option B disposition

The owner ratified **Option B** for this loop. Decisions 28 and 29 are preserved: legacy `agentTypeId: default` remains creation-capable in mixed fleets and fallback-only mode across the Gateway, UI, CLI, MCP, and dispatcher. Direct default creation and owner-preserving split behavior are compatible behavior, not bugs. The prior mixed-fleet Gateway rejection and history-only claims have been removed.

## Reachability guarantee

Sessions bound to `default` stay listed fleet-wide, listed under their own agentTypeId, and readable. Partial source failures keep the fallback route and error chrome visible while healthy authored sources continue loading.

## Proof

- Agent focused regressions: 5 files, 60 tests passed (Gateway compatibility, fallback-only creation, selection, dispatcher, MCP, `host.describe()`).
- Workspace focused regressions: 2 files, 132 tests passed (history reachability, partial errors, authored seat count, picker/card creation, explicit owner-preserving split).
- CLI mixed-fleet HTTP creation regression: 1 test passed.
- Typecheck: `@hachej/boring-agent`, `@hachej/boring-workspace`, and `@hachej/boring-ui-cli` passed.
- Invariants: agent, boring-bash, boring-sandbox, workspace plugin, alignment, and skill digest checks passed.
- `git diff --check`: passed.

Closes #1296
