### PR TITLE
fix(ask-user): correct inbox badge count + attention-amber alignment; export WorkspaceAttentionProvider value

### DIFF
--- a/packages/workspace/src/__tests__/index.exports.test.ts
+++ b/packages/workspace/src/__tests__/index.exports.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest"
+import { WorkspaceAttentionProvider } from "@hachej/boring-workspace"
+
+/**
+ * WorkspaceAttentionProvider was exported from the package root as a TYPE
+ * only, so a plugin importing the component (rather than the props type) got
+ * `undefined` at runtime — a failure TypeScript does not catch, because the
+ * type and the value share a name. Pin the value export directly so a
+ * regression here fails fast instead of surfacing as a blank Inbox badge in a
+ * downstream plugin.
+ */
+describe("package root exports", () => {
+  it("exports WorkspaceAttentionProvider as a component, not just a type", () => {
+    expect(typeof WorkspaceAttentionProvider).toBe("function")
+  })
+})

--- a/packages/workspace/src/globals.css
+++ b/packages/workspace/src/globals.css
@@ -64,6 +64,10 @@
   --boring-muted-foreground: oklch(0.52 0.008 72);
   --boring-destructive: oklch(0.577 0.245 27.325);
   --boring-destructive-foreground: oklch(0.985 0.002 72);
+  /* Ported ahead of the spike CSS it originated in: the Inbox count badge
+     (plugins/ask-user) needs an amber token distinct from --boring-accent
+     ("selected/active") to mark "waiting on you". */
+  --boring-attention: oklch(0.55 0.11 75);
   --boring-border: oklch(0.915 0.004 72);
   --boring-input: oklch(0.915 0.004 72);
   --boring-accent: oklch(0.62 0.14 65);
@@ -100,6 +104,7 @@
   --muted-foreground: var(--boring-muted-foreground);
   --destructive: var(--boring-destructive);
   --destructive-foreground: var(--boring-destructive-foreground);
+  --attention: var(--boring-attention);
   --border: var(--boring-border);
   --input: var(--boring-input);
   --accent: var(--boring-accent);
@@ -139,6 +144,7 @@
   --boring-success-soft: oklch(0.22 0.04 145);
   --boring-destructive: oklch(0.396 0.141 25.768);
   --boring-destructive-foreground: oklch(0.985 0 0);
+  --boring-attention: oklch(0.8 0.11 75);
   --boring-border: oklch(0.269 0.006 285.885);
   --boring-input: oklch(0.269 0.006 285.885);
   --boring-ring: oklch(0.72 0.13 65);
@@ -161,6 +167,7 @@
   --muted-foreground: var(--boring-muted-foreground);
   --destructive: var(--boring-destructive);
   --destructive-foreground: var(--boring-destructive-foreground);
+  --attention: var(--boring-attention);
   --border: var(--boring-border);
   --input: var(--boring-input);
   --accent: var(--boring-accent);

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -364,6 +364,11 @@ export {
   WORKSPACE_ATTENTION_ACTION_EVENT,
   emitWorkspaceAttentionAction,
   useWorkspaceAttention,
+  // The provider is a VALUE, not just a type: a plugin that contributes an
+  // attention-driven surface (the Inbox badge) has to be able to mount one to
+  // test it. Only the props type was exported, so importing the component from
+  // the package root silently yielded `undefined` at runtime.
+  WorkspaceAttentionProvider,
   workspaceAttentionSessionBadgeForBlocker,
 } from "./front/provider"
 export type {

--- a/plugins/ask-user/src/front/__tests__/inboxCountBadge.test.tsx
+++ b/plugins/ask-user/src/front/__tests__/inboxCountBadge.test.tsx
@@ -1,0 +1,107 @@
+import type { ReactNode } from "react"
+import { useEffect } from "react"
+import { render, screen, waitFor } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { WorkspaceAttentionProvider, useWorkspaceAttention } from "@hachej/boring-workspace"
+import { captureFrontPlugin } from "@hachej/boring-workspace/plugin"
+import { createAskUserPlugin } from "../index"
+
+/**
+ * The Inbox is the ratified single triage surface, so its rail badge is THE
+ * "a human is blocking" signal in the app-left — it has to count SESSIONS,
+ * not the individual questions they asked, or it disagrees with every other
+ * attention count on the surface.
+ */
+function inboxTrailing(): ReactNode {
+  // Reached through the real plugin registration rather than by exporting the
+  // badge for the test, so losing the Inbox action fails here too.
+  const captured = captureFrontPlugin(createAskUserPlugin({ appLeftInbox: true }))
+  const actions = captured.registrations.appLeftActions as readonly { id: string; trailing?: unknown }[] | undefined
+  const inbox = actions?.find((action) => action.id === "inbox")
+  if (!inbox?.trailing) throw new Error("ask-user no longer contributes an Inbox app-left action with a trailing badge")
+  const Trailing = inbox.trailing as () => ReactNode
+  return <Trailing />
+}
+
+function Seed({ questions }: { questions: readonly { id: string; sessionId?: string; agentTypeId?: string }[] }) {
+  const { addBlocker, removeBlocker } = useWorkspaceAttention()
+  useEffect(() => {
+    for (const question of questions) {
+      addBlocker({
+        id: question.id,
+        reason: "ask-user.question",
+        ...(question.sessionId ? { sessionId: question.sessionId } : {}),
+        ...(question.agentTypeId ? { agentTypeId: question.agentTypeId } : {}),
+        // `inbox` is what makes a blocker an INBOX item — the badge counts the
+        // Inbox's own contents, not every attention blocker on the surface.
+        inbox: { kind: "question", sourceLabel: "Ask user" },
+        sessionBadge: { kind: "question", label: "question", tone: "attention", priority: 10 },
+      })
+    }
+    return () => { for (const question of questions) removeBlocker(question.id) }
+  }, [addBlocker, removeBlocker, questions])
+  return null
+}
+
+function renderBadge(questions: readonly { id: string; sessionId?: string; agentTypeId?: string }[]) {
+  return render(
+    <WorkspaceAttentionProvider>
+      <Seed questions={questions} />
+      {inboxTrailing()}
+    </WorkspaceAttentionProvider>,
+  )
+}
+
+const badge = () => document.querySelector('[data-boring-workspace-part="app-left-inbox-count"]')
+
+describe("Inbox app-left count badge", () => {
+  it("renders nothing at all when no one is waiting", async () => {
+    renderBadge([])
+    await waitFor(() => expect(badge()).toBeNull())
+  })
+
+  it("counts the chats waiting for a human, not the questions they asked", async () => {
+    renderBadge([
+      { id: "q1", sessionId: "s1", agentTypeId: "alpha" },
+      // Same chat, second question: one chat still needs you, not two.
+      { id: "q2", sessionId: "s1", agentTypeId: "alpha" },
+      { id: "q3", sessionId: "s2", agentTypeId: "beta" },
+    ])
+    await waitFor(() => expect(badge()).toHaveTextContent("2"))
+    expect(badge()).toHaveAttribute("aria-label", "2 chats waiting for you")
+  })
+
+  it("drops back down as blockers clear, and disappears at zero", async () => {
+    const { rerender } = renderBadge([
+      { id: "q1", sessionId: "s1", agentTypeId: "alpha" },
+      { id: "q2", sessionId: "s2", agentTypeId: "beta" },
+    ])
+    await waitFor(() => expect(badge()).toHaveTextContent("2"))
+
+    const only = [{ id: "q1", sessionId: "s1", agentTypeId: "alpha" }]
+    rerender(
+      <WorkspaceAttentionProvider>
+        <Seed questions={only} />
+        {inboxTrailing()}
+      </WorkspaceAttentionProvider>,
+    )
+    await waitFor(() => expect(badge()).toHaveTextContent("1"))
+
+    rerender(
+      <WorkspaceAttentionProvider>
+        <Seed questions={[]} />
+        {inboxTrailing()}
+      </WorkspaceAttentionProvider>,
+    )
+    await waitFor(() => expect(badge()).toBeNull())
+  })
+
+  it("caps a flooded inbox at 99+", async () => {
+    renderBadge(Array.from({ length: 120 }, (_, index) => ({
+      id: `q${index}`,
+      sessionId: `s${index}`,
+      agentTypeId: "alpha",
+    })))
+    await waitFor(() => expect(badge()).toHaveTextContent("99+"))
+  })
+})

--- a/plugins/ask-user/src/front/__tests__/inboxCountBadge.test.tsx
+++ b/plugins/ask-user/src/front/__tests__/inboxCountBadge.test.tsx
@@ -8,9 +8,10 @@ import { createAskUserPlugin } from "../index"
 
 /**
  * The Inbox is the ratified single triage surface, so its rail badge is THE
- * "a human is blocking" signal in the app-left — it has to count SESSIONS,
- * not the individual questions they asked, or it disagrees with every other
- * attention count on the surface.
+ * "a human is blocking" signal in the app-left — and it has to agree with the
+ * attention rollups the pane draws on its collapsed group headers, in both
+ * arithmetic (sessions, not items) and register (amber, not the accent that
+ * means "selected" everywhere else).
  */
 function inboxTrailing(): ReactNode {
   // Reached through the real plugin registration rather than by exporting the
@@ -69,6 +70,9 @@ describe("Inbox app-left count badge", () => {
     ])
     await waitFor(() => expect(badge()).toHaveTextContent("2"))
     expect(badge()).toHaveAttribute("aria-label", "2 chats waiting for you")
+    // Same mark and same token as the pane's collapsed-header rollups.
+    expect(badge()?.className).toContain("var(--attention)")
+    expect(badge()?.querySelector("span.rounded-full")).not.toBeNull()
   })
 
   it("drops back down as blockers clear, and disappears at zero", async () => {

--- a/plugins/ask-user/src/front/index.tsx
+++ b/plugins/ask-user/src/front/index.tsx
@@ -219,11 +219,26 @@ function InlineQuestion({ part }: { part: unknown }) {
   </section>
 }
 
+/**
+ * The Inbox is the single triage surface, so its badge is THE "a human is
+ * blocking" signal in the app-left rail: a count of SESSIONS waiting on you,
+ * not of the individual questions they asked.
+ *
+ * It counted raw blockers before, which double-counts a chat that asked two
+ * questions and disagreed with every other attention count on the surface.
+ */
 function InboxCountBadge() {
   const { blockers } = useWorkspaceAttention()
-  const count = blockers.filter(isInboxAttentionBlocker).length
+  const sessions = new Set<string>()
+  for (const blocker of blockers) {
+    if (!isInboxAttentionBlocker(blocker)) continue
+    // A blocker with no session still needs a human; key it by its own id so
+    // it counts once rather than collapsing every session-less item into one.
+    sessions.add(blocker.sessionId ? `session:${blocker.agentTypeId ?? ""}\u0000${blocker.sessionId}` : `blocker:${blocker.id}`)
+  }
+  const count = sessions.size
   if (count === 0) return null
-  return <span data-boring-workspace-part="app-left-inbox-count" aria-label={`${count} inbox item${count === 1 ? "" : "s"}`} className="inline-flex min-w-5 items-center justify-center rounded-full bg-[color:var(--accent)] px-1.5 py-0.5 text-[10px] font-semibold leading-none text-white shadow-sm">{count > 99 ? "99+" : String(count)}</span>
+  return <span data-boring-workspace-part="app-left-inbox-count" aria-label={`${count} chat${count === 1 ? "" : "s"} waiting for you`} className="inline-flex min-w-5 items-center justify-center rounded-full bg-[color:var(--accent)] px-1.5 py-0.5 text-[10px] font-semibold leading-none text-white shadow-sm">{count > 99 ? "99+" : String(count)}</span>
 }
 function AskUserInboxOverlay({ onClose, params }: BoringFrontAppLeftOverlayProps) {
   const { workspaceId } = useWorkspaceContext()

--- a/plugins/ask-user/src/front/index.tsx
+++ b/plugins/ask-user/src/front/index.tsx
@@ -221,11 +221,14 @@ function InlineQuestion({ part }: { part: unknown }) {
 
 /**
  * The Inbox is the single triage surface, so its badge is THE "a human is
- * blocking" signal in the app-left rail: a count of SESSIONS waiting on you,
- * not of the individual questions they asked.
+ * blocking" signal in the app-left rail — and it says the same thing, the same
+ * way, as the attention rollups on the pane's collapsed group headers: amber
+ * dot plus a count of SESSIONS, not of items.
  *
  * It counted raw blockers before, which double-counts a chat that asked two
- * questions and disagreed with every other attention count on the surface.
+ * questions and disagrees with every other attention count on the surface. It
+ * was also accent blue, which in this palette reads as "selected/active" —
+ * the wrong register for something waiting on you.
  */
 function InboxCountBadge() {
   const { blockers } = useWorkspaceAttention()
@@ -238,7 +241,16 @@ function InboxCountBadge() {
   }
   const count = sessions.size
   if (count === 0) return null
-  return <span data-boring-workspace-part="app-left-inbox-count" aria-label={`${count} chat${count === 1 ? "" : "s"} waiting for you`} className="inline-flex min-w-5 items-center justify-center rounded-full bg-[color:var(--accent)] px-1.5 py-0.5 text-[10px] font-semibold leading-none text-white shadow-sm">{count > 99 ? "99+" : String(count)}</span>
+  return (
+    <span
+      data-boring-workspace-part="app-left-inbox-count"
+      aria-label={`${count} chat${count === 1 ? "" : "s"} waiting for you`}
+      className="inline-flex items-center gap-1 text-[10px] font-medium tabular-nums leading-4 text-[color:var(--attention)]"
+    >
+      <span aria-hidden="true" className="size-1.5 rounded-full bg-[color:var(--attention)]" />
+      {count > 99 ? "99+" : String(count)}
+    </span>
+  )
 }
 function AskUserInboxOverlay({ onClose, params }: BoringFrontAppLeftOverlayProps) {
   const { workspaceId } = useWorkspaceContext()


### PR DESCRIPTION
## Bugs fixed

1. **Double-counted blockers.** The app-left Inbox badge (`plugins/ask-user`) counted raw attention blockers, so a chat that asked two questions counted twice — disagreeing with every other attention count on the surface (the pane's own collapsed-header rollups count sessions). Now counts distinct sessions; a session-less blocker is still keyed by its own id so it counts once.

2. **Type-only export = `undefined` at runtime.** `WorkspaceAttentionProvider` was not exported as a value from the workspace package root (`packages/workspace/src/index.ts`) — only its props type was. A plugin importing the component from `@hachej/boring-workspace` got `undefined` at runtime with no compile-time signal, because the type and the value share a name. Now exported as a value too, and pinned by a minimal test asserting `typeof WorkspaceAttentionProvider === "function"`.

## Design alignment (separate commit, reviewable independently)

Owner ruling: the Inbox badge is the canonical "a human is blocking" signal in the app-left rail, so it should mark "waiting on you" the same register the pane's own attention rollups use — amber, not the solid accent-blue pill it had (accent blue means "selected/active" everywhere else in this palette). This required porting a `--boring-attention` design token (light + dark) into `packages/workspace/src/globals.css`, since the workspace package's global CSS had no attention token at all before this — the badge's amber styling depends on it. The pane's existing collapsed-header rollups (`AppLeftPaneAgentCards.tsx`) still use Tailwind `amber-*` utilities directly rather than this token; unifying them is left for a follow-up.

## Commits

1. `fix(ask-user): inbox badge counts sessions, not blockers` — counting fix + 4 tests (kept the old blue pill markup so the fix is reviewable on its own)
2. `fix(workspace): export WorkspaceAttentionProvider as a value` — export fix + minimal export-shape test
3. `fix(ask-user): align inbox badge to attention amber` — the design alignment, isolated as its own commit

## Test results

- `plugins/ask-user` suite: **127 passed, 1 skipped, 0 failed** (17/18 files; the 1 skip is pre-existing/unrelated)
- `packages/workspace` typecheck (`tsc --noEmit` front + server source configs): **clean**
- `packages/workspace` targeted tests (`src/__tests__/index.exports.test.ts`, `src/front/attention/__tests__/WorkspaceAttentionProvider.test.tsx`): **5 passed, 0 failed**
- Full `packages/workspace` vitest suite was not run to completion in this session (interrupted while verifying); the targeted export/attention tests plus a clean typecheck are the coverage for the workspace-side change here, per the small size of this extraction.

## Content-identity check

Diffed against `weekend/console-left-pane-variant` (commit 07ca4b0dd) for every ported file — byte-identical:
- `packages/workspace/src/index.ts`
- `plugins/ask-user/src/front/index.tsx`
- `plugins/ask-user/src/front/__tests__/inboxCountBadge.test.tsx`
- The `--boring-attention` / `--attention` token lines in `packages/workspace/src/globals.css`

Extracted from spike PR #1393 (branch `weekend/console-left-pane-variant`, commit `07ca4b0dd`) so these shared fixes merge independently; #1393 rebases to a no-op on these files once this merges first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGA4RhWZGNR5QA9Y7dFzCF