### PR TITLE
Support hardened Docker Bubblewrap runtimes

### DIFF
--- a/packages/agent/host/sandbox.ts
+++ b/packages/agent/host/sandbox.ts
@@ -5,6 +5,8 @@ import {
 import {
   buildBwrapArgs,
   createBwrapSandboxProvider,
+  type BwrapArgsOptions,
+  type BwrapSandboxProviderOptions,
 } from '@hachej/boring-sandbox/providers/bwrap'
 import {
   createDirectSandboxProvider,
@@ -82,6 +84,39 @@ export const sandboxRuntimeHostOperations = agentSandboxRuntimeHostOperations
 
 export interface SandboxRuntimeModeOptions {
   readonly sandboxHandleStore?: SandboxHandleStore
+  readonly bwrap?: BwrapSandboxProviderOptions
+}
+
+type ResolvedBwrapPolicy = Required<Pick<
+  BwrapArgsOptions,
+  'namespaceProfile' | 'network' | 'dropAllCapabilities'
+>>
+
+function resolveBwrapPolicy(options: BwrapSandboxProviderOptions | undefined): ResolvedBwrapPolicy {
+  const sandbox = options?.sandbox
+  const namespaceProfile = sandbox?.namespaceProfile ?? 'full'
+  return {
+    namespaceProfile,
+    network: sandbox?.network ?? 'shared',
+    // Docker mode runs outside a nested user namespace. Never allow the outer
+    // container's SYS_ADMIN capability to reach any local execution path.
+    dropAllCapabilities: namespaceProfile === 'docker' || sandbox?.dropAllCapabilities === true,
+  }
+}
+
+function withBwrapPolicy(
+  runtimeHost: AgentRuntimeHostOperations,
+  policy: ResolvedBwrapPolicy,
+): AgentRuntimeHostOperations {
+  return {
+    ...runtimeHost,
+    buildBwrapArgs(workspaceRoot, executionOptions) {
+      return runtimeHost.buildBwrapArgs(workspaceRoot, {
+        ...executionOptions,
+        ...policy,
+      })
+    },
+  }
 }
 
 /** Built-in runtime layout root without exposing provider package constants to consumers. */
@@ -104,11 +139,20 @@ export function createSandboxRuntimeModeAdapter(
         provider: createDirectSandboxProvider(),
         runtimeHost: agentSandboxRuntimeHostOperations,
       })
-    case 'local':
+    case 'local': {
+      const policy = resolveBwrapPolicy(options.bwrap)
+      const runtimeHost = withBwrapPolicy(agentSandboxRuntimeHostOperations, policy)
       return createLocalModeAdapter({
-        provider: createBwrapSandboxProvider(),
-        runtimeHost: agentSandboxRuntimeHostOperations,
+        provider: createBwrapSandboxProvider({
+          ...options.bwrap,
+          sandbox: {
+            ...options.bwrap?.sandbox,
+            ...policy,
+          },
+        }),
+        runtimeHost,
       })
+    }
     case 'vercel-sandbox':
       return createVercelSandboxModeAdapter({
         provider: createVercelSandboxProvider({

--- a/packages/agent/src/server/runtime/modes/__tests__/localBwrapPolicy.argv.test.ts
+++ b/packages/agent/src/server/runtime/modes/__tests__/localBwrapPolicy.argv.test.ts
@@ -1,0 +1,117 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, expect, test, vi } from 'vitest'
+
+const providerOptions = vi.hoisted(() => [] as unknown[])
+vi.mock('@hachej/boring-sandbox/providers/bwrap', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@hachej/boring-sandbox/providers/bwrap')>()
+  return {
+    ...actual,
+    createBwrapSandboxProvider(options: unknown) {
+      providerOptions.push(options)
+      const provider = actual.createBwrapSandboxProvider()
+      return {
+        ...provider,
+        async create() {
+          const runtimeContext = { runtimeCwd: '/workspace' }
+          return {
+            workspace: {
+              root: '/workspace',
+              runtimeContext,
+              fsCapability: 'strong' as const,
+              async readFile() { return '' },
+              async writeFile() {},
+              async unlink() {},
+              async readdir() { return [] },
+              async stat() { return { kind: 'file' as const, size: 0, mtimeMs: 0 } },
+              async mkdir() {},
+              async rename() {},
+            },
+            sandbox: {
+              id: 'captured-bwrap',
+              placement: 'server' as const,
+              provider: 'bwrap',
+              capabilities: ['exec'] as const,
+              runtimeContext,
+              async exec() {
+                return {
+                  stdout: new Uint8Array(),
+                  stderr: new Uint8Array(),
+                  exitCode: 0,
+                  durationMs: 0,
+                  truncated: false,
+                }
+              },
+            },
+            async dispose() {},
+          }
+        },
+      }
+    },
+  }
+})
+
+import { createSandboxRuntimeModeAdapter } from '../../sandboxRuntimeHost'
+import { createLocalProvisioningAdapter } from '../provisioningAdapter'
+
+const tempDirs: string[] = []
+afterEach(async () => {
+  providerOptions.length = 0
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+function expectDockerPolicyArgs(args: readonly string[]): void {
+  expect(args).not.toContain('--unshare-all')
+  expect(args.slice(0, 4)).toEqual([
+    '--unshare-ipc',
+    '--unshare-pid',
+    '--unshare-uts',
+    '--unshare-cgroup',
+  ])
+  expect(args).toContain('--cap-drop')
+  expect(args[args.indexOf('--cap-drop') + 1]).toBe('ALL')
+}
+
+test('local runtime carries one docker bwrap policy into provisioning argv', async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), 'boring-local-policy-'))
+  tempDirs.push(workspaceRoot)
+  const adapter = createSandboxRuntimeModeAdapter('local', {
+    bwrap: {
+      sandbox: {
+        namespaceProfile: 'docker',
+        network: 'shared',
+        dropAllCapabilities: false,
+      },
+    },
+  })
+  const bundle = await adapter.create({ workspaceRoot, sessionId: 'policy-test' })
+
+  expect(providerOptions).toEqual([{
+    sandbox: {
+      namespaceProfile: 'docker',
+      network: 'shared',
+      dropAllCapabilities: true,
+    },
+  }])
+  const runtimeHost = bundle.runtimeHost
+  expect(runtimeHost).toBeDefined()
+  expectDockerPolicyArgs(runtimeHost!.buildBwrapArgs(workspaceRoot))
+
+  const runner = vi.fn(async (_command: string, _args: string[]) => ({ stdout: '', stderr: '', exitCode: 0 }))
+  const provisioning = createLocalProvisioningAdapter(
+    runtimeHost!.getBoringAgentRuntimePaths(workspaceRoot),
+    runtimeHost!,
+    runner,
+  )
+  await provisioning.exec('/usr/bin/true', [], {})
+
+  expect(runner).toHaveBeenCalledOnce()
+  const [command, args] = runner.mock.calls[0]
+  expect(command).toBe('bwrap')
+  expectDockerPolicyArgs(args)
+  expect(args).toContain('--dir')
+  expect(args).toContain('/mnt/boring-agent-sources')
+  await bundle.disposeRuntime?.()
+  await adapter.dispose?.()
+})

--- a/packages/agent/src/server/runtime/modes/__tests__/providerAdapter.test.ts
+++ b/packages/agent/src/server/runtime/modes/__tests__/providerAdapter.test.ts
@@ -1,5 +1,17 @@
 import { expect, test, vi } from 'vitest'
 
+const createBwrapSandboxProviderCalls = vi.hoisted(() => vi.fn())
+vi.mock('@hachej/boring-sandbox/providers/bwrap', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@hachej/boring-sandbox/providers/bwrap')>()
+  return {
+    ...actual,
+    createBwrapSandboxProvider: (...args: Parameters<typeof actual.createBwrapSandboxProvider>) => {
+      createBwrapSandboxProviderCalls(...args)
+      return actual.createBwrapSandboxProvider(...args)
+    },
+  }
+})
+
 import type { SandboxProviderV1 } from '@hachej/boring-sandbox/shared'
 import type { Sandbox, Workspace } from '../../../../shared'
 import type { RuntimeBundle } from '../../mode'
@@ -125,6 +137,22 @@ test('Agent owns built-in sandbox adapter selection and host operations', async 
   expect(adapter.runtimeHost).toBe(sandboxRuntimeHostOperations)
   await adapter.dispose?.()
   expect(() => createSandboxRuntimeModeAdapter('custom' as 'direct')).toThrow('no built-in adapter')
+})
+
+test('local adapter forwards bwrap sandbox options to its provider', async () => {
+  createBwrapSandboxProviderCalls.mockClear()
+  const bwrap = { sandbox: { namespaceProfile: 'docker' as const } }
+
+  const adapter = createSandboxRuntimeModeAdapter('local', { bwrap })
+
+  expect(createBwrapSandboxProviderCalls).toHaveBeenCalledWith({
+    sandbox: {
+      namespaceProfile: 'docker',
+      network: 'shared',
+      dropAllCapabilities: true,
+    },
+  })
+  await adapter.dispose?.()
 })
 
 test('cached runtime eviction awaits asynchronous provider invalidation', async () => {

--- a/packages/boring-bash/src/agent/index.ts
+++ b/packages/boring-bash/src/agent/index.ts
@@ -42,7 +42,7 @@ export {
   RO_BIND_TRY_DIRS,
   buildBwrapArgs,
 } from './runtime/buildBwrapArgs'
-export type { BwrapArgsOptions } from './runtime/buildBwrapArgs'
+export type { BwrapArgsOptions, BwrapNamespaceProfile } from './runtime/buildBwrapArgs'
 
 export { mergeRuntimeProvisioningEnv } from './runtime/env'
 export type {

--- a/packages/boring-bash/src/agent/runtime/__tests__/buildBwrapArgs.test.ts
+++ b/packages/boring-bash/src/agent/runtime/__tests__/buildBwrapArgs.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'vitest'
+
+import { buildBwrapArgs } from '../buildBwrapArgs'
+
+describe('docker bwrap namespace profile', () => {
+  test('uses explicit namespaces and mandatory capability dropping', () => {
+    const args = buildBwrapArgs('/tmp/workspace', {
+      namespaceProfile: 'docker',
+      dropAllCapabilities: false,
+    })
+
+    expect(args).not.toContain('--unshare-all')
+    expect(args.slice(0, 4)).toEqual([
+      '--unshare-ipc',
+      '--unshare-pid',
+      '--unshare-uts',
+      '--unshare-cgroup',
+    ])
+    expect(args).toContain('--cap-drop')
+    expect(args).toContain('ALL')
+  })
+
+  test('rejects unsupported profiles at runtime', () => {
+    expect(() => buildBwrapArgs('/tmp/workspace', {
+      namespaceProfile: 'typo' as 'docker',
+    })).toThrow('unsupported bwrap namespace profile: typo')
+  })
+
+  test('rejects unsupported network modes at runtime', () => {
+    expect(() => buildBwrapArgs('/tmp/workspace', {
+      namespaceProfile: 'docker',
+      network: 'isoltaed' as 'isolated',
+    })).toThrow('unsupported bwrap network mode: isoltaed')
+  })
+
+  test.each(['--cap-add', '--share-net', '--unshare-user', '--args'])(
+    'rejects raw policy counter-option %s',
+    (flag) => {
+      expect(() => buildBwrapArgs('/tmp/workspace', {
+        namespaceProfile: 'docker',
+        extraArgs: [flag],
+      })).toThrow(`forbids ${flag}`)
+    },
+  )
+
+  test('preserves full profile as the default', () => {
+    const args = buildBwrapArgs('/tmp/workspace')
+
+    expect(args).toContain('--unshare-all')
+    expect(args).toContain('--share-net')
+    expect(args).not.toContain('--cap-drop')
+  })
+})

--- a/packages/boring-bash/src/agent/runtime/buildBwrapArgs.ts
+++ b/packages/boring-bash/src/agent/runtime/buildBwrapArgs.ts
@@ -52,6 +52,8 @@ function validateWorkspaceRoot(workspaceRoot: string): void {
   }
 }
 
+export type BwrapNamespaceProfile = 'full' | 'docker'
+
 export interface BwrapArgsOptions {
   extraArgs?: string[]
   postWorkspaceArgs?: string[]
@@ -59,11 +61,45 @@ export interface BwrapArgsOptions {
   newSession?: boolean
   dropAllCapabilities?: boolean
   /**
+   * `full` preserves bwrap's default isolation by unsharing every supported
+   * namespace. `docker` avoids a nested user namespace for hardened outer
+   * containers that forbid mounting proc there; it must drop all capabilities.
+   */
+  namespaceProfile?: BwrapNamespaceProfile
+  /**
    * Workspace-relative prefixes re-bound readonly on top of the writable
    * workspace mount, so spawned shells cannot mutate protected paths that the
    * Operations layer already refuses to mutate.
    */
   readonlyPaths?: readonly string[]
+}
+
+const DOCKER_FORBIDDEN_RAW_FLAGS = new Set([
+  '--args',
+  '--cap-add',
+  '--share-net',
+  '--unshare-all',
+  '--userns',
+  '--userns2',
+  '--pidns',
+  '--uid',
+  '--gid',
+  '--disable-userns',
+  '--assert-userns-disabled',
+  '--userns-block-fd',
+])
+
+function assertDockerRawArgsSafe(args: readonly string[] | undefined, source: string): void {
+  for (const arg of args ?? []) {
+    const flag = arg.split('=', 1)[0]
+    if (
+      flag === '--'
+      || flag.startsWith('--unshare-')
+      || DOCKER_FORBIDDEN_RAW_FLAGS.has(flag)
+    ) {
+      throw new Error(`docker namespace profile forbids ${flag} in ${source}`)
+    }
+  }
 }
 
 function normalizeReadonlyPath(input: string): string {
@@ -88,12 +124,41 @@ export function buildBwrapArgs(workspaceRoot: string, options?: BwrapArgsOptions
   validateWorkspaceRoot(workspaceRoot)
 
   const network = options?.network ?? 'shared'
+  if (network !== 'shared' && network !== 'isolated') {
+    throw new Error(`unsupported bwrap network mode: ${String(network)}`)
+  }
+  const namespaceProfile = options?.namespaceProfile ?? 'full'
+  if (namespaceProfile !== 'full' && namespaceProfile !== 'docker') {
+    throw new Error(`unsupported bwrap namespace profile: ${String(namespaceProfile)}`)
+  }
+  if (namespaceProfile === 'docker') {
+    // Raw argument seams are needed for controlled mounts, but must not be able
+    // to counteract the namespace/capability policy emitted below.
+    assertDockerRawArgsSafe(options?.extraArgs, 'extraArgs')
+    assertDockerRawArgsSafe(options?.postWorkspaceArgs, 'postWorkspaceArgs')
+  }
+  const namespaceArgs = namespaceProfile === 'full'
+    ? [
+        '--unshare-all',
+        ...(network === 'shared' ? ['--share-net'] : []),
+      ]
+    : [
+        // bwrap always creates a mount namespace. Avoid only the nested user
+        // namespace that some hardened Docker hosts reject when mounting proc.
+        '--unshare-ipc',
+        '--unshare-pid',
+        '--unshare-uts',
+        '--unshare-cgroup',
+        ...(network === 'isolated' ? ['--unshare-net'] : []),
+      ]
+  // Docker-compatible mode executes outside a user namespace while the outer
+  // container has SYS_ADMIN. Capabilities must never reach the sandbox command.
+  const dropAllCapabilities = namespaceProfile === 'docker' || options?.dropAllCapabilities === true
   const args: string[] = [
-    '--unshare-all',
-    ...(network === 'shared' ? ['--share-net'] : []),
+    ...namespaceArgs,
     '--die-with-parent',
     ...(options?.newSession === false ? [] : ['--new-session']),
-    ...(options?.dropAllCapabilities ? ['--cap-drop', 'ALL'] : []),
+    ...(dropAllCapabilities ? ['--cap-drop', 'ALL'] : []),
     '--tmpfs', '/',
     '--proc', '/proc',
     '--dev', '/dev',

--- a/packages/boring-bash/src/agent/tools/harness/__tests__/bashToolOptions.argv.test.ts
+++ b/packages/boring-bash/src/agent/tools/harness/__tests__/bashToolOptions.argv.test.ts
@@ -1,0 +1,44 @@
+import { expect, test, vi } from 'vitest'
+
+import type { RuntimeBundle } from '../../../runtime/types'
+import { buildBwrapArgs } from '../../../runtime/buildBwrapArgs'
+import { createBashToolOptionsForRuntime } from '../bashToolOptions'
+
+function createBundle(): RuntimeBundle {
+  return {
+    storageRoot: '/tmp/workspace',
+    workspace: { root: '/workspace' } as RuntimeBundle['workspace'],
+    sandbox: {
+      placement: 'server',
+      provider: 'bwrap',
+    } as RuntimeBundle['sandbox'],
+    fileSearch: {} as RuntimeBundle['fileSearch'],
+    bash: { kind: 'local-sandbox', sandboxRoot: '/workspace' },
+    runtimeHost: {
+      buildBwrapArgs(workspaceRoot, options) {
+        return buildBwrapArgs(workspaceRoot, {
+          ...options,
+          namespaceProfile: 'docker',
+          network: 'shared',
+          dropAllCapabilities: true,
+        })
+      },
+      withWorkspacePythonEnv: vi.fn(() => ({})),
+    },
+  }
+}
+
+test('local Agent bash spawn hook captures docker-profile bwrap argv', () => {
+  const options = createBashToolOptionsForRuntime(createBundle())
+  const spawned = options.spawnHook?.({
+    command: 'printf hello',
+    cwd: '/tmp/workspace',
+    env: {},
+  })
+
+  expect(spawned).toBeDefined()
+  expect(spawned?.command).toContain("'bwrap' '--unshare-ipc' '--unshare-pid' '--unshare-uts' '--unshare-cgroup'")
+  expect(spawned?.command).toContain("'--cap-drop' 'ALL'")
+  expect(spawned?.command).not.toContain('--unshare-all')
+  expect(spawned?.command).toContain("--' bash -lc 'printf hello'")
+})

--- a/packages/boring-sandbox/src/providers/README.md
+++ b/packages/boring-sandbox/src/providers/README.md
@@ -16,3 +16,26 @@ Concrete sandbox providers live behind this subpath as they move out of
 
 `resolveMode()` itself is owned by `@hachej/boring-bash/modes`. It resolves a
 mode id to one of these provider values; providers do not resolve modes.
+
+## Bubblewrap namespace profiles
+
+The bwrap provider defaults to `namespaceProfile: 'full'`, which preserves
+`--unshare-all`. Hardened Docker hosts that reject a proc mount inside a nested
+user namespace may opt into `namespaceProfile: 'docker'`. That profile keeps
+mount, IPC, PID, UTS, cgroup, and optional network isolation without creating a
+nested user namespace, and always emits `--cap-drop ALL`; callers cannot disable
+that capability drop. In this profile, raw `extraArgs`/`postWorkspaceArgs` may
+still add controlled mounts, but namespace controls, capability additions, and
+indirect `--args` expansion are rejected so later arguments cannot counteract
+the resolved policy.
+
+Applications select the profile through Agent's built-in local adapter:
+
+```ts
+createSandboxRuntimeModeAdapter('local', {
+  bwrap: { sandbox: { namespaceProfile: 'docker' } },
+})
+```
+
+The adapter resolves one policy and carries it through provider `Sandbox.exec`,
+Agent bash spawn hooks, and local provisioning commands.

--- a/packages/boring-sandbox/src/providers/bwrap/__tests__/buildBwrapArgs.test.ts
+++ b/packages/boring-sandbox/src/providers/bwrap/__tests__/buildBwrapArgs.test.ts
@@ -51,6 +51,80 @@ test('can isolate networking and drop capabilities for hardened worker mode', ()
   expect(findTupleIndex(args, ['--cap-drop', 'ALL'])).toBeGreaterThanOrEqual(0)
 })
 
+test('docker profile avoids the user namespace and retains explicit isolation', () => {
+  const args = buildBwrapArgs('/tmp/workspace', { namespaceProfile: 'docker' })
+
+  expect(args).not.toContain('--unshare-all')
+  expect(args.slice(0, 4)).toEqual([
+    '--unshare-ipc',
+    '--unshare-pid',
+    '--unshare-uts',
+    '--unshare-cgroup',
+  ])
+  expect(args).not.toContain('--unshare-user')
+  expect(args).not.toContain('--unshare-net')
+  expect(args).not.toContain('--share-net')
+})
+
+test('rejects unsupported namespace profiles at runtime', () => {
+  expect(() => buildBwrapArgs('/tmp/workspace', {
+    namespaceProfile: 'typo' as 'docker',
+  })).toThrow('unsupported bwrap namespace profile: typo')
+})
+
+test('rejects unsupported network modes at runtime', () => {
+  expect(() => buildBwrapArgs('/tmp/workspace', {
+    namespaceProfile: 'docker',
+    network: 'isoltaed' as 'isolated',
+  })).toThrow('unsupported bwrap network mode: isoltaed')
+})
+
+test('docker profile always drops capabilities even when explicitly disabled', () => {
+  const args = buildBwrapArgs('/tmp/workspace', {
+    namespaceProfile: 'docker',
+    dropAllCapabilities: false,
+  })
+
+  expect(findTupleIndex(args, ['--cap-drop', 'ALL'])).toBeGreaterThanOrEqual(0)
+})
+
+test('docker profile isolates networking only when requested', () => {
+  const args = buildBwrapArgs('/tmp/workspace', {
+    namespaceProfile: 'docker',
+    network: 'isolated',
+  })
+
+  expect(args).toContain('--unshare-net')
+  expect(args).not.toContain('--share-net')
+  expect(findTupleIndex(args, ['--cap-drop', 'ALL'])).toBeGreaterThanOrEqual(0)
+})
+
+test.each([
+  ['extraArgs', '--cap-add'],
+  ['extraArgs', '--share-net'],
+  ['extraArgs', '--unshare-user'],
+  ['extraArgs', '--args'],
+  ['postWorkspaceArgs', '--cap-add=ALL'],
+  ['postWorkspaceArgs', '--unshare-all'],
+] as const)('docker profile rejects raw policy counter-option in %s: %s', (source, flag) => {
+  expect(() => buildBwrapArgs('/tmp/workspace', {
+    namespaceProfile: 'docker',
+    [source]: [flag],
+  })).toThrow(`forbids ${flag.split('=', 1)[0]} in ${source}`)
+})
+
+test('docker profile still permits controlled raw mount arguments', () => {
+  const args = buildBwrapArgs('/tmp/workspace', {
+    namespaceProfile: 'docker',
+    extraArgs: ['--dir', '/mnt'],
+    postWorkspaceArgs: ['--ro-bind', '/tmp/source', '/workspace/source'],
+  })
+
+  expect(findTupleIndex(args, ['--dir', '/mnt'])).toBeGreaterThanOrEqual(0)
+  expect(findTupleIndex(args, ['--ro-bind', '/tmp/source', '/workspace/source']))
+    .toBeGreaterThanOrEqual(0)
+})
+
 test('binds workspace root exactly once and keeps it writable', () => {
   const workspaceRoot = '/tmp/workspace root/$(whoami)'
   const args = buildBwrapArgs(workspaceRoot)

--- a/packages/boring-sandbox/src/providers/bwrap/__tests__/createBwrapSandbox.argv.test.ts
+++ b/packages/boring-sandbox/src/providers/bwrap/__tests__/createBwrapSandbox.argv.test.ts
@@ -1,0 +1,70 @@
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, expect, test, vi } from 'vitest'
+
+const spawnCalls = vi.hoisted(() => [] as Array<{ command: string; args: string[] }>)
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>()
+  return {
+    ...actual,
+    spawn(command: string, args: readonly string[]) {
+      spawnCalls.push({ command, args: [...args] })
+      const child = new EventEmitter() as EventEmitter & {
+        stdout: PassThrough
+        stderr: PassThrough
+        pid: number
+      }
+      child.stdout = new PassThrough()
+      child.stderr = new PassThrough()
+      child.pid = 12345
+      queueMicrotask(() => {
+        child.stdout.end()
+        child.stderr.end()
+        child.emit('close', 0, null)
+      })
+      return child
+    },
+  }
+})
+
+import { createNodeWorkspace } from '../../node-workspace/createNodeWorkspace'
+import { createBwrapSandbox } from '../createBwrapSandbox'
+
+const tempDirs: string[] = []
+afterEach(async () => {
+  spawnCalls.length = 0
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+test('Sandbox.exec spawns the resolved docker namespace profile', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'boring-bwrap-argv-'))
+  tempDirs.push(root)
+  const workspace = createNodeWorkspace(root)
+  const sandbox = createBwrapSandbox({
+    hostWorkspaceRoot: root,
+    namespaceProfile: 'docker',
+    dropAllCapabilities: false,
+  })
+  await sandbox.init?.({ workspace, sessionId: 'argv-test' })
+
+  await sandbox.exec('true')
+
+  const executionCalls = spawnCalls.filter((call) => !call.args.includes('--version'))
+  expect(executionCalls).toHaveLength(1)
+  const [{ command, args }] = executionCalls
+  expect(command).toBe('bwrap')
+  expect(args).not.toContain('--unshare-all')
+  expect(args.slice(0, 4)).toEqual([
+    '--unshare-ipc',
+    '--unshare-pid',
+    '--unshare-uts',
+    '--unshare-cgroup',
+  ])
+  expect(args).toContain('--cap-drop')
+  expect(args[args.indexOf('--cap-drop') + 1]).toBe('ALL')
+  expect(args.slice(-3)).toEqual(['bash', '-c', 'true'])
+})

--- a/packages/boring-sandbox/src/providers/bwrap/buildBwrapArgs.ts
+++ b/packages/boring-sandbox/src/providers/bwrap/buildBwrapArgs.ts
@@ -52,6 +52,8 @@ function validateWorkspaceRoot(workspaceRoot: string): void {
   }
 }
 
+export type BwrapNamespaceProfile = 'full' | 'docker'
+
 export interface BwrapArgsOptions {
   extraArgs?: string[]
   postWorkspaceArgs?: string[]
@@ -59,11 +61,45 @@ export interface BwrapArgsOptions {
   newSession?: boolean
   dropAllCapabilities?: boolean
   /**
+   * `full` preserves bwrap's default isolation by unsharing every supported
+   * namespace. `docker` avoids a nested user namespace for hardened outer
+   * containers that forbid mounting proc there; it must drop all capabilities.
+   */
+  namespaceProfile?: BwrapNamespaceProfile
+  /**
    * Workspace-relative prefixes re-bound readonly on top of the writable
    * workspace mount, so spawned shells cannot mutate protected paths that the
    * Operations layer already refuses to mutate.
    */
   readonlyPaths?: readonly string[]
+}
+
+const DOCKER_FORBIDDEN_RAW_FLAGS = new Set([
+  '--args',
+  '--cap-add',
+  '--share-net',
+  '--unshare-all',
+  '--userns',
+  '--userns2',
+  '--pidns',
+  '--uid',
+  '--gid',
+  '--disable-userns',
+  '--assert-userns-disabled',
+  '--userns-block-fd',
+])
+
+function assertDockerRawArgsSafe(args: readonly string[] | undefined, source: string): void {
+  for (const arg of args ?? []) {
+    const flag = arg.split('=', 1)[0]
+    if (
+      flag === '--'
+      || flag.startsWith('--unshare-')
+      || DOCKER_FORBIDDEN_RAW_FLAGS.has(flag)
+    ) {
+      throw new Error(`docker namespace profile forbids ${flag} in ${source}`)
+    }
+  }
 }
 
 function normalizeReadonlyPath(input: string): string {
@@ -88,12 +124,41 @@ export function buildBwrapArgs(workspaceRoot: string, options?: BwrapArgsOptions
   validateWorkspaceRoot(workspaceRoot)
 
   const network = options?.network ?? 'shared'
+  if (network !== 'shared' && network !== 'isolated') {
+    throw new Error(`unsupported bwrap network mode: ${String(network)}`)
+  }
+  const namespaceProfile = options?.namespaceProfile ?? 'full'
+  if (namespaceProfile !== 'full' && namespaceProfile !== 'docker') {
+    throw new Error(`unsupported bwrap namespace profile: ${String(namespaceProfile)}`)
+  }
+  if (namespaceProfile === 'docker') {
+    // Raw argument seams are needed for controlled mounts, but must not be able
+    // to counteract the namespace/capability policy emitted below.
+    assertDockerRawArgsSafe(options?.extraArgs, 'extraArgs')
+    assertDockerRawArgsSafe(options?.postWorkspaceArgs, 'postWorkspaceArgs')
+  }
+  const namespaceArgs = namespaceProfile === 'full'
+    ? [
+        '--unshare-all',
+        ...(network === 'shared' ? ['--share-net'] : []),
+      ]
+    : [
+        // bwrap always creates a mount namespace. Avoid only the nested user
+        // namespace that some hardened Docker hosts reject when mounting proc.
+        '--unshare-ipc',
+        '--unshare-pid',
+        '--unshare-uts',
+        '--unshare-cgroup',
+        ...(network === 'isolated' ? ['--unshare-net'] : []),
+      ]
+  // Docker-compatible mode executes outside a user namespace while the outer
+  // container has SYS_ADMIN. Capabilities must never reach the sandbox command.
+  const dropAllCapabilities = namespaceProfile === 'docker' || options?.dropAllCapabilities === true
   const args: string[] = [
-    '--unshare-all',
-    ...(network === 'shared' ? ['--share-net'] : []),
+    ...namespaceArgs,
     '--die-with-parent',
     ...(options?.newSession === false ? [] : ['--new-session']),
-    ...(options?.dropAllCapabilities ? ['--cap-drop', 'ALL'] : []),
+    ...(dropAllCapabilities ? ['--cap-drop', 'ALL'] : []),
     '--tmpfs', '/',
     '--proc', '/proc',
     '--dev', '/dev',

--- a/packages/boring-sandbox/src/providers/bwrap/createBwrapSandbox.ts
+++ b/packages/boring-sandbox/src/providers/bwrap/createBwrapSandbox.ts
@@ -8,6 +8,7 @@ import {
   BWRAP_TIMEOUT_SECONDS,
   KILL_GRACE_SECONDS,
   buildBwrapArgs,
+  type BwrapNamespaceProfile,
 } from './buildBwrapArgs'
 import { getNodeWorkspaceHostRoot } from '../node-workspace/createNodeWorkspace'
 import { withWorkspacePythonEnv } from '../node-workspace/workspacePythonEnv'
@@ -196,6 +197,7 @@ export interface CreateBwrapSandboxOptions {
   runtimeContext?: WorkspaceRuntimeContext
   network?: 'shared' | 'isolated'
   dropAllCapabilities?: boolean
+  namespaceProfile?: BwrapNamespaceProfile
   resourceLimits?: BwrapResourceLimits
 }
 
@@ -275,6 +277,7 @@ export function createBwrapSandbox(opts: CreateBwrapSandboxOptions = {}): Sandbo
         postWorkspaceArgs,
         network: sandboxOptions.network,
         dropAllCapabilities: sandboxOptions.dropAllCapabilities,
+        namespaceProfile: sandboxOptions.namespaceProfile,
       })
       const args = [
         ...withSandboxCwd(baseArgs, sandboxCwd),

--- a/packages/boring-sandbox/src/providers/bwrap/index.ts
+++ b/packages/boring-sandbox/src/providers/bwrap/index.ts
@@ -3,7 +3,7 @@ export type {
   BwrapSandboxProviderOptions,
 } from './createBwrapProvider'
 export { buildBwrapArgs } from './buildBwrapArgs'
-export type { BwrapArgsOptions } from './buildBwrapArgs'
+export type { BwrapArgsOptions, BwrapNamespaceProfile } from './buildBwrapArgs'
 export { computeSandboxCwd, createBwrapSandbox } from './createBwrapSandbox'
 export type {
   BwrapResourceLimits,


### PR DESCRIPTION
## Problem
Bubblewrap `--unshare-all --proc /proc` fails inside hardened Docker hosts that reject the nested user namespace. Falling back to direct execution or broad `--privileged` mode is not acceptable.

## Changes
- add opt-in `namespaceProfile: docker` while preserving `full` as default
- retain mount/PID/IPC/UTS/cgroup isolation and network semantics
- force `--cap-drop ALL` for Docker profile
- reject raw counter-options and invalid runtime discriminants
- thread one resolved policy through provider exec, primary Agent bash, and provisioning
- add argv tests at every execution seam

## Validation
- sandbox full suite: 587 tests passed
- boring-bash full suite: 93 tests passed
- focused post-review suites: sandbox 34, boring-bash 8, agent 6
- sandbox, boring-bash, and agent typechecks passed
- sandbox and boring-bash invariants passed
- independent security review: ACCEPT with residual runtime qualification required

## Deployment intent
Constellation will opt into this profile and execute a live target-host capability/namespace probe before cutover.