### PR TITLE
fix(workspace): tab representation for open files (#1297)

### DIFF
--- a/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
@@ -259,6 +259,38 @@ function prepareFilePreview(
   preview.api.close()
 }
 
+/**
+ * Upper bound on file-backed tabs kept open at once. Agent-driven opens are
+ * persistent (each requested file keeps its own tab), so an agent looping over
+ * a directory would otherwise pin hundreds of tabs and make the tab strip
+ * useless. Oldest tab loses; the tab just opened and the active tab are never
+ * evicted.
+ */
+export const MAX_OPEN_FILE_TABS = 12
+
+function evictExcessFileTabs(
+  api: DockviewApi,
+  fileBackedPanelIds: Set<string>,
+  keepPanelId: string,
+): void {
+  const fileTabs = api.panels.filter((panel) => fileBackedPath(
+    { id: panel.id, params: panel.params as Record<string, unknown> | undefined },
+    fileBackedPanelIds,
+  ) !== null)
+  let excess = fileTabs.length - MAX_OPEN_FILE_TABS
+  if (excess <= 0) return
+  const activePanelId = api.activePanel?.id
+  // `api.panels` is tab order, so the front of the list is the oldest tab —
+  // the same one a user would close first.
+  for (const panel of fileTabs) {
+    if (excess <= 0) return
+    if (panel.id === keepPanelId || panel.id === activePanelId) continue
+    panel.api.close()
+    fileBackedPanelIds.delete(panel.id)
+    excess -= 1
+  }
+}
+
 function ok(): CommandResult {
   return { seq: ++seqCounter, status: "ok" }
 }
@@ -551,6 +583,7 @@ export function SurfaceShell({
       })) {
         return { ok: false, code: "not-ready", message: "surface not ready" }
       }
+      evictExcessFileTabs(api, fileBackedPanelIdsRef.current, panelId)
       return finish()
     }
 

--- a/packages/workspace/src/front/chrome/artifact-surface/__tests__/SurfaceShell.test.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/__tests__/SurfaceShell.test.tsx
@@ -1,7 +1,7 @@
 import type { FunctionComponent } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
-import { SurfaceShell, type SurfaceShellApi, type SurfaceShellProps } from "../SurfaceShell"
+import { MAX_OPEN_FILE_TABS, SurfaceShell, type SurfaceShellApi, type SurfaceShellProps } from "../SurfaceShell"
 import { RegistryProvider } from "../../../registry"
 import { PanelRegistry } from "../../../registry/PanelRegistry"
 import { CommandRegistry } from "../../../../shared/plugins/CommandRegistry"
@@ -352,6 +352,56 @@ describe("SurfaceShell", () => {
       ],
       activeTab: "file:user:three.md",
     })
+  })
+
+  it("bounds persistent file tabs so a looping agent cannot pin hundreds", async () => {
+    let surface: SurfaceShellApi | undefined
+    mockAddPanel.mockImplementation((config: any) => {
+      const panel = {
+        ...config,
+        api: {
+          setActive: () => { mockActivePanel = panel },
+          updateParameters: (params: Record<string, unknown>) => { panel.params = params },
+          close: () => {
+            // Mutate in place: SurfaceShell captured this exact array as
+            // `api.panels`, so reassigning would hide the close from it.
+            const index = mockPanels.indexOf(panel)
+            if (index >= 0) mockPanels.splice(index, 1)
+            if (mockActivePanel === panel) mockActivePanel = null
+          },
+        },
+      }
+      mockPanels.push(panel)
+      mockActivePanel = panel
+      return panel
+    })
+    mockGetPanel = (id: string) => mockPanels.find((panel) => panel.id === id)
+    const panelRegistry = new PanelRegistry()
+    panelRegistry.register("editor", { title: "Editor", placement: "center", component: () => null })
+    const surfaceResolverRegistry = new SurfaceResolverRegistry()
+    surfaceResolverRegistry.register("filesystem", {
+      source: "builtin",
+      resolve: (request) => request.kind === WORKSPACE_OPEN_PATH_SURFACE_KIND
+        ? { component: "editor", params: { path: request.target }, score: 0 }
+        : undefined,
+    })
+
+    renderSurface("workspace-a", { onReady: (api) => { surface = api } }, panelRegistry, surfaceResolverRegistry)
+    await waitFor(() => expect(surface).toBeDefined())
+
+    const paths = Array.from({ length: MAX_OPEN_FILE_TABS + 3 }, (_, index) => `file-${index}.md`)
+    act(() => {
+      for (const path of paths) surface?.openFile(path, { preview: false })
+    })
+
+    const snapshot = surface?.getSnapshot()
+    expect(snapshot?.openTabs).toHaveLength(MAX_OPEN_FILE_TABS)
+    // The three oldest tabs are evicted; every newer one, including the last
+    // file the agent asked for, is still open and focused.
+    expect(snapshot?.openTabs.map((tab) => tab.id)).toEqual(
+      paths.slice(3).map((path) => `file:user:${path}`),
+    )
+    expect(snapshot?.activeTab).toBe(`file:user:${paths[paths.length - 1]}`)
   })
 
   it("promotes an existing preview when an agent persistently opens the same file", async () => {


### PR DESCRIPTION
## The design question, resolved

**Is single-panel reuse a deliberate design decision, or a defect?**

Both — depending on provenance, and that distinction is now the ratified answer.

- The workbench has exactly one shared Dockview (`docs/issues/398/plugin-tabs-workspace-layout/08-dockview-ownership.md`: no nested per-plugin Dockviews). File panels are *already* real Dockview tabs, keyed `file:<filesystem>:<path>`, so tab representation was never suppressed.
- What collapsed N opens to one was the **VS Code-style preview tab**: `SurfaceShell.prepareFilePreview` closes the existing preview before opening the next one. That is correct and wanted for *user* opens from the file tree — click through a tree without drowning in tabs.
- It was wrong for *agent* opens, where "here are the three files I changed" needs all three to survive.

`fbc3a8cb4` + `39a6dba6c` (merged to `main` in #1301 ~an hour before this branch was cut) already fixed that half, the right way: persistence is **dispatch provenance**, not wire data. `startUiCommandStream` sets `fileDisposition: "persistent"`, so server-streamed agent opens pass `preview: false` and each keeps its own tab, while local/file-tree opens keep the replaceable preview. No new `replace | newTab` wire parameter was needed, matching the owner's "smallest first" comment on the issue.

So this PR does **not** rebuild tabs and does not fight the preview design. It closes the one bullet of #1297 that the merged work left open:

> Consider a bound on tab count so an agent looping over a directory cannot open hundreds.

## Change

`packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx`

- `MAX_OPEN_FILE_TABS = 12`.
- `evictExcessFileTabs(api, fileBackedPanelIds, keepPanelId)` runs after a new file panel is added. It evicts oldest-first in tab order (the tab a user would close first), and **never** evicts the tab just opened or the active tab — so the file the agent asked for is always the one you end up looking at.
- Evicted ids are dropped from the file-backed panel id set so the tracking set does not leak.

No new chrome, no new affordance, no touch targets added — Dockview's native tab strip is untouched, so the 48px hard gate is unaffected.

## Proof

- `SurfaceShell.test.tsx`: **29/29 pass**, including the new `bounds persistent file tabs so a looping agent cannot pin hundreds` — opens `MAX_OPEN_FILE_TABS + 3` files persistently, asserts exactly 12 tabs remain, that they are the 12 newest in order, and that the last requested file is active.
- `packages/workspace` typecheck: `tsconfig.server.source.json` clean. `tsconfig.front.source.json` reports one error, `WorkspaceAgentFront.tsx(565,31) setArchived`, which reproduces identically on the unmodified baseline (stale `@hachej/boring-agent` dts in an uninstalled worktree) — **pre-existing, untouched by this diff**.
- Full `packages/workspace` suite: 2229 passed on this branch vs 2243 on baseline, with both runs showing an overlapping set of load-dependent failures under full-suite parallelism (`WorkspaceAgentFront`, plugin-runtime, admission-composition). Every one of those files passes in isolation on this branch (`WorkspaceAgentFront.test.tsx`: 97/97). Baseline is not green on this machine either, so no regression is attributable here.
- No playground screenshots: this worktree has no `node_modules` (no install), so the app could not be driven. The behavior is covered by the deterministic tab-identity assertions above.

## Note for the owner

The user-visible symptom in #1297 was already fixed on `main` by #1301, which did not link the issue. This PR finishes the remaining design note. Verify the merged behavior in the app before closing #1297 on the strength of this diff alone.

Fixes #1297