### PR TITLE
Clarify named filesystem scope in bash guidance

### DIFF
--- a/packages/boring-bash/src/__tests__/dualTargetParity.contract.test.ts
+++ b/packages/boring-bash/src/__tests__/dualTargetParity.contract.test.ts
@@ -394,6 +394,10 @@ describe.each(targets)('$name frozen contract', (target) => {
     expect(observation.metadata.harness.map((tool) => tool.name)).toEqual([
       'bash', 'execute_isolated_code',
     ])
+    const bashPrompt = observation.metadata.harness.find((tool) => tool.name === 'bash')?.promptSnippet
+    expect(bashPrompt).toContain('user runtime workspace')
+    expect(bashPrompt).toContain('named filesystem bindings are not shell paths')
+    expect(bashPrompt).not.toContain('bash commands (ls, grep, find')
     expect(observation.metadata.upload.map((tool) => tool.name)).toEqual(['upload_file'])
     expect(observation.results.readResult.isError).toBe(false)
     expect(observation.results.bashResult.isError).toBe(false)
@@ -433,6 +437,23 @@ describe.each(targets)('$name frozen contract', (target) => {
       payload: expect.stringContaining('event: unsupported'),
     })
   })
+})
+
+test('file tools explain named filesystem bindings generically', () => {
+  const bundle: TestRuntimeBundle = {
+    storageRoot: '/workspace',
+    workspace: inMemoryWorkspace(),
+    sandbox: fakeSandbox(),
+    fileSearch: { async search() { return [] } },
+    filesystem: { kind: 'remote-workspace' },
+  }
+  const [read] = buildFilesystemAgentTools(bundle, { getFilesystemBindings: async () => [] })
+
+  expect(read!.promptSnippet).toContain(
+    'Named filesystem bindings are logical filesystems exposed through first-class file tools; they are not shell paths.',
+  )
+  expect(read!.promptSnippet).toContain('File tools default to the user workspace when filesystem is omitted.')
+  expect(read!.promptSnippet).toContain('Use the filesystem parameter explicitly for named context')
 })
 
 test('upload_file falls back to the host storage root when binary reads are unavailable', async () => {

--- a/packages/boring-bash/src/agent/tools/filesystem/index.ts
+++ b/packages/boring-bash/src/agent/tools/filesystem/index.ts
@@ -242,7 +242,8 @@ function withBoundFilesystemPromptGuidance(promptSnippet: string | undefined, fi
   if (filesystemIds.length === 0 && !dynamicBindings) return promptSnippet
   const target = filesystemIds.length > 0 ? ` (${filesystemIds.join(', ')})` : ''
   const guidance = [
-    'Named filesystem bindings: file tools default to the user workspace when filesystem is omitted.',
+    'Named filesystem bindings are logical filesystems exposed through first-class file tools; they are not shell paths.',
+    'File tools default to the user workspace when filesystem is omitted.',
     `Use the filesystem parameter explicitly for named context${target}, and start browsing at / unless told otherwise.`,
     'A binding may be readonly or readwrite; do not use path prefixes like filesystem:/x to switch filesystem.',
   ].join('\n')

--- a/packages/boring-bash/src/agent/tools/harness/index.ts
+++ b/packages/boring-bash/src/agent/tools/harness/index.ts
@@ -83,7 +83,10 @@ function adaptPiTool(
   return {
     name: template.name,
     description: template.description,
-    promptSnippet: template.promptSnippet,
+    promptSnippet: [
+      'Run shell commands in the user runtime workspace.',
+      'Use first-class file tools for file listing, search, and reads; named filesystem bindings are not shell paths.',
+    ].join('\n'),
     parameters: template.parameters as unknown as Record<string, unknown>,
     readinessRequirements: ['sandbox-exec'],
     async execute(params, ctx) {


### PR DESCRIPTION
## Summary
- replace Pi's broad bash snippet that recommends `ls`, `grep`, and `find`
- define named filesystem bindings generically in first-class file-tool guidance
- add regression coverage for both prompt contracts

## Validation
- `pnpm --filter @hachej/boring-bash test` (87 tests)
- `pnpm --filter @hachej/boring-bash typecheck`
- `pnpm --filter @hachej/boring-bash run check:invariants`
- `pnpm --filter @hachej/boring-bash build`

Fixes #1419
