### PR TITLE
#1426 fix(workspace): keep new chats out of split panes

### DIFF
--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -2106,11 +2106,6 @@ export function WorkspaceAgentFront<
     )
   ), [createChatPaneAfter, fleetModeEnabled, effectiveAgentTypeId])
 
-  const createChatSessionPreferNewPane = useCallback((ownerAgentTypeId = newChatAgentTypeId) => {
-    if (chatPaneIds.length >= 2) return createChatPaneAfter(activeChatPaneId, undefined, ownerAgentTypeId)
-    return createChatSession(ownerAgentTypeId)
-  }, [activeChatPaneId, newChatAgentTypeId, chatPaneIds.length, createChatPaneAfter, createChatSession])
-
   const [autoSubmitHydrationDisabled, setAutoSubmitHydrationDisabled] = useState(requestedAutoSubmitInitialDraft)
   const autoSubmitHydrationWorkspaceRef = useRef(workspaceId)
   useEffect(() => {
@@ -2750,7 +2745,7 @@ export function WorkspaceAgentFront<
             // without a switch needs the pending-entry contract (plan §5.1) — deferred.
             if (projectId === (appLeftActiveProjectId ?? workspaceId)) {
               setLeftOverlay(null)
-              void createChatSessionPreferNewPane()
+              void createChatSession()
             } else {
               onSwitchAppLeftProject?.(projectId)
             }

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -1195,6 +1195,46 @@ describe("WorkspaceAgentFront", () => {
     expect(within(appNav).queryByText("Active project session")).not.toBeInTheDocument()
   })
 
+  it("replaces the active pane when creating a project chat from a split layout", async () => {
+    const user = userEvent.setup()
+    localStorage.setItem(
+      "boring-workspace:chat-panes:project-new-chat-replaces",
+      JSON.stringify({ ids: ["s1", "s2"], activeId: "s2" }),
+    )
+
+    function Harness() {
+      const [sessions, setSessions] = useState([
+        { id: "s1", title: "First session" },
+        { id: "s2", title: "Second session" },
+      ])
+      const [activeSessionId, setActiveSessionId] = useState("s2")
+      return (
+        <WorkspaceAgentFront
+          workspaceId="project-new-chat-replaces"
+          workspaceLayout="plugin-tabs"
+          appLeftLayoutMode="multi-project"
+          chatPanel={SessionIdChatPanel}
+          sessions={sessions}
+          activeSessionId={activeSessionId}
+          appLeftProjects={[{ id: "project-new-chat-replaces", name: "Project Alpha" }]}
+          onCreateSession={() => {
+            const created = { id: "created", title: "Created session" }
+            setSessions((previous) => [created, ...previous])
+            setActiveSessionId(created.id)
+            return Promise.resolve(created)
+          }}
+        />
+      )
+    }
+
+    render(<Harness />)
+
+    await waitFor(() => expect(visibleChatSessionIds()).toEqual(["s1", "s2"]))
+    await user.click(screen.getByRole("button", { name: "New chat in Project Alpha" }))
+
+    await waitFor(() => expect(visibleChatSessionIds()).toEqual(["s1", "created"]))
+  })
+
   it("keeps classic workspace sources available outside plugin-tabs mode", async () => {
     function SourcePanel() {
       return <div>Classic source body</div>


### PR DESCRIPTION
Closes #1426

## Summary
- route active-project New chat through the replacement transaction
- retain explicit split behavior only for the split control
- cover a persisted two-pane layout regression

## Validation
- `vitest run src/app/front/__tests__/WorkspaceAgentFront.test.tsx` (98 passed)
- `tsc --noEmit -p tsconfig.json`