### PR TITLE
fix(ui-kit): close dropdown menus on Escape (#1391)

### DIFF
--- a/apps/workspace-playground/e2e/dropdown-escape.spec.ts
+++ b/apps/workspace-playground/e2e/dropdown-escape.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "@playwright/test"
+
+/**
+ * Regression test for #1391: dropdown menus (Radix DropdownMenu, e.g. the
+ * left pane's session "Chat actions" kebab menu) did not close on Escape
+ * in a real browser, even though jsdom unit tests passed.
+ *
+ * Root cause: ChatLayout registers a global, `document`-level,
+ * capture-phase Escape shortcut ("focus chat") via useKeyboardShortcuts.
+ * It mounts once at app-shell boot, before any dropdown opens, so its
+ * `document.addEventListener("keydown", ..., true)` always fires first.
+ * It called `event.preventDefault()` unconditionally, which set
+ * `event.defaultPrevented = true` before Radix's own DismissableLayer
+ * (also a `document`-level, capture-phase listener, but mounted later
+ * when the menu opens) got to check that flag and decide whether to
+ * dismiss — so the menu silently never closed.
+ *
+ * jsdom component tests for the dropdown alone can't catch this: they
+ * never mount ChatLayout, so there's no competing global listener to
+ * race against. Only a real browser run against the full app shell
+ * reproduces it, which is why this lives in Playwright rather than a
+ * unit test.
+ */
+
+test.describe("dropdown menus close on Escape", () => {
+  test("the session kebab menu closes on Escape in the real app shell", async ({ page }) => {
+    test.setTimeout(60_000)
+
+    await page.goto("/")
+    await expect(page.locator('aside[aria-label="App navigation"]')).toBeVisible({ timeout: 10_000 })
+    const composer = page.getByRole("textbox", { name: "Agent prompt" })
+    await expect(composer).toBeVisible({ timeout: 30_000 })
+
+    // Create a session so a "Chat actions" kebab menu exists to open.
+    await page.keyboard.press("ControlOrMeta+KeyK")
+    const palette = page.getByRole("dialog", { name: /command palette/i })
+    await expect(palette).toBeVisible()
+    await page.keyboard.type(">New Chat")
+    await page.getByRole("option", { name: /New Chat/i }).first().click()
+    await expect(palette).toBeHidden()
+    await expect.poll(
+      () => page.locator('[data-boring-workspace-part="app-session-row"]').count(),
+      { timeout: 15_000 },
+    ).toBeGreaterThan(0)
+
+    const sessionRow = page.locator('[data-boring-workspace-part="app-session-row"]').first()
+    await sessionRow.hover()
+    const chatActionsPattern = new RegExp("^Chat actions for ")
+    const kebab = sessionRow.getByRole("button", { name: chatActionsPattern })
+    await kebab.click()
+
+    const menu = page.getByRole("menu")
+    await expect(menu).toBeVisible({ timeout: 5_000 })
+
+    await page.keyboard.press("Escape")
+
+    await expect(menu).toBeHidden({ timeout: 2_000 })
+  })
+})

--- a/packages/workspace/src/front/hooks/__tests__/useKeyboardShortcuts.test.ts
+++ b/packages/workspace/src/front/hooks/__tests__/useKeyboardShortcuts.test.ts
@@ -172,6 +172,92 @@ describe("useKeyboardShortcuts", () => {
   })
 })
 
+describe("useKeyboardShortcuts shouldHandle (#1391 regression)", () => {
+  // Simulates Radix's DismissableLayer: a document-level, capture-phase
+  // keydown listener that is registered *after* this hook's own listener
+  // (mirroring an on-demand dropdown that opens after the app shell has
+  // already mounted its global shortcuts), and that only dismisses when
+  // the event has not already been marked defaultPrevented by an earlier
+  // capture-phase listener on the same node. This is the actual event
+  // wiring that broke in production: a naive jsdom keydown against the
+  // dropdown alone never exercises this race, since there's no competing
+  // listener to lose to.
+  function mountFakeDismissableLayer(onDismiss: () => void) {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return
+      if (!event.defaultPrevented) onDismiss()
+    }
+    document.addEventListener("keydown", handleKeyDown, { capture: true })
+    return () => document.removeEventListener("keydown", handleKeyDown, { capture: true })
+  }
+
+  it("without a guard, an unconditional Escape shortcut blocks a later-registered dismissable layer from closing", () => {
+    // This reproduces the pre-fix bug: ChatLayout's Escape binding had no
+    // shouldHandle guard, so it always preventDefault()'d first.
+    const focusChat = vi.fn()
+    renderHook(() =>
+      useKeyboardShortcuts({ shortcuts: [{ key: "Escape", allowInEditable: true, handler: focusChat }] }),
+    )
+    const onDismiss = vi.fn()
+    const unmountLayer = mountFakeDismissableLayer(onDismiss)
+
+    fireKey("Escape")
+
+    expect(focusChat).toHaveBeenCalledOnce()
+    expect(onDismiss).not.toHaveBeenCalled() // the bug: the "overlay" never closes
+
+    unmountLayer()
+  })
+
+  it("with shouldHandle guarding an open overlay, Escape reaches the dismissable layer instead", () => {
+    const focusChat = vi.fn()
+    let overlayOpen = true
+    renderHook(() =>
+      useKeyboardShortcuts({
+        shortcuts: [{
+          key: "Escape",
+          allowInEditable: true,
+          shouldHandle: () => !overlayOpen,
+          handler: focusChat,
+        }],
+      }),
+    )
+    const onDismiss = vi.fn()
+    const unmountLayer = mountFakeDismissableLayer(onDismiss)
+
+    fireKey("Escape")
+
+    expect(focusChat).not.toHaveBeenCalled()
+    expect(onDismiss).toHaveBeenCalledOnce() // the fix: the overlay closes itself
+
+    unmountLayer()
+  })
+
+  it("shouldHandle true still lets the shortcut fire and preventDefault as before", () => {
+    const focusChat = vi.fn()
+    const overlayOpen = false
+    renderHook(() =>
+      useKeyboardShortcuts({
+        shortcuts: [{
+          key: "Escape",
+          allowInEditable: true,
+          shouldHandle: () => !overlayOpen,
+          handler: focusChat,
+        }],
+      }),
+    )
+    const onDismiss = vi.fn()
+    const unmountLayer = mountFakeDismissableLayer(onDismiss)
+
+    fireKey("Escape")
+
+    expect(focusChat).toHaveBeenCalledOnce()
+    expect(onDismiss).not.toHaveBeenCalled()
+
+    unmountLayer()
+  })
+})
+
 describe("formatShortcut", () => {
   it("formats mod+key", () => {
     const result = formatShortcut({ key: "b", mod: true })

--- a/packages/workspace/src/front/hooks/useKeyboardShortcuts.ts
+++ b/packages/workspace/src/front/hooks/useKeyboardShortcuts.ts
@@ -7,6 +7,21 @@ export interface ShortcutBinding {
   mod?: boolean
   shift?: boolean
   allowInEditable?: boolean
+  /**
+   * Evaluated at keydown time (not at binding-creation time) once the key
+   * combo otherwise matches. Return false to skip this binding entirely —
+   * no preventDefault/stopPropagation, no handler call — so the event keeps
+   * propagating to whatever should actually own it.
+   *
+   * This matters for keys like Escape: this hook listens on `document` in
+   * the capture phase, which typically mounts before an on-demand overlay
+   * (a Radix dropdown/dialog/popover) does. Radix's own DismissableLayer
+   * also listens on `document` in the capture phase and checks
+   * `event.defaultPrevented` before dismissing — so an unconditional
+   * `preventDefault()` here, fired first because it mounted first, silently
+   * blocks the overlay from ever closing on Escape. See #1391.
+   */
+  shouldHandle?: (e: KeyboardEvent) => boolean
   handler: () => void
 }
 
@@ -51,6 +66,7 @@ export function useKeyboardShortcuts({ shortcuts, enabled = true }: UseKeyboardS
       for (const binding of shortcutsRef.current) {
         if (inEditable && !binding.allowInEditable) continue
         if (matchesShortcut(e, binding)) {
+          if (binding.shouldHandle && !binding.shouldHandle(e)) continue
           e.preventDefault()
           e.stopPropagation()
           binding.handler()

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -262,7 +262,18 @@ export function ChatLayout(props: ChatLayoutProps) {
         shortcuts.push({ key: "3", mod: true, allowInEditable: true, handler: toggleSidebar })
       }
       if (!sidebarOpen && !navOpen && centerId === "chat") {
-        shortcuts.push({ key: "Escape", allowInEditable: true, handler: focusChat })
+        shortcuts.push({
+          key: "Escape",
+          allowInEditable: true,
+          // An open dropdown/dialog/popover should get first crack at
+          // Escape and close itself. Without this guard, this shortcut's
+          // unconditional preventDefault() fires before Radix's own
+          // Escape handling ever runs (both listen on `document` in the
+          // capture phase, and this one mounts first), so the overlay
+          // silently never closes. See #1391.
+          shouldHandle: () => !isDismissableOverlayOpen(),
+          handler: focusChat,
+        })
       }
       if (centerId === "chat") {
         shortcuts.push({ key: "\\", mod: true, allowInEditable: true, handler: toggleChatCollapsed })
@@ -782,6 +793,17 @@ export function ChatLayout(props: ChatLayoutProps) {
 
 function clamp(n: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, n))
+}
+
+// Radix (dropdown menu, dialog, popover, ...) renders open overlays via a
+// portal and marks them with these attributes. When one is open, Escape
+// belongs to it — not to the "focus chat" shortcut below. See #1391.
+const DISMISSABLE_OVERLAY_OPEN_SELECTOR =
+  '[data-radix-popper-content-wrapper], [role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"]'
+
+function isDismissableOverlayOpen(): boolean {
+  if (typeof document === "undefined") return false
+  return document.querySelector(DISMISSABLE_OVERLAY_OPEN_SELECTOR) !== null
 }
 
 type StoredNumberUpdate = number | ((previous: number) => number)


### PR DESCRIPTION
Fixes #1391

## Root cause

Not a Radix or `dropdown-menu.tsx` bug. `packages/workspace/src/front/layout/ChatLayout.tsx` registers a global "Escape → focus chat" shortcut via `useKeyboardShortcuts`, which listens on `document` in the **capture phase**:

```ts
document.addEventListener("keydown", handleKeyDown, true)
```

`ChatLayout` mounts once at app-shell boot, so this listener is always registered before any dropdown opens. Radix's `DismissableLayer` (used internally by `DropdownMenuContent`) *also* listens on `document` in the capture phase, but only mounts when the menu opens — i.e., later. Because the DOM dispatches capture-phase listeners on the same node in registration order, `ChatLayout`'s handler always runs first.

That handler called `event.preventDefault()` unconditionally for every matched binding:

```ts
if (matchesShortcut(e, binding)) {
  e.preventDefault()
  e.stopPropagation()
  binding.handler()
  return
}
```

Radix's `DismissableLayer` checks `event.defaultPrevented` before dismissing:

```js
// @radix-ui/react-dismissable-layer
if (!event.defaultPrevented && onDismiss) {
  event.preventDefault()
  onDismiss()
}
```

Since `defaultPrevented` was already `true` by the time Radix's listener ran, `onDismiss()` (the call that closes the menu) never fired — Escape was silently swallowed by the "focus chat" shortcut instead. Outside-click worked fine because it doesn't go through this listener at all.

This is invisible in jsdom because a unit test that mounts `DropdownMenuContent` alone never mounts `ChatLayout`, so there's no competing capture-phase listener to race against — only a real browser run against the full app shell reproduces the race.

## Fix

- `packages/workspace/src/front/hooks/useKeyboardShortcuts.ts`: added an optional `shouldHandle?: (e: KeyboardEvent) => boolean` to `ShortcutBinding`, evaluated at keydown time (not binding-creation time). When it returns `false`, the binding is skipped entirely — no `preventDefault`/`stopPropagation`, so the event keeps propagating to whatever should actually own it.
- `packages/workspace/src/front/layout/ChatLayout.tsx`: the "Escape → focus chat" binding now guards with `shouldHandle: () => !isDismissableOverlayOpen()`, where `isDismissableOverlayOpen()` checks for an open Radix dropdown/dialog/popover (`[data-radix-popper-content-wrapper]`, `[role="dialog"][data-state="open"]`, `[role="alertdialog"][data-state="open"]`). An open overlay now gets first claim on Escape; "focus chat" only fires when nothing else needs it.

## Tests

- `packages/workspace/src/front/hooks/__tests__/useKeyboardShortcuts.test.ts`: added 3 tests that reconstruct the actual event-wiring race (a fake `document`-capture "DismissableLayer" registered *after* the hook, checking `event.defaultPrevented`) — not a vacuous jsdom Escape-on-an-isolated-dropdown test, which would pass before and after the fix. One test reproduces the pre-fix bug (`shouldHandle` absent → overlay never closes), two confirm the fix (`shouldHandle` false → overlay closes; `shouldHandle` true → shortcut still fires as before).
- `apps/workspace-playground/e2e/dropdown-escape.spec.ts` (new Playwright spec): opens the session "Chat actions" kebab dropdown in the real shipped app shell and asserts Escape closes it — the actual real-browser regression path called out in the issue.

## Proof

```
$ npx vitest run useKeyboardShortcuts
 Test Files  1 passed (1)
      Tests  18 passed (18)
```

`packages/workspace` typecheck: front + server tsconfigs pass for all files touched by this change. One pre-existing, unrelated typecheck error remains in `src/app/front/WorkspaceAgentFront.tsx` (`Property 'setArchived' does not exist on type 'UsePiSessionsResult'`) — introduced by PR #1376 (archive sessions), not touched by this diff, confirmed present on `origin/main` before this branch.

The new Playwright spec (`dropdown-escape.spec.ts`) wasn't run in this sandbox (no headed browser / full app boot available here); it follows the exact pattern of the existing `cmd-palette.spec.ts` regression test in the same suite and should run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQgxe5KTr2N2pjgjgKPXHK