### PR TITLE
test(bi-dashboard): stop the catalog pagination test from racing its observer

### DIFF
--- a/plugins/bi-dashboard/src/front/DashboardCatalogPane.test.tsx
+++ b/plugins/bi-dashboard/src/front/DashboardCatalogPane.test.tsx
@@ -18,6 +18,12 @@ class IntersectionObserverStub {
   readonly thresholds = [0]
 
   static async trigger() {
+    // The pane rebuilds its observer in a passive effect once a page settles,
+    // so the observer for the *current* page can still be a tick away when
+    // findByText resolves. Waiting for a live observer makes the trigger
+    // deterministic instead of racing that effect — without it this test fails
+    // roughly one run in eight.
+    await waitFor(() => expect(this.instances.some((instance) => instance.active)).toBe(true))
     const observer = [...this.instances].reverse().find((instance) => instance.active)
     await observer?.callback([{ isIntersecting: true } as IntersectionObserverEntry], observer as unknown as IntersectionObserver)
   }


### PR DESCRIPTION
## What

`DashboardCatalogPane.test.tsx` → *"keeps asynchronous pagination alive and advances by consumed rows"* fails roughly **1 run in 8**, on main and on whatever branch is unlucky enough to be running.

Measured on `origin/main`: **7 passed, 1 failed over 8 runs**.

## Why

The pane rebuilds its `IntersectionObserver` in a passive effect once a page settles. `await screen.findByText("One")` can resolve a tick *before* that effect runs, so `IntersectionObserverStub.trigger()` finds no active observer, fires nothing, and the second search never happens — reported as `expected 2 times, got 1`.

## Fix

`trigger()` waits for a live observer before firing. This synchronizes the trigger with the effect; it does not relax a single assertion.

**10/10 passes after the change**, from 7/8 before.

## Why it matters

It landed on PR #1362 and read as a regression from that PR's mobile work. It isn't — it reproduces identically on main. Shared flakes like this cost other people's CI cycles and send them debugging the wrong diff. Found while sweeping every open PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SqFadabn7hUwqfcs7AUbW