### PR TITLE
docs: agent development map + vertical-agent deploy golden path

### DIFF
--- a/docs/AGENT-DEVELOPMENT-MAP.md
+++ b/docs/AGENT-DEVELOPMENT-MAP.md
@@ -1,0 +1,126 @@
+# Agent Development Map
+
+Canonical "where do I X" map for agent development in this repo. Every path
+below is verified against `main`. Depth lives beside the code: package docs are
+indexed in [`docs/README.md`](./README.md); contracts live next to their types.
+
+## Where things live
+
+| Concern | Path | Entry points |
+| --- | --- | --- |
+| Agent runtime | `packages/agent/src/server/` | `createStandaloneAgentApp.ts` (standalone), `agent-host/` (session host + HTTP projection), `harness/pi-coding-agent/createHarness.ts` (Pi loop), `runtime/mode.ts` (`direct`/`local`/`blaxel`/`vercel-sandbox`), `models/modelConfig.ts` (provider registration) |
+| Agent UI (chat) | `packages/agent/src/front/` | `ChatPanel` — see `packages/agent/docs/README.md` |
+| Workspace UI / Workbench | `packages/workspace/src/front/` | Dockview workbench: `chrome/artifact-surface/SurfaceShell.tsx`; bridge dispatch: `front/bridge/uiCommandDispatcher.ts` |
+| UI primitives | `packages/ui/` | ~50 shadcn-style components; `packages/ui/README.md` |
+| Plugins (package shape) | `plugins/<name>/` | `src/front/index.ts` = `definePlugin(...)`, `src/server/index.ts` = `defineServerPlugin(...)` — layout: `packages/workspace/docs/PLUGIN_STRUCTURE.md`, contract: `packages/workspace/docs/PLUGIN_SYSTEM.md` |
+| Plugins (runtime/hot-reload) | `.pi/extensions/<name>/` | Scaffolded via `boring-ui-plugin scaffold <name>` (`packages/plugin-cli/`) |
+| Agent/persona packages | `.agents/personas/<seat>/` (`instructions.md`, `knowledge/`, `package.json`) | Fleet roster: `.agents/factory/fleet.yaml`; loader: `packages/agent/src/server/agentDefinition/loadConfiguredAgentFleet.ts`; stage contract: `.agents/factory/README.md` |
+| Credentials | BYOK vault library: `packages/agent/src/server/credentials/vault/` (+ `hostResolver.ts`, `withResolvedCredential.ts`) — **library only, not yet wired into a running app** (issue #820, plan-only). What actually carries secrets today: env config via `packages/core/src/server/config/loadConfig.ts` (`WORKSPACE_SETTINGS_ENCRYPTION_KEY`), per-workspace settings encryption in `packages/core/src/server/db/stores/PostgresWorkspaceStore.ts` |
+| Persistence | Postgres schema + stores: `packages/core/src/server/db/{schema.ts,migrate.ts,stores/}`; migrations runner used by apps: `apps/full-app/src/server/migrate.ts`. Chat transcripts: Pi JSONL under `BORING_AGENT_SESSION_ROOT` (`packages/agent/src/server/harness/pi-coding-agent/sessions.ts`). Ask-user answers: `<workspaceRoot>/.boring/ask-user.json` (`plugins/ask-user/src/server/askUserStore.ts`) |
+| App composition root | `apps/full-app/src/server/main.ts` → `createCoreWorkspaceAgentServer()` (`packages/core/src/app/server/createCoreWorkspaceAgentServer.ts`) |
+
+## How to add an agent (persona + fleet)
+
+1. Create a persona package under `.agents/personas/<seat>/` with
+   `instructions.md`, optional `knowledge/`, and a `package.json` — copy the
+   shape of an existing seat such as `.agents/personas/orchestrator/`.
+2. Add a `seats:` entry to `.agents/factory/fleet.yaml`: `seat`,
+   `agentTypeId`, per-seat `skills` with pinned sha256 digests. Skill digest
+   pins are refreshed via `pnpm check:skill-digests` /
+   `scripts/refresh-skill-digests.mjs --write` — a stale pin silently drops
+   the seat.
+3. The fleet loads when `BORING_AGENT_FLEET=1` via
+   `loadConfiguredAgentFleet()` (`packages/agent/src/server/agentDefinition/loadConfiguredAgentFleet.ts`);
+   model tiers come from `models.tiers` in `fleet.yaml` resolved through
+   `.agents/factory/policy.yaml`.
+4. Roster changes are owner-ratified (see the header comments in
+   `.agents/factory/fleet.yaml`).
+
+## How to add a tool
+
+1. Preferred path: a server plugin's `agentTools` array —
+   `defineServerPlugin({ agentTools: [{ name, description, parameters,
+   execute }] })` (`packages/workspace/src/server/plugins/defineServerPlugin.ts`);
+   tools are projected into the session at
+   `packages/workspace/src/app/server/createWorkspaceAgentServer.ts`
+   (`extraTools`). Reference implementations:
+   `plugins/ask-user/src/server/askUserServerPlugin.ts`,
+   `plugins/boring-mcp/src/server/serverPlugin.ts`.
+2. Compose the plugin where it is needed: app shells register server plugins
+   statically (`apps/full-app/src/server/plugins.ts`, consumed by
+   `apps/full-app/src/server/main.ts`); playground apps pass them to
+   `createWorkspaceAgentServer`.
+3. Server plugin changes require restarting the workspace process (no hot
+   reload for boot-time plugins — `packages/workspace/docs/PLUGIN_STRUCTURE.md`).
+4. Built-in tool catalog (non-plugin): `packages/agent/src/server/tools/` and
+   `packages/agent/src/server/catalog/`.
+
+## How to add a Workbench surface
+
+1. Front plugin registers a panel + surface resolver:
+   `definePlugin({ panels, surfaceResolvers, ... })`
+   (`packages/workspace/src/shared/plugins/frontFactory.ts`); resolvers are
+   hot-loaded through `packages/workspace/src/front/agentPlugins/registerAgentPlugin.tsx`.
+2. Surface types live in `packages/workspace/src/shared/types/surface.ts`
+   (`SurfaceOpenRequest`, resolver descriptors with `metaSchema`/`examples`
+   advertised to agents).
+3. Agents open surfaces with the `exec_ui` tool (`openSurface` kind) —
+   `packages/workspace/src/server/ui-control/tools/uiTools.ts`; dispatch flows
+   over the UiBridge SSE/poll transport (`packages/workspace/src/server/ui-control/http/uiRoutes.ts`)
+   into the dockview panel activation in
+   `packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx`.
+4. Validate the resolver component against the PanelRegistry — unknown
+   components fail loudly in `SurfaceShell.tsx`.
+
+## How to add an integration
+
+Two shapes exist:
+
+- **Consume external MCP/tool sources** → extend or compose the `boring-mcp`
+  plugin (`plugins/boring-mcp/src/server/`): per-app connector configs live in
+  `apps/full-app/src/server/boringMcp.ts`; server-only secrets resolve through
+  the managed connector secret resolver (`COMPOSIO_API_KEY`, never mirrored as
+  `VITE_*`). Governed read-only calls + source registry:
+  `plugins/boring-mcp/src/server/appServerBinding.ts`.
+- **Expose an agent to external MCP clients** → the bearer-token managed-agent
+  endpoint `/mcp/managed-agent` (`apps/full-app/src/server/managedAgentMcp.ts`),
+  dark by default, enabled via `BORING_MANAGED_AGENT_MCP_ENABLED=1` plus token/
+  workspace/user vars (`apps/full-app/README.md` § Managed Agent MCP Endpoint).
+- New first-party plugin packages: `boring-ui-plugin create <name> --path plugins`
+  (template: `packages/plugin-cli/templates/plugin/`), then compose per "How to
+  add a tool". Per-agent connector grants (`packages/agent/src/server/agent-host/mcpGrants.ts`)
+  exist but are not threaded through the core composition root yet — treat as
+  dormant.
+
+## How to test
+
+```bash
+pnpm test                 # build packages, then all workspace suites (root package.json)
+pnpm test:changed         # affected workspaces only (scripts/test-changed-workspaces.mjs)
+pnpm --filter full-app typecheck
+pnpm --filter full-app e2e            # Playwright suite: apps/full-app/e2e/
+pnpm --filter workspace-playground e2e # playground e2e incl. bridge specs
+pnpm --filter full-app smoke:mcp-managed-agent
+pnpm --filter full-app smoke:remote-worker
+```
+
+CI wiring: `.github/workflows/ci.yml` (affected unit tests via `test:changed`,
+package-scoped jobs, e2e gated by path filter). Package tests sit beside code
+under `__tests__/`.
+
+## How to deploy
+
+The repo ships images but does not publish/deploy them — production apps own
+image, secrets, migrations, and post-deploy proof (`apps/full-app/README.md`
+§ Container reference). Golden path:
+
+1. Build: `apps/full-app/Dockerfile` — default target `runtime` (web);
+   worker image via `--target worker-runtime`. Entrypoints repair mounted
+   volume ownership then drop privileges (`apps/full-app/docker/web-entrypoint.sh`).
+2. Configure from `apps/full-app/.env.example` (contract table:
+   `apps/full-app/README.md` § Env vars).
+3. Migrate: `pnpm --filter full-app migrate` (`apps/full-app/src/server/migrate.ts`).
+4. Production gate: remote agent mode required unless overridden —
+   `apps/full-app/src/server/productionSafety.ts`.
+5. Verify with the smoke scripts above; details and honest gaps:
+   [`DEPLOY-VERTICAL-AGENT.md`](./DEPLOY-VERTICAL-AGENT.md).

--- a/docs/DEPLOY-VERTICAL-AGENT.md
+++ b/docs/DEPLOY-VERTICAL-AGENT.md
@@ -1,0 +1,143 @@
+# Deploy a Vertical Agent — Golden Path (as it exists today)
+
+How to stand up a privately-hosted, single-tenant vertical agent from the
+`apps/full-app` reference shape **using only what is implemented today**.
+This doc records reality, not intent: known gaps are listed at the bottom,
+unresolved. Deployment-shaped reference: `apps/full-app/README.md`; the repo
+does not publish or deploy images (`apps/full-app/README.md` § Container
+reference) — the deploying app owns image, secrets, migrations, and proof.
+
+## 1. Build
+
+```bash
+# web image (default target)
+docker build -t my-vertical-agent -f apps/full-app/Dockerfile .
+
+# worker image (provider-neutral remote worker; excludes frontend)
+docker build --target worker-runtime -t my-vertical-agent-worker -f apps/full-app/Dockerfile .
+```
+
+- Multi-stage `apps/full-app/Dockerfile`: deps → build (ordered package builds
+  + dist-drift assertion) → `runtime` (web, default) / `worker-runtime`.
+  Non-root uid 10001, bubblewrap installed, `/data/workspaces` + `/data/pi-sessions`
+  volume roots, healthcheck `/health`, EXPOSE 3000.
+- Entrypoints: `apps/full-app/docker/web-entrypoint.sh` repairs mounted-volume
+  ownership then drops privileges; `apps/full-app/docker/worker-entrypoint.sh`
+  applies bwrap resource limits via env.
+
+## 2. Secrets & env contract
+
+Source of truth: `apps/full-app/.env.example` + env table in
+`apps/full-app/README.md`. Validation lives in
+`packages/core/src/server/config/loadConfig.ts` (fails closed on missing
+secrets outside dev).
+
+Required:
+
+| Secret | Purpose |
+| --- | --- |
+| `DATABASE_URL` | Postgres connection string |
+| `BETTER_AUTH_SECRET` | Auth secret |
+| `BETTER_AUTH_URL` | Base URL — also drives CORS defaults, secure cookies, CSP-upgrade-insecure when https (`loadConfig.ts`) |
+| `WORKSPACE_SETTINGS_ENCRYPTION_KEY` | 32-byte hex; encrypts per-workspace settings at rest (`PostgresWorkspaceStore.ts`) |
+| `MAIL_FROM`, `MAIL_TRANSPORT_URL` (`console://` for dev; Resend via `RESEND_API_KEY`) | Verification/reset mail |
+
+Model + runtime (typical vertical):
+
+| Var | Notes |
+| --- | --- |
+| `INFOMANIAK_API_TOKEN` + `BORING_AGENT_INFOMANIAK_PRODUCT_ID/_MODEL` or `BORING_AGENT_DEFAULT_MODEL_PROVIDER/_ID` | Default chat model (`packages/agent/src/server/models/modelConfig.ts`) |
+| `BORING_AGENT_MODE=vercel-sandbox` | Production requires a remote mode unless `BORING_ALLOW_UNSAFE_AGENT_MODE=1` (`apps/full-app/src/server/productionSafety.ts`). Blaxel additionally needs `BL_WORKSPACE`/`BL_API_KEY`/`BORING_BLAXEL_REGION` and still requires the unsafe-mode override pending its security gate (`apps/full-app/README.md`) |
+| `VERCEL_TEAM_ID`, `VERCEL_PROJECT_ID` (+ `VERCEL_TOKEN` where OIDC unavailable) | Vercel sandbox credentials |
+| `BORING_AGENT_WORKSPACE_ROOT=/data/workspaces`, `BORING_AGENT_SESSION_ROOT=/data/pi-sessions` | Durable host anchors (sibling roots; see `AGENTS.md` rule 9) |
+| `CORS_ORIGINS` | Explicit origin list |
+| Optional integrations | `BORING_MCP_ENABLED` + `COMPOSIO_API_KEY` (server-only), `BORING_MANAGED_AGENT_MCP_*` for external agent access |
+
+## 3. Migrations
+
+```bash
+pnpm --filter full-app migrate   # runs apps/full-app/src/server/migrate.ts
+```
+
+Applies core migrations plus additional plugin migrations (currently boring-
+automation) via `runCoreMigrationsFromEnv` against `DATABASE_URL`.
+
+## 4. Hostname configuration (exact-hostname rules)
+
+No DNS automation exists in-repo; hostname is pure config, TLS terminates at
+the platform.
+
+- `BETTER_AUTH_URL` sets the canonical base URL; secure-cookie and
+  CSP-upgrade-insecure flip on automatically when it is https; `CORS_ORIGINS`
+  must include the served origins (`loadConfig.ts` security projection).
+- Signup default agent: `BORING_SIGNUP_AGENT_DEFAULTS_JSON` maps **exact**
+  lowercase hostnames (no wildcards) to an initial `defaultAgentTypeId` for a
+  newly created default workspace only — boot-validated
+  (`packages/core/src/server/schema.ts` config schema), applied through the
+  signup post-hook (`packages/core/src/server/signupAgentDefaults.ts`,
+  `postSignupHook.ts`; Decision 28). Exact match is load-bearing: hostname
+  never grants authority beyond this initialization.
+- Presentation-only landing per hostname may be declared statically (Decision
+  30, `docs/DECISIONS.md` §30): hostname selects pixels, never routing,
+  membership, or persisted defaults.
+
+## 5. Verify (smoke scripts)
+
+```bash
+pnpm --filter full-app smoke:mcp-managed-agent   # route/protocol/binding contract, no live model call
+pnpm --filter full-app smoke:remote-worker       # remote-worker contract/isolation
+pnpm --filter full-app e2e                       # Playwright incl. e2e/smoke spec
+```
+
+Manual checks after first deploy: sign-up flow lands on the expected default
+agent (per §4 mapping); chat transcript persists across restart under
+`/data/pi-sessions/<workspaceId>`; `/health` passes container healthcheck;
+sandbox files appear in Vercel `/workspace`, not `/data/workspaces/<id>`
+(`apps/full-app/README.md` § Container reference).
+
+## 6. Rollback
+
+**Rollback = redeploy the previous image tag.** Keep every deployed image
+tagged; there is no in-repo release automation to lean on
+(`.github/workflows/release.yml` does not publish these images).
+
+Data safety before rollback:
+
+- Fly.io volume snapshots are enforced daily by
+  `.github/workflows/fly-worker-volume-backup.yml` +
+  `apps/full-app/scripts/fly-worker-volume-backup.mjs` (requires `FLY_API_TOKEN`;
+  snapshots app `boring-sandbox-worker`, volume `worker_workspace_data`,
+  retention configurable, manual dispatch supported). Take an immediate
+  snapshot via workflow_dispatch before any risky redeploy.
+- Postgres: use your platform's PITR/snapshot tooling; nothing in-repo backs up
+  the database.
+- Durable state locations to snapshot: `/data/pi-sessions` (transcripts),
+  `/data/workspaces` (host anchor, normally near-empty in sandbox mode),
+  `.boring/ask-user.json` inside each workspace root, and Postgres itself.
+
+## 7. Honest gaps (as of this writing)
+
+1. **No provisioner.** Every step above is manual: platform console for app/
+   volume creation, hand-delivered secrets, migrations run as a one-off
+   command, smoke as script-not-pipeline. `.agents/skills/boring-app-setup/SKILL.md`
+   codifies the playbook but no idempotent provisioner exists.
+2. **Installing an agent package requires restart.** Boot-time server plugins
+   and fleet changes are static composition; adding/changing an agent package
+   means a rebuild + process restart — no hot reload for server contributions
+   (`packages/workspace/docs/PLUGIN_STRUCTURE.md`; only `.pi/extensions`
+   front/Pi resources hot-reload).
+3. **BYOK model keys do not flow.** The vault library
+   (`packages/agent/src/server/credentials/vault/`) is tested but unwired; a
+   vertical shares the host's env-level provider key today (issue #820,
+   plan-only).
+4. **Per-agent MCP grants dormant.** `packages/agent/src/server/agent-host/mcpGrants.ts`
+   exists but the core composition root does not thread grant options
+   (`packages/core/src/app/server/createCoreWorkspaceAgentServer.ts`); connector
+   authorization rests on boring-mcp actor scoping alone.
+5. **Blaxel production requires `BORING_ALLOW_UNSAFE_AGENT_MODE=1`** pending
+   its security gate — restricts worker placement choices today
+   (`apps/full-app/src/server/productionSafety.ts`).
+6. **MCP managed-agent receipt/status state is process-local**, lost on
+   restart (`apps/full-app/README.md` § Managed Agent MCP Endpoint).
+7. **Credential rotation UX absent**: vault rewrap/version rotation exist in
+   library form with no routes/UI.


### PR DESCRIPTION
## Summary

Adds two ground-truth documents from the weekend recon: an agent development map and a vertical-agent deploy golden path. Every claim cites verified paths; honest gaps are listed. Docs-only.

## What's included

- Agent development map
- Vertical-agent deploy golden path
- Verified-path citations throughout, with honest gaps listed

## Review ladder

- Reviewer: gpt-5.6-sol xhigh via codex
- No formal review rounds recorded for this branch (docs-only)

## Test results

- N/A — docs-only change

## Residuals / merge notes

- None; docs-only, no follow-up required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGA4RhWZGNR5QA9Y7dFzCF
