### PR TITLE
fix(core): automatic JSX runtime for built templates (#1438)

### DIFF
--- a/packages/core/src/server/mail/templates/__tests__/jsxRuntimeBuild.test.ts
+++ b/packages/core/src/server/mail/templates/__tests__/jsxRuntimeBuild.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, afterAll } from 'vitest'
+import { build, type BuildOptions } from 'esbuild'
+import { render } from '@react-email/render'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+// Regression test for #1438: mail templates crashed at SSR with
+// "React is not defined" because the *build* (packages/core/tsup.config.ts)
+// used esbuild's default CLASSIC jsx transform while the templates (authored
+// for tsconfig's "jsx": "react-jsx") import no React.
+//
+// A unit test that imports the templates straight from src (like
+// templates.test.ts) can't catch this class of bug: vitest transforms .tsx
+// on the fly with its own automatic-jsx pipeline, so it passes regardless of
+// what the *shipped build* does. This test instead runs the templates
+// through the real tsup.config.ts esbuild pipeline and — crucially — points
+// esbuild at an explicit tsconfig that has no "jsx" compiler option, so the
+// result depends only on what tsup.config.ts itself configures, not on
+// tsconfig.json auto-discovery (which is what let a local `pnpm build`
+// accidentally succeed even before the fix). Before the fix (no `jsx` set in
+// tsup.config.ts's esbuildOptions), this reproduces the exact crash; after
+// the fix (`options.jsx = 'automatic'`), it renders successfully.
+
+const here = dirname(fileURLToPath(import.meta.url))
+const templatesDir = join(here, '..')
+const packageRoot = join(here, '..', '..', '..', '..', '..')
+
+const tmpDir = mkdtempSync(join(tmpdir(), 'core-jsx-runtime-build-'))
+afterAll(() => {
+  rmSync(tmpDir, { recursive: true, force: true })
+})
+
+// A tsconfig with no "jsx" field at all, deliberately shadowing
+// packages/core/tsconfig.json's "jsx": "react-jsx" so esbuild's tsconfig
+// auto-detection cannot rescue an unfixed build config.
+const noJsxTsconfigPath = join(tmpDir, 'tsconfig.no-jsx.json')
+writeFileSync(
+  noJsxTsconfigPath,
+  JSON.stringify({ compilerOptions: { module: 'esnext', target: 'es2022' } }),
+)
+
+async function buildTemplate(entryFile: string, outFile: string) {
+  const { esbuildOptions } = (await import(
+    pathToFileURL(join(packageRoot, 'tsup.config.ts')).href
+  ).then((m) => {
+    const cfg = m.default
+    const entryCfg = Array.isArray(cfg) ? cfg[0] : cfg
+    return entryCfg
+  })) as { esbuildOptions?: (options: BuildOptions) => void }
+
+  const options: BuildOptions = {
+    entryPoints: [join(templatesDir, entryFile)],
+    bundle: true,
+    format: 'esm',
+    platform: 'node',
+    write: false,
+    tsconfig: noJsxTsconfigPath,
+    external: ['react', 'react-dom', '@react-email/components'],
+  }
+
+  // Apply the package's real build config, mirroring exactly what
+  // `pnpm --filter @hachej/boring-core build` runs.
+  esbuildOptions?.(options)
+
+  const result = await build(options)
+  const code = result.outputFiles![0]!.text
+  const outPath = join(tmpDir, outFile)
+  writeFileSync(outPath, code)
+  return import(pathToFileURL(outPath).href)
+}
+
+describe('mail templates built via the real tsup esbuild config (#1438)', () => {
+  it('renderVerifyEmail: built VerifyEmail produces non-empty HTML without throwing', async () => {
+    const mod = await buildTemplate('VerifyEmail.tsx', 'VerifyEmail.mjs')
+    const element = mod.VerifyEmail({
+      verifyUrl: 'https://app.test/verify?token=abc',
+      appName: 'TestApp',
+      expiresInHours: 24,
+    })
+    const html = await render(element)
+    expect(html.length).toBeGreaterThan(0)
+    expect(html).toContain('Verify your email address')
+  })
+
+  it('renderWelcome: built Welcome produces non-empty HTML without throwing', async () => {
+    const mod = await buildTemplate('Welcome.tsx', 'Welcome.mjs')
+    const element = mod.Welcome({
+      appName: 'TestApp',
+      getStartedUrl: 'https://app.test/dashboard',
+    })
+    const html = await render(element)
+    expect(html.length).toBeGreaterThan(0)
+    expect(html).toContain('TestApp')
+  })
+})

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -36,6 +36,18 @@ export default defineConfig([
     outDir: 'dist',
     target: 'es2022',
     external: EXTERNALS,
+    // esbuild otherwise falls back to the CLASSIC jsx transform (which
+    // requires `React` in scope) unless it can auto-detect "jsx": "react-jsx"
+    // from tsconfig.json. That auto-detection is implicit and cwd/tooling
+    // dependent (it silently breaks if tsconfig.json isn't resolvable from
+    // wherever esbuild is invoked, e.g. a Docker build context) — mail
+    // templates like VerifyEmail.tsx/Welcome.tsx are authored for the
+    // automatic runtime and import no React, so a classic-transform build
+    // crashes at SSR with "React is not defined" (#1438). Set it explicitly
+    // so the build doesn't depend on tsconfig resolution succeeding.
+    esbuildOptions(options) {
+      options.jsx = 'automatic'
+    },
     async onSuccess() {
       for (const rel of CSS_ASSETS) {
         const dest = `dist/${rel}`


### PR DESCRIPTION
## Root cause

`packages/core/tsup.config.ts` built with esbuild's default **classic** JSX transform (no `jsx` option configured), while `packages/core/tsconfig.json` declares `"jsx": "react-jsx"` (automatic). The mail templates (`server/mail/templates/VerifyEmail.tsx`, `Welcome.tsx`, etc.) are correctly authored for the automatic runtime and import no `React`. esbuild *can* auto-detect `"jsx"` from `tsconfig.json`, and locally that auto-detection happened to mask the bug — but it's implicit and depends on esbuild being able to resolve the right `tsconfig.json` from wherever it's invoked (e.g. a Docker build context), which is exactly the class of thing that broke in production: SSR crashed with `ReferenceError: React is not defined`, taking `POST /auth/send-verification-email` (500) and the whole signup/auth funnel down with it.

## Fix

Set the JSX runtime explicitly in the build config rather than relying on tsconfig auto-detection, and rather than adding per-file `React` imports to the templates (which are correct as written for the automatic runtime):

```ts
// packages/core/tsup.config.ts
esbuildOptions(options) {
  options.jsx = 'automatic'
},
```

This matches the shape of the bug: the templates are fine, the *build* was wrong.

## Regression test

`packages/core/src/server/mail/templates/__tests__/jsxRuntimeBuild.test.ts` runs `VerifyEmail.tsx`/`Welcome.tsx` through the real `tsup.config.ts` esbuild pipeline, but points esbuild at an explicit tsconfig with no `"jsx"` field — deliberately bypassing tsconfig auto-detection so the test's outcome depends only on what `tsup.config.ts` itself configures. It asserts `renderVerifyEmail`/`renderWelcome`-equivalent renders produce non-empty HTML without throwing.

A src-level unit test (like the existing `templates.test.ts`) can't catch this class of bug: vitest transforms `.tsx` on the fly with its own automatic-jsx pipeline, so it passes regardless of what the shipped build does.

**Proof it's a real regression test — failing-before evidence:**

Ran the new test against the tsup config *without* the fix (esbuildOptions block removed):

```
FAIL (2)
1. renderVerifyEmail: built VerifyEmail produces non-empty HTML without throwing
   ReferenceError: React is not defined
       at Module.VerifyEmail (/tmp/core-jsx-runtime-build-MZE87Q/VerifyEmail.mjs:55:3)
2. renderWelcome: built Welcome produces non-empty HTML without throwing
   ReferenceError: React is not defined
       at Module.Welcome (/tmp/core-jsx-runtime-build-MZE87Q/Welcome.mjs:51:3)
```

With the fix restored: `PASS (2) FAIL (0)`.

## Proof

- `pnpm --filter @hachej/boring-core build` — green, `build:assert` passes (all exported artifacts + stylesheets present).
- New test: `PASS (2) FAIL (0)`.
- Existing `src/server/mail/**` tests: `PASS (32) FAIL (0)`.
- Existing `src/server/auth/**` tests: same failures with and without this change (pre-existing, DB-dependent — no Postgres available in this sandbox; confirmed via `git stash`/`stash pop` A/B).
- `tsc --noEmit` (core): one pre-existing unrelated error in `packages/workspace/src/app/front/WorkspaceAgentFront.tsx` (not touched by this change), present with or without this diff.
- Boot check — required the built dist directly and called the render functions:
  ```
  verify html len 4097 welcome html len 3855
  ```

Fixes #1438