### PR TITLE
fix(ui-kit): shadow-md transparent in both themes (#1392)

### DIFF
--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -45,4 +45,15 @@
   --radius-xl: var(--boring-radius-xl);
   --font-sans: var(--boring-font-sans);
   --font-mono: var(--boring-font-mono);
+  /* Pin the elevation scale explicitly rather than relying on Tailwind's
+   * built-in --shadow-* defaults. shadow-md rendered fully transparent
+   * (rgba(0,0,0,0) 0 0 0 0) on popover surfaces in both themes (#1392) — the
+   * implicit default is fragile across this kit's import chain (ui-kit ->
+   * workspace/agent globals.css each re-import "tailwindcss", so the
+   * generated utility can end up depending on cascade/build order instead of
+   * an explicit value). Values match Tailwind's own shadow-sm/md/lg ramp so
+   * elevation stays visually consistent, just no longer implicit. */
+  --shadow-sm: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
 }

--- a/packages/workspace/src/__tests__/theme-css-contract.test.ts
+++ b/packages/workspace/src/__tests__/theme-css-contract.test.ts
@@ -39,4 +39,36 @@ describe("dark theme CSS contract", () => {
       "--primary-foreground: var(--boring-primary-foreground, oklch(0.205 0.006 285.885));",
     )
   })
+
+  it("gives shadow-md (and its sm/lg neighbors) a visible, non-transparent value (#1392)", () => {
+    const uiStyles = readPackageCss("ui/src/styles.css")
+    const themeBlockMatch = uiStyles.match(/@theme inline\s*{(?<block>[\s\S]*?)\n}/)
+    const themeBlock = themeBlockMatch?.groups?.block ?? ""
+
+    for (const size of ["sm", "md", "lg"] as const) {
+      const declMatch = themeBlock.match(
+        new RegExp(`--shadow-${size}:\\s*([^;]+);`),
+      )
+      expect(
+        declMatch,
+        `--shadow-${size} must be explicitly declared in ui/src/styles.css's @theme block`,
+      ).toBeTruthy()
+
+      const value = declMatch![1]
+      // Pin against the exact regression from #1392: shadow-md silently
+      // resolving to a fully transparent shadow (0 alpha / rgba(0,0,0,0)) in
+      // both themes. Every declared shadow color component must carry a
+      // non-zero alpha.
+      const alphaMatches = [...value.matchAll(/\/\s*([\d.]+)\s*\)/g)]
+      expect(
+        alphaMatches.length,
+        `--shadow-${size} value "${value}" has no color alpha component to check`,
+      ).toBeGreaterThan(0)
+      for (const [, alpha] of alphaMatches) {
+        expect(Number(alpha)).toBeGreaterThan(0)
+      }
+      expect(value).not.toMatch(/rgba\(0,?\s*0,?\s*0,?\s*0\)/)
+      expect(value).not.toMatch(/\btransparent\b/)
+    }
+  })
 })


### PR DESCRIPTION
## Root cause

`packages/ui/src/styles.css` never declared `--shadow-sm`/`--shadow-md`/`--shadow-lg` itself — it relied entirely on Tailwind v4's implicit theme defaults. Every `shadow-md` consumer kit-wide (popover, dropdown-menu, select, hover-card, dialog, sheet, toast, ...) therefore depended on an *implicit* value that is only ever baked into the generated utility CSS through the build/import chain (ui-kit's `styles.css` re-imports `tailwindcss/theme.css`, and every consumer — `packages/workspace/src/globals.css`, `packages/agent/src/front/styles/globals.css` — separately `@import "tailwindcss"` on top of that and then re-imports `@hachej/boring-ui-kit/styles.css`). That chain is fragile: nothing in the ui-kit's own source pinned the value, so a build/import-order variant that dropped or shadowed the implicit default silently left `shadow-md` fully transparent (`rgba(0,0,0,0) 0px 0px 0px 0`) in both light and dark themes — exactly as reported, discovered on the console-spike branch where every popover surface lost its elevation shadow.

Confirmed via a real postcss/`@tailwindcss/postcss` build of both `packages/ui/src/styles.css` and the actual consumer `packages/workspace/src/globals.css`: no explicit `--shadow-*` token existed anywhere in the repo (`packages/ui/src/tokens.css`, `packages/workspace/src/globals.css`, `packages/agent/src/front/styles/globals.css`, `packages/core/src/front/theme.css`) — the elevation scale was 100% implicit.

## Fix

Pin `--shadow-sm`, `--shadow-md`, `--shadow-lg` explicitly in `packages/ui/src/styles.css`'s `@theme` block (the single source every consumer already imports via `@hachej/boring-ui-kit/styles.css`, so no duplication needed across workspace/agent/core). Values match Tailwind's own elevation ramp so nothing visually changes when it *is* working — the fix is making the value explicit and independent of import-order/build chain, not changing the design:

```css
--shadow-sm: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
--shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
--shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
```

Before: no declaration in kit source → `.shadow-md` generation depended entirely on Tailwind's implicit default surviving the import chain (and per #1392, it silently didn't, in at least one real build).
After: `.shadow-md` always resolves to `--tw-shadow: 0 4px 6px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 2px 4px -2px var(--tw-shadow-color, rgb(0 0 0 / 0.1))` — verified in `packages/ui/dist/styles.css` after `node scripts/build-styles.mjs`.

## Test

Extended the dark-theme CSS drift guard (`packages/workspace/src/__tests__/theme-css-contract.test.ts`) with a new case that parses `ui/src/styles.css`'s `@theme` block, requires `--shadow-sm/md/lg` to be explicitly declared, and asserts every color-alpha component in each value is non-zero (and that no declared value contains `transparent` or `rgba(0,0,0,0)`) — pinning the exact #1392 regression shape.

## Proof

- `pnpm -C packages/ui test` — 7 passed
- `pnpm -C packages/ui typecheck` — clean
- `pnpm -C packages/ui exec node scripts/build-styles.mjs` — builds; `dist/styles.css` `.shadow-md` confirmed non-transparent
- `pnpm -C packages/workspace vitest run src/__tests__/theme-css-contract.test.ts` — 3 passed (new case included)
- `pnpm -C packages/workspace exec tsc --noEmit` — clean

Fixes #1392