### PR TITLE
feat(workspace): scope extra commands to chat owner

### DIFF
--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -342,7 +342,10 @@ export interface WorkspaceAgentFrontProps<
    */
   hotReloadEnabled?: boolean
   extraPanels?: string[]
+  /** Fleet-wide commands supplied to every chat pane. */
   extraCommands?: SlashCommand[]
+  /** Commands resolved for the Agent that owns each individual chat pane. */
+  getExtraCommandsForAgent?: (agentTypeId: string) => readonly SlashCommand[]
   provisionWorkspace?: boolean
   /**
    * Opt in/out of server-backed pi-chat sessions independently of workspace
@@ -777,6 +780,7 @@ export function WorkspaceAgentFront<
   frontPluginHotReload,
   extraPanels,
   extraCommands,
+  getExtraCommandsForAgent,
   provisionWorkspace,
   remoteSessionsEnabled,
   bootPreloadPaths,
@@ -2207,6 +2211,8 @@ export function WorkspaceAgentFront<
     (sessionKey: string) => {
       const sessionRef = workspaceSessionRefFromKey(sessionKey)
       const sessionId = sessionRef.sessionId
+      const paneAgentTypeId = sessionRef.agentTypeId ?? selectedAgentTypeId
+      const paneExtraCommands = getExtraCommandsForAgent?.(paneAgentTypeId) ?? []
       const chatToolRenderers = (chatParams?.toolRenderers && typeof chatParams.toolRenderers === "object")
         ? chatParams.toolRenderers as ToolRendererOverrides
         : undefined
@@ -2214,7 +2220,7 @@ export function WorkspaceAgentFront<
       ...chatParams,
       ...(delayAutoSubmitDraft ? { autoSubmitInitialDraft: false, initialDraft: undefined } : {}),
       sessionId,
-      agentTypeId: sessionRef.agentTypeId ?? selectedAgentTypeId,
+      agentTypeId: paneAgentTypeId,
       apiBaseUrl,
       workspaceId,
       storageScope: workspaceId,
@@ -2225,7 +2231,7 @@ export function WorkspaceAgentFront<
       toolRenderers: { ...pluginToolRenderers, ...(chatToolRenderers ?? {}) },
       bridgeEndpoint: null,
       surfaceDispatch,
-      extraCommands,
+      extraCommands: [...(extraCommands ?? []), ...paneExtraCommands],
       workspaceWarmupStatus,
       hydrateMessages,
       allowPromptDuringInitialHydration: emptySessionIds.has(sessionKey),
@@ -2261,7 +2267,7 @@ export function WorkspaceAgentFront<
       ...(resolvedHotReloadEnabled !== undefined ? { hotReloadEnabled: resolvedHotReloadEnabled } : {}),
     }
     },
-    [apiBaseUrl, chatParams, chatRemoteSessionOptions, delayAutoSubmitDraft, resolvedRequestHeaders, surfaceDispatch, extraCommands, workspaceWarmupStatus, hydrateMessages, emptySessionIds, resolvedHotReloadEnabled, pluginToolRenderers, reloadAgentPluginsForSession, selectedAgentTypeId, sessionSourceIsCurrent, workspaceId],
+    [apiBaseUrl, chatParams, chatRemoteSessionOptions, delayAutoSubmitDraft, resolvedRequestHeaders, surfaceDispatch, extraCommands, getExtraCommandsForAgent, workspaceWarmupStatus, hydrateMessages, emptySessionIds, resolvedHotReloadEnabled, pluginToolRenderers, reloadAgentPluginsForSession, selectedAgentTypeId, sessionSourceIsCurrent, workspaceId],
   )
   const centerParams = useMemo(
     () => makeCenterParams(chatSessionKey),

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -2570,6 +2570,82 @@ describe("WorkspaceAgentFront", () => {
     expect(createOwners).toEqual(["default"])
   })
 
+  it("resolves extra slash commands from each split pane's owning Agent", async () => {
+    const capturedByOwner = new Map<string, WorkspaceChatPanelProps>()
+    const CapturingChatPanel = (props: WorkspaceChatPanelProps) => {
+      capturedByOwner.set(props.agentTypeId ?? "", props)
+      return <div data-testid={`commands-${props.agentTypeId}`}>Commands for {props.agentTypeId}</div>
+    }
+    localStorage.setItem(
+      "boring-workspace:chat-panes:fleet-agent-commands",
+      JSON.stringify({
+        version: 2,
+        refs: [
+          { kind: "addressed", sessionId: "alpha-one", agentTypeId: "alpha" },
+          { kind: "addressed", sessionId: "beta-one", agentTypeId: "beta" },
+        ],
+        activeRef: { kind: "addressed", sessionId: "alpha-one", agentTypeId: "alpha" },
+      }),
+    )
+    const useFleetSelection = () => ({
+      agents: [
+        { agentTypeId: "alpha", label: "Boring Alpha" },
+        { agentTypeId: "beta", label: "Boring Beta" },
+      ],
+      selectedAgentTypeId: "alpha",
+      loading: false,
+      error: undefined,
+      selectAgentTypeId: vi.fn(),
+    })
+    const useFleetSessions: UseWorkspaceAgentSessions = (options) => {
+      const session = {
+        id: `${options.agentTypeId}-one`,
+        agentTypeId: options.agentTypeId,
+        title: `${options.agentTypeId} session`,
+      }
+      return {
+        sourceIdentity: options.sourceIdentity,
+        sessions: [session],
+        loading: false,
+        activeSessionId: session.id,
+        activeSessionAgentTypeId: options.agentTypeId,
+        activeSession: session,
+        switch: vi.fn(),
+        delete: vi.fn(),
+        create: vi.fn(),
+      }
+    }
+    const alphaCommand = {
+      name: "alpha-only",
+      description: "Only Alpha gets this command",
+      handler: vi.fn(),
+    }
+    const getExtraCommandsForAgent = vi.fn((agentTypeId: string) =>
+      agentTypeId === "alpha" ? [alphaCommand] : [],
+    )
+
+    render(
+      <WorkspaceAgentFront
+        workspaceId="fleet-agent-commands"
+        workspaceLayout="plugin-tabs"
+        chatPanel={CapturingChatPanel}
+        addressedAgentSelection
+        useAddressedAgentSelection={useFleetSelection}
+        useSessions={useFleetSessions}
+        getExtraCommandsForAgent={getExtraCommandsForAgent}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(capturedByOwner.has("alpha")).toBe(true)
+      expect(capturedByOwner.has("beta")).toBe(true)
+    })
+    expect(capturedByOwner.get("alpha")?.extraCommands).toEqual([alphaCommand])
+    expect(capturedByOwner.get("beta")?.extraCommands).toEqual([])
+    expect(getExtraCommandsForAgent).toHaveBeenCalledWith("alpha")
+    expect(getExtraCommandsForAgent).toHaveBeenCalledWith("beta")
+  })
+
   it("splits a pane into a chat owned by THAT pane's Agent, not the picker target", async () => {
     const user = userEvent.setup()
     const createOwners: (string | undefined)[] = []


### PR DESCRIPTION
## Summary
- add a per-Agent extra-command resolver at the workspace boundary
- resolve commands from each split chat pane's immutable owning Agent
- retain fleet-wide `extraCommands` compatibility
- prove mixed-Agent split panes do not share commands

## Validation
- WorkspaceAgentFront: 99 tests passed
- workspace source typecheck passed
- workspace build passed
- `git diff --check`

Full package test after a fresh partial dependency build reached 1,599 passes; unrelated fixture/import setup failures remained outside this diff.