### PR TITLE
docs(ratified): multi-seat Threads amendment — 1 Thread = 1 job

### DIFF
--- a/docs/plans/long-term/ratified/RECONCILIATION.md
+++ b/docs/plans/long-term/ratified/RECONCILIATION.md
@@ -175,3 +175,45 @@ AgentId ── DefinitionDigest (exact version)
 **FREEZE.** Ontology, security model, durability model, migration doctrine,
 product ladder, and DAG are settled. Next feedback comes from implementation
 and the first real Agent Product — not another abstraction pass.
+
+---
+
+## 7. OWNER RULING — 2026-08-24 (amendment; multi-seat Thread; tracked in #1399)
+
+Additive to §6, not a reopening: the frozen ontology and invariants above are
+unchanged. This closes the one item §6 left implicit — how a Thread relates to
+more than one Seat's Runs.
+
+**Ruling.** *A Thread may span multiple Seats, projected as one timeline; one
+Thread per job.* Mechanism: no new machinery. Per-Run seat attribution already
+exists — the ratified trajectory spine (Q3 above, `runId · agentId ·
+definitionDigest · seatId · workspaceId · input · trajectory · artifacts ·
+usage · cost · human intervention · evaluation · business outcome`) already
+carries `seatId` per Run. A multi-seat Thread is that same spine read across
+Runs from more than one Seat and rendered as one collapsed timeline; Thread
+still "owns one record and many Runs" per VISION R-c, now including Runs
+authored under different Seats.
+
+**Naming ruling.** This concept is named **multi-seat Thread** / **Job
+Thread**. It is never called a "channel": `channel` stays reserved for
+transport/ingress surfaces (C5 durable pause's "channel-answerable" delivery,
+Track C, Slack/CLI ingress). Thread is the collapse point on the product side;
+channel is how a message reaches or leaves the system. Do not conflate them.
+
+**Explicit non-change.** This ruling does **not** activate A2A loopback or a
+shared-runtime "room" where agents call agents. v0 realization stays
+projection-based: an orchestrator Seat relays between per-agent sessions as an
+ordinary client of each session's record — agents never invoke agents
+directly, and no shared-transcript runtime primitive is promoted by this
+ruling. Any future shared-transcript runtime primitive keeps its own
+promotion gate (Rule of Three / second runtime mode, per VISION R-e) and is
+out of scope here.
+
+**Console/#1355 hook.** Console conversation references must be typed to
+allow a Thread with more than one Seat from the start — contracts must not
+assume single-seat Threads. This is a naming/typing constraint on #1355's
+planning, not new scope for it.
+
+**Deferred (unchanged from RECONCILIATION §5 / VISION §10).** The human-facing
+multi-agent selector/switch UX remains a separate product decision; this
+amendment ratifies the data-model sentence only.

--- a/docs/plans/long-term/ratified/VISION.md
+++ b/docs/plans/long-term/ratified/VISION.md
@@ -114,6 +114,15 @@ Session is the runtime implementation it recasts (A2a per-session record = the
 thread's record). The V2 doc's warning stands: a Thread is not a Pi session,
 transcript, or tab — it *owns* one record and many Runs.
 
+> **Amendment — 2026-08-24 (owner ruling, tracked in #1399; full text in
+> RECONCILIATION.md §7):** a Thread may span multiple Seats, projected as one
+> timeline; one Thread per job. Mechanism = per-Run `seatId` on the existing
+> trajectory spine (Q3), no new machinery. Named **multi-seat Thread / Job
+> Thread**, never "channel" (channel stays reserved for transport/ingress —
+> C5, Track C, Slack/CLI). Does not activate A2A loopback or a shared-runtime
+> room: v0 is projection-based, an orchestrator Seat relaying between
+> per-agent sessions as a client of each; agents never call agents.
+
 **R-d. "RuntimeFilesystem" rename** (V2 §17): correct and cheap — the agent
 package's internal `Workspace` type is filesystem/execution state and collides
 with the product noun. Do at A1 (types extraction) where the rename is free.


### PR DESCRIPTION
## Summary

Ratifies the multi-seat Thread amendment per owner ruling 2026-08-24, tracked in #1399.

- **RECONCILIATION.md §7 (new):** additive dated ruling entry appended after the §6 FREEZE — does not reopen or rewrite frozen text. Records: the core sentence ("A Thread may span multiple Seats, projected as one timeline; one Thread per job."), the mechanism (per-Run `seatId` already on the trajectory spine, no new machinery), the naming ruling (multi-seat Thread / Job Thread, never "channel" — channel stays reserved for transport/ingress: C5, Track C, Slack/CLI), the explicit non-change (no A2A loopback, no shared-runtime room — v0 stays projection-based, orchestrator Seat as a client of each per-agent session), and the #1355 Console hook (typed conversation references must not assume single-seat Threads).
- **VISION.md R-c:** additive amendment blockquote appended directly under the frozen R-c paragraph, pointing to RECONCILIATION.md §7 for full text — R-c itself is untouched.

No product code, no reopening of frozen ontology/invariants/DAG. Owner merge = ratification.

## Test plan

- [x] Additive only — verified no existing ratified text was edited or removed (`git diff` shows insertions only)
- [x] Naming disambiguation cross-checked against existing "channel-answerable" C5 usage in ARCHITECTURE-PLAN.md
- [x] #1355 (Console) confirmed as the open planning issue this typing constraint hooks into

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGA4RhWZGNR5QA9Y7dFzCF