### PR TITLE
fix(workspace): AgentPage NUL bytes — file was binary in every diff

### DIFF
--- a/packages/workspace/src/front/chrome/skills/AgentPage.tsx
+++ b/packages/workspace/src/front/chrome/skills/AgentPage.tsx
@@ -257,7 +257,7 @@ function SkillsSection({
               <li
                 key={`${skill.resource
                   ? uiFileResourceKey(skill.resource)
-                  : `${skill.name} ${skill.source ?? ""} ${skill.description ?? ""}`} ${index}`}
+                  : `${skill.name}\u0000${skill.source ?? ""}\u0000${skill.description ?? ""}`}\u0000${index}`}
                 className="min-w-0"
               >
                 {resource ? (
@@ -338,7 +338,7 @@ function ToolsSection({
           {tools.map((tool, index) => {
             // The server may report duplicate names; a name-only key collides
             // AND makes both rows expand together.
-            const toolKey = `${tool.name} ${index}`
+            const toolKey = `${tool.name}\u0000${index}`
             const expanded = expandedTool === toolKey
             return (
               <li key={toolKey} className="min-w-0">


### PR DESCRIPTION
One-line class of fix: 4 raw NUL bytes in AgentPage.tsx made Git treat the file as binary, so all changes to it shipped unreviewable (#1398). Replaced with textual escapes — identical runtime values, file now diffs as text. Follow-up idea from the issue: a CI guard rejecting NUL bytes in source.

Fixes #1398

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGA4RhWZGNR5QA9Y7dFzCF