### PR TITLE
chore: make resource diagnostics private and document ledger cutover

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "release:minor": "bash scripts/cut-release.sh minor",
     "release:major": "bash scripts/cut-release.sh major",
     "build:packages": "pnpm -r --filter './packages/*' --filter './plugins/*' --workspace-concurrency=4 run build",
+    "dev:packages": "pnpm -r --parallel --filter './packages/*' run dev",
     "build:app-deps": "pnpm -r --workspace-concurrency=1 --filter '{./apps/*}...' --filter '!{./apps/*}' run build",
     "typecheck:changed": "node scripts/typecheck-changed-workspaces.mjs",
     "review:workspace-ui": "node scripts/review-workspace-playground-ui.mjs",

--- a/packages/agent/src/server/__tests__/createStandaloneAgentHostApp.requestLedger.test.ts
+++ b/packages/agent/src/server/__tests__/createStandaloneAgentHostApp.requestLedger.test.ts
@@ -42,7 +42,7 @@ test('standalone host writes the request ledger to an explicit host-owned path',
   }
 }, 120_000)
 
-test('standalone host falls back to the host session root, option before env', async () => {
+test('standalone host forwards its session root before the environment fallback', async () => {
   const workspaceRoot = await makeTempDir('boring-standalone-ledger-ws-')
   const sessionRoot = await makeTempDir('boring-standalone-ledger-sessions-')
   const envRoot = await makeTempDir('boring-standalone-ledger-env-')
@@ -59,22 +59,7 @@ test('standalone host falls back to the host session root, option before env', a
   }
 }, 120_000)
 
-test('standalone host falls back to BORING_AGENT_SESSION_ROOT when no option is set', async () => {
-  const workspaceRoot = await makeTempDir('boring-standalone-ledger-ws-')
-  const envRoot = await makeTempDir('boring-standalone-ledger-env-')
-  setEnvForTest('BORING_AGENT_SESSION_ROOT', envRoot)
-
-  const app = await createStandaloneAgentHostApp({ workspaceRoot, logger: false })
-
-  try {
-    expect(existsSync(join(envRoot, '.agent-request-ledger.sqlite'))).toBe(true)
-    expect(existsSync(join(workspaceRoot, '.boring'))).toBe(false)
-  } finally {
-    await app.close()
-  }
-}, 120_000)
-
-test('standalone host keeps the legacy workspace ledger when no host path is configured', async () => {
+test('standalone host keeps its legacy .boring ledger without a host root', async () => {
   const workspaceRoot = await makeTempDir('boring-standalone-ledger-ws-')
   setEnvForTest('BORING_AGENT_SESSION_ROOT', undefined)
 

--- a/packages/agent/src/server/agent-host/requestLedgerPath.ts
+++ b/packages/agent/src/server/agent-host/requestLedgerPath.ts
@@ -55,7 +55,15 @@ export interface ResolveRequestLedgerPathInput {
 }
 
 /**
- * Resolve the durable request ledger file for an agent host.
+  * Resolve the durable request ledger file for an agent host.
+ *
+ * **Ledger cutover note:** adopting BORING_AGENT_SESSION_ROOT (or an
+ * explicit requestLedgerPath) after running with the legacy in-workspace
+ * location RELOCATES the sqlite ledger. Effect-idempotency keys recorded
+ * at the legacy path are stranded there; retries that span the upgrade
+ * may be re-admitted once against the new ledger. Copy or drain the
+ * legacy file as part of the cutover if exactly-once effects must
+ * survive it.
  *
  * The request ledger is host application state, not workspace content, so the
  * chain prefers host-owned storage: explicit option, then the caller's

--- a/packages/agent/src/server/index.ts
+++ b/packages/agent/src/server/index.ts
@@ -243,7 +243,6 @@ export {
 } from './piPackages'
 export {
   DEFAULT_PI_RESOURCE_DIGEST_LIMITS,
-  SKIPPABLE_RESOURCE_CODES,
   createPiResourceDigestFence,
   createPiResourceDigestInput,
   digestPiResourceInputs,

--- a/packages/agent/src/server/piResourceDigest.ts
+++ b/packages/agent/src/server/piResourceDigest.ts
@@ -240,17 +240,16 @@ type UnadmittedEntryPolicy = 'reject' | 'skip'
 /**
  * The error codes that mean "this entry is not admissible", as opposed to "the
  * resolver is broken". Only these may be degraded to a skip; every other error
- * class must propagate. Exported so the workspace layer's shared-skill probe
- * degrades on exactly the same verdicts instead of keeping its own copy.
+ * class must propagate. This policy is private to Pi's resource walk.
  */
-export const SKIPPABLE_RESOURCE_CODES: ReadonlySet<string> = new Set<string>([
+const SKIPPABLE_PI_RESOURCE_CODES: ReadonlySet<string> = new Set<string>([
   ErrorCode.enum.PATH_ESCAPE,
   ErrorCode.enum.PATH_SYMLINK_ESCAPE,
 ])
 
 function skippableResourceCode(error: unknown): string | undefined {
   const code = (error as { code?: unknown })?.code
-  return typeof code === 'string' && SKIPPABLE_RESOURCE_CODES.has(code) ? code : undefined
+  return typeof code === 'string' && SKIPPABLE_PI_RESOURCE_CODES.has(code) ? code : undefined
 }
 
 /** The entry whose admission was refused, and how this walk frames a skip of it. */
@@ -275,7 +274,7 @@ type PiEntryRefusal =
  * The single admission gate for a refused Pi resource entry.
  *
  * Under `reject` — and for any refusal that is a resolver defect rather than an
- * admission verdict (see {@link SKIPPABLE_RESOURCE_CODES}) — this throws. Under
+ * admission verdict (see {@link SKIPPABLE_PI_RESOURCE_CODES}) — this throws. Under
  * `skip` it frames the verdict and returns, and the caller must abandon the
  * entry: a skipped entry is never realpath'd, opened, or mounted. The skip is
  * still framed into the hash, so the digest moves when a skipped entry appears

--- a/packages/cli/src/server/modeApps.ts
+++ b/packages/cli/src/server/modeApps.ts
@@ -694,11 +694,9 @@ export async function createWorkspacesModeApp(opts: {
     backendRegistry: InstanceType<typeof workspaceServer.RuntimeBackendRegistry>
     ensureLoaded: Promise<void>
   }>()
-  type CliPackageResourceRegistry = Awaited<ReturnType<typeof workspaceServer.resolveWorkspacePackageResources>>
-  interface CliPackageResourceSnapshot {
-    readonly registry: CliPackageResourceRegistry
-    readonly binding?: RuntimeFilesystemBinding
-  }
+  type CliPackageResourceSnapshot = Awaited<ReturnType<
+    typeof workspaceServer.resolveWorkspacePackageResourceSnapshot<RuntimeFilesystemBinding>
+  >>
   const pluginPiSnapshots = new Map<string, CliPluginPiSnapshot>()
   const packageResourceSnapshots = new Map<string, CliPackageResourceSnapshot>()
   const packageResourceDiagnostics = new Map<string, Array<{ source: string; message: string; pluginId?: string }>>()

--- a/packages/workspace/src/app/server/__tests__/createWorkspaceAgentServer.requestLedger.test.ts
+++ b/packages/workspace/src/app/server/__tests__/createWorkspaceAgentServer.requestLedger.test.ts
@@ -51,7 +51,7 @@ describe("workspace agent server request ledger placement", () => {
     }
   }, 120_000)
 
-  test("falls back to the host session root, option before env", async () => {
+  test("forwards the host session root before the environment fallback", async () => {
     const workspaceRoot = await tempDir("boring-ws-ledger-root-")
     const sessionRoot = await tempDir("boring-ws-ledger-sessions-")
     const envRoot = await tempDir("boring-ws-ledger-env-")
@@ -68,22 +68,7 @@ describe("workspace agent server request ledger placement", () => {
     }
   }, 120_000)
 
-  test("falls back to BORING_AGENT_SESSION_ROOT when no option is set", async () => {
-    const workspaceRoot = await tempDir("boring-ws-ledger-root-")
-    const envRoot = await tempDir("boring-ws-ledger-env-")
-    process.env.BORING_AGENT_SESSION_ROOT = envRoot
-
-    const server = await createWorkspaceAgentServer({ ...baseOptions, workspaceRoot })
-
-    try {
-      expect(existsSync(join(envRoot, ".agent-request-ledger.sqlite"))).toBe(true)
-      expect(existsSync(join(workspaceRoot, ".boring", "agent-request-ledger.sqlite"))).toBe(false)
-    } finally {
-      await server.close()
-    }
-  }, 120_000)
-
-  test("keeps the legacy workspace ledger when no host path is configured", async () => {
+  test("keeps the legacy .boring workspace ledger when no host path is configured", async () => {
     const workspaceRoot = await tempDir("boring-ws-ledger-root-")
     delete process.env.BORING_AGENT_SESSION_ROOT
 

--- a/packages/workspace/src/server/__tests__/packageResourcesPublicApi.test.ts
+++ b/packages/workspace/src/server/__tests__/packageResourcesPublicApi.test.ts
@@ -1,0 +1,13 @@
+import { expectTypeOf, test } from 'vitest'
+
+import {
+  resolveWorkspacePackageResources,
+  type ResolvedWorkspacePackageResourceRegistry,
+} from '../index'
+
+test('public package-resource resolver retains its required-only contract', () => {
+  expectTypeOf<Awaited<ReturnType<typeof resolveWorkspacePackageResources>>>()
+    .toEqualTypeOf<ResolvedWorkspacePackageResourceRegistry>()
+  expectTypeOf<keyof NonNullable<Parameters<typeof resolveWorkspacePackageResources>[1]>>()
+    .toEqualTypeOf<'sharedSkillPaths'>()
+})

--- a/packages/workspace/src/server/index.ts
+++ b/packages/workspace/src/server/index.ts
@@ -176,7 +176,6 @@ export type {
   ResolveWorkspacePackageResourcesOptions,
   ResolvedWorkspacePackageResourceRegistry,
   SharedSkillPath,
-  SkippedWorkspacePackageResource,
 } from "./plugins/packageResources"
 // Boring plugin asset manager + reload-pluggability helpers.
 export { buildBoringSystemPrompt } from "./boringSystemPrompt"

--- a/packages/workspace/src/server/plugins/__tests__/packageResources.test.ts
+++ b/packages/workspace/src/server/plugins/__tests__/packageResources.test.ts
@@ -305,6 +305,35 @@ describe('resolveWorkspacePackageResources', () => {
     expect(updated.generation).not.toBe(registry.generation)
   })
 
+  test('preserves the stable error for an invalid required shared skill', async () => {
+    const root = await tempRoot()
+    const missingSkill = join(root, 'missing', 'SKILL.md')
+
+    await expect(resolveWorkspacePackageResources([], {
+      sharedSkillPaths: [{ id: 'required-missing', skillFile: missingSkill }],
+    })).rejects.toMatchObject({
+      name: 'WorkspacePackageResourceRegistryError',
+      code: PACKAGE_RESOURCE_INVALID_CODE,
+      packageName: 'shared/pi-agent',
+    })
+  })
+
+  test('ignores snapshot-private skippable inputs passed through a structural options object', async () => {
+    const root = await tempRoot()
+    const skillRoot = join(root, 'global-skills', 'hidden')
+    await mkdir(skillRoot, { recursive: true })
+    const skillFile = join(skillRoot, 'SKILL.md')
+    await writeFile(skillFile, '---\nname: hidden\ndescription: Hidden.\n---\n', 'utf8')
+    const structuralOptions = {
+      sharedSkillPaths: [],
+      skippableSharedSkillPaths: [{ id: 'hidden', skillFile }],
+    }
+
+    const registry = await resolveWorkspacePackageResources([], structuralOptions)
+
+    expect(registry.skills).toEqual([])
+  })
+
   // gh-1196: one unadmittable shared-skill entry must not fail the scan closed.
   test('degrades an unadmittable shared skill to a diagnostic and keeps the rest', async () => {
     const root = await tempRoot()
@@ -343,33 +372,6 @@ describe('resolveWorkspacePackageResources', () => {
       .not.toContain(await realpath(danglingRoot))
   })
 
-  // gh-1196 follow-up: the per-entry probe degrades admission verdicts only.
-  // A resolver defect must not be laundered into "was not admissible".
-  test('propagates a non-admission error from the shared-skill probe', async () => {
-    const root = await tempRoot()
-    const packageRoot = await packageFixture(root)
-    const sharedRoot = join(root, 'global-skills', 'shared-authoring')
-    await mkdir(sharedRoot, { recursive: true })
-    const sharedFile = join(sharedRoot, 'SKILL.md')
-    await writeFile(sharedFile, '---\nname: shared-authoring\ndescription: Shared.\n---\n', 'utf8')
-
-    const defect = Object.assign(new Error('resolver blew up'), { code: 'EACCES' })
-    const shared = {
-      id: 'shared-authoring',
-      // A getter is the least invasive way to make the probe's own read throw
-      // with a non-admission error code.
-      get skillFile(): string {
-        throw defect
-      },
-    }
-
-    await expect(resolveWorkspacePackageResourceSnapshot({
-      declared: [{ pluginId: 'direct', packageName: '@example/plugin', packageRoot }],
-      scanned: [],
-      sharedSkillPaths: [shared, { id: 'other', skillFile: sharedFile }],
-    })).rejects.toBe(defect)
-  })
-
   test('propagates an unexpected filesystem failure while resolving a scanned skill declaration', async () => {
     const root = await tempRoot()
     const packageRoot = await packageFixture(root, { skills: ['x'.repeat(300)] })
@@ -378,6 +380,41 @@ describe('resolveWorkspacePackageResources', () => {
       declared: [],
       scanned: [{ pluginId: 'scan', packageName: '@example/plugin', packageRoot }],
     })).rejects.toMatchObject({ code: 'ENAMETOOLONG' })
+  })
+
+  test('propagates a malformed optional skill instead of laundering it into a diagnostic', async () => {
+    const root = await tempRoot()
+    const skillRoot = join(root, 'global-skills', 'malformed')
+    await mkdir(skillRoot, { recursive: true })
+    const skillFile = join(skillRoot, 'SKILL.md')
+    await writeFile(skillFile, '---\nname: [unterminated\n---\n', 'utf8')
+
+    const error = await resolveWorkspacePackageResourceSnapshot({
+      declared: [],
+      scanned: [],
+      sharedSkillPaths: [{ id: 'malformed', skillFile }],
+    }).then(() => undefined, (cause: unknown) => cause)
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error).not.toMatchObject({ code: PACKAGE_RESOURCE_INVALID_CODE })
+  })
+
+  test('propagates a foreign error that spoofs the invalid-resource code', async () => {
+    const foreignError = Object.assign(new Error('foreign resolver failure'), {
+      code: PACKAGE_RESOURCE_INVALID_CODE,
+    })
+    const shared = {
+      id: 'spoofed',
+      get skillFile(): string {
+        throw foreignError
+      },
+    }
+
+    await expect(resolveWorkspacePackageResourceSnapshot({
+      declared: [],
+      scanned: [],
+      sharedSkillPaths: [shared],
+    })).rejects.toBe(foreignError)
   })
 
   test("rejects the host-shared reserved package name", async () => {

--- a/packages/workspace/src/server/plugins/packageResources.ts
+++ b/packages/workspace/src/server/plugins/packageResources.ts
@@ -10,7 +10,7 @@ import {
   ErrorCode,
   type AgentSkillResource,
 } from '@hachej/boring-agent/shared'
-import { SKIPPABLE_RESOURCE_CODES, parseSkillMetadataFrontmatter } from '@hachej/boring-agent/server'
+import { parseSkillMetadataFrontmatter } from '@hachej/boring-agent/server'
 
 import type { WorkspacePackageResourceRecord } from './bootstrapServer'
 
@@ -73,8 +73,6 @@ export interface AgentResourceReadonlyMount {
 
 export interface ResolvedWorkspacePackageResourceRegistry {
   readonly generation: string
-  /** Entries the caller marked skippable that this resolve declined to admit. */
-  readonly skipped: readonly SkippedWorkspacePackageResource[]
   readonly additionalSkillPaths: readonly string[]
   readonly skills: readonly ResolvedAgentPackageSkill[]
   readonly managedSkills: readonly ResolvedAgentManagedSkill[]
@@ -158,12 +156,9 @@ function isExpectedPathAdmissionError(error: unknown): boolean {
 }
 
 function admissionRefusal(error: unknown): { code: string; message: string } | undefined {
-  const code = resourceAdmissionCode(error)
-  if (!code) return undefined
-  return {
-    code,
-    message: error instanceof Error ? error.message : `package resource admission failed (${code})`,
-  }
+  if (!(error instanceof WorkspacePackageResourceRegistryError)
+    || error.code !== PACKAGE_RESOURCE_INVALID_CODE) return undefined
+  return { code: error.code, message: error.message }
 }
 
 function packageRootPath(input: string | URL, packageName: string): string {
@@ -281,7 +276,7 @@ export interface SharedSkillPath {
  * One entry the resolver declined to admit. Only entries the caller marked
  * skippable can appear here; a required entry still fails the whole resolve.
  */
-export interface SkippedWorkspacePackageResource {
+interface SkippedPackageResource {
   readonly kind: 'package-contribution' | 'shared-skill'
   /** Package name for a contribution, shared skill id for a shared skill. */
   readonly id: string
@@ -294,19 +289,13 @@ export interface SkippedWorkspacePackageResource {
 export interface ResolveWorkspacePackageResourcesOptions {
   /** Host-declared shared skills. An inadmissible entry fails the resolve. */
   sharedSkillPaths?: readonly SharedSkillPath[]
-  /**
-   * Speculatively scanned contributions. An entry that is not independently
-   * admissible is reported in `skipped` instead of failing the resolve, and is
-   * never mounted or exposed.
-   */
-  skippableContributions?: readonly WorkspacePackageResourceRecord[]
-  /**
-   * Ambient shared skills discovered in the user's tree (`~/.pi/agent/skills`
-   * is normally a tree of symlinks, so a stale entry is routine). Degrades the
-   * same way as `skippableContributions`, but only on an admission verdict —
-   * a resolver defect still propagates (gh-1196).
-   */
-  skippableSharedSkillPaths?: readonly SharedSkillPath[]
+}
+
+/** Snapshot-only inputs whose rejected entries are returned as diagnostics. */
+interface ResolveWorkspacePackageResourcesWithDiagnosticsOptions
+  extends ResolveWorkspacePackageResourcesOptions {
+  readonly skippableContributions?: readonly WorkspacePackageResourceRecord[]
+  readonly skippableSharedSkillPaths?: readonly SharedSkillPath[]
 }
 
 /** A contribution that passed independent admission: canonical root + manifest. */
@@ -414,11 +403,24 @@ export async function resolveWorkspacePackageResources(
   contributions: readonly WorkspacePackageResourceRecord[],
   options: ResolveWorkspacePackageResourcesOptions = {},
 ): Promise<ResolvedWorkspacePackageResourceRegistry> {
+  const requiredOptions: ResolveWorkspacePackageResourcesOptions = {
+    ...(options.sharedSkillPaths ? { sharedSkillPaths: options.sharedSkillPaths } : {}),
+  }
+  return (await resolveWorkspacePackageResourcesWithDiagnostics(contributions, requiredOptions)).registry
+}
+
+async function resolveWorkspacePackageResourcesWithDiagnostics(
+  contributions: readonly WorkspacePackageResourceRecord[],
+  options: ResolveWorkspacePackageResourcesWithDiagnosticsOptions = {},
+): Promise<{
+  readonly registry: ResolvedWorkspacePackageResourceRegistry
+  readonly diagnostics: readonly PackageResourceDiagnostic[]
+}> {
   const skippableContributions = options.skippableContributions ?? []
   // Package skips are reported in skippable-input order regardless of which
   // phase rejected them, so callers see one stable diagnostic sequence.
-  const packageSkips: { order: number; entry: SkippedWorkspacePackageResource }[] = []
-  const sharedSkips: SkippedWorkspacePackageResource[] = []
+  const packageSkips: { order: number; entry: SkippedPackageResource }[] = []
+  const sharedSkips: SkippedPackageResource[] = []
 
   // Phase 1 — independent admission. Required entries fail the resolve; a
   // skippable entry is dropped here and never touched again.
@@ -517,22 +519,23 @@ export async function resolveWorkspacePackageResources(
   }
 
   const sharedLocatorAliases = new Map<string, AgentSkillResource>()
+
+  /**
+   * Resolve every shared-skill entry exactly once. Required entries preserve
+   * the original stable error; only ambient/skippable entries may degrade to a
+   * diagnostic, and only for this resolver's own invalid-resource verdict.
+   */
   const admitShared = async (entries: readonly SharedSkillPath[], skippable: boolean) => {
     for (const shared of entries) {
-      let resolved: Awaited<ReturnType<typeof resolveSharedSkill>>
       try {
-        resolved = await resolveSharedSkill(shared)
+        const { sourceFile, ...skill } = await resolveSharedSkill(shared)
+        sharedLocatorAliases.set(sourceFile, skill.resource)
+        skills.push({ ...skill, pluginIds: ['host:shared-skill'] })
       } catch (error) {
-        // Only an admission verdict is routine. A resolver defect must surface,
-        // not masquerade as a stale symlink.
-        const refusal = skippable ? admissionRefusal(error) : undefined
-        if (!refusal) throw error
+        const refusal = admissionRefusal(error)
+        if (!skippable || !refusal) throw error
         sharedSkips.push({ kind: 'shared-skill', id: shared.id, ...refusal })
-        continue
       }
-      const { sourceFile, ...skill } = resolved
-      sharedLocatorAliases.set(sourceFile, skill.resource)
-      skills.push({ ...skill, pluginIds: ['host:shared-skill'] })
     }
   }
   await admitShared(options.sharedSkillPaths ?? [], false)
@@ -577,33 +580,49 @@ export async function resolveWorkspacePackageResources(
     locatorByFile.set(skill.skillFile, skill.resource)
   }
 
-  return {
-    generation: generationHash.digest('hex'),
-    skipped: [
-      ...packageSkips.sort((left, right) => left.order - right.order).map(({ entry }) => entry),
-      ...sharedSkips,
-    ],
-    additionalSkillPaths: [...new Set(skills
-      .filter((skill) => skill.packageName !== 'shared/pi-agent')
-      .map((skill) => skill.mountRoot))],
-    skills,
-    managedSkills: skills
-      .filter((skill): skill is typeof skill & { name: string } => typeof skill.name === 'string')
-      .map((skill) => ({
-        name: skill.name,
-        description: skill.description ?? '',
-        resource: skill.resource,
-        invocable: false,
-        source: skill.packageName,
-      })),
-    handledPackageRoots: [...packageRecords.values()].map((record) => record.root).sort(),
-    readonlyMounts: skills.map((skill) => ({
-      logicalRoot: posix.dirname(skill.resource.path),
-      sourceRoot: skill.mountRoot,
+  // Typed skip diagnostics are assembled here, at the single point that knows
+  // both skip kinds — callers never see a `skipped` bag to reinterpret.
+  const diagnostics: PackageResourceDiagnostic[] = [
+    ...packageSkips.sort((left, right) => left.order - right.order).map(({ entry }): PackageResourceDiagnostic => ({
+      source: 'package-resource-scan',
+      message: entry.message,
+      pluginId: entry.id,
+      code: entry.code,
     })),
-    systemPrompts,
-    locateSkill(filePath) {
-      return locatorByFile.get(resolve(filePath))
+    ...sharedSkips.map((entry): PackageResourceDiagnostic => ({
+      source: 'shared-skill-scan',
+      message: `shared skill "${entry.id}" was not admissible and was skipped: ${entry.message}`,
+      pluginId: 'shared/pi-agent',
+      code: entry.code,
+    })),
+  ]
+
+  return {
+    diagnostics,
+    registry: {
+      generation: generationHash.digest('hex'),
+      additionalSkillPaths: [...new Set(skills
+        .filter((skill) => skill.packageName !== 'shared/pi-agent')
+        .map((skill) => skill.mountRoot))],
+      skills,
+      managedSkills: skills
+        .filter((skill): skill is typeof skill & { name: string } => typeof skill.name === 'string')
+        .map((skill) => ({
+          name: skill.name,
+          description: skill.description ?? '',
+          resource: skill.resource,
+          invocable: false,
+          source: skill.packageName,
+        })),
+      handledPackageRoots: [...packageRecords.values()].map((record) => record.root).sort(),
+      readonlyMounts: skills.map((skill) => ({
+        logicalRoot: posix.dirname(skill.resource.path),
+        sourceRoot: skill.mountRoot,
+      })),
+      systemPrompts,
+      locateSkill(filePath) {
+        return locatorByFile.get(resolve(filePath))
+      },
     },
   }
 }
@@ -619,24 +638,6 @@ export interface PackageResourceDiagnostic {
   readonly pluginId?: string
   /** The admission verdict that caused the entry to be skipped, when there was one. */
   readonly code?: string
-}
-
-/**
- * Speculative package/shared-skill inputs may degrade only when the host
- * explicitly declines to admit them. `SKIPPABLE_RESOURCE_CODES` carries the
- * path-admission verdicts shared with the digest layer;
- * `PACKAGE_RESOURCE_INVALID_CODE` is this layer's own validated-input verdict.
- * Anything else — a conflict, TypeError, EACCES, or resolver defect — must
- * propagate rather than masquerade as a routine skip.
- */
-const RESOURCE_ADMISSION_CODES: ReadonlySet<string> = new Set<string>([
-  ...SKIPPABLE_RESOURCE_CODES,
-  PACKAGE_RESOURCE_INVALID_CODE,
-])
-
-function resourceAdmissionCode(error: unknown): string | undefined {
-  const code = (error as { code?: unknown })?.code
-  return typeof code === 'string' && RESOURCE_ADMISSION_CODES.has(code) ? code : undefined
 }
 
 export function packageResourceHandlesPath(
@@ -721,24 +722,10 @@ export async function resolveWorkspacePackageResourceSnapshot<TBinding = never>(
   // routine, and failing the whole scan closed used to 500 every agent-scoped
   // route. The resolver reports these per entry in a single pass — do not
   // reintroduce a probe that re-runs it once per candidate.
-  const registry = await resolveWorkspacePackageResources(input.declared, {
+  const { registry, diagnostics } = await resolveWorkspacePackageResourcesWithDiagnostics(input.declared, {
     skippableContributions: input.scanned,
     skippableSharedSkillPaths: input.sharedSkillPaths ?? [],
   })
-  const diagnostics: PackageResourceDiagnostic[] = registry.skipped.map((entry) =>
-    entry.kind === 'package-contribution'
-      ? {
-          source: 'package-resource-scan',
-          message: entry.message,
-          pluginId: entry.id,
-          code: entry.code,
-        }
-      : {
-          source: 'shared-skill-scan',
-          message: `shared skill "${entry.id}" was not admissible and was skipped: ${entry.message}`,
-          pluginId: 'shared/pi-agent',
-          code: entry.code,
-        })
   const binding = registry.readonlyMounts.length > 0 && input.createBinding
     ? await input.createBinding(registry.readonlyMounts)
     : undefined


### PR DESCRIPTION
## Why this PR exists

PR #1358 already shipped the user-visible fixes:

- request ledgers can live in host-owned storage instead of inside a user workspace;
- one rejected ambient skill no longer takes every agent-scoped route down.

This PR does **not** reimplement those fixes. It closes the review debt they left behind so the new behavior has a clean, safe boundary.

Without this follow-up:

1. The public workspace API exposes internal “skippable input” options and a raw `skipped` result bag. Callers can depend on machinery that should belong only to ambient discovery.
2. Optional resource failures are recognized by matching error-code strings. An unrelated error carrying the same string can be mistaken for a routine rejected skill and silently downgraded to a diagnostic.
3. Moving an existing request ledger to host storage has no migration warning. Old idempotency keys remain in the previous SQLite file, so a retry spanning the cutover can be admitted once more.
4. The root command for running package watchers, removed during the parallel-dev fix, is still missing.

## What changes

### 1. Keep package-resource recovery private

- `resolveWorkspacePackageResources()` remains the strict public resolver and returns only a registry.
- Only the snapshot/discovery path may submit optional scanned resources and receive diagnostics for rejected entries.
- The public registry no longer exposes a raw `skipped` bag.
- A failure may degrade only when it is an owned `WorkspacePackageResourceRegistryError`; foreign filesystem/parser/resolver failures still propagate.
- The CLI derives its cache type from the snapshot resolver instead of publishing another cross-package type.

### 2. Make ledger cutover behavior explicit

- Document that changing to `BORING_AGENT_SESSION_ROOT` or `requestLedgerPath` relocates the SQLite ledger; deployments needing exactly-once continuity must copy or drain the old ledger.
- Keep unit ownership of the precedence matrix while retaining host-level tests proving both `requestLedgerPath` and `sessionRoot` are actually forwarded.

### 3. Restore the package watcher command

- Add `pnpm dev:packages` as the root passthrough for package watch mode.

## User-visible impact

No new product feature or UI. Normal successful behavior is unchanged.

The value is narrower APIs, fewer accidentally swallowed failures, an explicit deployment warning, and restored developer ergonomics.

## Scope after rebase

#1358 and #1374 are already on `main`; their inherited commits were removed. This PR contains three focused commits across 11 files.

## Validation

- Workspace resource/ledger suites: 29 passed
- Agent ledger suites: 11 passed
- Agent typecheck: clean
- Workspace typecheck: clean
- Sol xhigh thermo re-review: **APPROVE — no material findings**
- CLI typecheck is left to clean-checkout CI because this nested worktree resolves duplicate React/Lucide installations from the canonical checkout