### PR TITLE
Fix single-agent quick chat creation

### DIFF
--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -2441,7 +2441,15 @@ export function WorkspaceAgentFront<
     // became independent is no longer always the addressed one.
     const requestedAgentTypeId = options?.agentTypeId ?? selectedAgentTypeId
     try {
-      const session = await coordinateRemoteCreate(dedupeKey, options)
+      // `agentTypeId` addresses the fleet wrapper; it is not part of the
+      // canonical single-Agent create-session body. Forwarding the synthetic
+      // `default` owner made strict Agent hosts reject quick-chat creation.
+      const createInput = fleetModeEnabled
+        ? options
+        : options?.title
+          ? { title: options.title }
+          : undefined
+      const session = await coordinateRemoteCreate(dedupeKey, createInput)
       const sessionId = createdSessionId(session)
       if (!sessionId) return { success: false as const, reason: "create-failed" as const, message: "Chat session creation did not return a canonical session." }
       const returnedAgentTypeId = (session as { agentTypeId?: unknown }).agentTypeId
@@ -2475,7 +2483,7 @@ export function WorkspaceAgentFront<
     } catch (error) {
       return { success: false as const, reason: "create-failed" as const, message: error instanceof Error ? error.message : "Chat session creation failed." }
     }
-  }, [coordinateRemoteCreate, rawDelete, rawSwitch, selectedAgentTypeId])
+  }, [coordinateRemoteCreate, fleetModeEnabled, rawDelete, rawSwitch, selectedAgentTypeId])
   const createShellChatSession = useCallback(async (options?: { title?: string }) => {
     shellSessionCreateSequenceRef.current += 1
     return await createAddressedSessionWithoutActivating(`shell:${shellSessionCreateSequenceRef.current}`, {

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -3431,6 +3431,34 @@ describe("WorkspaceAgentFront", () => {
     await act(async () => { releaseCreate() })
   })
 
+  it("does not send a synthetic Agent owner when creating a single-Agent quick chat", async () => {
+    const create = vi.fn(async () => ({ id: "quick", agentTypeId: "default", title: "Quick", updatedAt: Date.now(), turnCount: 0 }))
+
+    render(
+      <WorkspaceAgentFront
+        workspaceId="single-agent-quick-create"
+        workspaceLayout="plugin-tabs"
+        chatPanel={ChatPanel}
+        useSessions={() => ({
+          sessions: [{ id: "existing", title: "Existing", updatedAt: Date.now(), turnCount: 0 }],
+          activeSessionId: "existing",
+          activeSession: { id: "existing", title: "Existing", updatedAt: Date.now(), turnCount: 0 },
+          loading: false,
+          create,
+          switch: vi.fn(),
+          delete: vi.fn(),
+        })}
+        persistenceEnabled={false}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Quick chat" }))
+
+    await waitFor(() => expect(create).toHaveBeenCalledOnce())
+    expect(create).toHaveBeenCalledWith({ title: "New session" })
+    expect(await screen.findByRole("button", { name: "Dock panel" })).toBeInTheDocument()
+  })
+
   it("does not pass the New chat click event into remote session creation", async () => {
     const create = vi.fn(async () => ({ id: "manual", title: "Manual", updatedAt: Date.now(), turnCount: 0 }))
 


### PR DESCRIPTION
Single-agent Quick Chat currently forwards the synthetic `agentTypeId: "default"` owner inside the canonical create-session body. Strict Agent hosts reject that unknown field with HTTP 400, so the detached chat silently fails to open.

Strip `agentTypeId` only for single-Agent transport while retaining it for fleet routing and internal owner validation.

Production evidence: Constellation emitted the exact 47-byte body `{"title":"New session","agentTypeId":"default"}` and returned 400; canonical `{}` and `{requestId}` canary requests returned 201.

Validation: focused UI regression test passed, workspace front/server typecheck passed, independent review approved. The broad package test invocation was noisy from unrelated concurrent full-suite timeouts; the focused test was rerun isolated and passed.