### PR TITLE
Pass runtime workspace ID to agent-scoped tool factories

### DIFF
--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
@@ -541,6 +541,7 @@ test('core/full-app grants addressed tools only to the selected agent type', asy
     execute: vi.fn(async () => ({ content: [{ type: 'text' as const, text: 'ok' }] })),
   })
   const seenAgentTypes: string[] = []
+  const seenWorkspaceIds: string[] = []
   let macroSearchDescription = 'macro search v1'
 
   const { createCoreWorkspaceAgentServer } = await import('../createCoreWorkspaceAgentServer.js')
@@ -548,8 +549,9 @@ test('core/full-app grants addressed tools only to the selected agent type', asy
     config: createTestCoreConfig({ stores: 'postgres', databaseUrl: 'postgres://test' }),
     workspaceRoot: '/tmp/full-app-workspaces',
     getExtraTools: async () => [tool('shared_tool')],
-    getAgentExtraTools: async ({ agentTypeId }) => {
+    getAgentExtraTools: async ({ agentTypeId, workspaceId }) => {
       seenAgentTypes.push(agentTypeId)
+      seenWorkspaceIds.push(workspaceId)
       return agentTypeId === 'macro'
         ? [tool('macro_search', macroSearchDescription), tool('persist_derived_series')]
         : []
@@ -563,6 +565,7 @@ test('core/full-app grants addressed tools only to the selected agent type', asy
     const scope = await projection.authorizeAgentRequest(fakeRequest('workspace-a', 'user-a'))
     const verifiedClaim = { workspaceScopeId: 'workspace-a', authSubjectId: 'user-a' }
     const environment = {
+      runtimeWorkspaceId: 'runtime-workspace-a',
       workspaceRoot: '/tmp/full-app-workspaces/workspace-a',
       placementIdentity: 'workspace-a',
       provisioningFingerprint: 'test-provisioning',
@@ -592,6 +595,11 @@ test('core/full-app grants addressed tools only to the selected agent type', asy
     expect(changedMacroContract.physicalBindingIdentity).not.toBe(macro.physicalBindingIdentity)
     expect(changedMacroContract.resourceInputDigest).not.toBe(macro.resourceInputDigest)
     expect(seenAgentTypes).toEqual(['macro', 'charlotteledoux', 'macro'])
+    expect(seenWorkspaceIds).toEqual([
+      'runtime-workspace-a',
+      'runtime-workspace-a',
+      'runtime-workspace-a',
+    ])
   } finally {
     await app.close()
   }

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -1659,7 +1659,7 @@ export async function createCoreWorkspaceAgentServer(
 
       const agentTools = await options.getAgentExtraTools({
         agentTypeId,
-        workspaceId: verifiedClaim.workspaceScopeId,
+        workspaceId: environment.runtimeWorkspaceId ?? verifiedClaim.workspaceScopeId,
         workspaceRoot: environment.workspaceRoot,
         runtimeMode: runtimeModeAdapter.id,
         workspaceFsCapability: runtimeModeAdapter.workspaceFsCapability,


### PR DESCRIPTION
`getAgentExtraTools.workspaceId` was populated with the encoded authorization scope (`[workspaceId, sessionNamespace]`) rather than the callback contract's runtime workspace ID. Use `environment.runtimeWorkspaceId`, retaining the authorization scope only as a compatibility fallback.

This lets host-owned per-agent tools apply stable workspace ownership/namespace rules across sessions. The existing provisioning test now asserts the callback receives `runtimeWorkspaceId`.

Local note: the Core provisioning test file hit its existing 15s timeout in this worktree; PR CI is the authoritative validation.