### PR TITLE
Scope trusted host tools by agent type

### DIFF
--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
@@ -1,4 +1,4 @@
-import { ErrorCode, type AuthorizedAgentScope } from '@hachej/boring-agent/shared'
+import { ErrorCode, type AgentTool, type AuthorizedAgentScope } from '@hachej/boring-agent/shared'
 import { randomUUID } from 'node:crypto'
 import { access, mkdtemp, readFile, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -521,6 +521,81 @@ test('core/full-app defaults an internal session namespace to workspace id', asy
     await app.close()
   }
 })
+
+test('core/full-app grants addressed tools only to the selected agent type', async () => {
+  mocks.collectWorkspaceAgentServerPlugins.mockReturnValue({
+    runtimePlugins: [],
+    provisioningContributions: [],
+    agentOptions: {
+      extraTools: [],
+      pi: { additionalSkillPaths: [], packages: [] },
+      systemPromptAppend: undefined,
+    },
+    preservedUiStateKeys: [],
+    routeContributions: [],
+  })
+  const tool = (name: string, description = name): AgentTool => ({
+    name,
+    description,
+    parameters: { type: 'object', properties: {} },
+    execute: vi.fn(async () => ({ content: [{ type: 'text' as const, text: 'ok' }] })),
+  })
+  const seenAgentTypes: string[] = []
+  let macroSearchDescription = 'macro search v1'
+
+  const { createCoreWorkspaceAgentServer } = await import('../createCoreWorkspaceAgentServer.js')
+  const app = await createCoreWorkspaceAgentServer({
+    config: createTestCoreConfig({ stores: 'postgres', databaseUrl: 'postgres://test' }),
+    workspaceRoot: '/tmp/full-app-workspaces',
+    getExtraTools: async () => [tool('shared_tool')],
+    getAgentExtraTools: async ({ agentTypeId }) => {
+      seenAgentTypes.push(agentTypeId)
+      return agentTypeId === 'macro'
+        ? [tool('macro_search', macroSearchDescription), tool('persist_derived_series')]
+        : []
+    },
+    serveFrontend: false,
+  })
+
+  try {
+    const hostOptions = (mocks.createAgentHost as any).mock.calls[0]?.[0]
+    const projection = (mocks.hostRegisterDirectRoutes as any).mock.calls[0]?.[0]
+    const scope = await projection.authorizeAgentRequest(fakeRequest('workspace-a', 'user-a'))
+    const verifiedClaim = { workspaceScopeId: 'workspace-a', authSubjectId: 'user-a' }
+    const environment = {
+      workspaceRoot: '/tmp/full-app-workspaces/workspace-a',
+      placementIdentity: 'workspace-a',
+      provisioningFingerprint: 'test-provisioning',
+    }
+    const resolveFor = async (agentTypeId: string) => hostOptions.resolveAuthorizedAgentRuntimeScope({
+      authorizedScope: scope,
+      verifiedClaim,
+      agentTypeId,
+      environment,
+      intent: { kind: 'agent-binding', operation: 'new-binding', requestId: `request-${agentTypeId}` },
+    })
+
+    const macro = await resolveFor('macro')
+    const charlotte = await resolveFor('charlotteledoux')
+    macroSearchDescription = 'macro search v2'
+    const changedMacroContract = await resolveFor('macro')
+    expect(macro.extraTools.map((entry: { name: string }) => entry.name)).toEqual([
+      'shared_tool',
+      'macro_search',
+      'persist_derived_series',
+    ])
+    expect(charlotte.extraTools.map((entry: { name: string }) => entry.name)).toEqual(['shared_tool'])
+    expect(macro.identity).not.toBe(charlotte.identity)
+    expect(macro.physicalBindingIdentity).not.toBe(charlotte.physicalBindingIdentity)
+    expect(macro.resourceInputDigest).not.toBe(charlotte.resourceInputDigest)
+    expect(changedMacroContract.identity).not.toBe(macro.identity)
+    expect(changedMacroContract.physicalBindingIdentity).not.toBe(macro.physicalBindingIdentity)
+    expect(changedMacroContract.resourceInputDigest).not.toBe(macro.resourceInputDigest)
+    expect(seenAgentTypes).toEqual(['macro', 'charlotteledoux', 'macro'])
+  } finally {
+    await app.close()
+  }
+}, 15_000)
 
 test('core/full-app keeps semantic identity stable across physical workspace roots', async () => {
   mocks.collectWorkspaceAgentServerPlugins.mockReturnValue({

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -180,6 +180,36 @@ export type CoreWorkspacePluginEntry = CoreWorkspaceAgentServerPlugin | CoreWork
 
 type CoreWorkspaceBridgeExtraTool = AgentTool
 
+function canonicalToolContractValue(value: unknown, field: string): string {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return JSON.stringify(value)
+  if (typeof value === 'number' && Number.isFinite(value)) return JSON.stringify(value)
+  if (Array.isArray(value)) {
+    return `[${value.map((entry, index) => canonicalToolContractValue(entry, `${field}[${index}]`)).join(',')}]`
+  }
+  if (!value || typeof value !== 'object' || value instanceof URL) {
+    throw new Error(`${field} contains an opaque value without a stable tool contract`)
+  }
+  const prototype = Object.getPrototypeOf(value)
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new Error(`${field} contains an opaque value without a stable tool contract`)
+  }
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, entry]) => entry !== undefined)
+    .sort(([left], [right]) => left.localeCompare(right))
+  return `{${entries.map(([key, entry]) => (
+    `${JSON.stringify(key)}:${canonicalToolContractValue(entry, `${field}.${key}`)}`
+  )).join(',')}}`
+}
+
+function addressedToolContractDigests(tools: readonly AgentTool[]): string[] {
+  return tools.map((tool) => {
+    const { execute: _execute, ...contract } = tool
+    return createHash('sha256')
+      .update(canonicalToolContractValue(contract, `agentTool.${tool.name}`))
+      .digest('hex')
+  }).sort()
+}
+
 export interface CoreWorkspaceBridgeExtraToolsContext {
   workspaceId: string
   workspaceRoot: string
@@ -239,6 +269,19 @@ export interface CreateCoreWorkspaceAgentServerOptions {
   }) => Readonly<{ identity: string; loadSystemPromptAppend?: () => Promise<string | undefined> }>
     | Promise<Readonly<{ identity: string; loadSystemPromptAppend?: () => Promise<string | undefined> }>>
   getExtraTools?: (ctx: {
+    workspaceId: string
+    workspaceRoot: string
+    runtimeMode: RuntimeModeId
+    workspaceFsCapability?: RuntimeModeAdapter['workspaceFsCapability']
+    authSubject?: string
+  }) => AgentTool[] | Promise<AgentTool[]>
+  /**
+   * Trusted host tools granted to one addressed agent type only. These are
+   * composed after Host authorization, so a fleet sibling never receives or
+   * advertises another agent's capabilities.
+   */
+  getAgentExtraTools?: (ctx: {
+    agentTypeId: string
     workspaceId: string
     workspaceRoot: string
     runtimeMode: RuntimeModeId
@@ -1446,7 +1489,7 @@ export async function createCoreWorkspaceAgentServer(
     const identity = createResolvedRuntimeScopeIdentity({
       artifacts: pluginArtifacts,
       validatedConfig: piIdentity,
-      grants: options.getExtraTools ? [userId] : [],
+      grants: options.getExtraTools || options.getAgentExtraTools ? [userId] : [],
       placementClassIdentity: runtimeModeAdapter.id,
       isolationMode: runtimeModeAdapter.id,
       toolContractDigests: extraTools.map((tool) => tool.name),
@@ -1605,8 +1648,42 @@ export async function createCoreWorkspaceAgentServer(
     async resolveAuthorizedEnvironmentScope({ authorizedScope }) {
       return scopeAuthority.resolveEnvironment(authorizedScope)
     },
-    async resolveAuthorizedAgentRuntimeScope({ authorizedScope }) {
-      return scopeAuthority.resolveAgentRuntime(authorizedScope)
+    async resolveAuthorizedAgentRuntimeScope({
+      authorizedScope,
+      verifiedClaim,
+      agentTypeId,
+      environment,
+    }) {
+      const runtime = scopeAuthority.resolveAgentRuntime(authorizedScope)
+      if (!options.getAgentExtraTools) return runtime
+
+      const agentTools = await options.getAgentExtraTools({
+        agentTypeId,
+        workspaceId: verifiedClaim.workspaceScopeId,
+        workspaceRoot: environment.workspaceRoot,
+        runtimeMode: runtimeModeAdapter.id,
+        workspaceFsCapability: runtimeModeAdapter.workspaceFsCapability,
+        authSubject: verifiedClaim.authSubjectId,
+      })
+      const extraTools = [...(runtime.extraTools ?? []), ...agentTools]
+      const toolContractDigests = addressedToolContractDigests(agentTools)
+      const scopedToolIdentity = JSON.stringify({
+        baseIdentity: runtime.identity,
+        agentTypeId,
+        toolContractDigests,
+      })
+      const identity = createHash('sha256').update(scopedToolIdentity).digest('hex')
+      const physicalBindingIdentity = createHash('sha256').update(JSON.stringify({
+        basePhysicalBindingIdentity: runtime.physicalBindingIdentity ?? runtime.identity,
+        agentTypeId,
+        toolContractDigests,
+      })).digest('hex')
+      const resourceInputDigest = `sha256:${createHash('sha256').update(JSON.stringify({
+        baseResourceInputDigest: runtime.resourceInputDigest ?? null,
+        agentTypeId,
+        toolContractDigests,
+      })).digest('hex')}`
+      return { ...runtime, identity, physicalBindingIdentity, resourceInputDigest, extraTools }
     },
   })
 


### PR DESCRIPTION
## Summary
- add host-owned `getAgentExtraTools` composition after addressed-agent authorization
- include complete scoped tool contract digests in semantic, physical-binding, and resource identities
- prove Macro-only tools do not appear in Charlotte while shared tools remain available

## Architecture
This implements the ratified invariants that tool registration is host authority and effective capability is agent-declared/granted intersection. It does not infer authority from request headers or authored runtime state.

## Validation
- `pnpm --filter @hachej/boring-core typecheck`
- targeted Core provisioning test
- `pnpm --filter @hachej/boring-core build`
