### PR TITLE
feat(chat): copy/open hover actions for URLs (#1395)

### DIFF
--- a/packages/agent/src/front/primitives/__tests__/markdownLink.test.tsx
+++ b/packages/agent/src/front/primitives/__tests__/markdownLink.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { rehypeMarkdownLinkActions } from "../markdownLink";
 import { MessageResponse } from "../message";
 
 const TEST_URL = "https://github.com/hachej/boring-ui";
@@ -93,6 +94,42 @@ describe("MessageResponse link affordances (#1395)", () => {
     expect(screen.queryByRole("link", { name: "bad" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Copy URL" })).toBeNull();
     expect(screen.getByText(/bad \[blocked\]/)).toBeTruthy();
+  });
+
+  it("does not duplicate controls when the decorator is registered more than once", () => {
+    render(
+      <MessageResponse
+        linkSafety={{ enabled: false }}
+        rehypePlugins={[rehypeMarkdownLinkActions, rehypeMarkdownLinkActions]}
+      >
+        {MARKDOWN_LINK}
+      </MessageResponse>,
+    );
+
+    expect(screen.getAllByRole("button", { name: "Copy URL" })).toHaveLength(1);
+    expect(screen.getAllByRole("button", { name: "Open URL in new tab" })).toHaveLength(1);
+  });
+
+  it("does not decorate incomplete streaming links", () => {
+    render(<MessageResponse>{"[unfinished](https://example.com"}</MessageResponse>);
+
+    expect(screen.queryByRole("button", { name: "Copy URL" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Open URL in new tab" })).toBeNull();
+  });
+
+  it("retains Streamdown's allowedTags sanitize-schema augmentation", () => {
+    render(
+      <MessageResponse
+        allowedTags={{ mention: ["user_id"] }}
+        linkSafety={{ enabled: false }}
+      >
+        {'<mention user_id="123">@agent</mention>'}
+      </MessageResponse>,
+    );
+
+    const mention = document.querySelector("mention");
+    expect(mention?.textContent).toBe("@agent");
+    expect(mention?.getAttribute("user_id")).toBe("123");
   });
 
   it("leaves non-link content untouched", () => {

--- a/packages/agent/src/front/primitives/__tests__/markdownLink.test.tsx
+++ b/packages/agent/src/front/primitives/__tests__/markdownLink.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MessageResponse } from "../message";
+
+const renderMarkdown = (md: string) =>
+  render(<MessageResponse>{md}</MessageResponse>);
+
+describe("MessageResponse link affordances (#1395)", () => {
+  const clipboardWrite = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: { writeText: clipboardWrite },
+    });
+    Object.defineProperty(window, "isSecureContext", { value: true, configurable: true });
+    vi.stubGlobal("open", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    clipboardWrite.mockClear();
+  });
+
+  const link = () => screen.getByRole("link", { name: "boring-ui repo" });
+  const copyBtn = () => screen.getByRole("button", { name: "Copy URL" });
+  const openBtn = () => screen.getByRole("button", { name: "Open URL in new tab" });
+
+  it("renders hover actions for markdown links without altering the anchor", () => {
+    renderMarkdown("See the [boring-ui repo](https://github.com/hachej/boring-ui) here.");
+
+    const a = link();
+    expect(a.getAttribute("href")).toBe("https://github.com/hachej/boring-ui");
+    expect(a.getAttribute("target")).toBe("_blank");
+    expect(a.getAttribute("rel")).toContain("noopener");
+    // Actions exist in the DOM; visibility is hover/focus-driven CSS.
+    expect(copyBtn()).toBeTruthy();
+    expect(openBtn()).toBeTruthy();
+    expect(document.querySelector('[data-boring-agent-part="chat-url-actions"]')).toBeTruthy();
+  });
+
+  it("reveals actions on link hover and focus-within", () => {
+    renderMarkdown("See the [boring-ui repo](https://github.com/hachej/boring-ui) here.");
+    const group = document.querySelector('[data-boring-agent-part="chat-url-actions"]') as HTMLElement;
+    expect(group.className).toContain("opacity-0");
+
+    fireEvent.mouseOver(link());
+    fireEvent.mouseEnter(link().closest("span.group")!);
+    expect(group.className).toMatch(/group-hover:opacity-100/);
+
+    fireEvent.focus(copyBtn());
+    expect(group.className).toMatch(/group-focus-within:opacity-100/);
+  });
+
+  it("copies the raw href via the clipboard on Copy click", async () => {
+    renderMarkdown("See the [boring-ui repo](https://github.com/hachej/boring-ui) here.");
+    fireEvent.click(copyBtn());
+    await waitFor(() => expect(clipboardWrite).toHaveBeenCalledWith("https://github.com/hachej/boring-ui"));
+    // Copied feedback swaps the icon button's title.
+    await waitFor(() => expect((copyBtn() as HTMLButtonElement).title).toBe("Copied"));
+  });
+
+  it("opens the raw href in a new tab via the Open action", () => {
+    renderMarkdown("See the [boring-ui repo](https://github.com/hachej/boring-ui) here.");
+    fireEvent.click(openBtn());
+
+    expect(window.open).toHaveBeenCalledWith(
+      "https://github.com/hachej/boring-ui",
+      "_blank",
+      "noopener,noreferrer",
+    );
+  });
+
+  it("leaves non-link content untouched", () => {
+    renderMarkdown("Just **bold** words, no links at all.");
+    expect(screen.queryByRole("button", { name: "Copy URL" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Open URL in new tab" })).toBeNull();
+    expect(screen.getByText(/no links at all/)).toBeTruthy();
+  });
+});

--- a/packages/agent/src/front/primitives/__tests__/markdownLink.test.tsx
+++ b/packages/agent/src/front/primitives/__tests__/markdownLink.test.tsx
@@ -110,6 +110,25 @@ describe("MessageResponse link affordances (#1395)", () => {
     expect(screen.getAllByRole("button", { name: "Open URL in new tab" })).toHaveLength(1);
   });
 
+  it("keeps the rehype pipeline stable across streaming token updates", async () => {
+    let transformerRuns = 0;
+    const probePlugin = () => () => {
+      transformerRuns += 1;
+    };
+    const rehypePlugins = [probePlugin];
+    const view = render(
+      <MessageResponse rehypePlugins={rehypePlugins}>{"settled block\n\nstream"}</MessageResponse>,
+    );
+    await waitFor(() => expect(transformerRuns).toBeGreaterThanOrEqual(2));
+    transformerRuns = 0;
+
+    view.rerender(
+      <MessageResponse rehypePlugins={rehypePlugins}>{"settled block\n\nstreaming"}</MessageResponse>,
+    );
+
+    await waitFor(() => expect(transformerRuns).toBe(1));
+  });
+
   it("does not decorate incomplete streaming links", () => {
     render(<MessageResponse>{"[unfinished](https://example.com"}</MessageResponse>);
 

--- a/packages/agent/src/front/primitives/__tests__/markdownLink.test.tsx
+++ b/packages/agent/src/front/primitives/__tests__/markdownLink.test.tsx
@@ -1,19 +1,23 @@
 // @vitest-environment jsdom
-import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MessageResponse } from "../message";
 
-const renderMarkdown = (md: string) =>
-  render(<MessageResponse>{md}</MessageResponse>);
+const TEST_URL = "https://github.com/hachej/boring-ui";
+const MARKDOWN_LINK = `See the [boring-ui repo](${TEST_URL}) here.`;
+
+const renderMarkdown = (markdown: string) =>
+  render(<MessageResponse linkSafety={{ enabled: false }}>{markdown}</MessageResponse>);
+
+const renderedLink = () => screen.getByRole("link", { name: "boring-ui repo" });
+const copyButton = () => screen.getByRole("button", { name: "Copy URL" });
+const openButton = () => screen.getByRole("button", { name: "Open URL in new tab" });
 
 describe("MessageResponse link affordances (#1395)", () => {
   const clipboardWrite = vi.fn().mockResolvedValue(undefined);
 
   beforeEach(() => {
-    Object.assign(navigator, {
-      clipboard: { writeText: clipboardWrite },
-    });
-    Object.defineProperty(window, "isSecureContext", { value: true, configurable: true });
+    Object.assign(navigator, { clipboard: { writeText: clipboardWrite } });
     vi.stubGlobal("open", vi.fn());
   });
 
@@ -23,53 +27,64 @@ describe("MessageResponse link affordances (#1395)", () => {
     clipboardWrite.mockClear();
   });
 
-  const link = () => screen.getByRole("link", { name: "boring-ui repo" });
-  const copyBtn = () => screen.getByRole("button", { name: "Copy URL" });
-  const openBtn = () => screen.getByRole("button", { name: "Open URL in new tab" });
+  it("decorates Streamdown links without replacing their anchor behavior", () => {
+    renderMarkdown(MARKDOWN_LINK);
 
-  it("renders hover actions for markdown links without altering the anchor", () => {
-    renderMarkdown("See the [boring-ui repo](https://github.com/hachej/boring-ui) here.");
-
-    const a = link();
-    expect(a.getAttribute("href")).toBe("https://github.com/hachej/boring-ui");
-    expect(a.getAttribute("target")).toBe("_blank");
-    expect(a.getAttribute("rel")).toContain("noopener");
-    // Actions exist in the DOM; visibility is hover/focus-driven CSS.
-    expect(copyBtn()).toBeTruthy();
-    expect(openBtn()).toBeTruthy();
-    expect(document.querySelector('[data-boring-agent-part="chat-url-actions"]')).toBeTruthy();
+    const anchor = renderedLink();
+    expect(anchor.getAttribute("href")).toBe(TEST_URL);
+    expect(anchor.getAttribute("target")).toBe("_blank");
+    expect(anchor.getAttribute("rel")).toContain("noreferrer");
+    expect(anchor.className).toContain("wrap-anywhere");
+    expect(anchor.getAttribute("data-streamdown")).toBe("link");
+    expect(copyButton()).toBeTruthy();
+    expect(openButton()).toBeTruthy();
   });
 
-  it("reveals actions on link hover and focus-within", () => {
-    renderMarkdown("See the [boring-ui repo](https://github.com/hachej/boring-ui) here.");
-    const group = document.querySelector('[data-boring-agent-part="chat-url-actions"]') as HTMLElement;
-    expect(group.className).toContain("opacity-0");
+  it("scopes reveal styles to the URL group and blocks pointer events while hidden", () => {
+    renderMarkdown(MARKDOWN_LINK);
 
-    fireEvent.mouseOver(link());
-    fireEvent.mouseEnter(link().closest("span.group")!);
-    expect(group.className).toMatch(/group-hover:opacity-100/);
+    const group = document.querySelector('[data-boring-agent-part="chat-url-group"]') as HTMLElement;
+    const actions = document.querySelector('[data-boring-agent-part="chat-url-actions"]') as HTMLElement;
 
-    fireEvent.focus(copyBtn());
-    expect(group.className).toMatch(/group-focus-within:opacity-100/);
+    expect(group.className).toContain("group/markdown-link");
+    expect(actions.className).toContain("opacity-0");
+    expect(actions.className).toContain("pointer-events-none");
+    expect(actions.className).toContain("group-hover/markdown-link:opacity-100");
+    expect(actions.className).toContain("group-hover/markdown-link:pointer-events-auto");
+    expect(actions.hasAttribute("node")).toBe(false);
   });
 
-  it("copies the raw href via the clipboard on Copy click", async () => {
-    renderMarkdown("See the [boring-ui repo](https://github.com/hachej/boring-ui) here.");
-    fireEvent.click(copyBtn());
-    await waitFor(() => expect(clipboardWrite).toHaveBeenCalledWith("https://github.com/hachej/boring-ui"));
-    // Copied feedback swaps the icon button's title.
-    await waitFor(() => expect((copyBtn() as HTMLButtonElement).title).toBe("Copied"));
+  it("copies the raw markdown href through the canonical clipboard helper", async () => {
+    renderMarkdown(MARKDOWN_LINK);
+    fireEvent.click(copyButton());
+
+    await waitFor(() => expect(clipboardWrite).toHaveBeenCalledWith(TEST_URL));
+    await waitFor(() => expect(copyButton().getAttribute("title")).toBe("Copied"));
   });
 
-  it("opens the raw href in a new tab via the Open action", () => {
-    renderMarkdown("See the [boring-ui repo](https://github.com/hachej/boring-ui) here.");
-    fireEvent.click(openBtn());
+  it("delegates Open to the original Streamdown link", () => {
+    renderMarkdown(MARKDOWN_LINK);
+    const anchor = renderedLink();
+    const click = vi.spyOn(anchor, "click").mockImplementation(() => undefined);
 
-    expect(window.open).toHaveBeenCalledWith(
-      "https://github.com/hachej/boring-ui",
-      "_blank",
-      "noopener,noreferrer",
+    fireEvent.click(openButton());
+
+    expect(click).toHaveBeenCalledOnce();
+  });
+
+  it("preserves Streamdown linkSafety for Open", async () => {
+    const onLinkCheck = vi.fn().mockResolvedValue(true);
+    render(
+      <MessageResponse linkSafety={{ enabled: true, onLinkCheck }}>
+        {MARKDOWN_LINK}
+      </MessageResponse>,
     );
+
+    expect(screen.getByRole("button", { name: "boring-ui repo" }).getAttribute("data-streamdown")).toBe("link");
+    fireEvent.click(openButton());
+
+    await waitFor(() => expect(onLinkCheck).toHaveBeenCalledWith(TEST_URL));
+    await waitFor(() => expect(window.open).toHaveBeenCalledWith(TEST_URL, "_blank", "noreferrer"));
   });
 
   it("leaves non-link content untouched", () => {

--- a/packages/agent/src/front/primitives/__tests__/markdownLink.test.tsx
+++ b/packages/agent/src/front/primitives/__tests__/markdownLink.test.tsx
@@ -87,6 +87,14 @@ describe("MessageResponse link affordances (#1395)", () => {
     await waitFor(() => expect(window.open).toHaveBeenCalledWith(TEST_URL, "_blank", "noreferrer"));
   });
 
+  it("retains Streamdown's malicious-URL hardening before decoration", () => {
+    renderMarkdown("[bad](javascript:alert(1))");
+
+    expect(screen.queryByRole("link", { name: "bad" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Copy URL" })).toBeNull();
+    expect(screen.getByText(/bad \[blocked\]/)).toBeTruthy();
+  });
+
   it("leaves non-link content untouched", () => {
     renderMarkdown("Just **bold** words, no links at all.");
     expect(screen.queryByRole("button", { name: "Copy URL" })).toBeNull();

--- a/packages/agent/src/front/primitives/__tests__/markdownLink.test.tsx
+++ b/packages/agent/src/front/primitives/__tests__/markdownLink.test.tsx
@@ -129,9 +129,16 @@ describe("MessageResponse link affordances (#1395)", () => {
     await waitFor(() => expect(transformerRuns).toBe(1));
   });
 
-  it("does not decorate incomplete streaming links", () => {
-    render(<MessageResponse>{"[unfinished](https://example.com"}</MessageResponse>);
+  it("does not decorate Streamdown's rendered incomplete-link sentinel", () => {
+    render(
+      <MessageResponse rehypePlugins={[]}>
+        {"[unfinished](https://example.com"}
+      </MessageResponse>,
+    );
 
+    const incompleteLink = screen.getByRole("button", { name: "unfinished" });
+    expect(incompleteLink.getAttribute("data-streamdown")).toBe("link");
+    expect(incompleteLink.getAttribute("data-incomplete")).toBe("true");
     expect(screen.queryByRole("button", { name: "Copy URL" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Open URL in new tab" })).toBeNull();
   });
@@ -142,13 +149,14 @@ describe("MessageResponse link affordances (#1395)", () => {
         allowedTags={{ mention: ["user_id"] }}
         linkSafety={{ enabled: false }}
       >
-        {'<mention user_id="123">@agent</mention>'}
+        {'<mention user_id="123">@agent</mention><script>alert(1)</script>'}
       </MessageResponse>,
     );
 
     const mention = document.querySelector("mention");
     expect(mention?.textContent).toBe("@agent");
     expect(mention?.getAttribute("user_id")).toBe("123");
+    expect(document.querySelector("script")).toBeNull();
   });
 
   it("leaves non-link content untouched", () => {

--- a/packages/agent/src/front/primitives/markdownLink.tsx
+++ b/packages/agent/src/front/primitives/markdownLink.tsx
@@ -96,12 +96,11 @@ export function markdownLinkRehypePlugins(
     attributes: { ...schema.attributes, ...allowedTags },
   };
 
-  return [
-    defaultRehypePlugins.raw,
-    [sanitize[0], augmentedSchema],
-    defaultRehypePlugins.harden,
-    rehypeMarkdownLinkActions,
-  ];
+  const augmentedSanitize: RehypePlugins[number] = [sanitize[0], augmentedSchema];
+  const augmentedDefaults = Object.entries(defaultRehypePlugins).map<RehypePlugins[number]>(([name, plugin]) =>
+    name === "sanitize" ? augmentedSanitize : plugin,
+  );
+  return [...augmentedDefaults, rehypeMarkdownLinkActions];
 }
 
 type MarkdownLinkActionsProps = {

--- a/packages/agent/src/front/primitives/markdownLink.tsx
+++ b/packages/agent/src/front/primitives/markdownLink.tsx
@@ -1,11 +1,13 @@
 import { CheckIcon, CopyIcon, ExternalLinkIcon } from "lucide-react";
 import {
+  ComponentProps,
   MouseEvent as ReactMouseEvent,
   useCallback,
   useEffect,
   useRef,
   useState,
 } from "react";
+import { defaultRehypePlugins, Streamdown } from "streamdown";
 import { copyTextToClipboard } from "../clipboard";
 import { cn } from "../lib";
 
@@ -26,6 +28,7 @@ type HastNode = {
  */
 function decorateLinks(node: HastNode): void {
   if (!node.children) return;
+  if (node.properties?.["data-boring-agent-part"] === "chat-url-group") return;
 
   for (const child of node.children) decorateLinks(child);
 
@@ -59,6 +62,47 @@ function decorateLinks(node: HastNode): void {
 export const rehypeMarkdownLinkActions = () => (tree: HastNode) => {
   decorateLinks(tree);
 };
+
+type StreamdownProps = ComponentProps<typeof Streamdown>;
+type RehypePlugins = NonNullable<StreamdownProps["rehypePlugins"]>;
+type AllowedTags = StreamdownProps["allowedTags"];
+type SanitizeSchema = {
+  tagNames?: string[];
+  attributes?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+/**
+ * Extend Streamdown's effective rehype pipeline without losing its defaults.
+ * Streamdown only augments the default sanitize schema for `allowedTags` when
+ * its own default array identity is used; appending our plugin requires doing
+ * that exported-schema composition explicitly.
+ */
+export function markdownLinkRehypePlugins(
+  configured: StreamdownProps["rehypePlugins"],
+  allowedTags: AllowedTags,
+): RehypePlugins {
+  if (configured) return [...configured, rehypeMarkdownLinkActions];
+
+  const sanitize = defaultRehypePlugins.sanitize;
+  if (!allowedTags || !Array.isArray(sanitize) || typeof sanitize[1] !== "object" || sanitize[1] === null) {
+    return [...Object.values(defaultRehypePlugins), rehypeMarkdownLinkActions];
+  }
+
+  const schema = sanitize[1] as SanitizeSchema;
+  const augmentedSchema: SanitizeSchema = {
+    ...schema,
+    tagNames: [...(schema.tagNames ?? []), ...Object.keys(allowedTags)],
+    attributes: { ...schema.attributes, ...allowedTags },
+  };
+
+  return [
+    defaultRehypePlugins.raw,
+    [sanitize[0], augmentedSchema],
+    defaultRehypePlugins.harden,
+    rehypeMarkdownLinkActions,
+  ];
+}
 
 type MarkdownLinkActionsProps = {
   href?: string;

--- a/packages/agent/src/front/primitives/markdownLink.tsx
+++ b/packages/agent/src/front/primitives/markdownLink.tsx
@@ -1,0 +1,85 @@
+import { ComponentProps, MouseEvent as ReactMouseEvent, useCallback, useEffect, useRef, useState } from "react";
+import { CheckIcon, CopyIcon, ExternalLinkIcon } from "lucide-react";
+import { copyTextToClipboard } from "../clipboard";
+import { cn } from "../lib";
+
+/**
+ * Hover/focus affordances for URLs rendered inside chat markdown (#1395):
+ * Copy writes the raw href; Open mirrors the anchor's own navigation
+ * semantics. The anchor itself keeps its href untouched — actions are
+ * additive siblings inside an inline group so text flow is preserved.
+ */
+export const MarkdownLink = ({ href, children, ...props }: ComponentProps<"a">) => {
+  const [copied, setCopied] = useState(false);
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => () => clearTimeout(copiedTimerRef.current), []);
+
+  const markCopied = useCallback(() => {
+    setCopied(true);
+    clearTimeout(copiedTimerRef.current);
+    copiedTimerRef.current = setTimeout(() => setCopied(false), 1500);
+  }, []);
+
+  const handleCopy = useCallback(
+    async (event: ReactMouseEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (!href) return;
+      if (await copyTextToClipboard(href)) markCopied();
+    },
+    [href, markCopied],
+  );
+
+  const handleOpen = useCallback(
+    (event: ReactMouseEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (!href) return;
+      window.open(href, "_blank", "noopener,noreferrer");
+    },
+    [href],
+  );
+
+  return (
+    <span className="group">
+      <a href={href} target="_blank" rel="noopener noreferrer" {...props}>
+        {children}
+      </a>
+      <span
+        className="inline-flex shrink-0 items-center gap-px opacity-0 transition-opacity duration-150 group-focus-within:opacity-100 group-hover:opacity-100"
+        data-boring-agent-part="chat-url-actions"
+      >
+        <button
+          type="button"
+          onClick={handleCopy}
+          aria-label="Copy URL"
+          title={copied ? "Copied" : "Copy URL"}
+          className={cn(
+            "inline-flex size-4 items-center justify-center rounded-[2px]",
+            "text-muted-foreground/70 transition-colors duration-150",
+            "hover:bg-foreground/[0.06] hover:text-muted-foreground",
+            "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[color:var(--accent)]/40",
+          )}
+        >
+          {copied ? <CheckIcon className="size-3" aria-hidden="true" /> : <CopyIcon className="size-3" aria-hidden="true" />}
+        </button>
+        <button
+          type="button"
+          onClick={handleOpen}
+          aria-label="Open URL in new tab"
+          title="Open URL in new tab"
+          className={cn(
+            "inline-flex size-4 items-center justify-center rounded-[2px]",
+            "text-muted-foreground/70 transition-colors duration-150",
+            "hover:bg-foreground/[0.06] hover:text-muted-foreground",
+            "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[color:var(--accent)]/40",
+          )}
+        >
+          <ExternalLinkIcon className="size-3" aria-hidden="true" />
+        </button>
+      </span>
+    </span>
+  );
+};
+

--- a/packages/agent/src/front/primitives/markdownLink.tsx
+++ b/packages/agent/src/front/primitives/markdownLink.tsx
@@ -1,15 +1,75 @@
-import { ComponentProps, MouseEvent as ReactMouseEvent, useCallback, useEffect, useRef, useState } from "react";
 import { CheckIcon, CopyIcon, ExternalLinkIcon } from "lucide-react";
+import {
+  MouseEvent as ReactMouseEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { copyTextToClipboard } from "../clipboard";
 import { cn } from "../lib";
 
+const LINK_ACTIONS_TAG = "boring-link-actions";
+const INCOMPLETE_LINK_HREF = "streamdown:incomplete-link";
+
+type HastNode = {
+  type: string;
+  tagName?: string;
+  properties?: Record<string, unknown>;
+  children?: HastNode[];
+};
+
 /**
- * Hover/focus affordances for URLs rendered inside chat markdown (#1395):
- * Copy writes the raw href; Open mirrors the anchor's own navigation
- * semantics. The anchor itself keeps its href untouched — actions are
- * additive siblings inside an inline group so text flow is preserved.
+ * Decorate markdown links without replacing Streamdown's anchor renderer.
+ * Keeping the original `a` node means Streamdown continues to own URL
+ * transformation, incomplete-link behavior, styling, and linkSafety.
  */
-export const MarkdownLink = ({ href, children, ...props }: ComponentProps<"a">) => {
+function decorateLinks(node: HastNode): void {
+  if (!node.children) return;
+
+  for (const child of node.children) decorateLinks(child);
+
+  node.children = node.children.flatMap((child) => {
+    if (child.type !== "element" || child.tagName !== "a") return [child];
+
+    const href = child.properties?.href;
+    if (typeof href !== "string" || href === INCOMPLETE_LINK_HREF) return [child];
+
+    return [{
+      type: "element",
+      tagName: "span",
+      properties: {
+        className: ["group/markdown-link"],
+        "data-boring-agent-part": "chat-url-group",
+      },
+      children: [
+        child,
+        {
+          type: "element",
+          tagName: LINK_ACTIONS_TAG,
+          properties: { href },
+          children: [],
+        },
+      ],
+    }];
+  });
+}
+
+/** Rehype plugin installed by MessageResponse for chat URL affordances. */
+export const rehypeMarkdownLinkActions = () => (tree: HastNode) => {
+  decorateLinks(tree);
+};
+
+type MarkdownLinkActionsProps = {
+  href?: string;
+  node?: unknown;
+};
+
+/**
+ * Action controls paired with the preceding Streamdown link. Open delegates
+ * to that link's click behavior so linkSafety remains the single policy owner.
+ */
+export const MarkdownLinkActions = ({ href }: MarkdownLinkActionsProps) => {
   const [copied, setCopied] = useState(false);
   const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
@@ -25,61 +85,61 @@ export const MarkdownLink = ({ href, children, ...props }: ComponentProps<"a">) 
     async (event: ReactMouseEvent<HTMLButtonElement>) => {
       event.preventDefault();
       event.stopPropagation();
-      if (!href) return;
-      if (await copyTextToClipboard(href)) markCopied();
+      if (href && await copyTextToClipboard(href)) markCopied();
     },
     [href, markCopied],
   );
 
-  const handleOpen = useCallback(
-    (event: ReactMouseEvent<HTMLButtonElement>) => {
-      event.preventDefault();
-      event.stopPropagation();
-      if (!href) return;
-      window.open(href, "_blank", "noopener,noreferrer");
-    },
-    [href],
-  );
+  const handleOpen = useCallback((event: ReactMouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    event.currentTarget
+      .closest('[data-boring-agent-part="chat-url-group"]')
+      ?.querySelector<HTMLElement>('[data-streamdown="link"]')
+      ?.click();
+  }, []);
 
   return (
-    <span className="group">
-      <a href={href} target="_blank" rel="noopener noreferrer" {...props}>
-        {children}
-      </a>
-      <span
-        className="inline-flex shrink-0 items-center gap-px opacity-0 transition-opacity duration-150 group-focus-within:opacity-100 group-hover:opacity-100"
-        data-boring-agent-part="chat-url-actions"
+    <span
+      className={cn(
+        "pointer-events-none inline-flex shrink-0 items-center gap-px opacity-0 transition-opacity duration-150",
+        "group-hover/markdown-link:pointer-events-auto group-hover/markdown-link:opacity-100",
+        "group-focus-within/markdown-link:pointer-events-auto group-focus-within/markdown-link:opacity-100",
+      )}
+      data-boring-agent-part="chat-url-actions"
+    >
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label="Copy URL"
+        title={copied ? "Copied" : "Copy URL"}
+        className={cn(
+          "inline-flex size-4 items-center justify-center rounded-[2px]",
+          "text-muted-foreground/70 transition-colors duration-150",
+          "hover:bg-foreground/[0.06] hover:text-muted-foreground",
+          "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[color:var(--accent)]/40",
+        )}
       >
-        <button
-          type="button"
-          onClick={handleCopy}
-          aria-label="Copy URL"
-          title={copied ? "Copied" : "Copy URL"}
-          className={cn(
-            "inline-flex size-4 items-center justify-center rounded-[2px]",
-            "text-muted-foreground/70 transition-colors duration-150",
-            "hover:bg-foreground/[0.06] hover:text-muted-foreground",
-            "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[color:var(--accent)]/40",
-          )}
-        >
-          {copied ? <CheckIcon className="size-3" aria-hidden="true" /> : <CopyIcon className="size-3" aria-hidden="true" />}
-        </button>
-        <button
-          type="button"
-          onClick={handleOpen}
-          aria-label="Open URL in new tab"
-          title="Open URL in new tab"
-          className={cn(
-            "inline-flex size-4 items-center justify-center rounded-[2px]",
-            "text-muted-foreground/70 transition-colors duration-150",
-            "hover:bg-foreground/[0.06] hover:text-muted-foreground",
-            "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[color:var(--accent)]/40",
-          )}
-        >
-          <ExternalLinkIcon className="size-3" aria-hidden="true" />
-        </button>
-      </span>
+        {copied ? <CheckIcon className="size-3" aria-hidden="true" /> : <CopyIcon className="size-3" aria-hidden="true" />}
+      </button>
+      <button
+        type="button"
+        onClick={handleOpen}
+        aria-label="Open URL in new tab"
+        title="Open URL in new tab"
+        className={cn(
+          "inline-flex size-4 items-center justify-center rounded-[2px]",
+          "text-muted-foreground/70 transition-colors duration-150",
+          "hover:bg-foreground/[0.06] hover:text-muted-foreground",
+          "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[color:var(--accent)]/40",
+        )}
+      >
+        <ExternalLinkIcon className="size-3" aria-hidden="true" />
+      </button>
     </span>
   );
 };
 
+export const markdownLinkComponents = {
+  [LINK_ACTIONS_TAG]: MarkdownLinkActions,
+};

--- a/packages/agent/src/front/primitives/message.tsx
+++ b/packages/agent/src/front/primitives/message.tsx
@@ -23,7 +23,10 @@ import {
 } from "react";
 import { Streamdown } from "streamdown";
 import { useStreamdownPlugins } from "./useStreamdownPlugins";
-import { MarkdownLink } from "./markdownLink"
+import {
+  markdownLinkComponents,
+  rehypeMarkdownLinkActions,
+} from "./markdownLink";
 import {
   CodeBlock,
   CodeBlockCopyButton,
@@ -417,9 +420,6 @@ const MarkdownCode = ({
 const markdownComponents = {
   pre: MarkdownPre,
   code: MarkdownCode,
-  // Chat URLs get hover Copy/Open affordances (#1395); the href and text
-  // flow stay untouched.
-  a: MarkdownLink,
 } as unknown as ComponentProps<typeof Streamdown>["components"];
 
 export type BoringMessageResponseProps = MessageResponseProps & {
@@ -428,7 +428,7 @@ export type BoringMessageResponseProps = MessageResponseProps & {
 };
 
 export const MessageResponse = memo(
-  ({ className, shikiTheme, components, codeFilename, ...props }: BoringMessageResponseProps) => {
+  ({ className, shikiTheme, components, codeFilename, rehypePlugins, ...props }: BoringMessageResponseProps) => {
     const streamdownPlugins = useStreamdownPlugins(props.children, { code: false });
     return (
       <Streamdown
@@ -437,10 +437,12 @@ export const MessageResponse = memo(
           className
         )}
         plugins={streamdownPlugins}
+        rehypePlugins={[...(rehypePlugins ?? []), rehypeMarkdownLinkActions]}
         shikiTheme={shikiTheme ?? DEFAULT_SHIKI_THEME}
         components={{
           ...markdownComponents,
           ...(components ?? {}),
+          ...markdownLinkComponents,
           ...(codeFilename ? { pre: (props: ComponentProps<"pre">) => <MarkdownPre {...props} filename={codeFilename} /> } : {}),
         } as ComponentProps<typeof Streamdown>["components"]}
         {...props}

--- a/packages/agent/src/front/primitives/message.tsx
+++ b/packages/agent/src/front/primitives/message.tsx
@@ -23,6 +23,7 @@ import {
 } from "react";
 import { Streamdown } from "streamdown";
 import { useStreamdownPlugins } from "./useStreamdownPlugins";
+import { MarkdownLink } from "./markdownLink"
 import {
   CodeBlock,
   CodeBlockCopyButton,
@@ -416,6 +417,9 @@ const MarkdownCode = ({
 const markdownComponents = {
   pre: MarkdownPre,
   code: MarkdownCode,
+  // Chat URLs get hover Copy/Open affordances (#1395); the href and text
+  // flow stay untouched.
+  a: MarkdownLink,
 } as unknown as ComponentProps<typeof Streamdown>["components"];
 
 export type BoringMessageResponseProps = MessageResponseProps & {

--- a/packages/agent/src/front/primitives/message.tsx
+++ b/packages/agent/src/front/primitives/message.tsx
@@ -21,7 +21,7 @@ import {
   useMemo,
   useState,
 } from "react";
-import { Streamdown } from "streamdown";
+import { defaultRehypePlugins, Streamdown } from "streamdown";
 import { useStreamdownPlugins } from "./useStreamdownPlugins";
 import {
   markdownLinkComponents,
@@ -430,6 +430,7 @@ export type BoringMessageResponseProps = MessageResponseProps & {
 export const MessageResponse = memo(
   ({ className, shikiTheme, components, codeFilename, rehypePlugins, ...props }: BoringMessageResponseProps) => {
     const streamdownPlugins = useStreamdownPlugins(props.children, { code: false });
+    const baseRehypePlugins = rehypePlugins ?? Object.values(defaultRehypePlugins);
     return (
       <Streamdown
         className={cn(
@@ -437,7 +438,7 @@ export const MessageResponse = memo(
           className
         )}
         plugins={streamdownPlugins}
-        rehypePlugins={[...(rehypePlugins ?? []), rehypeMarkdownLinkActions]}
+        rehypePlugins={[...baseRehypePlugins, rehypeMarkdownLinkActions]}
         shikiTheme={shikiTheme ?? DEFAULT_SHIKI_THEME}
         components={{
           ...markdownComponents,

--- a/packages/agent/src/front/primitives/message.tsx
+++ b/packages/agent/src/front/primitives/message.tsx
@@ -430,6 +430,10 @@ export type BoringMessageResponseProps = MessageResponseProps & {
 export const MessageResponse = memo(
   ({ className, shikiTheme, components, codeFilename, rehypePlugins, allowedTags, ...props }: BoringMessageResponseProps) => {
     const streamdownPlugins = useStreamdownPlugins(props.children, { code: false });
+    const linkRehypePlugins = useMemo(
+      () => markdownLinkRehypePlugins(rehypePlugins, allowedTags),
+      [allowedTags, rehypePlugins],
+    );
     return (
       <Streamdown
         className={cn(
@@ -437,7 +441,7 @@ export const MessageResponse = memo(
           className
         )}
         plugins={streamdownPlugins}
-        rehypePlugins={markdownLinkRehypePlugins(rehypePlugins, allowedTags)}
+        rehypePlugins={linkRehypePlugins}
         allowedTags={allowedTags}
         shikiTheme={shikiTheme ?? DEFAULT_SHIKI_THEME}
         components={{

--- a/packages/agent/src/front/primitives/message.tsx
+++ b/packages/agent/src/front/primitives/message.tsx
@@ -21,11 +21,11 @@ import {
   useMemo,
   useState,
 } from "react";
-import { defaultRehypePlugins, Streamdown } from "streamdown";
+import { Streamdown } from "streamdown";
 import { useStreamdownPlugins } from "./useStreamdownPlugins";
 import {
   markdownLinkComponents,
-  rehypeMarkdownLinkActions,
+  markdownLinkRehypePlugins,
 } from "./markdownLink";
 import {
   CodeBlock,
@@ -428,9 +428,8 @@ export type BoringMessageResponseProps = MessageResponseProps & {
 };
 
 export const MessageResponse = memo(
-  ({ className, shikiTheme, components, codeFilename, rehypePlugins, ...props }: BoringMessageResponseProps) => {
+  ({ className, shikiTheme, components, codeFilename, rehypePlugins, allowedTags, ...props }: BoringMessageResponseProps) => {
     const streamdownPlugins = useStreamdownPlugins(props.children, { code: false });
-    const baseRehypePlugins = rehypePlugins ?? Object.values(defaultRehypePlugins);
     return (
       <Streamdown
         className={cn(
@@ -438,7 +437,8 @@ export const MessageResponse = memo(
           className
         )}
         plugins={streamdownPlugins}
-        rehypePlugins={[...baseRehypePlugins, rehypeMarkdownLinkActions]}
+        rehypePlugins={markdownLinkRehypePlugins(rehypePlugins, allowedTags)}
+        allowedTags={allowedTags}
         shikiTheme={shikiTheme ?? DEFAULT_SHIKI_THEME}
         components={{
           ...markdownComponents,


### PR DESCRIPTION
## Summary
- render Copy and Open actions beside markdown URLs on hover/focus
- preserve Streamdown as the canonical link renderer, including linkSafety, URL hardening, incomplete-link behavior, and wrap-anywhere styling
- reuse the canonical clipboard helper (including HTTP/dev fallback)
- preserve Streamdown default/custom rehype pipelines, allowedTags schema augmentation, and streaming block memoization

Closes #1395

## Proof
- agent TypeScript: clean
- markdown-link + chat component suites: 187/187 pass
- negative/security coverage: non-link markdown, malicious URLs, incomplete streaming links, duplicate plugin registration
- integration coverage: custom allowed tags retain sanitization; multi-block token update reparses only the changed block
- final Sol xhigh thermo verdict: APPROVE at df31a786