### PR TITLE
Fix main CI package publish condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -766,7 +766,7 @@ jobs:
   publish-ci:
     name: Publish CI packages to npm
     needs: [main-green-summary]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: ${{ github.ref_name == 'main' && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -766,7 +766,7 @@ jobs:
   publish-ci:
     name: Publish CI packages to npm
     needs: [main-green-summary]
-    if: ${{ github.ref_name == 'main' && github.event_name == 'push' }}
+    if: ${{ always() && needs.main-green-summary.result == 'success' && github.ref_name == 'main' && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
`publish-ci` has been skipped on every successful main run because its implicit `success()` status check is affected by skipped transitive dependencies, even though `Main Green Summary` succeeds via `always()`.

Make the publish gate explicit: run evaluation with `always()`, require `needs.main-green-summary.result == success`, and still require a push to `main`. Package publishing therefore cannot run unless the complete main gate passed.

Evidence: successful main runs 32961385341, 32808076064, and 32747545915 all skipped the job after `Main Green Summary` succeeded.