### PR TITLE
plan: Job Thread v0 — 1 Thread = 1 job (K7 demo)

### DIFF
--- a/docs/plans/job-thread-v0-plan-review.html
+++ b/docs/plans/job-thread-v0-plan-review.html
@@ -268,7 +268,8 @@ footer{margin:24px 0 8px;color:var(--muted);font-size:12.5px;text-align:center}
     <div class="slice"><h4>S3</h4><div class="b">Relay state machine + recovery. Chain advance, split
     cursors, caps per chain, full failure-table + 4-step recovery order.</div></div>
     <div class="arrow">→</div>
-    <div class="slice"><h4>S4</h4><div class="b">Front projection. Merged timeline by
+    <div class="slice"><h4>S4</h4><div class="b">Front projection. A message-source adapter feeding
+    the existing chat panel &mdash; not a new timeline view &mdash; merged by
     <code>(turnOrdinal, seq, markerOrdinal)</code>, ask-user join on the full triple.</div></div>
     <div class="arrow">→</div>
     <div class="slice"><h4>S5</h4><div class="b">K7 demo fixture. Scripted acceptance, Objective

--- a/docs/plans/job-thread-v0-plan-review.html
+++ b/docs/plans/job-thread-v0-plan-review.html
@@ -38,6 +38,20 @@ a{color:var(--blue)}
 .grid2{display:grid;grid-template-columns:1fr 1fr;gap:12px}
 @media(max-width:720px){.grid2{grid-template-columns:1fr}}
 .box{border:1px solid var(--line);border-radius:10px;padding:10px 12px;background:color-mix(in srgb,var(--muted) 5%,var(--card))}
+.dg{width:100%;height:auto;display:block;margin:8px 0 4px}
+.dg .bx{fill:color-mix(in srgb,var(--blue) 8%,var(--card));stroke:var(--line);stroke-width:1}
+.dg .bx2{fill:color-mix(in srgb,var(--green) 10%,var(--card));stroke:var(--line);stroke-width:1}
+.dg .bx3{fill:color-mix(in srgb,var(--amber) 13%,var(--card));stroke:var(--line);stroke-width:1}
+.dg .t{fill:var(--ink);font:600 12.5px ui-sans-serif,system-ui,sans-serif}
+.dg .c{fill:var(--muted);font:400 10px ui-monospace,SFMono-Regular,Menlo,monospace}
+.dg .lbl{fill:var(--muted);font:700 10.5px ui-sans-serif,system-ui,sans-serif;letter-spacing:.09em}
+.dg .ln{stroke:var(--line);stroke-width:1.4}
+.dg .ar{stroke:var(--blue);stroke-width:1.5;fill:none}
+.dg .arx{stroke:var(--muted);stroke-width:1.3;fill:none;stroke-dasharray:4 3}
+.dg .m{fill:var(--ink);font:400 11px ui-sans-serif,system-ui,sans-serif;stroke:var(--card);stroke-width:3.5;paint-order:stroke fill}
+.dg .gut{fill:var(--muted);font:700 9.5px ui-sans-serif,system-ui,sans-serif}
+.dg .n{fill:var(--blue);font:700 9.5px ui-sans-serif,system-ui,sans-serif}
+.dgcap{color:var(--muted);font-size:12.5px;margin:2px 0 0}
 .box b{display:block;margin-bottom:4px;font-size:12.5px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted)}
 .slices{display:flex;flex-wrap:wrap;gap:10px;align-items:stretch}
 .slice{border:1px solid var(--line);border-radius:10px;padding:10px 12px;min-width:150px;flex:1;background:color-mix(in srgb,var(--blue) 5%,var(--card))}
@@ -61,6 +75,47 @@ footer{margin:24px 0 8px;color:var(--muted);font-size:12.5px;text-align:center}
   <code>weekend/jobthread-v0-plan</code> · No implementation before owner sign-off</div>
 </header>
 
+<section class="card">
+  <h2>What this plan builds</h2>
+  <p class="tldr">Twelve artifacts, nothing else. Named in product words, with the code noun
+  underneath. Ordering lives in the Slices section &mdash; this is composition, not sequence.</p>
+<svg class="dg" viewBox="0 0 1050 500" role="img" aria-label="Component map: everything this plan builds, grouped by layer">
+<defs><marker id="ah" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 z" fill="var(--muted)"/></marker>
+<marker id="ahb" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 z" fill="var(--blue)"/></marker></defs>
+<text class="lbl" x="30" y="24">THE ONE VIEW THE OWNER READS &#183; S4</text>
+<rect class="bx" x="350" y="36" width="340" height="46" rx="8"/><text class="t" x="520.0" y="55.0" text-anchor="middle">Merged timeline</text><text class="c" x="520.0" y="71.0" text-anchor="middle">src/front/</text>
+<text class="lbl" x="30" y="132">WHAT DECIDES WHAT HAPPENS NEXT &#183; S2, S3</text>
+<rect class="bx2" x="30" y="148" width="225" height="52" rx="8"/><text class="t" x="142.5" y="170.0" text-anchor="middle">Sending one turn</text><text class="c" x="142.5" y="186.0" text-anchor="middle">relayTurn.ts</text><rect class="bx2" x="275" y="148" width="225" height="52" rx="8"/><text class="t" x="387.5" y="170.0" text-anchor="middle">&#8220;Pass this on&#8221;</text><text class="c" x="387.5" y="186.0" text-anchor="middle">handoffTool.ts</text><rect class="bx2" x="520" y="148" width="225" height="52" rx="8"/><text class="t" x="632.5" y="170.0" text-anchor="middle">Who goes next + caps</text><text class="c" x="632.5" y="186.0" text-anchor="middle">relayChain.ts</text><rect class="bx2" x="765" y="148" width="225" height="52" rx="8"/><text class="t" x="877.5" y="170.0" text-anchor="middle">Picking up after a crash</text><text class="c" x="877.5" y="186.0" text-anchor="middle">recovery.ts</text>
+<text class="lbl" x="30" y="240">THE ONE LOCKED WRITE THAT MAKES IT CRASH-SAFE &#183; S1</text>
+<rect class="bx" x="350" y="252" width="340" height="46" rx="8"/><text class="t" x="520.0" y="271.0" text-anchor="middle">Reserve the turn before sending</text><text class="c" x="520.0" y="287.0" text-anchor="middle">openEdge()  &#183;  src/server/edgeLog.ts</text>
+<text class="lbl" x="30" y="336">WHAT IS WRITTEN DOWN &#183; S1</text>
+<rect class="bx3" x="30" y="352" width="150" height="64" rx="8"/><text class="t" x="105.0" y="380.0" text-anchor="middle">The saved job</text><text class="c" x="105.0" y="396.0" text-anchor="middle">JobProjectionV0</text><rect class="bx3" x="196" y="352" width="150" height="64" rx="8"/><text class="t" x="271.0" y="380.0" text-anchor="middle">Its participants</text><text class="c" x="271.0" y="396.0" text-anchor="middle">JobParticipantV0</text><rect class="bx3" x="362" y="352" width="150" height="64" rx="8"/><text class="t" x="437.0" y="380.0" text-anchor="middle">One turn hop</text><text class="c" x="437.0" y="396.0" text-anchor="middle">JobRelayEdgeV0</text><rect class="bx3" x="528" y="352" width="150" height="64" rx="8"/><text class="t" x="603.0" y="380.0" text-anchor="middle">What happened to it</text><text class="c" x="603.0" y="396.0" text-anchor="middle">JobRelayTransitionV0</text><rect class="bx3" x="694" y="352" width="150" height="64" rx="8"/><text class="t" x="769.0" y="380.0" text-anchor="middle">The cap ledger</text><text class="c" x="769.0" y="396.0" text-anchor="middle">JobChainStateV0</text><rect class="bx3" x="860" y="352" width="150" height="64" rx="8"/><text class="t" x="935.0" y="380.0" text-anchor="middle">How far we&#8217;ve read</text><text class="c" x="935.0" y="396.0" text-anchor="middle">JobCursorV0</text>
+<path class="ar" d="M520,250 L520,206" marker-end="url(#ahb)"/>
+<path class="ar" d="M520,300 L520,346" marker-end="url(#ahb)"/>
+<path class="arx" d="M1010,384 L1032,384 L1032,59 L694,59" marker-end="url(#ah)"/>
+<text class="c" x="1044" y="222" text-anchor="middle" transform="rotate(-90 1044 222)">projected into the timeline</text>
+<rect class="bx" x="30" y="440" width="980" height="40" rx="8"/><text class="t" x="520.0" y="456.0" text-anchor="middle">Proof the whole path works &#8212; scripted, deterministic, zero live model calls</text><text class="c" x="520.0" y="472.0" text-anchor="middle">K7 demo fixture  &#183;  S5  &#183;  src/server/__tests__/k7Demo.test.ts</text>
+</svg>
+  <p class="dgcap">All paths are under <code>plugins/job-threads/</code>.</p>
+  <h3>One handoff turn &mdash; and what the participants share</h3>
+<svg class="dg" viewBox="0 0 1050 606" role="img" aria-label="One full handoff turn, and the shared workspace beneath both participants">
+<defs>
+<marker id="ah2" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 z" fill="var(--blue)"/></marker>
+<marker id="ah3" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 z" fill="var(--muted)"/></marker>
+</defs>
+<rect class="bx" x="44" y="18" width="152" height="42" rx="8"/><text class="t" x="120" y="36" text-anchor="middle">Owner</text><text class="c" x="120" y="50" text-anchor="middle">the human</text><line class="ln" x1="120" y1="60" x2="120" y2="556"/><rect class="bx" x="244" y="18" width="152" height="42" rx="8"/><text class="t" x="320" y="36" text-anchor="middle">Relay</text><text class="c" x="320" y="50" text-anchor="middle">a service, not an agent</text><line class="ln" x1="320" y1="60" x2="320" y2="556"/><rect class="bx" x="444" y="18" width="152" height="42" rx="8"/><text class="t" x="520" y="36" text-anchor="middle">Store</text><text class="c" x="520" y="50" text-anchor="middle">job store, CAS</text><line class="ln" x1="520" y1="60" x2="520" y2="556"/><rect class="bx" x="654" y="18" width="152" height="42" rx="8"/><text class="t" x="730" y="36" text-anchor="middle">Worker</text><text class="c" x="730" y="50" text-anchor="middle">participant A</text><line class="ln" x1="730" y1="60" x2="730" y2="540"/><rect class="bx" x="854" y="18" width="152" height="42" rx="8"/><text class="t" x="930" y="36" text-anchor="middle">Reviewer</text><text class="c" x="930" y="50" text-anchor="middle">participant B</text><line class="ln" x1="930" y1="60" x2="930" y2="540"/><text class="gut" x="16" y="99">1</text><text class="m" x="220.0" y="90" text-anchor="middle">post a message to the JOB</text><path class="ar" d="M120,96 L320,96" marker-end="url(#ah2)"/><text class="gut" x="16" y="133">2</text><text class="m" x="420.0" y="124" text-anchor="middle">openEdge &#8212; new chain, ordinal 1, mint requestId, reserve caps, pending</text><path class="ar" d="M320,130 L520,130" marker-end="url(#ah2)"/><text class="gut" x="16" y="167">3</text><text class="m" x="420.0" y="158" text-anchor="middle">edge1</text><path class="arx" d="M520,164 L320,164" marker-end="url(#ah3)"/><text class="gut" x="16" y="201">4</text><text class="m" x="525.0" y="192" text-anchor="middle">dispatch keyed by edge1.requestId</text><path class="ar" d="M320,198 L730,198" marker-end="url(#ah2)"/><text class="gut" x="16" y="235">5</text><text class="m" x="525.0" y="226" text-anchor="middle">accepted &#8212; cursor, duplicate?</text><path class="arx" d="M730,232 L320,232" marker-end="url(#ah3)"/><text class="gut" x="16" y="269">6</text><text class="m" x="420.0" y="260" text-anchor="middle">append transition: accepted</text><path class="ar" d="M320,266 L520,266" marker-end="url(#ah2)"/><text class="gut" x="16" y="303">7</text><text class="m" x="525.0" y="294" text-anchor="middle">settles &#8212; agent-end, willRetry false, final post</text><path class="arx" d="M730,300 L320,300" marker-end="url(#ah3)"/><text class="gut" x="16" y="337">8</text><text class="m" x="420.0" y="328" text-anchor="middle">append transition: settled, advance cursor</text><path class="ar" d="M320,334 L520,334" marker-end="url(#ah2)"/><text class="gut" x="16" y="371">9</text><text class="m" x="525.0" y="362" text-anchor="middle">handoff to reviewer &#8212; typed tool, never parsed from prose</text><path class="arx" d="M730,368 L320,368" marker-end="url(#ah3)"/><text class="gut" x="16" y="405">10</text><text class="m" x="420.0" y="396" text-anchor="middle">openEdge &#8212; same chain, ordinal 2, hop 1</text><path class="ar" d="M320,402 L520,402" marker-end="url(#ah2)"/><text class="gut" x="16" y="439">11</text><text class="m" x="625.0" y="430" text-anchor="middle">dispatch keyed by edge2.requestId, context after B&#8217;s watermark</text><path class="ar" d="M320,436 L930,436" marker-end="url(#ah2)"/><text class="gut" x="16" y="473">12</text><text class="m" x="625.0" y="464" text-anchor="middle">settles &#8212; final post</text><path class="arx" d="M930,470 L320,470" marker-end="url(#ah3)"/><text class="gut" x="16" y="507">13</text><text class="m" x="220.0" y="498" text-anchor="middle">one timeline, ordered by (turnOrdinal, seq, markerOrdinal)</text><path class="ar" d="M320,504 L120,504" marker-end="url(#ah2)"/><rect class="bx2" x="620" y="548" width="420" height="46" rx="8"/><text class="t" x="830" y="566" text-anchor="middle">ONE shared workspace &#183; one canonical filesystem</text><text class="c" x="830" y="581" text-anchor="middle">the worker&#8217;s files ARE the reviewer&#8217;s files &#183; D25:410, D28:463</text><path class="arx" d="M730,540 L730,548"/><path class="arx" d="M930,540 L930,548"/></svg>
+  <p class="dgcap"><b>Two boundaries, only one restrictive.</b> Above the line, the
+  <b>conversation</b> boundary is closed: only the two settled <b>final posts</b> cross between
+  participants &mdash; private reasoning, tool calls and credentials never do. Below the line, the
+  <b>artifact</b> boundary is open: both participants share <b>one workspace and one canonical
+  filesystem</b> (D25 <code>:410</code>, D28 <code>:462-463</code>), so the reviewer reads the very
+  files the worker wrote &mdash; nothing is copied or synced. Participants share the work, not each
+  other&#8217;s minds and keys.</p>
+  <p class="dgcap">Steps 2 and 10 are the crash-safety keystone: a turn is reserved <b>before</b>
+  anything is sent, so a crash can never leave an unrecorded send or an escaped cap count. The plan
+  carries three further diagrams (data model, recovery order, edge lifecycle) as Mermaid in
+  <code>docs/plans/job-thread-v0-plan.md</code>.</p>
+</section>
 <section class="card">
   <h2>Review provenance</h2>
   <p>Round 1 went through a fresh-eyes pass and cross-model adversarial review; every accepted finding
@@ -121,16 +176,32 @@ footer{margin:24px 0 8px;color:var(--muted);font-size:12.5px;text-align:center}
   <div class="rec"><b>Recommended: accept display-grade for v0.</b> Envelope-grade attribution arrives
   with C7, not with this demo.</div>
 
-  <h3 class="qhead"><span class="qnum">4</span><span class="qtitle">Post/Run boundary — what crosses seats?</span></h3>
+  <h3 class="qhead"><span class="qnum">4</span><span class="qtitle">The two boundaries — what is shared, what is not?</span></h3>
+  <p>The plan has <b>two</b> boundaries and only one of them is restrictive. They are easy to
+  conflate, and conflating them makes the design read as agents walled off from each other, which is
+  the opposite of what it says.</p>
   <table class="two"><tr><th>Options</th><th>Unblocks / costs</th></tr>
-  <tr><td><b>Confirm narrow crossing</b> — only the settled final assistant message
+  <tr><td><b>Artifact boundary — OPEN.</b> Participants on a job share <b>one workspace and one
+  canonical filesystem</b>. Ratified, not invented: agents in a workspace &ldquo;intentionally share
+  filesystem/process/runtime authority while retaining distinct &hellip; session &hellip; and
+  provenance identity&rdquo; (D25 <code>:410</code>), and same-workspace agents get execution views
+  &ldquo;without copying the authoritative filesystem&rdquo; (D28 <code>:463</code>). Reach is
+  governed by mounts and per-participant tool authority, not by partition.</td>
+  <td><b>Confirms</b>: the reviewer reads the very files the worker wrote &mdash; nothing copied,
+  synced, or attached. This is the half of the shared-VM feel people actually like, delivered
+  natively and governed. Rejecting it would mean per-participant copies and a second authoritative
+  file tree, which D28 <code>:462</code> exists to prevent.</td></tr>
+  <tr><td><b>Conversation boundary — CLOSED.</b> Only the settled final assistant message
   (<code>message-end.final</code>, gated on non-<code>willRetry</code>) and relay-authored system
-  handoff markers cross seats. No tool calls, no intermediate messages, no private reasoning.</td>
-  <td><b>Confirms</b>: each seat's private reasoning/tool trace stays reachable only by drill-down —
-  the demo's privacy and noise story. A wider boundary would need re-litigating the handoff tool and
-  the merged-timeline renderer.</td></tr></table>
-  <div class="rec"><b>Recommended: confirm the narrow boundary.</b> This is the only shape in the plan;
-  no alternative is proposed.</div>
+  handoff markers enter another participant's <i>prompt</i>. No tool calls, no intermediate messages,
+  no private reasoning, no credentials.</td>
+  <td><b>Confirms</b>: each participant's private trace stays reachable only by drill-down — the
+  demo's privacy and noise story. A wider boundary would need re-litigating the handoff tool and the
+  merged-timeline renderer.</td></tr></table>
+  <div class="rec"><b>Recommended: confirm the pairing.</b> Participants share the work, not each
+  other's minds and keys. Sharing context windows is what makes multi-agent setups leak secrets and
+  drown in tool spew; sharing a filesystem is what lets them collaborate at all. v0 takes the second
+  and refuses the first.</div>
 
   <h3 class="qhead"><span class="qnum">5</span><span class="qtitle">Objective coupling — mandatory, or optional one-way ref?</span></h3>
   <table class="two"><tr><th>Options</th><th>Unblocks / costs</th></tr>

--- a/docs/plans/job-thread-v0-plan-review.html
+++ b/docs/plans/job-thread-v0-plan-review.html
@@ -273,6 +273,10 @@ footer{margin:24px 0 8px;color:var(--muted);font-size:12.5px;text-align:center}
     <div class="arrow">→</div>
     <div class="slice"><h4>S5</h4><div class="b">K7 demo fixture. Scripted acceptance, Objective
     compensation, labelled live smoke.</div></div>
+    <div class="slice" style="opacity:.6;background:color-mix(in srgb,var(--muted) 8%,var(--card))">
+    <h4>S6 &mdash; deferred</h4><div class="b">Staffing UI (add/remove participants), small. Chip
+    &quot;+&quot; picker, @mention add-confirm, remove affordance. Mechanics ship in S3; blocked by
+    S3, S4; not on the v0 critical path.</div></div>
   </div>
   <div class="grid2" style="margin-top:12px">
     <div class="box"><b>PR preconditions</b>

--- a/docs/plans/job-thread-v0-plan-review.html
+++ b/docs/plans/job-thread-v0-plan-review.html
@@ -173,7 +173,7 @@ footer{margin:24px 0 8px;color:var(--muted);font-size:12.5px;text-align:center}
   <h3 class="qhead"><span class="qnum">8</span><span class="qtitle">Acceptance bar — fixture-driven gate, live-model as labelled smoke?</span></h3>
   <table class="two"><tr><th>Options</th><th>Unblocks / costs</th></tr>
   <tr><td><b>Confirm (proposed)</b> — S5 acceptance runs a scripted model adapter emitting a fixed
-  event script, asserting exact <code>threadTurnId</code> sequence, handoff edges, cap outcomes, and
+  event script, asserting exact <code>turnOrdinal</code> sequence, handoff edges, cap outcomes, and
   final Objective state. A live-model walkthrough is kept but explicitly labelled non-deterministic —
   never a gate.</td>
   <td><b>Confirms</b>: nothing in CI depends on live-model determinism, which round 1 wrongly assumed.
@@ -187,17 +187,18 @@ footer{margin:24px 0 8px;color:var(--muted);font-size:12.5px;text-align:center}
   <p class="small">Ordering lives only here. The real critical path is the two open PRs, not the
   deferred #1355 gate.</p>
   <div class="slices">
-    <div class="slice"><h4>S1</h4><div class="b">Projection contract + store.<br><code>JobProjectionV0</code>,
-    <code>JobParticipantV0</code>, <code>JobRelayReceiptV0</code> schemas; file store, revision CAS.</div></div>
+    <div class="slice"><h4>S1</h4><div class="b">Contract + store + edge allocator.<br><code>JobProjectionV0</code>,
+    <code>JobRelayEdgeV0</code>, <code>JobRelayTransitionV0</code> schemas; CAS store; <code>openEdge()</code>
+    allocates the ordinal, mints <code>requestId</code>, reserves caps.</div></div>
     <div class="arrow">→</div>
     <div class="slice"><h4>S2</h4><div class="b">Relay dispatch + handoff tool.
     <code>runWithWorkspaceAgent</code>-based relay turn; typed <code>handoff({to,message})</code> tool.</div></div>
     <div class="arrow">→</div>
-    <div class="slice"><h4>S3</h4><div class="b">Relay state machine. Chain advance, caps, context
-    truncation, full failure-table + restart resume.</div></div>
+    <div class="slice"><h4>S3</h4><div class="b">Relay state machine + recovery. Chain advance, split
+    cursors, caps per chain, full failure-table + 4-step recovery order.</div></div>
     <div class="arrow">→</div>
     <div class="slice"><h4>S4</h4><div class="b">Front projection. Merged timeline by
-    <code>(threadTurnId, seq)</code>, ask-user join on the full triple.</div></div>
+    <code>(turnOrdinal, seq, markerOrdinal)</code>, ask-user join on the full triple.</div></div>
     <div class="arrow">→</div>
     <div class="slice"><h4>S5</h4><div class="b">K7 demo fixture. Scripted acceptance, Objective
     compensation, labelled live smoke.</div></div>
@@ -221,11 +222,15 @@ footer{margin:24px 0 8px;color:var(--muted);font-size:12.5px;text-align:center}
 <section class="card">
   <h2>Honest risks</h2>
   <table><tr><th>Risk</th><th>Likelihood</th><th>Impact</th><th>Mitigation</th></tr>
-  <tr><td>Receipt contract (<code>JobRelayReceiptV0</code>) is the newest, least-proven surface — it
-  carries the only total order across seats, idempotency, and cap enforcement in one record.</td>
-  <td class="med">Medium</td><td class="high">High</td>
-  <td>Scripted-adapter tests assert exact <code>threadTurnId</code> sequence and every row of the §2
-  failure table, including restart resume, before S4/S5 build on top of it.</td></tr>
+  <tr><td>Relay edge/transition contract is the newest surface — it carries the total order across
+  seats, send idempotency, and cap enforcement. <b>Hardened after a targeted verify pass</b>: the
+  send&rarr;persist crash window, a restart skip-hole, string-ordinal sorting, and in-place mutation
+  of an &ldquo;append-only&rdquo; record were all found and fixed.</td>
+  <td class="low">Low&ndash;Medium</td><td class="high">High</td>
+  <td>Pending edge written pre-dispatch under one CAS lock with a relay-minted <code>requestId</code>
+  (re-dispatch returns <code>duplicate:true</code>); store-owned integer ordinals; append-only
+  transitions; 4-step recovery reconciles durable state before <code>outcome-unknown</code>. S1/S3
+  negative proofs assert each.</td></tr>
   <tr><td>Critical path runs through two <b>open</b> PRs, not this gate: #1401 (naming ratification)
   blocks S1 directly; #1382 (objectives) blocks S5.</td>
   <td class="high">High</td><td class="high">High</td>

--- a/docs/plans/job-thread-v0-plan-review.html
+++ b/docs/plans/job-thread-v0-plan-review.html
@@ -1,0 +1,255 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Job Thread v0 — owner gate</title>
+<style>
+:root{color-scheme:light dark;--bg:#f3f5f8;--card:#fff;--ink:#172033;--muted:#647084;--line:#d9dee8;--blue:#2456d6;--green:#137a52;--amber:#916500;--red:#b42318}
+@media(prefers-color-scheme:dark){:root{--bg:#0f131b;--card:#181e29;--ink:#eef3fa;--muted:#a9b4c5;--line:#303a4b;--blue:#8cadff;--green:#65d7a5;--amber:#efc75f;--red:#ff8c84}}
+*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--ink);font:15px/1.55 ui-sans-serif,system-ui,-apple-system,Segoe UI,sans-serif}
+.wrap{max-width:1080px;margin:auto;padding:20px}
+.hero,.card{background:var(--card);border:1px solid var(--line);border-radius:14px;box-shadow:0 8px 28px #0000000d}
+.hero{padding:22px 24px;border-top:5px solid var(--blue)}
+.eyebrow{color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.09em}
+.row{display:flex;gap:12px;align-items:center;flex-wrap:wrap}
+h1{font-size:clamp(23px,4vw,36px);line-height:1.12;margin:6px 0}
+.pill{padding:4px 9px;border-radius:999px;background:#fff0c7;color:#6b4900;font-weight:700;font-size:12px}
+.meta,.small{color:var(--muted)}
+.tldr{font-size:17px;max-width:900px}
+.card{padding:20px 22px;margin-top:16px}
+h2{margin:0 0 12px;font-size:20px}
+h3{margin:18px 0 8px;font-size:15.5px}
+table{border-collapse:collapse;width:100%;display:block;overflow:auto}
+th,td{border:1px solid var(--line);padding:9px 11px;text-align:left;vertical-align:top;font-size:14px}
+th{background:color-mix(in srgb,var(--blue) 8%,var(--card))}
+.two td{width:50%}
+ul{margin:5px 0;padding-left:20px}
+code{background:color-mix(in srgb,var(--muted) 13%,transparent);padding:1px 5px;border-radius:5px;font-size:.92em}
+.low{background:color-mix(in srgb,var(--green) 14%,var(--card))}
+.med{background:color-mix(in srgb,var(--amber) 15%,var(--card))}
+.high{background:color-mix(in srgb,var(--red) 14%,var(--card))}
+.callout{border-left:4px solid var(--blue);padding:4px 0 4px 14px;margin-top:10px}
+.warn{border-left:4px solid var(--amber);padding:4px 0 4px 14px;margin-top:10px}
+.review{border-left:4px solid var(--amber);padding-left:14px}
+a{color:var(--blue)}
+.qnum{display:inline-flex;align-items:center;justify-content:center;width:26px;height:26px;border-radius:8px;background:var(--blue);color:#fff;font-weight:800;font-size:13px;margin-right:8px;flex:none}
+.qhead{display:flex;align-items:center;gap:2px}
+.qtitle{font-size:16px;font-weight:700}
+.rec{border:1px solid var(--line);border-radius:10px;padding:12px 14px;background:color-mix(in srgb,var(--green) 8%,var(--card));margin-top:10px}
+.rec b{color:var(--green)}
+.grid2{display:grid;grid-template-columns:1fr 1fr;gap:12px}
+@media(max-width:720px){.grid2{grid-template-columns:1fr}}
+.box{border:1px solid var(--line);border-radius:10px;padding:10px 12px;background:color-mix(in srgb,var(--muted) 5%,var(--card))}
+.box b{display:block;margin-bottom:4px;font-size:12.5px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted)}
+.slices{display:flex;flex-wrap:wrap;gap:10px;align-items:stretch}
+.slice{border:1px solid var(--line);border-radius:10px;padding:10px 12px;min-width:150px;flex:1;background:color-mix(in srgb,var(--blue) 5%,var(--card))}
+.slice h4{margin:0 0 4px;font-size:14px}
+.slice .b{font-size:12.5px;color:var(--muted)}
+.arrow{align-self:center;color:var(--muted);font-size:20px}
+.gate{border:1px dashed var(--amber);border-radius:10px;padding:8px 12px;background:color-mix(in srgb,var(--amber) 12%,var(--card));font-size:13px;margin-top:10px}
+footer{margin:24px 0 8px;color:var(--muted);font-size:12.5px;text-align:center}
+</style></head><body><main class="wrap">
+
+<header class="hero">
+  <div class="eyebrow">Gate 1 · Plan approval</div>
+  <div class="row"><h1>Job Thread v0 — 1 Thread = 1 job</h1><span class="pill">OWNER DECISION</span></div>
+  <p class="tldr">A <b>projection</b>, not a new Thread: several per-agent Pi sessions merged into one job
+  timeline via a stateless <b>relay</b>, with typed handoffs, centrally-enforced caps, and an honest
+  failure/restart contract. K7 demo — "grow audience 1,200 → 5,000" — proves it with two fleet agents
+  (worker/reviewer) and one Objective.</p>
+  <div class="meta">Round 2 (folds fresh-eyes + cross-model review) · PR
+  <a href="https://github.com/hachej/boring-ui/pull/1403">#1403</a> · Issue
+  <a href="https://github.com/hachej/boring-ui/issues/1399">#1399</a> · Branch
+  <code>weekend/jobthread-v0-plan</code> · No implementation before owner sign-off</div>
+</header>
+
+<section class="card">
+  <h2>Review provenance</h2>
+  <p>Round 1 went through a fresh-eyes pass and cross-model adversarial review; every accepted finding
+  is folded into this revision, not left as an open thread. Verdict on round 1 was
+  <code>revise</code> at commit <code>9e42e893a</code> — this document (<code>2e9d4ba41</code>) is the
+  answer to that verdict. Corrections carried in explicitly: the "no A2A loopback" framing was a
+  misread (Decision 24 ratifies a native in-process agent-to-agent binding; relay-vs-native is now
+  owner question 2, not a compliance requirement); the round-1 record silently minted a second Thread
+  object and called the relay an "orchestrator seat" against the frozen Seat definition — both
+  withdrawn; the per-Thread budget hook and the "deterministic live-model" acceptance claim were both
+  found unbuildable/false and dropped rather than fudged.</p>
+  <div class="callout"><strong>What v0 is not:</strong> no new canonical Thread or Seat identity, no
+  shared runtime transcript, no native agent-to-agent binding (available, ratified, deferred to a
+  question below), no per-Thread budget, no Level D conformance claim. Full list in §6 of the plan.</div>
+</section>
+
+<section class="card">
+  <h2>Owner questions — one decision per section</h2>
+  <p class="small">Each section: the question, the options on the table, the plan's recommendation with
+  its one-line reason, and what taking it unblocks or costs.</p>
+
+  <h3 class="qhead"><span class="qnum">1</span><span class="qtitle">The noun — new descriptor, or the canonical Thread?</span></h3>
+  <table class="two"><tr><th>Options</th><th>Unblocks / costs</th></tr>
+  <tr><td><b>Q1-A</b> — <code>JobProjectionV0</code>: a distinct, deletable record. Not a Thread. Leaves
+  frozen <code>Thread</code>/<code>Seat</code> untouched, R-c intact.<br><br>
+  <b>Q1-B</b> — <code>JobProjection</code> <i>is</i> the canonical Thread. Cheaper than round-1 review
+  assumed: frozen <code>Thread</code> already carries a <code>participants</code> field.</td>
+  <td><b>Q1-A unblocks</b>: S1 can start now; nothing to migrate later if v0 is killed.<br>
+  <b>Q1-B costs</b>: an explicit R-c amendment, pulls ratified P0 "<code>seatId</code> in C7" forward,
+  forces a rework of #1355's <code>ConsoleThreadRefV1</code> unique key <i>before</i> #1355
+  implements, and needs a migration for any Thread ref already written.</td></tr></table>
+  <div class="rec"><b>Recommended: Q1-A.</b> Better end state, wrong v0 — pay the ontology cost only
+  once the shape is proven.</div>
+
+  <h3 class="qhead"><span class="qnum">2</span><span class="qtitle">Relay vs. the ratified native agent-to-agent binding</span></h3>
+  <table class="two"><tr><th>Options</th><th>Unblocks / costs</th></tr>
+  <tr><td>Decision 24 already ratifies a native in-process binding (<code>input-required</code>,
+  two-way chat, no MCP loopback) for internal agent-to-agent consumption — it is available, not
+  forbidden.<br><br>
+  <b>Relay (proposed)</b> — a stateless, non-agent, non-Seat function over
+  <code>runWithWorkspaceAgent</code>; no new agent-facing capability.<br><br>
+  <b>Native binding</b> — build the ratified mechanism now instead.</td>
+  <td><b>Relay unblocks</b>: no new authority-bearing host seam, no long-lived scope, fully deletable,
+  caps enforced centrally outside agent code.<br>
+  <b>Native binding costs</b>: agents gain a direct calling capability that must then be scoped,
+  audited, and capped per-agent rather than in one place.</td></tr></table>
+  <div class="rec"><b>Recommended: relay.</b> This is a live product choice, not a compliance
+  requirement — v0 picks the cheaper, deletable shape.</div>
+
+  <h3 class="qhead"><span class="qnum">3</span><span class="qtitle">Attribution grade — display handle, or envelope-grade <code>seatId</code>?</span></h3>
+  <table class="two"><tr><th>Options</th><th>Unblocks / costs</th></tr>
+  <tr><td><b>Accept display-grade</b> — <code>participantId</code> is a temporary handle, no audit
+  weight, lives in a mutable record.<br><br>
+  <b>Pull C7 <code>seatId</code> forward</b> — envelope-grade attribution now, matching ratified P0.</td>
+  <td><b>Accept unblocks</b>: S1–S5 proceed against today's envelope shape (<code>agent-host/types.ts</code>
+  has no seat field yet).<br><b>Pulling C7 forward costs</b>: brings a ratified-but-not-yet-built C7
+  dependency into v0's critical path.</td></tr></table>
+  <div class="rec"><b>Recommended: accept display-grade for v0.</b> Envelope-grade attribution arrives
+  with C7, not with this demo.</div>
+
+  <h3 class="qhead"><span class="qnum">4</span><span class="qtitle">Post/Run boundary — what crosses seats?</span></h3>
+  <table class="two"><tr><th>Options</th><th>Unblocks / costs</th></tr>
+  <tr><td><b>Confirm narrow crossing</b> — only the settled final assistant message
+  (<code>message-end.final</code>, gated on non-<code>willRetry</code>) and relay-authored system
+  handoff markers cross seats. No tool calls, no intermediate messages, no private reasoning.</td>
+  <td><b>Confirms</b>: each seat's private reasoning/tool trace stays reachable only by drill-down —
+  the demo's privacy and noise story. A wider boundary would need re-litigating the handoff tool and
+  the merged-timeline renderer.</td></tr></table>
+  <div class="rec"><b>Recommended: confirm the narrow boundary.</b> This is the only shape in the plan;
+  no alternative is proposed.</div>
+
+  <h3 class="qhead"><span class="qnum">5</span><span class="qtitle">Objective coupling — mandatory, or optional one-way ref?</span></h3>
+  <table class="two"><tr><th>Options</th><th>Unblocks / costs</th></tr>
+  <tr><td><b>Optional one-way ref (proposed)</b> — job points at <code>objectiveId</code>;
+  <code>Objective</code> gains no <code>threadId</code>; PR <a href="https://github.com/hachej/boring-ui/pull/1382">#1382</a> stays untouched.
+  Compensated with <code>clientRequestId</code> if the projection write fails after Objective
+  creation.<br><br>
+  <b>Mandatory + back-ref</b> — <code>Objective</code> gains a <code>threadId</code>.</td>
+  <td><b>One-way ref unblocks</b>: #1382 (open) needs zero changes, S5 can build against it as-is.<br>
+  <b>Mandatory back-ref costs</b>: a schema change to an already-open PR, and a second write path to
+  keep consistent.</td></tr></table>
+  <div class="rec"><b>Recommended: optional one-way ref.</b> Keeps #1382 stable; the demo still works
+  end to end.</div>
+
+  <h3 class="qhead"><span class="qnum">6</span><span class="qtitle">Context truncation and budget — confirm both out-of-scope shapes</span></h3>
+  <table class="two"><tr><th>Options</th><th>Unblocks / costs</th></tr>
+  <tr><td><b>Confirm</b> — oldest-first truncation only, no summarization (a summarizer would be an
+  unreviewed model call inside the relay); per-Thread <i>spend</i> is out of v0 because
+  <code>MeteringRunScope</code> has no job/thread/participant dimension today.</td>
+  <td><b>Confirms</b>: v0 ships only relay-enforced hop/invocation caps, which bound hops, not money.
+  A real budget needs a job dimension threaded through the reservation path — named explicitly as v1
+  work, not a v0 claim.</td></tr></table>
+  <div class="rec"><b>Recommended: confirm both.</b> Building either now would be new unbudgeted scope
+  disguised as v0.</div>
+
+  <h3 class="qhead"><span class="qnum">7</span><span class="qtitle">Level D streaming conformance — complete now, or defer?</span></h3>
+  <table class="two"><tr><th>Options</th><th>Unblocks / costs</th></tr>
+  <tr><td><b>Ship against Level B (proposed)</b> — bounded in-process replay + snapshot rehydrate;
+  §3's receipts (not the event stream) own cross-seat causality, so a refetch rebuilds seat content
+  while ordering survives. Accepted gap: a turn in flight during a host restart cannot replay its
+  streaming detail, only its settled snapshot.<br><br>
+  <b>Complete Level D now</b> — every conformance test is currently <code>it.skip</code>, owner-annotated
+  to the streaming lane (<a href="https://github.com/hachej/boring-ui">#1009</a>).</td>
+  <td><b>Level B unblocks</b>: S3/S4 proceed with no new streaming-lane dependency.<br>
+  <b>Completing Level D costs</b>: pulls an entire deferred conformance lane into v0's critical
+  path for one edge case (in-flight-turn replay after restart).</td></tr></table>
+  <div class="rec"><b>Recommended: ship against Level B.</b> The one gap it accepts is narrow and named,
+  not hidden.</div>
+
+  <h3 class="qhead"><span class="qnum">8</span><span class="qtitle">Acceptance bar — fixture-driven gate, live-model as labelled smoke?</span></h3>
+  <table class="two"><tr><th>Options</th><th>Unblocks / costs</th></tr>
+  <tr><td><b>Confirm (proposed)</b> — S5 acceptance runs a scripted model adapter emitting a fixed
+  event script, asserting exact <code>threadTurnId</code> sequence, handoff edges, cap outcomes, and
+  final Objective state. A live-model walkthrough is kept but explicitly labelled non-deterministic —
+  never a gate.</td>
+  <td><b>Confirms</b>: nothing in CI depends on live-model determinism, which round 1 wrongly assumed.
+  Rejecting this would require inventing a determinism guarantee the underlying gateway does not
+  make.</td></tr></table>
+  <div class="rec"><b>Recommended: confirm.</b> The only honest gate available today.</div>
+</section>
+
+<section class="card">
+  <h2>Slices — S1 → S5, with gates and PR preconditions</h2>
+  <p class="small">Ordering lives only here. The real critical path is the two open PRs, not the
+  deferred #1355 gate.</p>
+  <div class="slices">
+    <div class="slice"><h4>S1</h4><div class="b">Projection contract + store.<br><code>JobProjectionV0</code>,
+    <code>JobParticipantV0</code>, <code>JobRelayReceiptV0</code> schemas; file store, revision CAS.</div></div>
+    <div class="arrow">→</div>
+    <div class="slice"><h4>S2</h4><div class="b">Relay dispatch + handoff tool.
+    <code>runWithWorkspaceAgent</code>-based relay turn; typed <code>handoff({to,message})</code> tool.</div></div>
+    <div class="arrow">→</div>
+    <div class="slice"><h4>S3</h4><div class="b">Relay state machine. Chain advance, caps, context
+    truncation, full failure-table + restart resume.</div></div>
+    <div class="arrow">→</div>
+    <div class="slice"><h4>S4</h4><div class="b">Front projection. Merged timeline by
+    <code>(threadTurnId, seq)</code>, ask-user join on the full triple.</div></div>
+    <div class="arrow">→</div>
+    <div class="slice"><h4>S5</h4><div class="b">K7 demo fixture. Scripted acceptance, Objective
+    compensation, labelled live smoke.</div></div>
+  </div>
+  <div class="grid2" style="margin-top:12px">
+    <div class="box"><b>PR preconditions</b>
+      S1 blocked by owner Q1 ruling + PR <a href="https://github.com/hachej/boring-ui/pull/1401">#1401</a>
+      merged (naming amendment). S5 additionally blocked by PR
+      <a href="https://github.com/hachej/boring-ui/pull/1382">#1382</a> merged (objectives).
+      <a href="https://github.com/hachej/boring-ui/pull/1393">#1393</a> blocks only the deferred
+      Console follow-on, not S1–S5.</div>
+    <div class="box"><b>Deferred, not a v0 slice</b>
+      Console nav reframe (jobs primary, agent directory, participant chips) — gate-blocked on
+      #1355 Gate 1 and #1393, needs a <code>ConsoleThreadRefV1</code> repair filed separately.
+      Does not depend on S4.</div>
+  </div>
+  <div class="gate">Gate G = #1355 Gate 1 architecture approval binds <b>only</b> the deferred
+  Console follow-on — v0 touches no Console store, so S1–S5 do not wait on it.</div>
+</section>
+
+<section class="card">
+  <h2>Honest risks</h2>
+  <table><tr><th>Risk</th><th>Likelihood</th><th>Impact</th><th>Mitigation</th></tr>
+  <tr><td>Receipt contract (<code>JobRelayReceiptV0</code>) is the newest, least-proven surface — it
+  carries the only total order across seats, idempotency, and cap enforcement in one record.</td>
+  <td class="med">Medium</td><td class="high">High</td>
+  <td>Scripted-adapter tests assert exact <code>threadTurnId</code> sequence and every row of the §2
+  failure table, including restart resume, before S4/S5 build on top of it.</td></tr>
+  <tr><td>Critical path runs through two <b>open</b> PRs, not this gate: #1401 (naming ratification)
+  blocks S1 directly; #1382 (objectives) blocks S5.</td>
+  <td class="high">High</td><td class="high">High</td>
+  <td>Both are named explicitly as blockers in §7 rather than assumed merged; S1–S4 can still proceed
+  on #1401 alone.</td></tr>
+  <tr><td>Per-Thread spend budget dropped from v0 — round 1 promised a budget hook that
+  <code>MeteringRunScope</code> cannot support today (no job/thread/participant field).</td>
+  <td class="low">Low (accepted)</td><td class="med">Medium</td>
+  <td>v0 ships hop/invocation caps only; a real budget is named as v1 work requiring a
+  <code>MeteringRunScope</code> schema change — not silently dropped, explicitly out.</td></tr>
+  <tr><td>Attribution is display-grade (<code>participantId</code>), not envelope-grade — round 1's
+  claim that per-Run <code>seatId</code> gives audit parity is withdrawn.</td>
+  <td class="med">Medium</td><td class="med">Medium</td>
+  <td>Recorded honestly in §8; causal initiator vs. authorization principal are distinguished in the
+  receipt (<code>sourceRef</code>/<code>handoffEdge</code>) even without seat identity.</td></tr>
+  </table>
+</section>
+
+<section class="card">
+  <h2>Owner action</h2>
+  <p>Rule on the 8 questions above (defaults shown are the plan's recommendation — silence is not
+  approval). Approval unlocks S1 only; it does not authorize skipping per-slice proof or merge gates.
+  Reject, request changes, or defer per question if needed.</p>
+</section>
+
+<footer>Job Thread v0 · round 2 · PR #1403 · built per <code>docs/procedures/visual-review-doc.md</code></footer>
+</main></body></html>

--- a/docs/plans/job-thread-v0-plan.md
+++ b/docs/plans/job-thread-v0-plan.md
@@ -1,8 +1,8 @@
 ---
 title: Job Thread v0 — 1 Thread = 1 job
-state: draft
+state: draft (round 2 — folds fresh-eyes + Sol adversarial review)
 issue: 1399
-review: pending cross-model review; no implementation before it
+review: verdict `revise` at 9e42e893a; this revision answers it. No implementation before owner sign-off.
 ---
 
 # Job Thread v0 — multi-seat Thread projection, K7 demo
@@ -10,291 +10,411 @@ review: pending cross-model review; no implementation before it
 **Concept** (owner, [#1399](https://github.com/hachej/boring-ui/issues/1399)): the Thread is the unit
 of WORK, not of agent. The human talks to the job; staffing collapses behind one merged timeline, and
 per-agent sessions demote to drill-down provenance — CI logs behind a PR check. Convergence:
-**1 Thread = 1 job = 1 Objective**, staffed by Seats.
+**1 Thread = 1 job = 1 Objective**.
 
-**Naming is ratified, not free**: *multi-seat Thread* / *Job Thread*, never "channel" — `channel` is
-reserved for transport/ingress (C5 "channel-answerable", Track C, Slack/CLI). See #1399's
-reconciliation comment and PR [#1401](https://github.com/hachej/boring-ui/pull/1401) (open), which
-appends to `RECONCILIATION.md` §7 and `VISION.md` R-c: *"A Thread may span multiple Seats, projected
-as one timeline; one Thread per job."*
+**Naming is ratified, not free**: the product concept is a *multi-seat Thread* / *Job Thread*, never
+"channel" (`channel` is reserved for transport/ingress: C5 "channel-answerable", Track C, Slack/CLI).
+PR [#1401](https://github.com/hachej/boring-ui/pull/1401) (open) appends to `RECONCILIATION.md` §7 and
+`VISION.md` R-c: *"A Thread may span multiple Seats, projected as one timeline; one Thread per job."*
 
-**Hard constraint (v0)**: no A2A loopback — agents never call agents. An **orchestrator seat**, an
-ordinary in-process gateway client and not an agent, relays between per-agent sessions; the Thread
-timeline is a **projection** merging per-session Runs. Decision 28 (`docs/DECISIONS.md:461`) defers
-A2A and v0 does not reopen it. Ordering and dependencies live only in §6; §§1–5 describe shape.
+**What v0 builds** is a *projection* over several per-agent Sessions, driven by a **relay** — a
+non-Seat, non-agent service. §1 asks the owner to rule on the noun before anything is built.
+Ordering and dependencies live only in §7; §§1–6 describe shape.
 
-## 1. Data — what a Job Thread record is, and where it lives
+> **Correction carried from review.** Round 1 claimed "no A2A loopback; agents never call agents" as
+> a ratified constraint. That misread the record. Decision 24 (`docs/DECISIONS.md:364`) ratifies **a
+> native in-process binding for internal agent-to-agent consumption** ("no MCP loopback, no
+> serialization; two-way chat via `input-required`") and states *"Adopting A2A internally is rejected
+> as unnecessary."* Decision 25 (`:413`) defers **A2A** — the external protocol binding — not
+> in-process collaboration. So relay-vs-native-binding is a **live product choice for v0, not a
+> compliance requirement**, and it is owner question Q2. v0 proposes the relay because it needs no
+> agent-facing capability and is deletable; it is not the only compliant shape.
+
+## 1. The noun — decide this first
 
 ### Today
 
-- **No Thread noun exists in code.** `ConversationRef|threadId|ThreadRef` and
-  `ConsoleCollection|ConsoleThreadRefV1|AutomationGroup` → 0 hits across `packages/ plugins/ apps/`.
-- The only shipped conversation address is `AgentSessionRef { agentTypeId, sessionId }`
-  (`packages/agent/src/shared/gateway/types.ts:54-57`), deliberately carrying no `hostId`
-  (Decision 29, `docs/DECISIONS.md:471`). Real identity is the triple
-  `(workspaceScopeId, agentTypeId, sessionId)` — `agent-host/agentSessionKey.ts:3`.
-- The 1355 Console plan (merged to main as `docs/issues/1355/plan.md`, PR #1356) proposes
-  `ConsoleThreadRefV1 { workspaceScopeId, agentTypeId, sessionId }` (`plan.md:74-78`), persisted in
-  `ConsoleCollectionThreadAssignment` under a unique key
-  `(appId, principalId, workspaceScopeId, agentTypeId, sessionId)` (`plan.md:102-104`).
-  **Single-seat by construction**: one Thread = one session tuple.
-- Run identity: the ratified `RunId := RequestKey` ships as `AgentRequestKey
-  { workspaceScopeId, authSubjectId, operation, target, requestId }` (`agent-host/types.ts:51-57`),
-  durably ledgered by `SqliteAgentRequestLedger` (`sqliteRequestLedger.ts:39`) at
-  `.agent-request-ledger.sqlite` (`createAgentHost.ts:291`).
-- **`seatId` does not exist anywhere in code**, and `trajectory` → 0 occurrences repo-wide. The
-  spine (`runId·agentId·digest·seatId·cost·outcome`, `VISION.md:37`, `RECONCILIATION.md:137`) and
-  `Seat { seatId; workspaceId; agentId; role?; budget?; permissions?; bindingState }`
-  (`V2-IMPLEMENTATION-SPEC.md:119`) are doc-only — 1355 says so itself: *"C7 SessionCatalog and
-  full Seat projection are target architecture, not current prior art"* (`plan.md:163-165`). The
-  `seat: string` in `loadConfiguredAgentFleet.ts:28` is an unrelated fleet.yaml field, explicitly
-  warned about at `agent-host/types.ts:148-149`.
-- Objectives (PR [#1382](https://github.com/hachej/boring-ui/pull/1382), **OPEN, not merged**)
-  persist `Objective { id, title, objective, metric, baseline, target, current, status,
-  constraints, evidenceRefs, outcome, ... }` (`plugins/objectives/src/shared/types.ts:10-27`) to
-  `.boring/objectives.json` via `FileObjectiveStore` (`objectiveStore.ts:58`) — versioned, lock
-  sidecar, atomic tmp-rename. **No session/thread/run ref field**; the only outbound seam is the
-  free-string `evidenceRefs: string[]`.
+`Thread` is frozen as one object with Session: *"a Thread is not a Pi session, transcript, or tab —
+it owns one record and many Runs"* (`VISION.md:112-115`), and the V2 spec's `Thread
+{ threadId; workspaceId; title; participants; workingSet }` (`V2-IMPLEMENTATION-SPEC.md:121`)
+**already carries a `participants` field**. `Seat { seatId; workspaceId; agentId; role?; budget?;
+permissions?; bindingState }` (`:119`) binds an *Agent* to a Workspace and "grants participation, not
+identity". No Thread, Seat, or participant noun exists in code (`ThreadRef|threadId|ConsoleCollection`
+→ 0 hits across `packages/ plugins/ apps/`); `seatId` and `trajectory` → 0 hits.
 
-### Delta
+### Delta — recommendation, and the cost of the alternative
 
-The smallest honest record — `objectiveId` and `seats` carry the whole concept:
+Round 1 minted `JobThreadV0` holding several session refs. That silently created a *second* Thread
+object against the frozen ruling, and called the relay an "orchestrator seat" against the frozen Seat
+definition. Both are withdrawn.
+
+**Recommended default (Q1-A): a projection descriptor with a distinct noun.**
 
 ```ts
-interface JobThreadV0 {
-  id: string                       // `jth-<uuid>`
+/** NOT a Thread. A saved description of how to project several Threads(=Sessions) as one job. */
+interface JobProjectionV0 {
+  id: string                        // `job-<uuid>`
   title: string
-  objectiveId?: string             // one-way ref into the objectives plugin; objectives unchanged
-  seats: JobThreadSeatV0[]         // v0: exactly 2 working seats (worker, reviewer) — see §5
+  objectiveId?: string              // one-way ref into the objectives plugin (§5)
+  participants: JobParticipantV0[]
   createdAt: string; updatedAt: string; revision: number
 }
-interface JobThreadSeatV0 {
-  seatId: string                   // FIRST real seatId in the codebase
-  role: "orchestrator" | "worker" | "reviewer"
-  conversation: ConsoleThreadRefV1 // { workspaceScopeId, agentTypeId, sessionId }
+interface JobParticipantV0 {
+  participantId: string             // TEMPORARY DISPLAY HANDLE — not a seatId, not audit identity
+  role: "worker" | "reviewer"
+  agentTypeId: string
+  conversation: { workspaceScopeId: string; agentTypeId: string; sessionId: string }
+  bindingState: "active" | "removed" // agent removal preserves history (cf. Seat.bindingState)
 }
 ```
 
-- **A Job Thread is a typed conversation *ref set* plus a role per ref.** It owns no transcript,
-  authority, or runtime, and each `conversation` is independently authorized on every read/write —
-  the 1355 rule that a collection "does not own a Thread record ... those domains expose
-  independently authorized references" (`plan.md:89-93`).
-- **Per-Run seat attribution**: the join is `seatId × AgentRequestKey`. The honest v0 move is *not*
-  to widen `AgentRequestKey` (P0 host work, `RECONCILIATION.md:153` "seatId in C7") but to **derive**
-  it: a `AgentRequestKey.target` of `{kind:'session', ref}` resolves to exactly one seat within a
-  Thread, so `runId → seatId` is a lookup over the ref set. v0 stores nothing extra. Promotion
-  trigger for a stored seatId: a second Thread sharing one session.
-- **Durable home**: a `plugins/job-threads/` file store cloned from `FileObjectiveStore` —
-  `.boring/job-threads.json`, same versioned + lock + atomic-rename pattern. Why not the 1355
-  Console store: its hosted persistence is `packages/core/src/server/db/stores/consoleCollectionStore`
-  (Postgres, `plan.md:512-519`) and is **gate-blocked** — Gate 1 (`plan.md:372-376`, *"No
-  implementation bead is ready before it"*) is unanswered, all 21 beads `status: open`. A plugin file
-  store needs no Core migration, no principal-ownership contract, and is deletable.
-- **The conflict to surface for 1355** (the hook PR #1401 names): `ConsoleThreadRefV1`'s unique key
-  is the session 5-tuple, so a Console collection cannot hold a multi-seat Thread as one row. Minimal
-  repair: an assignment's subject becomes `jobThreadId` *or* a session tuple. That is a **1355
-  amendment, not a v0 slice** — v0 ships without Console collection integration.
+Why `JobProjectionV0` rather than the reviewed suggestions `JobThreadProjectionV0` /
+`ThreadDescriptor`: both still lead with a Thread-noun and will be read as canonical Thread machinery
+in a year. The record's subject is the **job**; "Job Thread" stays the product concept per #1401,
+while the durable record never claims Thread-ness. The relay is named **relay** — a service, never a
+Seat — because a Seat contains `agentId` and binds an Agent, which the relay is not.
 
-## 2. Mechanism — the orchestrator relay
+This keeps frozen R-c intact and matches #1401's "no new machinery": nothing here is canonical
+identity, and deleting the record destroys no Runs, transcripts, or authority.
+
+**Alternative (Q1-B): JobProjection *is* the canonical Thread.** Cheaper than review assumed —
+frozen `Thread` already has `participants`, so the ontology has room. But the cost is real and must
+be paid up front: (i) an explicit R-c amendment, since Thread=Session becomes Thread⊇Sessions;
+(ii) C7/`SessionCatalog` becomes the owner of Thread identity, pulling ratified P0 "seatId in C7"
+(`RECONCILIATION.md:150-155`) into scope; (iii) #1355's `ConsoleThreadRefV1` and its
+`(appId, principalId, workspaceScopeId, agentTypeId, sessionId)` unique key
+(`docs/issues/1355/plan.md:74-78, 102-104`) must be reworked before #1355 implements, not after;
+(iv) a migration for any Thread ref already written. Q1-B is the better end state and the wrong v0.
+
+## 2. Mechanism — the relay
 
 ### Today
 
-- `EmbeddedAgentGateway` (`agent-host/embeddedGateway.ts:126`) is exported from
-  `packages/agent/src/server/index.ts:178`. Holding it plus one `AuthorizedAgentScope`, an in-process
-  caller can `connectSession` on **any** `(agentTypeId, sessionId)` it is authorized for and `send()`
-  on the returned `AgentSessionConnection` (`shared/gateway/types.ts:196-204`: `events`, `send`,
-  `interrupt`, `stop`, `clearQueue`, `close`). **Nothing forces one sender per session.** The
-  orchestrator seat needs no new machinery.
-- The two existing programmatic drivers are **unusable** for relay: `runWithWorkspaceAgentLease`
-  (`workspaceAgentLease.ts:87`) and `createBoundWorkspaceAgentDispatcher`
-  (`server/workspaceAgentDispatcher.ts:92`) are each bound to a single `agentTypeId`
-  (`WorkspaceAgentGatewayBinding {gateway, scope, agentTypeId}`, `shared/workspaceAgentDispatcher.ts:68-72`).
-- There is **no actor identity below the auth subject** — `AuthorizedAgentScope
-  { workspaceScopeId, authSubjectId }` (`shared/gateway/types.ts:44-48`) is all the model carries, so
-  the orchestrator acts *as the human's auth subject*. Correct: it is a client, not an agent, and
-  cannot mint authority (invariant 7, `VISION.md`).
-- Cost bounds are per-run and metering-local: reservations key on
-  `runId = pi-run:${sessionId}:prompt:${clientNonce}` (`pi-chat/metering.ts:197-202`). **No
-  per-Thread budget exists today.**
+- **Correction from review, verified.** Round 1 claimed the existing drivers are bound to one
+  `agentTypeId`. False for the one that matters: `runWithWorkspaceAgent(input, run)` takes
+  `agentTypeId` **per invocation** (`WorkspaceAgentDirectRunInput { agentTypeId, context, requestId }`,
+  `packages/agent/src/shared/workspaceAgentDispatcher.ts:57-71`). Only the long-lived
+  `WorkspaceAgentGatewayBinding {gateway, scope, agentTypeId}` (`:67-71`) is single-agent.
+- The trusted composition root already issues **per-request** scope and guards workspace selectors
+  (`createWorkspaceAgentServer.ts:2088-2101`): `scopeIssuer.issue({claim:{workspaceScopeId,
+  authSubjectId}})` then `agentHost.runWithWorkspaceAgent({...input, authorizedScope}, run)`.
+  Unbounded access was deliberately removed (`:2103-2104`).
+- The capability handed to the callback is **callback-scoped and non-retainable**:
+  `LeaseBoundWorkspaceAgent` is documented "lease guarded by the Host and must not be retained after
+  the callback" (`shared/workspaceAgentDispatcher.ts:40-42`). Its `dispatch(input, onEvent,
+  onAccepted)` returns `{ ref, receipt }` — an accepted Gateway receipt, persistable before events
+  are consumed (`:44-56`).
+- `EmbeddedAgentGateway` is exported at `packages/agent/src/server/index.ts:185`.
+- Turn events carry the anchors the relay needs: `agent-end { seq, turnId, status, willRetry? }` and
+  `message-end { seq, messageId, final: BoringChatMessage }` (`shared/chat/piChatEvent.ts:6-25`).
+  **`willRetry=true` marks a NON-terminal end** — the comment warns once-per-settle consumers to
+  ignore those.
 
 ### Delta
 
-An `OrchestratorRelay` in the job-threads plugin server: a plain class holding
-`{ gateway, scope, thread }`, no agent, no LLM.
+**Drop the gateway-holding plugin class from round 1.** It would have retained a lease-guarded
+capability across turns, which the contract forbids, and hard-coded the embedded tier. Instead the
+relay is a stateless function invoked once per seat turn, using the existing actor-aware callback
+seam — no new authority-bearing host seam, no long-lived scope, no D28 second composer:
 
-1. **Trigger**: a human message posted to the Thread, or a seat's Run reaching terminal state
-   (`agent-end` on that seat's `AgentSessionEvent` stream — the same signal
-   `AgentSessionActivityIndex` already consumes, `sessionInventory.ts:138-142`).
-2. **Fan-out of a human message**: addressing-gated (below). Unaddressed → the Thread's default
-   worker seat. Addressed → `connectSession` on that seat's ref and `send` the projected Thread
-   history since that seat's last turn, plus the new message.
-3. **Handoff**: when a seat's Run ends with an addressed handoff, the relay cross-posts that seat's
-   final message into the addressed seat's session as an attributed quote. **The relay is the only
-   writer**; neither seat has a tool that reaches the other.
-4. **Cost bounds**, enforced centrally in the relay and never in agent instructions:
-   `maxHandoffDepth` (default 3) and `maxSeatInvocations` per human turn, plus a per-Thread budget
-   hook in front of the existing reservation path (`metering.ts`). Exceeding a cap posts a terminal
-   system event on the Thread and stops — it does not silently truncate.
+```
+relayTurn(jobId, targetParticipant, payload):
+  runWithWorkspaceAgent({ agentTypeId: p.agentTypeId, context, requestId }, async (bound) => {
+    const { ref, receipt } = await bound.dispatch(..., onEvent, onAccepted)
+    // persist the relay receipt (§3) from `receipt` BEFORE consuming events
+  })
+```
 
-#### Turn policy — prior art: Buzz by Block
+**Structured handoff, not free-text parsing.** Round 1 parsed `@reviewer` out of prose. Withdrawn:
+quoted or incidental mentions branch the run and make acceptance untestable. v0 registers a
+**handoff tool** on each participant agent — `handoff({ to: <role enum>, message: string })` — so the
+target is typed, the payload is explicit, and the transition is a `tool-call` event the relay matches
+exactly. This is a workspace plugin tool the relay owns; it is *not* an agent-to-agent call (the tool
+returns immediately, the relay decides what happens next).
 
-[Buzz](https://block.xyz/) (Block, July 2026) is an @-mention-gated agent group chat on Nostr, and
-is the closest shipped prior art. What we adopt and what we fix:
+**Post-vs-Run boundary — only posts cross seats.** A seat's private reasoning, tool calls, and
+intermediate messages never enter another seat's context. Exactly two things cross: (a) the **final
+assistant message** of a settled turn (`message-end.final`, gated on an `agent-end` with
+`willRetry !== true`), and (b) **relay-authored system handoff markers**. Everything else stays in
+the originating session and is reachable only by drill-down.
 
-- **Addressing-gated turns.** A seat responds only when explicitly addressed — by the human, or by
-  another seat's relayed handoff. No ambient reactions, no router model in v0. Buzz's proven
-  anti-noise mechanism, and it maps one-to-one onto our per-`agentTypeId` session addressing
-  (`/api/v1/agents/:agentTypeId/sessions/...`, `httpProjection.ts:221-582`).
-- **Loop safety — Buzz's documented gap; do not repeat it.** Buzz leaves stopping conditions to
-  agent authors, and mention loops are a real failure mode. v0 enforces the §2.4 caps centrally.
-- **Transcript model.** One full shared timeline visible to all seats (Buzz-validated); each seat's
-  private session receives the projected history on its turn. **Attribution is free for us**: Buzz
-  needs signed per-agent Nostr identities, while per-Run `seatId` over the request ledger gives the
-  same audit story from the envelope rather than from cryptography.
-- **Human role.** Approver of terminal actions, not a participant in every turn — Buzz's "steer or
-  approve" is our Inbox Human Intentions surface. A convergence to cite, not a mode to invent.
-- **Modes.** Sequential handoff and parallel same-brief are distinct explicit modes (Buzz supports
-  both). **v0 ships handoff only**; parallel is v1 and its mechanism already has a name — 1355's
-  `AutomationGroup` fan-out (`plan.md:253-279`), each target getting its own Thread, Run, receipt.
-- **Posture.** Buzz (shared thread, mixed trust, signed identity) vs Grok Bot (single-owner private
-  fleet, internal handoffs): our product spans both, so we adopt Buzz's audit/identity posture even
-  while v0 runs a single-owner fleet.
+**Turn policy — addressing-gated, with prior art.** [Buzz](https://block.xyz/) (Block, July 2026) is
+an @-mention-gated agent group chat and the closest shipped prior art. Adopted: a participant acts
+only when explicitly addressed (here, by typed handoff or by the human), one shared timeline, human
+as approver rather than per-turn participant (our Inbox Human Intentions). Fixed: Buzz leaves
+stopping conditions to agent authors and mention loops are a known failure mode — v0 enforces caps
+centrally in the relay (§3), and replaces mention-parsing with the typed tool. Deferred: Buzz's
+parallel same-brief mode (v1; its mechanism is already named — #1355's `AutomationGroup` fan-out,
+`plan.md:253-279`). D24 already anticipated the caps as "consumption cycle/depth guards (A→B→A)"
+(`docs/DECISIONS.md:365`).
 
-#### ask-user gates on the Thread
+### Failure semantics
 
-Today: `AskUserQuestion { questionId, sessionId, ownerPrincipalId, status, schema, answerToken, ...}`
-(`plugins/ask-user/src/shared/types.ts:113-127`) is keyed by **`sessionId` only** — no `agentTypeId`,
-no thread — with one pending question per session (`getPending(sessionId)` is singular,
-`askUserStore.ts:28`). Pending state reaches the UI as
-`AskUserPendingState { hint, hintsBySession }` (`askUserStatePublisher.ts:6-21`); the Inbox left-pane
-action already exists (`plugins/ask-user/src/front/index.tsx:239-251`).
+Every abnormal end writes a terminal system event onto the projection; the relay never fails silent.
 
-Delta: **no ask-user change.** The Thread projection joins `hintsBySession` against the ref set
-(`sessionId ∈ thread.seats[].conversation.sessionId`) and renders the question inline with its seat's
-attribution; answering still routes through `ask-user.v1.answer` and its `answerToken` capability
-(`askUserRuntime.ts:160-177`). The relay treats a seat blocked on `ask_user` as *not* a terminal Run,
-and does not advance the handoff chain.
+| Case | Rule |
+| --- | --- |
+| Non-terminal end | `agent-end` with `willRetry === true` is ignored; the chain does not advance (`piChatEvent.ts:9-11`). |
+| Seat error run | `agent-end.status === 'error' \| 'aborted'` ends the chain, records `chainState: "failed"` with the source `turnId`, and posts a system event. No automatic retry in v0. |
+| Handoff to a removed participant | `bindingState === "removed"` → chain ends with `participant-unavailable`; history is preserved, never rewritten. |
+| Partial cross-post | The relay receipt is written from `onAccepted` *before* events are consumed, so a crash after dispatch is replayable: the destination `requestId` is the idempotency key and the send is never duplicated. |
+| Restart mid-chain | Durable `chainState` + per-ref processed cursors (§3) resume or terminate; a chain whose destination receipt exists but whose completion is unknown resolves to `outcome-unknown` and posts a system event rather than re-sending. |
+| Cap exceeded | Terminal system event naming the cap and the last `turnId`; no truncation, no silent stop. |
+| Blocked on `ask_user` | Not a terminal Run — the chain suspends, does not advance, and does not count against the hop cap until answered (§4). |
 
-## 3. Projection — the merged timeline
+## 3. Relay state — the durable receipt
 
 ### Today
 
-- The left-pane row model is `AppLeftPaneSession { id, agentTypeId?, title?, updatedAt?, turnCount?,
+Round 1's record explicitly owned no transcript or runtime, yet the relay needed "history since last
+turn", processed handoffs, per-turn depth, and terminal system events. Nothing owned that state.
+`AgentSessionEvent { ref, seq, event }` documents **"`seq` is the only replay cursor"**
+(`shared/gateway/events.ts:4-8`) — there is no wallclock, no thread id, no cross-stream correlation.
+Round 1's `(wallclock, seq)` merge key **is not implementable** and is withdrawn. The request ledger's
+target carries only the session ref, not a job or participant (`agent-host/types.ts:47-57`).
+
+The ratified home for this already has a name: **`Activity` — "what happened: runs, delegations,
+approvals, interventions (envelope projection — no second event system)"**
+(`V2-IMPLEMENTATION-SPEC.md:122-123`).
+
+### Delta
+
+A `JobRelayReceiptV0` append-only log beside the projection record in the same plugin store, written
+under the same `revision` CAS. It is an **envelope projection**, not a competing event system: every
+field is either relay-authored control state or copied from an existing receipt.
+
+```ts
+interface JobRelayReceiptV0 {
+  jobId: string
+  threadTurnId: string              // relay-assigned, monotonic — the ONLY total order across seats
+  sourceRef?: AgentSessionRef       // whose settled turn triggered this
+  sourceTurnId?: string             // from `agent-end.turnId`
+  destinationRef: AgentSessionRef
+  destinationRequestId: string      // from dispatch `onAccepted` receipt — the idempotency key
+  handoffEdge?: { fromRole: string; toRole: string }
+  processedCursors: Record<string, number>   // per-ref `seq` high-water mark
+  chainState: "running" | "suspended" | "completed" | "failed" | "capped" | "outcome-unknown"
+  capOutcome?: { cap: "hop" | "invocation"; limit: number; observed: number }
+  createdAt: string
+}
+```
+
+- **Ordering**: `threadTurnId` is the total order across seats; per-ref `seq` orders within a seat.
+  Merged rendering sorts by `(threadTurnId, seq)`. No wallclock anywhere.
+- **Idempotency / restart**: on boot the relay reads the last receipt per job. A receipt with a
+  `destinationRequestId` and no terminal state resolves per the §2 table — never a blind re-send.
+- **Caps**: `maxHopDepth` (default 3) and `maxInvocationsPerHumanTurn` are evaluated against the
+  receipt chain, so a restart cannot reset them.
+- **Context bound**: `processedCursors` is what "history since last turn" means concretely — a
+  participant receives posts (§2) after its own cursor, capped at `maxInjectedPosts` /
+  `maxInjectedBytes`; overflow drops **oldest-first** and inserts a relay-authored truncation marker.
+  No summarization in v0 (a summarizer would be an unreviewed model call inside the relay).
+
+**Per-Thread budget is dropped from v0 claims.** Round 1 promised a per-Thread budget hook. It cannot
+be built: `MeteringRunScope { workspaceId?, userId?, userEmail?, userEmailVerified?, sessionId,
+runId, source }` (`pi-chat/metering.ts:45-53`) has **no job, thread, or participant field**, and
+reservations key on `runId = pi-run:${sessionId}:prompt:${clientNonce}` (`:197-202`). v0 ships only
+the relay-enforced hop/invocation caps above, which bound *hops*, not spend. The named prerequisite
+for a real budget — a v1 slice, not a v0 claim — is adding a job dimension to `MeteringRunScope` and
+threading it through the reservation path.
+
+## 4. Projection — the merged timeline
+
+### Today
+
+- The left-pane row model `AppLeftPaneSession { id, agentTypeId?, title?, updatedAt?, turnCount?,
   nativeSessionId?, hasAssistantReply?, ephemeral?, status? }`
-  (`packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx:17-27`) — **session-shaped, with
-  no `kind` discriminator**, and PR [#1393](https://github.com/hachej/boring-ui/pull/1393) (OPEN)
-  leaves it byte-for-byte unchanged. Correcting the brief: the "conversation-kind-agnostic row model"
-  is **not yet built**. #1393 adds `AppLeftPaneConsoleSpike` with
-  `AppLeftPaneConsoleSpikeView = "recent" | "project" | "agent"`,
-  `ConsoleSpikeRowSlots { leadingBadge?, metaTag? }` and
-  `AppSessionRowAffordances = "default" | "console"` — the seams where it would land.
-- Per-session events are `AgentSessionEvent { ref, seq, event }` (`shared/gateway/events.ts:5-9`),
-  NDJSON at `GET /api/v1/agents/:agentTypeId/sessions/:sessionId/events` (`httpProjection.ts:402`),
-  cursor = `seq`. Transcripts are Pi JSONL under `sessionNamespaceForAgent()`
-  (`sessionInventory.ts:13-22`), rooted at `BORING_AGENT_SESSION_ROOT`.
-- **Durable replay is opt-in and off**: `BORING_CHAT_DURABLE_STREAM` / `.agent-event-stream.sqlite`
-  (`buildAgentComposition.ts:37-40`). Decision 29 shipped Conformance **Level B** and deferred Level
-  D because *"durable replay is only load-bearing once concurrent multi-agent streams exist"*
-  (`docs/DECISIONS.md:472`). **A Job Thread is exactly that condition arriving** — the single most
-  important Today/Delta finding in this plan.
+  (`packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx:17-27`) is session-shaped with no
+  `kind` discriminator, and PR [#1393](https://github.com/hachej/boring-ui/pull/1393) (OPEN) leaves it
+  unchanged. Correcting the brief: the "conversation-kind-agnostic row model" is **not yet built**.
+  #1393 adds `AppLeftPaneConsoleSpike`, `AppLeftPaneConsoleSpikeView = "recent" | "project" | "agent"`,
+  `ConsoleSpikeRowSlots { leadingBadge?, metaTag? }` and `AppSessionRowAffordances` — the seams.
+- Events stream as NDJSON at `GET /api/v1/agents/:agentTypeId/sessions/:sessionId/events`
+  (`agent-host/httpProjection.ts:402`), cursor = `seq`. `AgentSessionConnection` is a **server-side**
+  object (`shared/gateway/types.ts:196-204`) — round 1 wrongly implied a front-end client existed.
+- `AskUserQuestion` is keyed by `sessionId` alone (`plugins/ask-user/src/shared/types.ts:113-127`),
+  pending state published as `AskUserPendingState { hint, hintsBySession }`
+  (`askUserStatePublisher.ts:6-21`).
 
 ### Delta
 
-- **A Thread view is interleaved Runs with seat attribution.** New: a `useJobThreadTimeline` opening
-  one `AgentSessionConnection` per seat ref, merging frames on `(wallclock, seq)` per source and
-  tagging each with `seatId` + role. No new transport, no new store — a client-side merge over
-  streams that already exist. Cross-session ordering is best-effort and explicitly *not* a total
-  order; a system event marks each relayed handoff so the reader has an anchor.
-- **Drill-down**: each merged block links to its origin session's own view — the "CI logs behind a
-  PR check" affordance from #1399.
-- **Left-nav framing (owner direction, 2026-08-24)**: the primary list becomes **Threads (jobs)**;
-  **Agents becomes a DIRECTORY entry** (a roster of all agents); and Thread participation is an
-  **attribute on the Thread** — the 1..n participant chips rendered in #1393's
-  `ConsoleSpikeRowSlots.metaTag` slot. The **by-agent lens then reads as "Threads this agent
-  participates in"** (a directory view), *not* a grouping of private sessions. That is a semantic
-  change to #1393's `"agent"` view mode, whose `OrganizedSession` grouping assumes one `agentTypeId`
-  per row.
-- **Level D activation** is the honest prerequisite for a Thread surviving a reload with more than
-  one live stream. The v0 demo runs with `BORING_CHAT_DURABLE_STREAM` on; defaulting it is a
-  Decision-29 re-evaluation (`docs/DECISIONS.md:474`), out of scope here.
+- **Merged timeline** = posts (§2) ordered by `(threadTurnId, seq)` from §3, each tagged with its
+  participant's role and `agentTypeId`. Drill-down links each block to its origin session.
+- **ask-user join uses the full triple, not bare `sessionId`.** Round 1 joined on `sessionId` alone;
+  gateway session identity is scoped by `agentTypeId`, so equal ids under two agents could answer the
+  wrong participant's question. v0 matches
+  `(workspaceScopeId, agentTypeId, sessionId)` against `participants[].conversation` and ignores any
+  hint it cannot resolve to exactly one participant. **No ask-user change** is still required — the
+  answer routes through the existing `ask-user.v1.answer` bridge op and its `answerToken`
+  (`askUserRuntime.ts:160-177`).
 
-## 4. K7 demo — "grow audience X→Y"
+### Level D honesty
+
+Round 1 called enabling `BORING_CHAT_DURABLE_STREAM` "Level D activation". Withdrawn — **the flag is
+not conformance**. It installs a SQLite event store (`buildAgentComposition.ts:30-43`), while every
+Level D conformance test is `it.skip` and owner-annotated to the streaming lane
+(`agent-host/testing/gatewayConformance.ts:624-628`).
+
+What Level B *can* do: bounded in-process replay plus snapshot rehydrate; a cursor older than the
+window or from before a restart yields `REPLAY_GAP`/`CURSOR_AHEAD` and the client refetches — *"never
+a silent gap"* (`AGENT_GATEWAY_V0.md:116-124`). **v0 ships against Level B**, and that is sufficient
+because §3's receipts — not the event stream — own cross-seat causality and ordering; a refetch
+rebuilds seat content while `threadTurnId` preserves the merge.
+
+The one property Level B cannot reconstruct is **per-seat intra-turn event history across a host
+restart**: after a restart the timeline can show settled posts (from receipts + snapshot) but cannot
+replay the streaming detail of a turn that was in flight. v0 accepts that and renders such a turn
+from its snapshot. Whether to complete Level D is owner question Q7, not a claim this plan makes.
+
+## 5. K7 demo — "grow audience X→Y"
 
 ### Today
 
-The pieces exist but have never been composed. `Objective` (PR #1382, open) already has exactly the
-right shape for K7 — `metric`, `baseline`, `target`, `current`
-(`plugins/objectives/src/shared/types.ts:10-27`), created by the `create_objective` tool and
-navigable via the `objective` surface kind. There is no Thread, no second seat, no relay.
+`Objective { id, title, objective, metric, baseline, target, current, status, constraints,
+evidenceRefs, outcome, ... }` (PR [#1382](https://github.com/hachej/boring-ui/pull/1382), **OPEN**;
+`plugins/objectives/src/shared/types.ts:10-27`) already has the exact K7 shape, persisted to
+`.boring/objectives.json` by `FileObjectiveStore` (`objectiveStore.ts:58`) with versioned state, a
+lock sidecar, and atomic tmp-rename — the template §1's store clones. It has **no** session, thread,
+or run ref; the only outbound seam is the free-string `evidenceRefs: string[]`.
 
-### Delta — the scripted deterministic path
+### Delta — fixture-driven, with a labelled live smoke
 
-Fleet: two `agentTypeId`s in the demo `fleet.yaml` — `creator-growth-worker` and
-`creator-growth-reviewer` — plus the orchestrator seat (a client, not a fleet entry).
+**Acceptance is fixture-driven.** Round 1 called a live-model run "deterministic". It is not: nothing
+guarantees the worker emits the handoff, the reviewer replies, or `update_objective` is ever called.
+v0 acceptance runs a **scripted model adapter** emitting a fixed event script, asserting exact
+`threadTurnId` sequence, handoff edges, cap outcomes, and final Objective state. A **live-model
+walkthrough** is kept as an explicitly **non-deterministic smoke check**, never as a gate.
 
-1. Owner creates a Job Thread *"Grow audience 1,200 → 5,000"*. Creation calls `create_objective`
-   once (metric `followers`, baseline 1200, target 5000), stores the returned `obj-<uuid>` as
-   `objectiveId`, and `createSession`s one session per `agentTypeId` as the two seats.
-2. Owner posts one message to the **Thread**, not to an agent. Unaddressed → relay routes to worker.
-3. Worker drafts a growth plan, hands off `@reviewer`; relay cross-posts the draft. Depth = 1.
-4. Reviewer returns a critique addressed back to `@worker`. Depth = 2.
-5. Worker revises and calls `ask_user` to approve the terminal action (publish / move the
-   Objective's `current`). The gate appears **on the Thread** with worker attribution, and in Inbox.
-6. Owner approves; worker calls `update_objective`; relay stops. The depth cap (3) is never reached.
+Scripted path (two fleet agents, `creator-growth-worker` / `creator-growth-reviewer`, plus the relay):
 
-**What the owner sees**: one Thread row with two participant chips; one merged timeline where every
-block names its seat; one inline approval card; one Objective whose `current` moved. Sessions appear
-only on drill-down. No agent-to-agent call exists anywhere in the request ledger — every send
-carries `authSubjectId` = the owner. The demo is scripted (fixed prompts, fixed handoff points, caps
-never hit): a *demo path*, not a claim of general multi-agent competence.
+1. Owner creates the job *"Grow audience 1,200 → 5,000"* → `create_objective` (metric `followers`,
+   baseline 1200, target 5000), then one session per `agentTypeId`.
+2. Owner posts one message to the job. Unaddressed → the worker participant.
+3. Worker drafts, calls `handoff({to:"reviewer"})`. Relay cross-posts the final assistant message.
+   Hop 1.
+4. Reviewer critiques, calls `handoff({to:"worker"})`. Hop 2.
+5. Worker revises, calls `ask_user` to approve the terminal action. The gate renders on the job with
+   participant attribution and in the Inbox; the chain suspends.
+6. Owner approves → worker calls `update_objective` → `chainState: "completed"`. Cap (3) never hit.
 
-## 5. Non-goals for v0 (explicit)
+**Objective coupling is one-way and compensated.** The job points at `objectiveId`; `Objective` gains
+no `threadId`, so PR #1382 is untouched. Creation is two writes (Objective, then projection record),
+so it uses `clientRequestId` for the Objective (`types.ts:40`, "a retried create with the same key
+returns the original objective") and, if the projection write fails, retries against the same key
+rather than orphaning a second Objective. Whether an Objective is **mandatory** is owner question Q5.
 
-1. **No shared runtime transcript.** Seats keep private Pi JSONL sessions (`sessions.ts:154`); the
-   shared timeline is a projection only. No "room" object.
-2. **No A2A activation.** No agent-callable tool reaches another agent. Decision 28 defers A2A
-   (`docs/DECISIONS.md:461`); PR #1401's amendment states the non-change explicitly.
-3. **More than 2 working seats.** v0 is worker + reviewer + orchestrator; a third seat is a v1
-   routing question, not a mechanism question.
-4. **"Channels" in the transport sense.** No Slack/CLI/Nostr ingress binds to a Thread; `channel`
-   stays reserved for C5 channel-answerable / Track C.
-5. **Console collection integration** — no `ConsoleCollection`, Postgres store, or
-   `AutomationGroup`; gate-blocked (§1).
-6. **A durable `seatId` on the request ledger** — derived in v0 (§1).
-7. **Parallel same-brief mode.** Handoff only (§2).
-8. **Cross-Workspace Threads.** All seats share one `workspaceScopeId`, matching 1355's rule that
-   cross-Workspace transfer is a separate protocol (`plan.md:211-213`).
+**What the owner sees**: one job row with participant chips; one merged timeline where every block
+names its participant; one inline approval; one Objective whose `current` moved. Sessions appear only
+on drill-down.
 
-## 6. Slices
+## 6. Non-goals for v0 (explicit)
 
-Ordering lives here and nowhere else. **Gate G** = 1355 Gate 1 architecture approval
-(`docs/issues/1355/plan.md:372-376`, *"No implementation bead is ready before it"*), currently
-**unanswered** — all 21 `wt-391-forward-gh-1355-persistent-console-q9ba` beads are `status: open`.
-**Gate R** = owner merge of PR #1401 (the ratification of "one Thread per job").
+1. **No shared runtime transcript.** Participants keep private Pi sessions; the timeline is a
+   projection. No "room" object.
+2. **No native in-process agent-to-agent binding** — available and ratified (D24, `:364`), chosen
+   against for v0 (Q2), not forbidden. No external A2A either (D25, `:413`).
+3. **No canonical Thread or Seat identity minted.** `participantId` is a display handle (§8).
+4. **More than 2 working participants**; parallel same-brief mode; cross-Workspace jobs (all
+   participants share one `workspaceScopeId`, per `plan.md:211-213`).
+5. **"Channels" in the transport sense.** No Slack/CLI ingress binds to a job.
+6. **No Console collection integration** and no `AutomationGroup` (§7 gate note).
+7. **No per-Thread budget** (§3) and **no context summarization** — oldest-first truncation only.
+8. **No Level D claim** (§4).
 
-| # | Slice | Depends on | Gate |
-| --- | --- | --- | --- |
-| S1 | `plugins/job-threads` record + file store (`JobThreadV0`, `JobThreadSeatV0`, `.boring/job-threads.json`), cloned from `FileObjectiveStore`; bridge ops + schema; no UI | PR #1382 merged (for `objectiveId` to mean anything) | **Gate R** only — free of G |
-| S2 | `OrchestratorRelay`: multi-`agentTypeId` client over `EmbeddedAgentGateway`, addressing-gated turn policy, central depth/invocation caps, handoff cross-post. Server-only, driven by tests | S1 | free |
-| S3 | Thread timeline projection: multi-connection merge with `seatId` attribution, ask-user join over `hintsBySession`, drill-down links. Requires `BORING_CHAT_DURABLE_STREAM` on | S2 | free |
-| S4 | Left-nav reframe: Threads primary, Agents as directory, participant chips in `ConsoleSpikeRowSlots.metaTag`, by-agent lens = "Threads this agent participates in" | S3, PR #1393 | **Gate G** — touches the Console pane contract |
-| S5 | K7 demo composition: two-agent fleet, scripted path, owner-facing walkthrough | S3 (S4 optional for the demo) | free if run on the playground route; **Gate G** if it ships in the Console |
+## 7. Slices
 
-S1–S3 and S5 are deliverable without the 1355 decision — they add a plugin and a projection, touching
-no Console store and no Core migration. Only S4 negotiates the Console contract, carrying §1's
-`ConsoleThreadRefV1` repair: file that as a 1355 amendment before S4 starts.
+Ordering lives here and nowhere else. **The real critical path is open PRs**, not the #1355 gate:
+#1401 (naming ratification) and #1382 (objectives) block v0 content; #1393 blocks only the deferred
+Console item. **Gate G** = #1355 Gate 1 architecture approval (`docs/issues/1355/plan.md:372-376`,
+*"No implementation bead is ready before it"*), still unanswered — it binds **only** the deferred
+follow-on, because v0 touches no Console store. Each slice is one session and follows the #1355 bead
+idiom (`plan.md:378-417`).
 
-## Open questions for the owner
+**S1 — projection contract + store.** `JobProjectionV0`, `JobParticipantV0`, `JobRelayReceiptV0`
+schemas; file store with revision CAS, lock, atomic rename, load diagnostics. No relay, no UI, no
+agent tool.
+- *Blocked by:* owner ruling on Q1 (noun); PR #1401 merged.
+- *Scope:* `plugins/job-threads/src/shared/{types,schema}.ts`, `src/server/jobProjectionStore.ts` + tests.
+- *Proof:* `pnpm --filter @hachej/boring-job-threads test -- src/server/__tests__/jobProjectionStore.test.ts src/shared/__tests__/schema.test.ts`; `pnpm --filter @hachej/boring-job-threads typecheck`.
+- *Negative proof:* a record whose `participantId` collides, or whose CAS revision is stale, is
+  rejected rather than merged; `grep -r "seatId\|threadId" plugins/job-threads/src` returns nothing.
 
-1. **Derived vs stored `seatId`** (§1): accept the deferral, or pull "seatId in C7"
-   (`RECONCILIATION.md:153`) forward into v0?
-2. **Level D**: the Thread projection is the first genuine multi-stream consumer — the exact
-   re-evaluation trigger Decision 29 names (`docs/DECISIONS.md:474`). Flip
-   `BORING_CHAT_DURABLE_STREAM` default-on, or keep v0 behind the flag?
-3. **`ConsoleThreadRefV1` repair**: amend 1355 now (assignment subject becomes `jobThreadId` or a
-   session tuple), or ship v0 Console-less and amend later?
-4. **Objective coupling direction**: v0 points Thread → Objective one-way, leaving PR #1382
-   untouched. Acceptable, or should `Objective` gain a `threadId`?
-5. **Orchestrator identity**: the relay acts as the owner's `authSubjectId`, so every relayed send is
-   attributed to the human in the request ledger. Correct — it *is* the human's client — or does the
-   audit story need a distinct non-agent principal?
+**S2 — actor-scoped dispatch + handoff tool.** Relay turn function over `runWithWorkspaceAgent`
+(per-invocation `agentTypeId`); `handoff({to, message})` tool registration; receipt written from
+`onAccepted` before events are consumed. No chain logic yet.
+- *Blocked by:* S1.
+- *Scope:* `plugins/job-threads/src/server/{relayTurn,handoffTool}.ts` + tests.
+- *Proof:* `pnpm --filter @hachej/boring-job-threads test -- src/server/__tests__/relayTurn.test.ts`; `pnpm lint:invariants`.
+- *Negative proof:* the lease-bound capability is not retained past the callback (test asserts use
+  after return throws); no `new EmbeddedAgentGateway` anywhere in the plugin.
+
+**S3 — relay state machine.** Chain advance on settled turns, `willRetry` filtering, posts-only
+crossing, caps, context bound with truncation marker, and every row of §2's failure table including
+restart resume.
+- *Blocked by:* S2.
+- *Scope:* `plugins/job-threads/src/server/relayChain.ts` + tests (scripted adapter).
+- *Proof:* `pnpm --filter @hachej/boring-job-threads test -- src/server/__tests__/relayChain.test.ts`.
+- *Negative proof:* a restart mid-chain neither re-sends a dispatched turn nor resets the hop count;
+  `willRetry:true` does not advance the chain.
+
+**S4 — front projection.** Merged timeline by `(threadTurnId, seq)` with participant attribution,
+ask-user join on the full triple, drill-down links. Plugin panel only — no Console pane changes.
+- *Blocked by:* S3.
+- *Scope:* `plugins/job-threads/src/front/` + tests.
+- *Proof:* `pnpm --filter @hachej/boring-job-threads test -- src/front/__tests__/`.
+- *Negative proof:* an ask-user hint whose triple matches no participant renders nowhere and answers
+  nothing.
+
+**S5 — K7 demo fixture.** Two-agent fleet, scripted adapter acceptance asserting the §5 sequence,
+Objective compensation path, plus a separately-labelled live smoke.
+- *Blocked by:* S4; PR #1382 merged.
+- *Scope:* demo fleet config + `src/server/__tests__/k7Demo.test.ts`.
+- *Proof:* `pnpm --filter @hachej/boring-job-threads test -- src/server/__tests__/k7Demo.test.ts`.
+- *Negative proof:* the acceptance run performs zero live model calls; a failed projection write
+  after `create_objective` leaves exactly one Objective on retry.
+
+**Deferred follow-on (not v0) — Console nav reframe.** Jobs primary, Agents as a directory,
+participant chips in `ConsoleSpikeRowSlots.metaTag`, by-agent lens = "jobs this agent participates
+in". **Gate G blocked**, depends on #1393, and needs the `ConsoleThreadRefV1` repair below. It does
+not depend on S4.
+
+**Filed separately, not a v0 slice:** #1355's `ConsoleThreadRefV1` and its session-tuple unique key
+are single-seat by construction and cannot hold a multi-participant job as one row. Per #1401 this
+must be repaired **before #1355 implements**, independent of whether v0 ships.
+
+## 8. Audit honesty
+
+`participantId` values minted in this plugin are **temporary display handles**. They are not `seatId`,
+not envelope identity, and carry no audit weight: they live in a mutable record, and membership edits
+or deletion can change or destroy them retroactively. Round 1's claim that per-Run `seatId` gives
+"the same audit story from the envelope" is **withdrawn** — no seat attribution exists in the envelope
+(`agent-host/types.ts:47-57`), and ratified P0 puts `seatId` in C7 (`RECONCILIATION.md:150-155`).
+
+Two principals must not be conflated. The **authorization principal** for every relay send is the
+owner's `authSubjectId` — correct, and enforced: the lease rejects a mismatch between the verified
+claim and the request context (`workspaceAgentLease.ts:97-102`). The **causal initiator** may be the
+human (a posted message) or the relay (a handoff). v0 records the distinction in
+`JobRelayReceiptV0.sourceRef`/`handoffEdge` and renders it, matching D24's ratified audit model:
+*"the principal is the originating user/workspace, with the acting agent recorded as actor in
+provenance"* (`docs/DECISIONS.md:365`). Envelope-grade attribution arrives with C7, not with v0.
+
+## 9. Owner questions
+
+1. **The noun.** Q1-A projection descriptor with a distinct noun (`JobProjectionV0`, recommended,
+   R-c untouched) or Q1-B canonical multi-seat Thread (better end state; costs an R-c amendment, C7
+   Thread ownership, seatId-in-C7 pulled forward, and a #1355 ref rework)?
+2. **Relay vs native binding.** D24 (`:364`) ratifies a native in-process agent-to-agent binding with
+   `input-required`. v0 proposes the relay (no agent-facing capability, deletable, caps centrally
+   enforced). Confirm the relay for v0, or build the ratified binding instead?
+3. **Attribution grade.** Accept explicitly display-grade `participantId` for v0, or pull ratified
+   C7 `seatId` forward now so the demo's audit story is envelope-grade?
+4. **Post/Run boundary.** Confirm only settled final assistant posts + relay system markers cross
+   seats — no tool calls, no intermediate messages?
+5. **Objective coupling.** Is an Objective **mandatory** for a job? Confirm one-way ref with
+   `clientRequestId` compensation, or should `Objective` gain a `threadId`?
+6. **Context and budget.** Confirm oldest-first truncation with no summarization, and confirm that
+   per-Thread *spend* is out of v0 (it needs a job dimension on `MeteringRunScope`, §3)?
+7. **Level D.** v0 ships against Level B with the §4 limitation accepted. Complete Level D
+   conformance (streaming lane #1009) now, or defer?
+8. **Acceptance bar.** Confirm fixture-driven acceptance as the gate, with the live-model walkthrough
+   labelled a non-deterministic smoke check?

--- a/docs/plans/job-thread-v0-plan.md
+++ b/docs/plans/job-thread-v0-plan.md
@@ -102,8 +102,11 @@ be paid up front: (i) an explicit R-c amendment, since Thread=Session becomes Th
 - The capability handed to the callback is **callback-scoped and non-retainable**:
   `LeaseBoundWorkspaceAgent` is documented "lease guarded by the Host and must not be retained after
   the callback" (`shared/workspaceAgentDispatcher.ts:40-42`). Its `dispatch(input, onEvent,
-  onAccepted)` returns `{ ref, receipt }` — an accepted Gateway receipt, persistable before events
-  are consumed (`:44-56`).
+  onAccepted)` returns `{ ref, receipt }` (`:44-56`).
+- **Acceptance precedes any callback.** The lease awaits `dispatcher.dispatch(...)` and only then
+  runs `onAccepted` (`agent-host/workspaceAgentLease.ts:237-238`). So *any* persist-after-dispatch
+  design leaves a crash window in which a send has landed with nothing recorded — this is why §3
+  writes a pending edge **before** dispatching.
 - `EmbeddedAgentGateway` is exported at `packages/agent/src/server/index.ts:185`.
 - Turn events carry the anchors the relay needs: `agent-end { seq, turnId, status, willRetry? }` and
   `message-end { seq, messageId, final: BoringChatMessage }` (`shared/chat/piChatEvent.ts:6-25`).
@@ -119,11 +122,28 @@ seam — no new authority-bearing host seam, no long-lived scope, no D28 second 
 
 ```
 relayTurn(jobId, targetParticipant, payload):
-  runWithWorkspaceAgent({ agentTypeId: p.agentTypeId, context, requestId }, async (bound) => {
-    const { ref, receipt } = await bound.dispatch(..., onEvent, onAccepted)
-    // persist the relay receipt (§3) from `receipt` BEFORE consuming events
-  })
+  # 1. ONE locked CAS mutation, BEFORE any dispatch (§3): allocate turnOrdinal,
+  #    mint the caller-owned requestId, reserve hop/invocation counts,
+  #    append edge{phase:"pending"}.
+  edge = store.openEdge(jobId, chainId, targetParticipant, payload)
+  # 2. dispatch keyed by the id we already own — a retry cannot mint a new one
+  runWithWorkspaceAgent({ agentTypeId: p.agentTypeId, context, requestId: edge.requestId },
+    async (bound) => {
+      await bound.dispatch({ ...payload, requestId: edge.requestId }, onEvent, async (accepted) => {
+        store.appendTransition(edge.edgeId, "accepted", { cursor: accepted.receipt.cursor,
+                                                          duplicate: accepted.receipt.duplicate })
+      })
+    })
 ```
+
+**The `requestId` is ours, not the receipt's.** Round 1 said the idempotency key comes back "from the
+dispatch receipt". Wrong, and the correction is what makes the pre-dispatch edge work:
+`WorkspaceAgentDispatcherDispatchInput.requestId` is a **"durable caller-owned idempotency key"**
+(`shared/workspaceAgentDispatcher.ts:23`) and `AgentSendReceipt extends CommandReceipt
+{ accepted, cursor, disposition, clientNonce, duplicate?, clientSeq? }` (`shared/gateway/types.ts:168-177`)
+carries **no `requestId`**. Because the relay mints the key, a re-dispatch after a crash is safe by
+construction and returns `duplicate: true` rather than double-sending — that flag is the
+reconciliation primitive, and `receipt.cursor` is the durable accepted-position anchor.
 
 **Structured handoff, not free-text parsing.** Round 1 parsed `@reviewer` out of prose. Withdrawn:
 quoted or incidental mentions branch the run and make acceptance untestable. v0 registers a
@@ -155,11 +175,11 @@ Every abnormal end writes a terminal system event onto the projection; the relay
 | Case | Rule |
 | --- | --- |
 | Non-terminal end | `agent-end` with `willRetry === true` is ignored; the chain does not advance (`piChatEvent.ts:9-11`). |
-| Seat error run | `agent-end.status === 'error' \| 'aborted'` ends the chain, records `chainState: "failed"` with the source `turnId`, and posts a system event. No automatic retry in v0. |
-| Handoff to a removed participant | `bindingState === "removed"` → chain ends with `participant-unavailable`; history is preserved, never rewritten. |
-| Partial cross-post | The relay receipt is written from `onAccepted` *before* events are consumed, so a crash after dispatch is replayable: the destination `requestId` is the idempotency key and the send is never duplicated. |
-| Restart mid-chain | Durable `chainState` + per-ref processed cursors (§3) resume or terminate; a chain whose destination receipt exists but whose completion is unknown resolves to `outcome-unknown` and posts a system event rather than re-sending. |
-| Cap exceeded | Terminal system event naming the cap and the last `turnId`; no truncation, no silent stop. |
+| Seat error run | `agent-end.status === 'error' \| 'aborted'` appends `phase:"failed"`, `reason:"seat-error"` with the source `turnId`, and posts a system event. No automatic retry in v0. |
+| Handoff to a removed participant | `bindingState === "removed"` → `phase:"failed"`, `reason:"participant-unavailable"`; history is preserved, never rewritten. |
+| Crash between dispatch and persistence | Closed by the pre-dispatch pending edge (§2/§3). Acceptance happens inside `dispatch` *before* `onAccepted` runs (`workspaceAgentLease.ts:237-238`), so persistence-after-dispatch always leaves a window. Recovery re-dispatches the **same** `edge.requestId`; a send that already landed returns `duplicate: true` instead of a second post. |
+| Restart mid-chain | Recovery order below — the chain only resolves `outcome-unknown` after durable state has been consulted, never on the mere absence of a completion record. |
+| Cap exceeded | `phase:"capped"` naming the cap and the last `turnId`; no truncation, no silent stop. Counts were reserved pre-dispatch, so a crash cannot undercount them. |
 | Blocked on `ask_user` | Not a terminal Run — the chain suspends, does not advance, and does not count against the hop cap until answered (§4). |
 
 ## 3. Relay state — the durable receipt
@@ -179,34 +199,73 @@ approvals, interventions (envelope projection — no second event system)"**
 
 ### Delta
 
-A `JobRelayReceiptV0` append-only log beside the projection record in the same plugin store, written
-under the same `revision` CAS. It is an **envelope projection**, not a competing event system: every
-field is either relay-authored control state or copied from an existing receipt.
+Two append-only logs beside the projection record in the same plugin store, written under the same
+`revision` CAS. They are an **envelope projection**, not a competing event system: every field is
+either relay-authored control state or copied from an existing receipt. **Nothing is ever mutated** —
+round 1 declared receipts append-only while requiring `chainState` to change in place. Edges now have
+identity and state moves by appended transition records.
 
 ```ts
-interface JobRelayReceiptV0 {
+/** One attempted cross-post. Immutable once written. */
+interface JobRelayEdgeV0 {
+  edgeId: string                    // `edge-<uuid>`
   jobId: string
-  threadTurnId: string              // relay-assigned, monotonic — the ONLY total order across seats
+  chainId: string                   // the root human turn — cap scope (see Caps)
+  turnOrdinal: number               // store-owned monotonic INTEGER, allocated under the CAS lock
   sourceRef?: AgentSessionRef       // whose settled turn triggered this
   sourceTurnId?: string             // from `agent-end.turnId`
   destinationRef: AgentSessionRef
-  destinationRequestId: string      // from dispatch `onAccepted` receipt — the idempotency key
-  handoffEdge?: { fromRole: string; toRole: string }
-  processedCursors: Record<string, number>   // per-ref `seq` high-water mark
-  chainState: "running" | "suspended" | "completed" | "failed" | "capped" | "outcome-unknown"
-  capOutcome?: { cap: "hop" | "invocation"; limit: number; observed: number }
+  requestId: string                 // relay-minted caller-owned idempotency key (§2)
+  handoff?: { fromRole: string; toRole: string }
+  deliveredThroughOrdinal: number   // context watermark: what this send carried
   createdAt: string
 }
+
+/** Append-only state history for one edge. */
+interface JobRelayTransitionV0 {
+  edgeId: string
+  phase: "pending" | "accepted" | "settled" | "suspended" | "failed" | "capped" | "outcome-unknown"
+  reason?: "seat-error" | "participant-unavailable" | "hop-cap" | "invocation-cap"
+           | "ask-user" | "unreconcilable"
+  acceptedCursor?: number           // from `AgentSendReceipt.cursor`
+  duplicate?: boolean               // from `AgentSendReceipt.duplicate`
+  at: string
+}
+
+/** Per-chain counters, reserved pre-dispatch so a crash cannot undercount. */
+interface JobChainStateV0 { chainId: string; hops: number; invocations: number; ordinalHigh: number }
 ```
 
-- **Ordering**: `threadTurnId` is the total order across seats; per-ref `seq` orders within a seat.
-  Merged rendering sorts by `(threadTurnId, seq)`. No wallclock anywhere.
-- **Idempotency / restart**: on boot the relay reads the last receipt per job. A receipt with a
-  `destinationRequestId` and no terminal state resolves per the §2 table — never a blind re-send.
-- **Caps**: `maxHopDepth` (default 3) and `maxInvocationsPerHumanTurn` are evaluated against the
-  receipt chain, so a restart cannot reset them.
-- **Context bound**: `processedCursors` is what "history since last turn" means concretely — a
-  participant receives posts (§2) after its own cursor, capped at `maxInjectedPosts` /
+- **Ordering.** `turnOrdinal` is a store-owned monotonic **integer** allocated inside the same locked
+  CAS mutation that writes the pending edge — not an unconstrained string, so `1, 2, 10` cannot sort
+  as `1, 10, 2`. Within a destination, posts order by event `seq`; relay-authored system markers get a
+  durable `markerOrdinal` (an integer minted alongside the edge) as a deterministic tie-breaker, so
+  markers never float. Merged rendering sorts `(turnOrdinal, seq, markerOrdinal)`. No wallclock.
+- **Snapshot fallback, stated honestly.** `PiChatSnapshot` carries one session-level `seq` watermark
+  and `messages: BoringChatMessage[]` with **no per-message `seq`** (`shared/chat/piChatSnapshot.ts:16-23`).
+  So a turn rendered from a snapshot cannot reconstruct the original per-event tuple. Degraded rule:
+  such messages order by **array position** within their ref, anchored at the snapshot's `seq`
+  watermark, and the timeline marks the block as snapshot-derived. Cross-seat order is unaffected,
+  because that comes from `turnOrdinal`, which is relay-owned and durable.
+- **Split cursors.** Round 1's single `processedCursors` high-water map conflated two different
+  things and created a skip hole. v0 keeps both: a **consumed-source cursor** per source ref (how far
+  the relay has interpreted that seat's events) and a **delivered-context watermark** per destination
+  (`deliveredThroughOrdinal` — what a given send actually carried). A destination that completed and
+  emitted a handoff before a crash is therefore still discoverable after restart.
+- **Recovery order** (on boot, per job, for each edge lacking a terminal phase):
+  1. Re-read the destination session's durable state — the request ledger and, failing that, the
+     session snapshot — keyed by `requestId`.
+  2. If the send is found landed, append `accepted` (with `duplicate` if re-dispatched) and continue.
+  3. Advance the consumed-source cursor and process any handoff the destination emitted **before**
+     considering termination — this is the skip hole round 1 left open.
+  4. Only if steps 1–3 cannot resolve the edge, append `outcome-unknown` with
+     `reason:"unreconcilable"` and post a system event.
+- **Caps.** `maxHopDepth` (default 3) and `maxInvocationsPerChain` are counted on `JobChainStateV0`,
+  scoped to `chainId` = the **root human turn**. A new human message opens a new chain with fresh
+  counters; an interleaved message therefore neither inherits nor resets another chain's counts.
+  Counters are reserved in the pre-dispatch mutation, so an escaped invocation is impossible.
+- **Context bound.** `deliveredThroughOrdinal` is what "history since last turn" means concretely — a
+  participant receives posts (§2) after its own watermark, capped at `maxInjectedPosts` /
   `maxInjectedBytes`; overflow drops **oldest-first** and inserts a relay-authored truncation marker.
   No summarization in v0 (a summarizer would be an unreviewed model call inside the relay).
 
@@ -238,7 +297,7 @@ threading it through the reservation path.
 
 ### Delta
 
-- **Merged timeline** = posts (§2) ordered by `(threadTurnId, seq)` from §3, each tagged with its
+- **Merged timeline** = posts (§2) ordered by `(turnOrdinal, seq, markerOrdinal)` from §3, each tagged with its
   participant's role and `agentTypeId`. Drill-down links each block to its origin session.
 - **ask-user join uses the full triple, not bare `sessionId`.** Round 1 joined on `sessionId` alone;
   gateway session identity is scoped by `agentTypeId`, so equal ids under two agents could answer the
@@ -259,7 +318,7 @@ What Level B *can* do: bounded in-process replay plus snapshot rehydrate; a curs
 window or from before a restart yields `REPLAY_GAP`/`CURSOR_AHEAD` and the client refetches — *"never
 a silent gap"* (`AGENT_GATEWAY_V0.md:116-124`). **v0 ships against Level B**, and that is sufficient
 because §3's receipts — not the event stream — own cross-seat causality and ordering; a refetch
-rebuilds seat content while `threadTurnId` preserves the merge.
+rebuilds seat content while `turnOrdinal` preserves the merge.
 
 The one property Level B cannot reconstruct is **per-seat intra-turn event history across a host
 restart**: after a restart the timeline can show settled posts (from receipts + snapshot) but cannot
@@ -282,7 +341,7 @@ or run ref; the only outbound seam is the free-string `evidenceRefs: string[]`.
 **Acceptance is fixture-driven.** Round 1 called a live-model run "deterministic". It is not: nothing
 guarantees the worker emits the handoff, the reviewer replies, or `update_objective` is ever called.
 v0 acceptance runs a **scripted model adapter** emitting a fixed event script, asserting exact
-`threadTurnId` sequence, handoff edges, cap outcomes, and final Objective state. A **live-model
+`turnOrdinal` sequence, handoff edges, cap outcomes, and final Objective state. A **live-model
 walkthrough** is kept as an explicitly **non-deterministic smoke check**, never as a gate.
 
 Scripted path (two fleet agents, `creator-growth-worker` / `creator-growth-reviewer`, plus the relay):
@@ -295,7 +354,7 @@ Scripted path (two fleet agents, `creator-growth-worker` / `creator-growth-revie
 4. Reviewer critiques, calls `handoff({to:"worker"})`. Hop 2.
 5. Worker revises, calls `ask_user` to approve the terminal action. The gate renders on the job with
    participant attribution and in the Inbox; the chain suspends.
-6. Owner approves → worker calls `update_objective` → `chainState: "completed"`. Cap (3) never hit.
+6. Owner approves → worker calls `update_objective` → final edge appends `phase:"settled"`. Cap (3) never hit.
 
 **Objective coupling is one-way and compensated.** The job points at `objectiveId`; `Objective` gains
 no `threadId`, so PR #1382 is untouched. Creation is two writes (Objective, then projection record),
@@ -330,34 +389,41 @@ Console item. **Gate G** = #1355 Gate 1 architecture approval (`docs/issues/1355
 follow-on, because v0 touches no Console store. Each slice is one session and follows the #1355 bead
 idiom (`plan.md:378-417`).
 
-**S1 — projection contract + store.** `JobProjectionV0`, `JobParticipantV0`, `JobRelayReceiptV0`
-schemas; file store with revision CAS, lock, atomic rename, load diagnostics. No relay, no UI, no
-agent tool.
+**S1 — projection contract + store + edge allocator.** `JobProjectionV0`, `JobParticipantV0`,
+`JobRelayEdgeV0`, `JobRelayTransitionV0`, `JobChainStateV0` schemas; file store with revision CAS,
+lock, atomic rename, load diagnostics; and the **`openEdge()` allocator** — one locked mutation that
+allocates `turnOrdinal`/`markerOrdinal`, mints `requestId`, reserves chain counters, and appends the
+pending edge. Append-only enforced. No relay, no UI, no agent tool.
 - *Blocked by:* owner ruling on Q1 (noun); PR #1401 merged.
-- *Scope:* `plugins/job-threads/src/shared/{types,schema}.ts`, `src/server/jobProjectionStore.ts` + tests.
-- *Proof:* `pnpm --filter @hachej/boring-job-threads test -- src/server/__tests__/jobProjectionStore.test.ts src/shared/__tests__/schema.test.ts`; `pnpm --filter @hachej/boring-job-threads typecheck`.
-- *Negative proof:* a record whose `participantId` collides, or whose CAS revision is stale, is
-  rejected rather than merged; `grep -r "seatId\|threadId" plugins/job-threads/src` returns nothing.
+- *Scope:* `plugins/job-threads/src/shared/{types,schema}.ts`, `src/server/{jobProjectionStore,edgeLog}.ts` + tests.
+- *Proof:* `pnpm --filter @hachej/boring-job-threads test -- src/server/__tests__/jobProjectionStore.test.ts src/server/__tests__/edgeLog.test.ts src/shared/__tests__/schema.test.ts`; `pnpm --filter @hachej/boring-job-threads typecheck`.
+- *Negative proof:* concurrent `openEdge()` calls never allocate same `turnOrdinal` and never
+  double-reserve a cap; ordinals sort numerically (`1,2,10`, not `1,10,2`); any attempt to mutate a
+  written edge or transition is rejected; `grep -r "seatId\|threadId" plugins/job-threads/src` returns nothing.
 
 **S2 — actor-scoped dispatch + handoff tool.** Relay turn function over `runWithWorkspaceAgent`
-(per-invocation `agentTypeId`); `handoff({to, message})` tool registration; receipt written from
-`onAccepted` before events are consumed. No chain logic yet.
+(per-invocation `agentTypeId`); `handoff({to, message})` tool registration; dispatch keyed by the
+pre-allocated `edge.requestId`, with `onAccepted` appending the `accepted` transition. No chain logic yet.
 - *Blocked by:* S1.
 - *Scope:* `plugins/job-threads/src/server/{relayTurn,handoffTool}.ts` + tests.
 - *Proof:* `pnpm --filter @hachej/boring-job-threads test -- src/server/__tests__/relayTurn.test.ts`; `pnpm lint:invariants`.
 - *Negative proof:* the lease-bound capability is not retained past the callback (test asserts use
-  after return throws); no `new EmbeddedAgentGateway` anywhere in the plugin.
+  after return throws); no `new EmbeddedAgentGateway` anywhere in the plugin; a dispatch is never
+  issued without a pending edge already durable.
 
-**S3 — relay state machine.** Chain advance on settled turns, `willRetry` filtering, posts-only
-crossing, caps, context bound with truncation marker, and every row of §2's failure table including
-restart resume.
+**S3 — relay state machine + recovery.** Chain advance on settled turns, `willRetry` filtering,
+posts-only crossing, split cursors (consumed-source vs delivered-context), caps scoped to `chainId`,
+context bound with truncation marker, every row of §2's failure table, and the **4-step recovery
+order** from §3 (ledger/snapshot reconciliation before `outcome-unknown`).
 - *Blocked by:* S2.
-- *Scope:* `plugins/job-threads/src/server/relayChain.ts` + tests (scripted adapter).
-- *Proof:* `pnpm --filter @hachej/boring-job-threads test -- src/server/__tests__/relayChain.test.ts`.
-- *Negative proof:* a restart mid-chain neither re-sends a dispatched turn nor resets the hop count;
-  `willRetry:true` does not advance the chain.
+- *Scope:* `plugins/job-threads/src/server/{relayChain,recovery}.ts` + tests (scripted adapter).
+- *Proof:* `pnpm --filter @hachej/boring-job-threads test -- src/server/__tests__/relayChain.test.ts src/server/__tests__/recovery.test.ts`.
+- *Negative proof:* crash-after-accept re-dispatches the same `requestId` and yields `duplicate:true`
+  rather than a second post; a destination that settled and emitted a handoff before the crash is
+  **processed, not skipped**; `outcome-unknown` is never appended without steps 1-3 having run; a new
+  human turn opens a fresh `chainId` without inheriting or resetting the prior chain's counters.
 
-**S4 — front projection.** Merged timeline by `(threadTurnId, seq)` with participant attribution,
+**S4 — front projection.** Merged timeline by `(turnOrdinal, seq, markerOrdinal)` with participant attribution,
 ask-user join on the full triple, drill-down links. Plugin panel only — no Console pane changes.
 - *Blocked by:* S3.
 - *Scope:* `plugins/job-threads/src/front/` + tests.
@@ -394,7 +460,7 @@ Two principals must not be conflated. The **authorization principal** for every 
 owner's `authSubjectId` — correct, and enforced: the lease rejects a mismatch between the verified
 claim and the request context (`workspaceAgentLease.ts:97-102`). The **causal initiator** may be the
 human (a posted message) or the relay (a handoff). v0 records the distinction in
-`JobRelayReceiptV0.sourceRef`/`handoffEdge` and renders it, matching D24's ratified audit model:
+`JobRelayEdgeV0.sourceRef`/`handoff` and renders it, matching D24's ratified audit model:
 *"the principal is the originating user/workspace, with the acting agent recorded as actor in
 provenance"* (`docs/DECISIONS.md:365`). Envelope-grade attribution arrives with C7, not with v0.
 

--- a/docs/plans/job-thread-v0-plan.md
+++ b/docs/plans/job-thread-v0-plan.md
@@ -519,6 +519,28 @@ later reshape, while the add/remove **UI** itself is pushed to a deferred slice 
 
 ## 4. Projection — the merged timeline
 
+### Continuity principle (owner ruling, 2026-08-25)
+
+**The Job Thread renders as the existing chat surface, not a new timeline component.** A thread with
+one seat is indistinguishable from today's chat — same `PiChatPanel` (`packages/agent/src/front/chat/PiChatPanel.tsx:200`,
+props `PiChatPanelProps`, `:130`), same composer, same message list. Multi-agent only ever shows up as
+three additive marks on that existing surface: a per-message agent chip, quiet inline system lines for
+`joined`/handoff/`left` (§2, §3, §3's Staffing workflow subsection), and the ask-user block idiom already rendered today
+(`AskUserQuestion`, §4 Today below) — unchanged, just answering for whichever participant it is keyed
+to. There is one composer addressed to the thread; routing to the right seat is invisible plumbing
+(§2's handoff tool, or unaddressed-goes-to-worker per §5), and `@mention` stays optional, never
+required to route a message.
+
+**Today anchor**: `WorkspaceChatPanelProps` wraps `PiChatPanelProps<WorkspaceAttentionBlocker>`
+(`packages/workspace/src/front/chrome/chat/types.ts:9`) and the app shell — not workspace — "owns the
+actual chat implementation" (`:26-28`); that's the one surface a job thread must render through.
+
+**Delta shrinks accordingly.** §4's earlier framing implied a parallel merged-timeline view; it is not
+one. The projection is a **message-source adapter** feeding `PiChatPanel` a merged
+`(turnOrdinal, seq, markerOrdinal)` stream (below) instead of one session's events — no new
+timeline/list component, no new render tree. S4 (§7) shrinks to the adapter plus the three additive
+marks; it does not build a view.
+
 ### Today
 
 - The left-pane row model `AppLeftPaneSession { id, agentTypeId?, title?, updatedAt?, turnCount?,
@@ -662,13 +684,17 @@ order** from §3 (ledger/snapshot reconciliation before `outcome-unknown`).
   **processed, not skipped**; `outcome-unknown` is never appended without steps 1-3 having run; a new
   human turn opens a fresh `chainId` without inheriting or resetting the prior chain's counters.
 
-**S4 — front projection.** Merged timeline by `(turnOrdinal, seq, markerOrdinal)` with participant attribution,
-ask-user join on the full triple, drill-down links. Plugin panel only — no Console pane changes.
+**S4 — front projection.** Per §4's continuity principle, this is an adapter, not a new view: a
+message-source adapter feeding the existing `PiChatPanel` a merged `(turnOrdinal, seq,
+markerOrdinal)` stream (§3), plus the three additive marks — per-message agent chip, quiet inline
+`joined`/handoff/`left` system lines, ask-user join on the full triple against the existing block
+idiom. Drill-down links. No new timeline/list component, no Console pane changes.
 - *Blocked by:* S3.
-- *Scope:* `plugins/job-threads/src/front/` + tests.
+- *Scope:* `plugins/job-threads/src/front/{jobMessageSource,agentChip,systemLineMarkers}.ts` +
+  tests — smaller than a parallel view: no new render tree, no new list component.
 - *Proof:* `pnpm --filter @hachej/boring-job-threads test -- src/front/__tests__/`.
 - *Negative proof:* an ask-user hint whose triple matches no participant renders nowhere and answers
-  nothing.
+  nothing; a single-seat job renders byte-for-byte through the unmodified `PiChatPanel` path.
 
 **S5 — K7 demo fixture.** Two-agent fleet, scripted adapter acceptance asserting the §5 sequence,
 Objective compensation path, plus a separately-labelled live smoke.

--- a/docs/plans/job-thread-v0-plan.md
+++ b/docs/plans/job-thread-v0-plan.md
@@ -30,6 +30,171 @@ Ordering and dependencies live only in §7; §§1–6 describe shape.
 > compliance requirement**, and it is owner question Q2. v0 proposes the relay because it needs no
 > agent-facing capability and is deletable; it is not the only compliant shape.
 
+## What this plan builds
+
+Twelve artifacts, nothing else. Product words first, code noun in `code`. "Built by" points at §7,
+which remains the only place ordering lives.
+
+| Artifact | What it is | Built by | Lives in |
+| --- | --- | --- | --- |
+| The saved job — `JobProjectionV0` | Title, its Objective, its staffed participants. A description of how to project several Sessions as one job. **Not a Thread.** | S1 | `src/shared/types.ts` |
+| One staffed participant — `JobParticipantV0` | Role (worker/reviewer), which agent, which session, and whether it is still active. | S1 | `src/shared/types.ts` |
+| One turn hop — `JobRelayEdgeV0` | One attempted cross-post: who sent, to whom, under which idempotency key, carrying context up to where. Immutable. | S1 | `src/shared/types.ts` |
+| What happened to a hop — `JobRelayTransitionV0` | Appended state history: pending → accepted → settled / failed / capped / unknown, with a structured reason. | S1 | `src/shared/types.ts` |
+| The cap ledger — `JobChainStateV0` | Per-human-turn counters (hops, invocations) so a restart cannot reset them and a new message cannot inherit them. | S1 | `src/shared/types.ts` |
+| How far we have read — `JobCursorV0` | Per source session, the last event the relay has interpreted. Survives across turns. | S1 | `src/shared/types.ts` |
+| The reservation write — `openEdge()` | The single locked write that reserves a turn *before* anything is sent: allocates the ordinal, mints the request id, reserves caps. The crash-safety keystone. | S1 | `src/server/edgeLog.ts` |
+| Sending one turn — relay turn function | Hands one message to one participant through the host's existing per-invocation seam. Holds no capability afterwards. | S2 | `src/server/relayTurn.ts` |
+| "Pass this to the reviewer" — handoff tool | The typed tool a participant calls to hand off. Typed target, explicit payload — never parsed from prose. | S2 | `src/server/handoffTool.ts` |
+| Deciding who goes next — relay chain | Advances on settled turns, enforces caps, applies every failure rule, bounds injected context. | S3 | `src/server/relayChain.ts` |
+| Picking up after a crash — recovery routine | The 4-step reconciliation that consults durable state before ever declaring an outcome unknown. | S3 | `src/server/recovery.ts` |
+| The one view the owner reads — merged timeline | Interleaved posts with participant attribution, ask-user gates inline, drill-down to the private session. | S4 | `src/front/` |
+| Proof it works — K7 demo fixture | Scripted-adapter acceptance asserting the whole path deterministically. | S5 | `src/server/__tests__/k7Demo.test.ts` |
+
+All paths are under `plugins/job-threads/`.
+
+### The data model
+
+```mermaid
+erDiagram
+    OBJECTIVE ||--o| JOB : "measures X to Y"
+    JOB ||--|{ PARTICIPANT : "staffs"
+    PARTICIPANT }o--|| SESSION : "addresses one"
+    JOB ||--o{ CHAIN : "one per human turn"
+    CHAIN ||--|{ EDGE : "scopes caps for"
+    EDGE ||--|{ TRANSITION : "state history"
+    JOB ||--o{ CURSOR : "one per source session"
+
+    OBJECTIVE {
+        string id PK "obj-uuid, owned by the objectives plugin"
+        string metric
+        number baseline
+        number target
+        number current
+    }
+    JOB {
+        string id PK "job-uuid"
+        string title
+        string objectiveId FK "one-way ref, optional"
+        number revision "CAS"
+    }
+    PARTICIPANT {
+        string participantId "DISPLAY HANDLE, not a seatId"
+        string role "worker or reviewer"
+        string agentTypeId
+        string bindingState "active or removed"
+    }
+    SESSION {
+        string workspaceScopeId "canonical identity, owned elsewhere"
+        string agentTypeId
+        string sessionId
+    }
+    CHAIN {
+        string chainId PK "the root human turn"
+        number hops
+        number invocations
+        number ordinalHigh
+    }
+    EDGE {
+        string edgeId PK
+        number turnOrdinal "store-owned integer, total order"
+        string requestId "relay-minted idempotency key"
+        string sourceRef "absent when human-originated"
+        string destinationRef
+        number deliveredThroughOrdinal "context watermark"
+    }
+    TRANSITION {
+        string edgeId FK
+        number markerOrdinal "append index within the edge"
+        string phase
+        string reason "structured terminal cause"
+        number acceptedCursor "from AgentSendReceipt.cursor"
+        boolean duplicate "from AgentSendReceipt.duplicate"
+    }
+    CURSOR {
+        string refKey PK "workspace + agent + session"
+        number consumedThroughSeq
+    }
+```
+
+### One handoff turn, end to end
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor Owner
+    participant Relay as Relay — a service, not an agent
+    participant Store as Job store — CAS
+    participant A as Participant A — worker
+    participant B as Participant B — reviewer
+    participant View as Merged timeline
+
+    Owner->>Relay: post a message to the JOB
+    Relay->>Store: openEdge — new chainId, turnOrdinal 1,<br/>mint requestId, reserve caps, phase pending
+    Store-->>Relay: edge1
+    Relay->>A: dispatch keyed by edge1.requestId
+    A-->>Relay: accepted — cursor, duplicate?
+    Relay->>Store: append transition accepted
+    A-->>Relay: settles — agent-end, willRetry false
+    Relay->>Store: append transition settled, advance CURSOR
+    Relay->>View: final post, attributed to A
+    A->>Relay: handoff to reviewer — typed tool, not prose
+    Relay->>Store: openEdge — same chainId, turnOrdinal 2, hop 1
+    Store-->>Relay: edge2
+    Relay->>B: dispatch keyed by edge2.requestId,<br/>context after B's deliveredThroughOrdinal
+    B-->>Relay: accepted
+    Relay->>Store: append transition accepted
+    B-->>Relay: settles
+    Relay->>Store: append transition settled
+    Relay->>View: final post, attributed to B
+    View-->>Owner: one timeline, ordered by turnOrdinal, seq, markerOrdinal
+```
+
+Only the two **final posts** cross between participants. Everything else — reasoning, tool calls,
+intermediate messages — stays in the private session and is reachable only by drill-down.
+
+### Picking up after a crash
+
+```mermaid
+flowchart TD
+    Start["Restart: for each edge with no terminal phase"] --> St1
+    St1["1 — Re-read durable state by requestId:<br/>request ledger, else session snapshot"] --> Found{"Did the send land?"}
+    Found -- yes --> St2["2 — Append accepted"]
+    Found -- no --> Redo["Re-dispatch the SAME requestId<br/>a landed send returns duplicate true"]
+    Redo --> St2
+    St2 --> St3["3 — Advance the consumed-source cursor and<br/>process any handoff the destination already emitted"]
+    St3 --> Res{"Resolvable?"}
+    Res -- yes --> Go["Chain continues or settles normally"]
+    Res -- no --> St4["4 — Append outcome-unknown<br/>reason: unreconcilable"]
+    St4 --> Mark["Post a system marker on the timeline"]
+```
+
+Step 3 is the one round 2 was missing: a destination that settled and handed off *before* the crash
+is processed, not skipped.
+
+### The life of one turn hop
+
+```mermaid
+stateDiagram-v2
+    [*] --> pending: openEdge, under the CAS lock
+    pending --> accepted: dispatch acknowledged
+    pending --> failed: participant_unavailable
+    pending --> capped: hop or invocation cap
+    pending --> outcome_unknown: crash, unresolvable at recovery
+    accepted --> settled: agent_end, willRetry false
+    accepted --> suspended: ask_user gate opens
+    suspended --> settled: owner answers
+    accepted --> failed: seat_error
+    settled --> [*]
+    failed --> [*]
+    capped --> [*]
+    outcome_unknown --> [*]
+```
+
+The edge itself never changes. Each arrow is an **appended transition record**; the phase shown is
+the latest one. System markers on the timeline are *derived* from these transitions — there is no
+second event system.
+
 ## 1. The noun — decide this first
 
 ### Today
@@ -152,11 +317,43 @@ target is typed, the payload is explicit, and the transition is a `tool-call` ev
 exactly. This is a workspace plugin tool the relay owns; it is *not* an agent-to-agent call (the tool
 returns immediately, the relay decides what happens next).
 
-**Post-vs-Run boundary — only posts cross seats.** A seat's private reasoning, tool calls, and
-intermediate messages never enter another seat's context. Exactly two things cross: (a) the **final
-assistant message** of a settled turn (`message-end.final`, gated on an `agent-end` with
-`willRetry !== true`), and (b) **relay-authored system handoff markers**. Everything else stays in
-the originating session and is reachable only by drill-down.
+**Two boundaries — and only one of them is restrictive.** This is the single most misread part of
+the design, so state it plainly: *participants share the work, not each other's minds and keys.*
+
+- **The artifact boundary is OPEN.** Participants on a job **share one workspace and one canonical
+  filesystem**. Ratified, not invented: agents in a workspace "intentionally share
+  filesystem/process/runtime authority while retaining distinct route, prompt, tool, session,
+  readiness, receipt, log, and provenance identity" (D25, `docs/DECISIONS.md:410`), and same-workspace
+  agents share workspace data through the canonical Environment API, with narrower grants getting
+  "separately enforced execution views **without copying the authoritative filesystem**" (D28,
+  `:463`) — one API for tools, bash, UI and CLI precisely to prevent "filesystem split brain"
+  (`:462`). So the worker's files *are* the reviewer's files. The reviewer reads the branch the
+  worker wrote; nothing is copied, synced, or handed over as an attachment. Per-participant reach is
+  governed by mounts and tool authority, not by partition. This is the half of the shared-VM feel
+  people actually like, delivered natively and governed.
+- **The conversation boundary is CLOSED.** Posts-only governs one thing only: what enters a
+  participant's *prompt* from another participant's transcript. A seat's private reasoning, tool
+  calls, intermediate messages, and any credentials in them never cross. Exactly two things do:
+  (a) the **final assistant message** of a settled turn (`message-end.final`, gated on an `agent-end`
+  with `willRetry !== true`), and (b) **relay-authored system handoff markers**. Everything else stays
+  in the originating session, reachable only by drill-down.
+
+The pairing is the point. Sharing context windows is what makes multi-agent setups leak secrets and
+drown in each other's tool spew; sharing a filesystem is what makes them able to collaborate at all.
+v0 takes the second and refuses the first.
+
+```mermaid
+flowchart TB
+    subgraph conv["CONVERSATION — closed: only settled posts cross"]
+        direction LR
+        W["Worker<br/><i>private reasoning, tool calls, keys</i>"]
+        R["Reviewer<br/><i>private reasoning, tool calls, keys</i>"]
+        W -- "final post + handoff marker<br/>via the relay" --> R
+        R -- "final post + handoff marker" --> W
+    end
+    conv --> FS
+    FS["ARTIFACT — open: ONE canonical filesystem<br/>the worker's files ARE the reviewer's files<br/>governed by mounts + per-participant tool authority"]
+```
 
 **Turn policy — addressing-gated, with prior art.** [Buzz](https://block.xyz/) (Block, July 2026) is
 an @-mention-gated agent group chat and the closest shipped prior art. Adopted: a participant acts
@@ -199,11 +396,13 @@ approvals, interventions (envelope projection — no second event system)"**
 
 ### Delta
 
-Two append-only logs beside the projection record in the same plugin store, written under the same
-`revision` CAS. They are an **envelope projection**, not a competing event system: every field is
-either relay-authored control state or copied from an existing receipt. **Nothing is ever mutated** —
-round 1 declared receipts append-only while requiring `chainState` to change in place. Edges now have
-identity and state moves by appended transition records.
+Beside the projection record in the same plugin store, under the same `revision` CAS: **two
+append-only logs** (edges, transitions) plus **two CAS-updated counters** (chain state, cursors). The
+split matters — history is immutable, bookkeeping is not. Together they are an **envelope
+projection**, not a competing event system: every field is either relay-authored control state or
+copied from an existing receipt. **No edge or transition is ever mutated** — round 1 declared receipts
+append-only while requiring `chainState` to change in place. Edges now have identity, and their state
+moves only by appended transition records.
 
 ```ts
 /** One attempted cross-post. Immutable once written. */
@@ -234,13 +433,18 @@ interface JobRelayTransitionV0 {
 
 /** Per-chain counters, reserved pre-dispatch so a crash cannot undercount. */
 interface JobChainStateV0 { chainId: string; hops: number; invocations: number; ordinalHigh: number }
+
+/** How far the relay has interpreted one source session. Per job, not per chain. */
+interface JobCursorV0 { jobId: string; refKey: string; consumedThroughSeq: number }
 ```
 
 - **Ordering.** `turnOrdinal` is a store-owned monotonic **integer** allocated inside the same locked
   CAS mutation that writes the pending edge — not an unconstrained string, so `1, 2, 10` cannot sort
   as `1, 10, 2`. Within a destination, posts order by event `seq`; relay-authored system markers get a
-  durable `markerOrdinal` (an integer minted alongside the edge) as a deterministic tie-breaker, so
-  markers never float. Merged rendering sorts `(turnOrdinal, seq, markerOrdinal)`. No wallclock.
+  durable `markerOrdinal` — **the transition's append index within its edge** (the post itself is 0) —
+  as a deterministic tie-breaker, so markers never float. System markers are *derived from
+  transitions*, not stored as a separate kind of event, which is what keeps "no second event system"
+  true. Merged rendering sorts `(turnOrdinal, seq, markerOrdinal)`. No wallclock.
 - **Snapshot fallback, stated honestly.** `PiChatSnapshot` carries one session-level `seq` watermark
   and `messages: BoringChatMessage[]` with **no per-message `seq`** (`shared/chat/piChatSnapshot.ts:16-23`).
   So a turn rendered from a snapshot cannot reconstruct the original per-event tuple. Degraded rule:
@@ -248,8 +452,8 @@ interface JobChainStateV0 { chainId: string; hops: number; invocations: number; 
   watermark, and the timeline marks the block as snapshot-derived. Cross-seat order is unaffected,
   because that comes from `turnOrdinal`, which is relay-owned and durable.
 - **Split cursors.** Round 1's single `processedCursors` high-water map conflated two different
-  things and created a skip hole. v0 keeps both: a **consumed-source cursor** per source ref (how far
-  the relay has interpreted that seat's events) and a **delivered-context watermark** per destination
+  things and created a skip hole. v0 keeps both in separate records: a **consumed-source cursor** per
+  source ref, held in `JobCursorV0` (how far the relay has interpreted that seat's events) and a **delivered-context watermark** per destination
   (`deliveredThroughOrdinal` — what a given send actually carried). A destination that completed and
   emitted a handoff before a crash is therefore still discoverable after restart.
 - **Recovery order** (on boot, per job, for each edge lacking a terminal phase):
@@ -260,6 +464,9 @@ interface JobChainStateV0 { chainId: string; hops: number; invocations: number; 
      considering termination — this is the skip hole round 1 left open.
   4. Only if steps 1–3 cannot resolve the edge, append `outcome-unknown` with
      `reason:"unreconcilable"` and post a system event.
+- **Chains start with the human.** A human message posted to the job mints a new `chainId` and is
+  itself that chain's first edge, with `sourceRef` absent — which is why the field is optional. Every
+  later hop in the chain reuses the `chainId`.
 - **Caps.** `maxHopDepth` (default 3) and `maxInvocationsPerChain` are counted on `JobChainStateV0`,
   scoped to `chainId` = the **root human turn**. A new human message opens a new chain with fresh
   counters; an interleaved message therefore neither inherits nor resets another chain's counts.
@@ -390,10 +597,9 @@ follow-on, because v0 touches no Console store. Each slice is one session and fo
 idiom (`plan.md:378-417`).
 
 **S1 — projection contract + store + edge allocator.** `JobProjectionV0`, `JobParticipantV0`,
-`JobRelayEdgeV0`, `JobRelayTransitionV0`, `JobChainStateV0` schemas; file store with revision CAS,
+`JobRelayEdgeV0`, `JobRelayTransitionV0`, `JobChainStateV0`, `JobCursorV0` schemas; file store with revision CAS,
 lock, atomic rename, load diagnostics; and the **`openEdge()` allocator** — one locked mutation that
-allocates `turnOrdinal`/`markerOrdinal`, mints `requestId`, reserves chain counters, and appends the
-pending edge. Append-only enforced. No relay, no UI, no agent tool.
+allocates `turnOrdinal`, mints `requestId`, reserves chain counters, and appends the pending edge. Append-only enforced. No relay, no UI, no agent tool.
 - *Blocked by:* owner ruling on Q1 (noun); PR #1401 merged.
 - *Scope:* `plugins/job-threads/src/shared/{types,schema}.ts`, `src/server/{jobProjectionStore,edgeLog}.ts` + tests.
 - *Proof:* `pnpm --filter @hachej/boring-job-threads test -- src/server/__tests__/jobProjectionStore.test.ts src/server/__tests__/edgeLog.test.ts src/shared/__tests__/schema.test.ts`; `pnpm --filter @hachej/boring-job-threads typecheck`.
@@ -474,8 +680,12 @@ provenance"* (`docs/DECISIONS.md:365`). Envelope-grade attribution arrives with 
    enforced). Confirm the relay for v0, or build the ratified binding instead?
 3. **Attribution grade.** Accept explicitly display-grade `participantId` for v0, or pull ratified
    C7 `seatId` forward now so the demo's audit story is envelope-grade?
-4. **Post/Run boundary.** Confirm only settled final assistant posts + relay system markers cross
-   seats — no tool calls, no intermediate messages?
+4. **The two boundaries.** Confirm the pairing: the **artifact** boundary stays **open** — one shared
+   workspace and one canonical filesystem for all participants, per D25 (`:410`) / D28 (`:462-463`),
+   with reach governed by mounts and tool authority — while the **conversation** boundary stays
+   **closed**: only settled final assistant posts and relay system markers enter another
+   participant's prompt, never private reasoning, tool calls, or credentials. Agents share the work,
+   not each other's minds and keys.
 5. **Objective coupling.** Is an Objective **mandatory** for a job? Confirm one-way ref with
    `clientRequestId` compensation, or should `Objective` gain a `threadId`?
 6. **Context and budget.** Confirm oldest-first truncation with no summarization, and confirm that

--- a/docs/plans/job-thread-v0-plan.md
+++ b/docs/plans/job-thread-v0-plan.md
@@ -1,0 +1,300 @@
+---
+title: Job Thread v0 — 1 Thread = 1 job
+state: draft
+issue: 1399
+review: pending cross-model review; no implementation before it
+---
+
+# Job Thread v0 — multi-seat Thread projection, K7 demo
+
+**Concept** (owner, [#1399](https://github.com/hachej/boring-ui/issues/1399)): the Thread is the unit
+of WORK, not of agent. The human talks to the job; staffing collapses behind one merged timeline, and
+per-agent sessions demote to drill-down provenance — CI logs behind a PR check. Convergence:
+**1 Thread = 1 job = 1 Objective**, staffed by Seats.
+
+**Naming is ratified, not free**: *multi-seat Thread* / *Job Thread*, never "channel" — `channel` is
+reserved for transport/ingress (C5 "channel-answerable", Track C, Slack/CLI). See #1399's
+reconciliation comment and PR [#1401](https://github.com/hachej/boring-ui/pull/1401) (open), which
+appends to `RECONCILIATION.md` §7 and `VISION.md` R-c: *"A Thread may span multiple Seats, projected
+as one timeline; one Thread per job."*
+
+**Hard constraint (v0)**: no A2A loopback — agents never call agents. An **orchestrator seat**, an
+ordinary in-process gateway client and not an agent, relays between per-agent sessions; the Thread
+timeline is a **projection** merging per-session Runs. Decision 28 (`docs/DECISIONS.md:461`) defers
+A2A and v0 does not reopen it. Ordering and dependencies live only in §6; §§1–5 describe shape.
+
+## 1. Data — what a Job Thread record is, and where it lives
+
+### Today
+
+- **No Thread noun exists in code.** `ConversationRef|threadId|ThreadRef` and
+  `ConsoleCollection|ConsoleThreadRefV1|AutomationGroup` → 0 hits across `packages/ plugins/ apps/`.
+- The only shipped conversation address is `AgentSessionRef { agentTypeId, sessionId }`
+  (`packages/agent/src/shared/gateway/types.ts:54-57`), deliberately carrying no `hostId`
+  (Decision 29, `docs/DECISIONS.md:471`). Real identity is the triple
+  `(workspaceScopeId, agentTypeId, sessionId)` — `agent-host/agentSessionKey.ts:3`.
+- The 1355 Console plan (merged to main as `docs/issues/1355/plan.md`, PR #1356) proposes
+  `ConsoleThreadRefV1 { workspaceScopeId, agentTypeId, sessionId }` (`plan.md:74-78`), persisted in
+  `ConsoleCollectionThreadAssignment` under a unique key
+  `(appId, principalId, workspaceScopeId, agentTypeId, sessionId)` (`plan.md:102-104`).
+  **Single-seat by construction**: one Thread = one session tuple.
+- Run identity: the ratified `RunId := RequestKey` ships as `AgentRequestKey
+  { workspaceScopeId, authSubjectId, operation, target, requestId }` (`agent-host/types.ts:51-57`),
+  durably ledgered by `SqliteAgentRequestLedger` (`sqliteRequestLedger.ts:39`) at
+  `.agent-request-ledger.sqlite` (`createAgentHost.ts:291`).
+- **`seatId` does not exist anywhere in code**, and `trajectory` → 0 occurrences repo-wide. The
+  spine (`runId·agentId·digest·seatId·cost·outcome`, `VISION.md:37`, `RECONCILIATION.md:137`) and
+  `Seat { seatId; workspaceId; agentId; role?; budget?; permissions?; bindingState }`
+  (`V2-IMPLEMENTATION-SPEC.md:119`) are doc-only — 1355 says so itself: *"C7 SessionCatalog and
+  full Seat projection are target architecture, not current prior art"* (`plan.md:163-165`). The
+  `seat: string` in `loadConfiguredAgentFleet.ts:28` is an unrelated fleet.yaml field, explicitly
+  warned about at `agent-host/types.ts:148-149`.
+- Objectives (PR [#1382](https://github.com/hachej/boring-ui/pull/1382), **OPEN, not merged**)
+  persist `Objective { id, title, objective, metric, baseline, target, current, status,
+  constraints, evidenceRefs, outcome, ... }` (`plugins/objectives/src/shared/types.ts:10-27`) to
+  `.boring/objectives.json` via `FileObjectiveStore` (`objectiveStore.ts:58`) — versioned, lock
+  sidecar, atomic tmp-rename. **No session/thread/run ref field**; the only outbound seam is the
+  free-string `evidenceRefs: string[]`.
+
+### Delta
+
+The smallest honest record — `objectiveId` and `seats` carry the whole concept:
+
+```ts
+interface JobThreadV0 {
+  id: string                       // `jth-<uuid>`
+  title: string
+  objectiveId?: string             // one-way ref into the objectives plugin; objectives unchanged
+  seats: JobThreadSeatV0[]         // v0: exactly 2 working seats (worker, reviewer) — see §5
+  createdAt: string; updatedAt: string; revision: number
+}
+interface JobThreadSeatV0 {
+  seatId: string                   // FIRST real seatId in the codebase
+  role: "orchestrator" | "worker" | "reviewer"
+  conversation: ConsoleThreadRefV1 // { workspaceScopeId, agentTypeId, sessionId }
+}
+```
+
+- **A Job Thread is a typed conversation *ref set* plus a role per ref.** It owns no transcript,
+  authority, or runtime, and each `conversation` is independently authorized on every read/write —
+  the 1355 rule that a collection "does not own a Thread record ... those domains expose
+  independently authorized references" (`plan.md:89-93`).
+- **Per-Run seat attribution**: the join is `seatId × AgentRequestKey`. The honest v0 move is *not*
+  to widen `AgentRequestKey` (P0 host work, `RECONCILIATION.md:153` "seatId in C7") but to **derive**
+  it: a `AgentRequestKey.target` of `{kind:'session', ref}` resolves to exactly one seat within a
+  Thread, so `runId → seatId` is a lookup over the ref set. v0 stores nothing extra. Promotion
+  trigger for a stored seatId: a second Thread sharing one session.
+- **Durable home**: a `plugins/job-threads/` file store cloned from `FileObjectiveStore` —
+  `.boring/job-threads.json`, same versioned + lock + atomic-rename pattern. Why not the 1355
+  Console store: its hosted persistence is `packages/core/src/server/db/stores/consoleCollectionStore`
+  (Postgres, `plan.md:512-519`) and is **gate-blocked** — Gate 1 (`plan.md:372-376`, *"No
+  implementation bead is ready before it"*) is unanswered, all 21 beads `status: open`. A plugin file
+  store needs no Core migration, no principal-ownership contract, and is deletable.
+- **The conflict to surface for 1355** (the hook PR #1401 names): `ConsoleThreadRefV1`'s unique key
+  is the session 5-tuple, so a Console collection cannot hold a multi-seat Thread as one row. Minimal
+  repair: an assignment's subject becomes `jobThreadId` *or* a session tuple. That is a **1355
+  amendment, not a v0 slice** — v0 ships without Console collection integration.
+
+## 2. Mechanism — the orchestrator relay
+
+### Today
+
+- `EmbeddedAgentGateway` (`agent-host/embeddedGateway.ts:126`) is exported from
+  `packages/agent/src/server/index.ts:178`. Holding it plus one `AuthorizedAgentScope`, an in-process
+  caller can `connectSession` on **any** `(agentTypeId, sessionId)` it is authorized for and `send()`
+  on the returned `AgentSessionConnection` (`shared/gateway/types.ts:196-204`: `events`, `send`,
+  `interrupt`, `stop`, `clearQueue`, `close`). **Nothing forces one sender per session.** The
+  orchestrator seat needs no new machinery.
+- The two existing programmatic drivers are **unusable** for relay: `runWithWorkspaceAgentLease`
+  (`workspaceAgentLease.ts:87`) and `createBoundWorkspaceAgentDispatcher`
+  (`server/workspaceAgentDispatcher.ts:92`) are each bound to a single `agentTypeId`
+  (`WorkspaceAgentGatewayBinding {gateway, scope, agentTypeId}`, `shared/workspaceAgentDispatcher.ts:68-72`).
+- There is **no actor identity below the auth subject** — `AuthorizedAgentScope
+  { workspaceScopeId, authSubjectId }` (`shared/gateway/types.ts:44-48`) is all the model carries, so
+  the orchestrator acts *as the human's auth subject*. Correct: it is a client, not an agent, and
+  cannot mint authority (invariant 7, `VISION.md`).
+- Cost bounds are per-run and metering-local: reservations key on
+  `runId = pi-run:${sessionId}:prompt:${clientNonce}` (`pi-chat/metering.ts:197-202`). **No
+  per-Thread budget exists today.**
+
+### Delta
+
+An `OrchestratorRelay` in the job-threads plugin server: a plain class holding
+`{ gateway, scope, thread }`, no agent, no LLM.
+
+1. **Trigger**: a human message posted to the Thread, or a seat's Run reaching terminal state
+   (`agent-end` on that seat's `AgentSessionEvent` stream — the same signal
+   `AgentSessionActivityIndex` already consumes, `sessionInventory.ts:138-142`).
+2. **Fan-out of a human message**: addressing-gated (below). Unaddressed → the Thread's default
+   worker seat. Addressed → `connectSession` on that seat's ref and `send` the projected Thread
+   history since that seat's last turn, plus the new message.
+3. **Handoff**: when a seat's Run ends with an addressed handoff, the relay cross-posts that seat's
+   final message into the addressed seat's session as an attributed quote. **The relay is the only
+   writer**; neither seat has a tool that reaches the other.
+4. **Cost bounds**, enforced centrally in the relay and never in agent instructions:
+   `maxHandoffDepth` (default 3) and `maxSeatInvocations` per human turn, plus a per-Thread budget
+   hook in front of the existing reservation path (`metering.ts`). Exceeding a cap posts a terminal
+   system event on the Thread and stops — it does not silently truncate.
+
+#### Turn policy — prior art: Buzz by Block
+
+[Buzz](https://block.xyz/) (Block, July 2026) is an @-mention-gated agent group chat on Nostr, and
+is the closest shipped prior art. What we adopt and what we fix:
+
+- **Addressing-gated turns.** A seat responds only when explicitly addressed — by the human, or by
+  another seat's relayed handoff. No ambient reactions, no router model in v0. Buzz's proven
+  anti-noise mechanism, and it maps one-to-one onto our per-`agentTypeId` session addressing
+  (`/api/v1/agents/:agentTypeId/sessions/...`, `httpProjection.ts:221-582`).
+- **Loop safety — Buzz's documented gap; do not repeat it.** Buzz leaves stopping conditions to
+  agent authors, and mention loops are a real failure mode. v0 enforces the §2.4 caps centrally.
+- **Transcript model.** One full shared timeline visible to all seats (Buzz-validated); each seat's
+  private session receives the projected history on its turn. **Attribution is free for us**: Buzz
+  needs signed per-agent Nostr identities, while per-Run `seatId` over the request ledger gives the
+  same audit story from the envelope rather than from cryptography.
+- **Human role.** Approver of terminal actions, not a participant in every turn — Buzz's "steer or
+  approve" is our Inbox Human Intentions surface. A convergence to cite, not a mode to invent.
+- **Modes.** Sequential handoff and parallel same-brief are distinct explicit modes (Buzz supports
+  both). **v0 ships handoff only**; parallel is v1 and its mechanism already has a name — 1355's
+  `AutomationGroup` fan-out (`plan.md:253-279`), each target getting its own Thread, Run, receipt.
+- **Posture.** Buzz (shared thread, mixed trust, signed identity) vs Grok Bot (single-owner private
+  fleet, internal handoffs): our product spans both, so we adopt Buzz's audit/identity posture even
+  while v0 runs a single-owner fleet.
+
+#### ask-user gates on the Thread
+
+Today: `AskUserQuestion { questionId, sessionId, ownerPrincipalId, status, schema, answerToken, ...}`
+(`plugins/ask-user/src/shared/types.ts:113-127`) is keyed by **`sessionId` only** — no `agentTypeId`,
+no thread — with one pending question per session (`getPending(sessionId)` is singular,
+`askUserStore.ts:28`). Pending state reaches the UI as
+`AskUserPendingState { hint, hintsBySession }` (`askUserStatePublisher.ts:6-21`); the Inbox left-pane
+action already exists (`plugins/ask-user/src/front/index.tsx:239-251`).
+
+Delta: **no ask-user change.** The Thread projection joins `hintsBySession` against the ref set
+(`sessionId ∈ thread.seats[].conversation.sessionId`) and renders the question inline with its seat's
+attribution; answering still routes through `ask-user.v1.answer` and its `answerToken` capability
+(`askUserRuntime.ts:160-177`). The relay treats a seat blocked on `ask_user` as *not* a terminal Run,
+and does not advance the handoff chain.
+
+## 3. Projection — the merged timeline
+
+### Today
+
+- The left-pane row model is `AppLeftPaneSession { id, agentTypeId?, title?, updatedAt?, turnCount?,
+  nativeSessionId?, hasAssistantReply?, ephemeral?, status? }`
+  (`packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx:17-27`) — **session-shaped, with
+  no `kind` discriminator**, and PR [#1393](https://github.com/hachej/boring-ui/pull/1393) (OPEN)
+  leaves it byte-for-byte unchanged. Correcting the brief: the "conversation-kind-agnostic row model"
+  is **not yet built**. #1393 adds `AppLeftPaneConsoleSpike` with
+  `AppLeftPaneConsoleSpikeView = "recent" | "project" | "agent"`,
+  `ConsoleSpikeRowSlots { leadingBadge?, metaTag? }` and
+  `AppSessionRowAffordances = "default" | "console"` — the seams where it would land.
+- Per-session events are `AgentSessionEvent { ref, seq, event }` (`shared/gateway/events.ts:5-9`),
+  NDJSON at `GET /api/v1/agents/:agentTypeId/sessions/:sessionId/events` (`httpProjection.ts:402`),
+  cursor = `seq`. Transcripts are Pi JSONL under `sessionNamespaceForAgent()`
+  (`sessionInventory.ts:13-22`), rooted at `BORING_AGENT_SESSION_ROOT`.
+- **Durable replay is opt-in and off**: `BORING_CHAT_DURABLE_STREAM` / `.agent-event-stream.sqlite`
+  (`buildAgentComposition.ts:37-40`). Decision 29 shipped Conformance **Level B** and deferred Level
+  D because *"durable replay is only load-bearing once concurrent multi-agent streams exist"*
+  (`docs/DECISIONS.md:472`). **A Job Thread is exactly that condition arriving** — the single most
+  important Today/Delta finding in this plan.
+
+### Delta
+
+- **A Thread view is interleaved Runs with seat attribution.** New: a `useJobThreadTimeline` opening
+  one `AgentSessionConnection` per seat ref, merging frames on `(wallclock, seq)` per source and
+  tagging each with `seatId` + role. No new transport, no new store — a client-side merge over
+  streams that already exist. Cross-session ordering is best-effort and explicitly *not* a total
+  order; a system event marks each relayed handoff so the reader has an anchor.
+- **Drill-down**: each merged block links to its origin session's own view — the "CI logs behind a
+  PR check" affordance from #1399.
+- **Left-nav framing (owner direction, 2026-08-24)**: the primary list becomes **Threads (jobs)**;
+  **Agents becomes a DIRECTORY entry** (a roster of all agents); and Thread participation is an
+  **attribute on the Thread** — the 1..n participant chips rendered in #1393's
+  `ConsoleSpikeRowSlots.metaTag` slot. The **by-agent lens then reads as "Threads this agent
+  participates in"** (a directory view), *not* a grouping of private sessions. That is a semantic
+  change to #1393's `"agent"` view mode, whose `OrganizedSession` grouping assumes one `agentTypeId`
+  per row.
+- **Level D activation** is the honest prerequisite for a Thread surviving a reload with more than
+  one live stream. The v0 demo runs with `BORING_CHAT_DURABLE_STREAM` on; defaulting it is a
+  Decision-29 re-evaluation (`docs/DECISIONS.md:474`), out of scope here.
+
+## 4. K7 demo — "grow audience X→Y"
+
+### Today
+
+The pieces exist but have never been composed. `Objective` (PR #1382, open) already has exactly the
+right shape for K7 — `metric`, `baseline`, `target`, `current`
+(`plugins/objectives/src/shared/types.ts:10-27`), created by the `create_objective` tool and
+navigable via the `objective` surface kind. There is no Thread, no second seat, no relay.
+
+### Delta — the scripted deterministic path
+
+Fleet: two `agentTypeId`s in the demo `fleet.yaml` — `creator-growth-worker` and
+`creator-growth-reviewer` — plus the orchestrator seat (a client, not a fleet entry).
+
+1. Owner creates a Job Thread *"Grow audience 1,200 → 5,000"*. Creation calls `create_objective`
+   once (metric `followers`, baseline 1200, target 5000), stores the returned `obj-<uuid>` as
+   `objectiveId`, and `createSession`s one session per `agentTypeId` as the two seats.
+2. Owner posts one message to the **Thread**, not to an agent. Unaddressed → relay routes to worker.
+3. Worker drafts a growth plan, hands off `@reviewer`; relay cross-posts the draft. Depth = 1.
+4. Reviewer returns a critique addressed back to `@worker`. Depth = 2.
+5. Worker revises and calls `ask_user` to approve the terminal action (publish / move the
+   Objective's `current`). The gate appears **on the Thread** with worker attribution, and in Inbox.
+6. Owner approves; worker calls `update_objective`; relay stops. The depth cap (3) is never reached.
+
+**What the owner sees**: one Thread row with two participant chips; one merged timeline where every
+block names its seat; one inline approval card; one Objective whose `current` moved. Sessions appear
+only on drill-down. No agent-to-agent call exists anywhere in the request ledger — every send
+carries `authSubjectId` = the owner. The demo is scripted (fixed prompts, fixed handoff points, caps
+never hit): a *demo path*, not a claim of general multi-agent competence.
+
+## 5. Non-goals for v0 (explicit)
+
+1. **No shared runtime transcript.** Seats keep private Pi JSONL sessions (`sessions.ts:154`); the
+   shared timeline is a projection only. No "room" object.
+2. **No A2A activation.** No agent-callable tool reaches another agent. Decision 28 defers A2A
+   (`docs/DECISIONS.md:461`); PR #1401's amendment states the non-change explicitly.
+3. **More than 2 working seats.** v0 is worker + reviewer + orchestrator; a third seat is a v1
+   routing question, not a mechanism question.
+4. **"Channels" in the transport sense.** No Slack/CLI/Nostr ingress binds to a Thread; `channel`
+   stays reserved for C5 channel-answerable / Track C.
+5. **Console collection integration** — no `ConsoleCollection`, Postgres store, or
+   `AutomationGroup`; gate-blocked (§1).
+6. **A durable `seatId` on the request ledger** — derived in v0 (§1).
+7. **Parallel same-brief mode.** Handoff only (§2).
+8. **Cross-Workspace Threads.** All seats share one `workspaceScopeId`, matching 1355's rule that
+   cross-Workspace transfer is a separate protocol (`plan.md:211-213`).
+
+## 6. Slices
+
+Ordering lives here and nowhere else. **Gate G** = 1355 Gate 1 architecture approval
+(`docs/issues/1355/plan.md:372-376`, *"No implementation bead is ready before it"*), currently
+**unanswered** — all 21 `wt-391-forward-gh-1355-persistent-console-q9ba` beads are `status: open`.
+**Gate R** = owner merge of PR #1401 (the ratification of "one Thread per job").
+
+| # | Slice | Depends on | Gate |
+| --- | --- | --- | --- |
+| S1 | `plugins/job-threads` record + file store (`JobThreadV0`, `JobThreadSeatV0`, `.boring/job-threads.json`), cloned from `FileObjectiveStore`; bridge ops + schema; no UI | PR #1382 merged (for `objectiveId` to mean anything) | **Gate R** only — free of G |
+| S2 | `OrchestratorRelay`: multi-`agentTypeId` client over `EmbeddedAgentGateway`, addressing-gated turn policy, central depth/invocation caps, handoff cross-post. Server-only, driven by tests | S1 | free |
+| S3 | Thread timeline projection: multi-connection merge with `seatId` attribution, ask-user join over `hintsBySession`, drill-down links. Requires `BORING_CHAT_DURABLE_STREAM` on | S2 | free |
+| S4 | Left-nav reframe: Threads primary, Agents as directory, participant chips in `ConsoleSpikeRowSlots.metaTag`, by-agent lens = "Threads this agent participates in" | S3, PR #1393 | **Gate G** — touches the Console pane contract |
+| S5 | K7 demo composition: two-agent fleet, scripted path, owner-facing walkthrough | S3 (S4 optional for the demo) | free if run on the playground route; **Gate G** if it ships in the Console |
+
+S1–S3 and S5 are deliverable without the 1355 decision — they add a plugin and a projection, touching
+no Console store and no Core migration. Only S4 negotiates the Console contract, carrying §1's
+`ConsoleThreadRefV1` repair: file that as a 1355 amendment before S4 starts.
+
+## Open questions for the owner
+
+1. **Derived vs stored `seatId`** (§1): accept the deferral, or pull "seatId in C7"
+   (`RECONCILIATION.md:153`) forward into v0?
+2. **Level D**: the Thread projection is the first genuine multi-stream consumer — the exact
+   re-evaluation trigger Decision 29 names (`docs/DECISIONS.md:474`). Flip
+   `BORING_CHAT_DURABLE_STREAM` default-on, or keep v0 behind the flag?
+3. **`ConsoleThreadRefV1` repair**: amend 1355 now (assignment subject becomes `jobThreadId` or a
+   session tuple), or ship v0 Console-less and amend later?
+4. **Objective coupling direction**: v0 points Thread → Objective one-way, leaving PR #1382
+   untouched. Acceptable, or should `Objective` gain a `threadId`?
+5. **Orchestrator identity**: the relay acts as the owner's `authSubjectId`, so every relayed send is
+   attributed to the human in the request ledger. Correct — it *is* the human's client — or does the
+   audit story need a distinct non-agent principal?

--- a/docs/plans/job-thread-v0-plan.md
+++ b/docs/plans/job-thread-v0-plan.md
@@ -484,6 +484,39 @@ the relay-enforced hop/invocation caps above, which bound *hops*, not spend. The
 for a real budget — a v1 slice, not a v0 claim — is adding a job dimension to `MeteringRunScope` and
 threading it through the reservation path.
 
+### Staffing workflow — designed now, UI deferred
+
+**Today**: no add/remove flow exists anywhere in this plan — `participants` (§1) has been treated as
+set once at job creation, and §2–§3's mechanism never revisits membership.
+
+**Delta**: v0 decides staffing *mechanics* now, so S3's CAS/transition machinery does not need a
+later reshape, while the add/remove **UI** itself is pushed to a deferred slice (S6, §7).
+
+- **Entry points — both human-initiated.** A `+` on the thread-header participant chips opens a
+  picker sourced from the Agents directory; an `@mention` of an agent not yet in `participants`,
+  typed into the composer, surfaces an inline add-confirm rather than resolving to nothing. Staffing
+  is an explicit **human** act in v0 — no agent tool stages a new participant; agent-initiated
+  staffing is out of scope and would need a riskTier'd human approval gate before it could ship, not a
+  bare tool call.
+- **Mechanics.** Adding a seat is one CAS-append to `participants: JobParticipantV0[]` under the
+  projection's `revision` (§1), paired with creating that seat's session in the job's shared
+  `workspaceScopeId` (§6, "all participants share one `workspaceScopeId`") — the same
+  session-creation path S2 already uses, no new session machinery. The relay then posts a **`joined`
+  system marker**: transition-derived like every other marker, keeping §3's "no second event system"
+  true for staffing as well.
+- **Onboarding context is bounded by construction.** A newly-added seat starts with
+  `deliveredThroughOrdinal = 0` (§3) — nothing delivered yet — so its first turn reads job history
+  back to `turnOrdinal` 1. That is exactly the case §3's context bound already handles:
+  `maxInjectedPosts`/`maxInjectedBytes` cap it, oldest-first drop, truncation marker inserted. No new
+  cap and no new code path; a long-lived job's new-seat catch-up runs through the same door as
+  ordinary per-turn delivery.
+- **Departure preserves history, never rewrites it.** Removing a participant appends no deletions:
+  `bindingState` (§1) doubles as v0's "left" state — the existing `"removed"` value is what a
+  departure sets — and every edge/transition the seat produced stays exactly as written, consistent
+  with §2's rule for handoff to a removed participant (`phase:"failed",
+  reason:"participant-unavailable"`). The relay posts a **`left` system marker**, transition-derived
+  the same way `joined` is.
+
 ## 4. Projection — the merged timeline
 
 ### Today
@@ -644,6 +677,17 @@ Objective compensation path, plus a separately-labelled live smoke.
 - *Proof:* `pnpm --filter @hachej/boring-job-threads test -- src/server/__tests__/k7Demo.test.ts`.
 - *Negative proof:* the acceptance run performs zero live model calls; a failed projection write
   after `create_objective` leaves exactly one Objective on retry.
+
+**S6 — staffing UI (add/remove participants) — deferred, post-v0, small.** `+` picker on the
+thread-header participant chips sourced from the Agents directory; inline add-confirm on an unstaffed
+`@mention` in the composer; a remove affordance setting `bindingState:"removed"`. The mechanics this
+UI drives — CAS-append, seat session creation, `joined`/`left` markers (§3) — already ship in S3; this
+slice is UI only.
+- *Blocked by:* S3, S4.
+- *Scope:* `plugins/job-threads/src/front/{ParticipantPicker,AddParticipantConfirm}.tsx` + tests.
+- *Proof:* `pnpm --filter @hachej/boring-job-threads test -- src/front/__tests__/participantStaffing.test.tsx`.
+- *Negative proof:* removing a participant deletes or mutates no prior edge/transition of theirs; an
+  add for an agent already `active` in `participants` is a no-op, not a duplicate append.
 
 **Deferred follow-on (not v0) — Console nav reframe.** Jobs primary, Agents as a directory,
 participant chips in `ConsoleSpikeRowSlots.metaTag`, by-agent lens = "jobs this agent participates


### PR DESCRIPTION
Plan for **Job Thread v0** — multi-seat Threads ("1 Thread = 1 job"), demoed as the K7 creator-growth vertical. Round 2: folded fresh-eyes + cross-model adversarial review (round-1 verdict: revise; all findings dispositioned in-plan).

**Shape (round-2, current):** `JobProjectionV0` — a projection descriptor, NOT a second canonical Thread (frozen R-c untouched; canonical multi-seat Thread priced as owner option Q1-B — frozen `Thread.participants` makes it cheaper than assumed). A non-Seat **relay service** drives per-agent sessions via the existing actor-aware callback seam (`runWithWorkspaceAgent`, per-invocation `agentTypeId`); handoffs are a structured **tool call**, not free-text @-parsing; durable `JobRelayReceiptV0` gives idempotent, restart-safe chains; only settled posts + system markers cross seat boundaries; ask-user joins on the full triple. **Correction from round 1:** D24 ratifies a native in-process agent-to-agent binding — the relay is a v0 product choice (owner Q2), not an A2A-compliance requirement.

**Owner gate:** 8 rulings, presented in `docs/plans/job-thread-v0-plan-review.html` (in this PR). Beads: epic `wt-391-forward-jfxd`, P0 gate bead + S1–S5 (dep-cycles clean). Preconditions: PRs #1401 (amendment), #1382 (objectives); #1393 only for the deferred Console follow-on.

Provenance: #1399 (north star), fresh-eyes + gpt-5.6-sol xhigh reviews, targeted §3 verify in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGA4RhWZGNR5QA9Y7dFzCF