### PR TITLE
Persist and enforce workspace Agent Seats

### DIFF
--- a/packages/agent/src/server/index.ts
+++ b/packages/agent/src/server/index.ts
@@ -221,7 +221,11 @@ export type {
 } from './agent-host/types'
 export type { LeaseBoundWorkspaceAgent } from '../shared/workspaceAgentDispatcher'
 export type {
+  AgentAccessDecision,
+  AgentAccessOperation,
   AuthorizedAgentScope,
+  ResolveAgentAccess,
+  ResolveAgentAccessInput,
   VerifiedAgentScopeClaim,
 } from '../shared/gateway/types'
 export type { AgentHarnessFactory, AgentHarnessFactoryInput } from '../shared/harness'

--- a/packages/core/drizzle/0026_workspace_agent_seats.sql
+++ b/packages/core/drizzle/0026_workspace_agent_seats.sql
@@ -1,0 +1,41 @@
+-- Keep this rollout additive for older writers. A later cutover migration may
+-- validate a NOT NULL default only after every writer creates defaults + Seats.
+ALTER TABLE "workspaces"
+  DROP CONSTRAINT IF EXISTS "workspaces_default_agent_type_id_required_check";
+--> statement-breakpoint
+CREATE TABLE "workspace_agent_seats" (
+  "seat_id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "workspace_id" uuid NOT NULL,
+  "agent_type_id" text NOT NULL,
+  "source" text NOT NULL,
+  "enrolled_by_user_id" uuid,
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  CONSTRAINT "workspace_agent_seats_agent_type_id_check"
+    CHECK ("workspace_agent_seats"."agent_type_id" ~ '^[a-z][a-z0-9-]{0,62}$'),
+  CONSTRAINT "workspace_agent_seats_source_check"
+    CHECK ("workspace_agent_seats"."source" IN ('signup-intent', 'generic-default', 'user-add', 'migration-default', 'migration-session', 'operator'))
+);
+--> statement-breakpoint
+ALTER TABLE "workspace_agent_seats"
+  ADD CONSTRAINT "workspace_agent_seats_workspace_id_workspaces_id_fk"
+  FOREIGN KEY ("workspace_id") REFERENCES "public"."workspaces"("id")
+  ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "workspace_agent_seats"
+  ADD CONSTRAINT "workspace_agent_seats_enrolled_by_user_id_users_id_fk"
+  FOREIGN KEY ("enrolled_by_user_id") REFERENCES "public"."users"("id")
+  ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+CREATE UNIQUE INDEX "workspace_agent_seats_workspace_agent_idx"
+  ON "workspace_agent_seats" USING btree ("workspace_id", "agent_type_id");
+--> statement-breakpoint
+CREATE INDEX "workspace_agent_seats_workspace_id_idx"
+  ON "workspace_agent_seats" USING btree ("workspace_id");
+--> statement-breakpoint
+INSERT INTO "workspace_agent_seats" (
+  "workspace_id", "agent_type_id", "source", "enrolled_by_user_id"
+)
+SELECT "id", "default_agent_type_id", 'migration-default', "created_by"
+FROM "workspaces"
+WHERE "default_agent_type_id" IS NOT NULL
+ON CONFLICT ("workspace_id", "agent_type_id") DO NOTHING;

--- a/packages/core/drizzle/meta/_journal.json
+++ b/packages/core/drizzle/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1787875200000,
       "tag": "0025_workspace_default_agent_type_id_required",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1787961600000,
+      "tag": "0026_workspace_agent_seats",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
@@ -122,6 +122,166 @@ test('core/full-app composition forwards collected runtime provisioning plugins 
   }
 }, 15_000) // Full Core composition can exceed Vitest's default timeout on a cold module load.
 
+test('core enforces workspace Seats before product entitlement policy', async () => {
+  mocks.collectWorkspaceAgentServerPlugins.mockReturnValue({
+    runtimePlugins: [],
+    agentOptions: { extraTools: [], pi: {}, systemPromptAppend: undefined },
+    preservedUiStateKeys: [],
+    routeContributions: [],
+  })
+  mocks.getWorkspace.mockImplementation(async (id) => ({
+    id,
+    appId: 'boring-ui-v2-test',
+    defaultAgentTypeId: 'default',
+  }))
+  mocks.hasAgentSeat.mockImplementation(async (_workspaceId, agentTypeId) => agentTypeId === 'default')
+  const resolveAgentEntitlement = vi.fn(async () => ({ state: 'allowed' as const, seatId: 'seat-default' }))
+  const { createCoreWorkspaceAgentServer } = await import('../createCoreWorkspaceAgentServer.js')
+  const app = await createCoreWorkspaceAgentServer({
+    config: createTestCoreConfig({ stores: 'postgres', databaseUrl: 'postgres://test' }),
+    workspaceRoot: '/tmp/full-app-workspaces',
+    serveFrontend: false,
+    workspaceAgentAccessMode: 'enforce',
+    resolveAgentEntitlement,
+  })
+
+  try {
+    const hostOptions = (mocks.createAgentHost as any).mock.calls[0]?.[0] as Record<string, any>
+    const projection = (mocks.hostRegisterDirectRoutes as any).mock.calls[0]?.[0] as Record<string, any>
+    const scope = await projection.authorizeAgentRequest(fakeRequest('workspace-a', 'user-a'))
+    const verifiedClaim = await hostOptions.scopeVerifier.verify(scope)
+    await expect(hostOptions.resolveAgentAccess({
+      verifiedClaim,
+      agentTypeId: 'other-agent',
+      operation: 'session.create',
+    })).resolves.toEqual({ state: 'not-available', reason: 'not-seated' })
+    expect(resolveAgentEntitlement).not.toHaveBeenCalled()
+
+    await expect(hostOptions.resolveAgentAccess({
+      verifiedClaim,
+      agentTypeId: 'default',
+      operation: 'session.create',
+    })).resolves.toEqual({ state: 'allowed', seatId: 'seat-default' })
+    expect(mocks.hasAgentSeat).toHaveBeenCalledWith('workspace-a', 'default')
+    expect(resolveAgentEntitlement).toHaveBeenCalledWith({
+      workspaceId: 'workspace-a',
+      userId: 'user-a',
+      agentTypeId: 'default',
+      operation: 'session.create',
+    })
+  } finally {
+    await app.close()
+  }
+}, 15_000)
+
+test('core exposes idempotent add-only workspace Agent Seat routes', async () => {
+  mocks.collectWorkspaceAgentServerPlugins.mockReturnValue({
+    runtimePlugins: [],
+    agentOptions: { extraTools: [], pi: {}, systemPromptAppend: undefined },
+    preservedUiStateKeys: [],
+    routeContributions: [],
+  })
+  mocks.getWorkspace.mockImplementation(async (id) => ({
+    id,
+    appId: 'boring-ui-v2-test',
+    defaultAgentTypeId: 'default',
+  }))
+  mocks.listAgentSeats.mockResolvedValue([{
+    seatId: 'seat-default',
+    workspaceId: 'workspace-a',
+    agentTypeId: 'default',
+    source: 'operator',
+    enrolledByUserId: 'private-operator-id',
+    createdAt: '2026-08-27T00:00:00.000Z',
+  }])
+  let entitlementUnavailable = false
+  const { createCoreWorkspaceAgentServer } = await import('../createCoreWorkspaceAgentServer.js')
+  const app = await createCoreWorkspaceAgentServer({
+    config: createTestCoreConfig({ stores: 'postgres', databaseUrl: 'postgres://test' }),
+    workspaceRoot: '/tmp/full-app-workspaces',
+    serveFrontend: false,
+    canEnrollAgent: async () => true,
+    resolveAgentEntitlement: async () => entitlementUnavailable
+      ? { state: 'policy-unavailable' }
+      : { state: 'allowed', seatId: 'seat-default' },
+    requestScopeResolver: () => ({
+      bindingId: 'binding-a',
+      workspaceId: 'workspace-a',
+      defaultDeploymentId: 'deployment-a',
+      activeRevision: 'revision-a',
+      resolvedDigest: 'digest-a',
+    }),
+  })
+
+  try {
+    const listed = await app.inject({
+      method: 'GET',
+      url: '/api/v1/workspaces/workspace-a/agent-seats',
+      headers: { 'x-test-user-id': 'user-a' },
+    })
+    expect(listed.statusCode).toBe(200)
+    expect(listed.json()).toEqual({
+      seats: [{ agentTypeId: 'default', createdAt: '2026-08-27T00:00:00.000Z' }],
+    })
+    expect(listed.body).not.toContain('source')
+    expect(listed.body).not.toContain('private-operator-id')
+
+    entitlementUnavailable = true
+    const unavailable = await app.inject({
+      method: 'GET',
+      url: '/api/v1/workspaces/workspace-a/agent-seats',
+      headers: { 'x-test-user-id': 'user-a' },
+    })
+    expect(unavailable.statusCode).toBe(503)
+    entitlementUnavailable = false
+
+    const added = await app.inject({
+      method: 'POST',
+      url: '/api/v1/workspaces/workspace-a/agent-seats/default',
+      headers: {
+        'x-test-user-id': 'user-a',
+        'x-boring-workspace-id': 'workspace-a',
+        origin: 'http://localhost:3000',
+      },
+    })
+    expect(added.statusCode, added.body).toBe(200)
+    expect(added.json()).toMatchObject({
+      seat: { agentTypeId: 'default' },
+    })
+    expect(added.json().seat).not.toHaveProperty('source')
+    expect(added.json().seat).not.toHaveProperty('enrolledByUserId')
+    expect(mocks.addAgentSeat).toHaveBeenCalledWith(
+      'workspace-a',
+      'default',
+      'user-add',
+      'user-a',
+    )
+
+    const unknown = await app.inject({
+      method: 'POST',
+      url: '/api/v1/workspaces/workspace-a/agent-seats/not-deployed',
+      headers: {
+        'x-test-user-id': 'user-a',
+        'x-boring-workspace-id': 'workspace-a',
+        origin: 'http://localhost:3000',
+      },
+    })
+    expect(unknown.statusCode).toBe(404)
+
+    const crossBound = await app.inject({
+      method: 'POST',
+      url: '/api/v1/workspaces/workspace-b/agent-seats/default',
+      headers: {
+        'x-test-user-id': 'user-a',
+        origin: 'http://localhost:3000',
+      },
+    })
+    expect(crossBound.statusCode).toBe(421)
+  } finally {
+    await app.close()
+  }
+}, 30_000)
+
 test('core/full-app gives strong admission only to the direct Host projection', async () => {
   mocks.collectWorkspaceAgentServerPlugins.mockReturnValue({
     runtimePlugins: [],

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.testHarness.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.testHarness.ts
@@ -48,7 +48,7 @@ export const mocks = (() => {
     getUser: vi.fn(async (id: string) => ({ id })),
     countNullDefaultAgentTypeIds: vi.fn(async (_appId: string): Promise<number> => 0),
     compareAndSetNullDefaultAgentTypeId: vi.fn(async (_appId: string, _value: string) => 0),
-    listAgentSeats: vi.fn(async (_workspaceId: string) => []),
+    listAgentSeats: vi.fn(async (_workspaceId: string): Promise<any[]> => []),
     hasAgentSeat: vi.fn(async (_workspaceId: string, _agentTypeId: string) => false),
     addAgentSeat: vi.fn(),
     getMemberRole: vi.fn(async (_workspaceId: string, _userId: string) => 'owner'),

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.testHarness.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.testHarness.ts
@@ -48,6 +48,10 @@ export const mocks = (() => {
     getUser: vi.fn(async (id: string) => ({ id })),
     countNullDefaultAgentTypeIds: vi.fn(async (_appId: string): Promise<number> => 0),
     compareAndSetNullDefaultAgentTypeId: vi.fn(async (_appId: string, _value: string) => 0),
+    listAgentSeats: vi.fn(async (_workspaceId: string) => []),
+    hasAgentSeat: vi.fn(async (_workspaceId: string, _agentTypeId: string) => false),
+    addAgentSeat: vi.fn(),
+    getMemberRole: vi.fn(async (_workspaceId: string, _userId: string) => 'owner'),
     actualCreateAgentHost: undefined as undefined | ((options: any) => Promise<any>),
     actualCreateSandboxRuntimeModeAdapter: undefined as undefined | ((mode: 'direct') => any),
     runtimeHost: {
@@ -164,6 +168,12 @@ vi.doMock('../../../server/db/index.js', () => ({
     compareAndSetNullDefaultAgentTypeId(appId: string, value: string) {
       return mocks.compareAndSetNullDefaultAgentTypeId(appId, value)
     }
+    listAgentSeats(workspaceId: string) { return mocks.listAgentSeats(workspaceId) }
+    hasAgentSeat(workspaceId: string, agentTypeId: string) { return mocks.hasAgentSeat(workspaceId, agentTypeId) }
+    addAgentSeat(workspaceId: string, agentTypeId: string, source: string, enrolledByUserId?: string) {
+      return mocks.addAgentSeat(workspaceId, agentTypeId, source, enrolledByUserId)
+    }
+    getMemberRole(workspaceId: string, userId: string) { return mocks.getMemberRole(workspaceId, userId) }
   },
 }))
 
@@ -183,6 +193,17 @@ beforeEach(() => {
   mocks.getUser.mockImplementation(async (id: string) => ({ id }))
   mocks.countNullDefaultAgentTypeIds.mockResolvedValue(0)
   mocks.compareAndSetNullDefaultAgentTypeId.mockResolvedValue(0)
+  mocks.listAgentSeats.mockResolvedValue([])
+  mocks.hasAgentSeat.mockResolvedValue(false)
+  mocks.getMemberRole.mockResolvedValue('owner')
+  mocks.addAgentSeat.mockImplementation(async (workspaceId, agentTypeId, source, enrolledByUserId) => ({
+    seatId: `seat-${agentTypeId}`,
+    workspaceId,
+    agentTypeId,
+    source,
+    enrolledByUserId: enrolledByUserId ?? null,
+    createdAt: '2026-08-27T00:00:00.000Z',
+  }))
 })
 
 export function fakeRequest(workspaceId: string, userId: string) {

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -18,6 +18,8 @@ import {
   resolveDefaultAgentFleet,
   resolveRequestLedgerPath,
   withRuntimeEnvContributions,
+  type AgentAccessDecision,
+  type AgentAccessOperation,
   type AgentEffectAdmission,
   type AgentFleetCompiler,
   type AgentGatewayEffect,
@@ -87,7 +89,10 @@ import {
   type BetterAuthInstance,
   type CoreDynamicAuthBaseURL,
 } from '../../server/auth/index.js'
-import { REQUEST_SCOPE_WORKSPACE_HEADER } from '../../server/auth/requestWorkspaceScope.js'
+import {
+  authorizeRequestScopedWorkspace,
+  REQUEST_SCOPE_WORKSPACE_HEADER,
+} from '../../server/auth/requestWorkspaceScope.js'
 import {
   createCoreApp,
   registerRoutes,
@@ -354,6 +359,24 @@ export interface CreateCoreWorkspaceAgentServerOptions {
   sandboxHandleStore?: SandboxHandleStore
   /** Trusted Agent fleet compiled before any Agent route is mounted. */
   agents?: readonly AgentHostAgentSpec[]
+  /**
+   * Workspace Seat enforcement is opt-in for rolling migrations. `compat`
+   * preserves legacy fleet-wide access; `enforce` requires a durable Seat.
+   */
+  workspaceAgentAccessMode?: 'compat' | 'enforce'
+  /** Product-owned entitlement decision, evaluated only after a Seat exists. */
+  resolveAgentEntitlement?: (ctx: {
+    workspaceId: string
+    userId: string
+    agentTypeId: string
+    operation: AgentAccessOperation
+  }) => Promise<AgentAccessDecision>
+  /** Explicit app policy enabling add-only Seat management for eligible products. */
+  canEnrollAgent?: (ctx: {
+    workspaceId: string
+    userId: string
+    agentTypeId: string
+  }) => boolean | Promise<boolean>
   /**
    * Repository root used to resolve `.agents/{personas,factory}` when
    * `BORING_AGENT_FLEET=1` composes the fleet and `agents` is not supplied.
@@ -1742,6 +1765,23 @@ export async function createCoreWorkspaceAgentServer(
     }),
     hostId: options.agentHostId ?? (sessionRoot ? undefined : 'core-workspace-agent'),
     scopeVerifier: scopeAuthority.verifier,
+    ...(options.workspaceAgentAccessMode === 'enforce'
+      ? {
+          resolveAgentAccess: async ({ verifiedClaim, agentTypeId, operation }) => {
+            const workspaceId = scopeAuthority.resolveWorkspaceId(verifiedClaim)
+            const seated = await workspaceStore.hasAgentSeat(workspaceId, agentTypeId)
+            if (!seated) return { state: 'not-available' as const, reason: 'not-seated' as const }
+            return options.resolveAgentEntitlement
+              ? await options.resolveAgentEntitlement({
+                  workspaceId,
+                  userId: verifiedClaim.authSubjectId,
+                  agentTypeId,
+                  operation,
+                })
+              : { state: 'allowed' as const }
+          },
+        }
+      : {}),
     runtimeModeAdapter: hostRuntimeModeAdapter,
     runtimeHost,
     telemetry,
@@ -1799,6 +1839,80 @@ export async function createCoreWorkspaceAgentServer(
       log: app.log,
     })
 
+    if (options.canEnrollAgent) {
+      app.get('/api/v1/workspaces/:workspaceId/agent-seats', async (request, reply) => {
+        const userId = request.user?.id
+        if (!userId) return reply.code(401).send({ error: 'authentication required' })
+        const { workspaceId } = request.params as { workspaceId: string }
+        const scoped = await authorizeRequestScopedWorkspace(request, workspaceId)
+        if (!scoped) {
+          await getActiveAppWorkspace(workspaceId)
+          if (!await workspaceStore.isMember(workspaceId, userId)) {
+            return reply.code(404).send({ error: 'workspace not found' })
+          }
+        }
+        const visible: Array<{ agentTypeId: string; createdAt: string }> = []
+        for (const seat of await workspaceStore.listAgentSeats(workspaceId)) {
+          if (!agentTypeIds.includes(seat.agentTypeId)) continue
+          let decision: AgentAccessDecision
+          try {
+            decision = options.resolveAgentEntitlement
+              ? await options.resolveAgentEntitlement({
+                  workspaceId,
+                  userId,
+                  agentTypeId: seat.agentTypeId,
+                  operation: 'catalog',
+                })
+              : { state: 'allowed', seatId: seat.seatId }
+          } catch {
+            return reply.code(503).send({ error: 'agent access policy is unavailable' })
+          }
+          if (decision.state === 'policy-unavailable') {
+            return reply.code(503).send({ error: 'agent access policy is unavailable' })
+          }
+          if (decision.state === 'allowed') {
+            visible.push({ agentTypeId: seat.agentTypeId, createdAt: seat.createdAt })
+          }
+        }
+        return reply.code(200).send({ seats: visible })
+      })
+
+      app.post('/api/v1/workspaces/:workspaceId/agent-seats/:agentTypeId', async (request, reply) => {
+        const userId = request.user?.id
+        if (!userId) return reply.code(401).send({ error: 'authentication required' })
+        const { workspaceId, agentTypeId } = request.params as {
+          workspaceId: string
+          agentTypeId: string
+        }
+        const scoped = await authorizeRequestScopedWorkspace(request, workspaceId, 'editor')
+        if (!scoped) {
+          await getActiveAppWorkspace(workspaceId)
+          const role = await workspaceStore.getMemberRole(workspaceId, userId)
+          if (!role) return reply.code(404).send({ error: 'workspace not found' })
+          if (role === 'viewer') return reply.code(403).send({ error: 'workspace editor role required' })
+        }
+        if (!agentTypeIds.includes(agentTypeId)) {
+          return reply.code(404).send({ error: 'agent type is not available' })
+        }
+        let eligible: boolean
+        try {
+          eligible = await options.canEnrollAgent({ workspaceId, userId, agentTypeId })
+        } catch {
+          return reply.code(503).send({ error: 'agent enrollment policy is unavailable' })
+        }
+        if (!eligible) return reply.code(404).send({ error: 'agent type is not available' })
+        const seat = await workspaceStore.addAgentSeat(
+          workspaceId,
+          agentTypeId,
+          'user-add',
+          userId,
+        )
+        return reply.code(200).send({
+          seat: { agentTypeId: seat.agentTypeId, createdAt: seat.createdAt },
+        })
+      })
+    }
+
     app.get('/api/v1/workspace/meta', async (request, reply) => {
       try {
         const workspaceId = await resolveWorkspaceId(request)
@@ -1806,6 +1920,11 @@ export async function createCoreWorkspaceAgentServer(
         // retained membership on a soft-deleted row cannot recreate its root.
         const workspace = await getActiveAppWorkspace(workspaceId)
         const workspaceRootForRequest = await resolveRoot(workspaceId, request)
+        const defaultEligibleAgentTypeIds = options.workspaceAgentAccessMode === 'enforce'
+          ? (await workspaceStore.listAgentSeats(workspaceId))
+              .map((seat) => seat.agentTypeId)
+              .filter((agentTypeId) => agentTypeIds.includes(agentTypeId))
+          : agentTypeIds
         return {
           workspaceId,
           workspaceRoot: workspaceRootForRequest,
@@ -1816,7 +1935,7 @@ export async function createCoreWorkspaceAgentServer(
           defaultAgentTypeId: resolveWorkspaceDefaultAgentTypeId({
             persistedDefaultAgentTypeId: workspace.defaultAgentTypeId,
             applicationDefaultAgentTypeId,
-            regularAgentTypeIds: agentTypeIds,
+            regularAgentTypeIds: defaultEligibleAgentTypeIds,
             onUnknownPersistedSeat: (diagnostic) => {
               request.log.warn(
                 { workspaceId, ...diagnostic },

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -1839,7 +1839,8 @@ export async function createCoreWorkspaceAgentServer(
       log: app.log,
     })
 
-    if (options.canEnrollAgent) {
+    const canEnrollAgent = options.canEnrollAgent
+    if (canEnrollAgent) {
       app.get('/api/v1/workspaces/:workspaceId/agent-seats', async (request, reply) => {
         const userId = request.user?.id
         if (!userId) return reply.code(401).send({ error: 'authentication required' })
@@ -1896,7 +1897,7 @@ export async function createCoreWorkspaceAgentServer(
         }
         let eligible: boolean
         try {
-          eligible = await options.canEnrollAgent({ workspaceId, userId, agentTypeId })
+          eligible = await canEnrollAgent({ workspaceId, userId, agentTypeId })
         } catch {
           return reply.code(503).send({ error: 'agent enrollment policy is unavailable' })
         }

--- a/packages/core/src/server/__tests__/signupAgentDefaults.test.ts
+++ b/packages/core/src/server/__tests__/signupAgentDefaults.test.ts
@@ -228,6 +228,8 @@ describe('signup-domain default-agent initialization (Decision 28 hook)', () => 
     expect(create.mock.calls[0]![3]).toEqual({
       isDefault: true,
       defaultAgentTypeId: 'boring-v2',
+      initialAgentSeatSource: 'generic-default',
+      enrolledByUserId: user.id,
     })
   })
 
@@ -237,19 +239,31 @@ describe('signup-domain default-agent initialization (Decision 28 hook)', () => 
     expect(create).toHaveBeenCalledWith(user.id, 'Default workspace', 'test-app', {
       isDefault: true,
       defaultAgentTypeId: 'legal',
+      initialAgentSeatSource: 'signup-intent',
+      enrolledByUserId: user.id,
     })
   })
 
   it('normalizes the host (case/port) before the exact lookup', async () => {
     const { create } = await runSignup({ headers: { [TRUSTED_SIGNUP_HOSTNAME_HEADER]: 'Legal.Example:443' } })
-    expect(create.mock.calls[0]![3]).toEqual({ isDefault: true, defaultAgentTypeId: 'legal' })
+    expect(create.mock.calls[0]![3]).toEqual({
+      isDefault: true,
+      defaultAgentTypeId: 'legal',
+      initialAgentSeatSource: 'signup-intent',
+      enrolledByUserId: user.id,
+    })
   })
 
   it('falls back to the boot default for unmapped hosts; email domain never selects', async () => {
     // User email is someone@legal.example, but the request host is unmapped:
     // the email domain must have no effect on seat selection.
     const { create } = await runSignup({ headers: { [TRUSTED_SIGNUP_HOSTNAME_HEADER]: 'unmapped.example' } })
-    expect(create.mock.calls[0]![3]).toEqual({ isDefault: true, defaultAgentTypeId: 'boring-v2' })
+    expect(create.mock.calls[0]![3]).toEqual({
+      isDefault: true,
+      defaultAgentTypeId: 'boring-v2',
+      initialAgentSeatSource: 'generic-default',
+      enrolledByUserId: user.id,
+    })
   })
 
   it('rejects a missing application default before signup can initialize a Workspace', () => {
@@ -273,7 +287,12 @@ describe('signup-domain default-agent initialization (Decision 28 hook)', () => 
         query: { hostname: 'legal.example', agentTypeId: 'legal' },
       },
     })
-    expect(create.mock.calls[0]![3]).toEqual({ isDefault: true, defaultAgentTypeId: 'boring-v2' })
+    expect(create.mock.calls[0]![3]).toEqual({
+      isDefault: true,
+      defaultAgentTypeId: 'boring-v2',
+      initialAgentSeatSource: 'generic-default',
+      enrolledByUserId: user.id,
+    })
   })
 
   it('does not persist the signup hostname as product identity', async () => {
@@ -281,7 +300,12 @@ describe('signup-domain default-agent initialization (Decision 28 hook)', () => 
     const [, name, appId, options] = create.mock.calls[0]!
     expect(name).toBe('Default workspace')
     expect(appId).toBe('test-app')
-    expect(Object.keys(options as object).sort()).toEqual(['defaultAgentTypeId', 'isDefault'])
+    expect(Object.keys(options as object).sort()).toEqual([
+      'defaultAgentTypeId',
+      'enrolledByUserId',
+      'initialAgentSeatSource',
+      'isDefault',
+    ])
     expect(JSON.stringify(create.mock.calls[0])).not.toContain('legal.example')
   })
 

--- a/packages/core/src/server/app/types.ts
+++ b/packages/core/src/server/app/types.ts
@@ -4,6 +4,8 @@ import type {
   CapabilitiesResponse,
   User,
   Workspace,
+  WorkspaceAgentSeat,
+  WorkspaceAgentSeatSource,
   WorkspaceMember,
   WorkspaceInvite,
   WorkspaceRuntime,
@@ -42,6 +44,9 @@ export interface WorkspaceStoreCreateOptions {
   /** Required real application-fleet Agent; stores validate but never select it. */
   readonly defaultAgentTypeId: string
   readonly workspaceTypeId?: string
+  /** Defaults to generic-default and is inserted atomically with the workspace. */
+  readonly initialAgentSeatSource?: WorkspaceAgentSeatSource
+  readonly enrolledByUserId?: string
   isDefault?: boolean
   id?: string
   managedBy?: string
@@ -50,6 +55,14 @@ export interface WorkspaceStoreCreateOptions {
 export interface WorkspaceStore {
   create(userId: string, name: string, appId: string, opts: WorkspaceStoreCreateOptions): Promise<Workspace>
   list(userId: string, appId: string): Promise<Workspace[]>
+  listAgentSeats(workspaceId: string): Promise<WorkspaceAgentSeat[]>
+  hasAgentSeat(workspaceId: string, agentTypeId: string): Promise<boolean>
+  addAgentSeat(
+    workspaceId: string,
+    agentTypeId: string,
+    source: WorkspaceAgentSeatSource,
+    enrolledByUserId?: string,
+  ): Promise<WorkspaceAgentSeat>
   /** Count rolling-migration rows that still lack a persisted default Agent. */
   countNullDefaultAgentTypeIds(appId: string): Promise<number>
   /** Idempotent compare-and-set backfill: only rows still NULL may change. */

--- a/packages/core/src/server/auth/__tests__/postSignupHook.requestScope.test.ts
+++ b/packages/core/src/server/auth/__tests__/postSignupHook.requestScope.test.ts
@@ -34,6 +34,8 @@ describe('request-scoped post-signup workspace creation', () => {
     expect(create).toHaveBeenCalledWith(user.id, 'Default workspace', config.appId, {
       isDefault: true,
       defaultAgentTypeId: 'default',
+      initialAgentSeatSource: 'generic-default',
+      enrolledByUserId: user.id,
     })
   })
 

--- a/packages/core/src/server/auth/postSignupHook.ts
+++ b/packages/core/src/server/auth/postSignupHook.ts
@@ -114,10 +114,10 @@ export function createPostSignupHook(deps: PostSignupHookDeps) {
 
     if (!inviteAccepted && !disableDefaultWorkspaceCreation) {
       // Decision 28 hook: an exact trusted signup-domain mapping may
-      // initialize the default seat of this newly created default Workspace.
-      // The hostname is read once, matched exactly against boot-validated
-      // trusted host configuration, then discarded — it is never persisted
-      // and has no routing, membership, selection, or authorization effect.
+      // initialize the default Agent and its authorization Seat atomically.
+      // The hostname is read once and matched exactly against boot-validated
+      // trusted host configuration; only the resolved Agent id and source are
+      // persisted.
       const signupHostname = normalizeSignupHostname(
         readHeader(ctx, TRUSTED_SIGNUP_HOSTNAME_HEADER),
       )
@@ -125,8 +125,10 @@ export function createPostSignupHook(deps: PostSignupHookDeps) {
       const initialSeat = signupSeat ?? applicationDefaultAgentTypeId
       await workspaceStore.create(user.id, 'Default workspace', config.appId, {
         isDefault: true,
-        // Decision 28: every initialized Workspace persists a real seat.
+        // Decision 28: every initialized Workspace persists a real default.
         defaultAgentTypeId: initialSeat,
+        initialAgentSeatSource: signupSeat ? 'signup-intent' : 'generic-default',
+        enrolledByUserId: user.id,
       })
     }
 

--- a/packages/core/src/server/db/__tests__/storeConformance.ts
+++ b/packages/core/src/server/db/__tests__/storeConformance.ts
@@ -382,6 +382,56 @@ export function describeWorkspaceStoreConformance(
     )
 
     it(
+      'creates exactly one initial Agent Seat atomically and adds Seats idempotently',
+      withTaskId(TASK_ID, async ({ assertionPassed }) => {
+        const { workspaceStore, appId, users } = await setup()
+        const workspace = await createWorkspace(
+          workspaceStore,
+          users.owner.id,
+          'Seat conformance',
+          appId,
+          {
+            defaultAgentTypeId: 'charlotteledoux',
+            initialAgentSeatSource: 'signup-intent',
+            enrolledByUserId: users.owner.id,
+          },
+        )
+
+        expect(await workspaceStore.hasAgentSeat(workspace.id, 'charlotteledoux')).toBe(true)
+        expect(await workspaceStore.listAgentSeats(workspace.id)).toEqual([
+          expect.objectContaining({
+            workspaceId: workspace.id,
+            agentTypeId: 'charlotteledoux',
+            source: 'signup-intent',
+            enrolledByUserId: users.owner.id,
+          }),
+        ])
+
+        const first = await workspaceStore.addAgentSeat(
+          workspace.id,
+          'macro-analyst',
+          'user-add',
+          users.owner.id,
+        )
+        const repeated = await workspaceStore.addAgentSeat(
+          workspace.id,
+          'macro-analyst',
+          'operator',
+          users.other.id,
+        )
+        expect(repeated).toEqual(first)
+        expect(await workspaceStore.listAgentSeats(workspace.id)).toHaveLength(2)
+        await expect(workspaceStore.addAgentSeat(
+          workspace.id,
+          'Macro Analyst',
+          'user-add',
+          users.owner.id,
+        )).rejects.toMatchObject({ code: ERROR_CODES.INVALID_DEFAULT_AGENT_TYPE_ID })
+        assertionPassed('workspace-agent-seats-atomic-and-idempotent')
+      }),
+    )
+
+    it(
       'counts and compare-and-sets NULL defaults without touching non-NULL rows',
       withTaskId(TASK_ID, async ({ assertionPassed }) => {
         const { workspaceStore, appId, otherAppId, users } = await setup()
@@ -396,6 +446,7 @@ export function describeWorkspaceStoreConformance(
         expect(await workspaceStore.countNullDefaultAgentTypeIds(appId)).toBe(0)
         expect(await workspaceStore.compareAndSetNullDefaultAgentTypeId(appId, 'default')).toBe(0)
         expect((await workspaceStore.get(legacy.id))?.defaultAgentTypeId).toBe('default')
+        expect(await workspaceStore.hasAgentSeat(legacy.id, 'default')).toBe(true)
         expect((await workspaceStore.get(known.id))?.defaultAgentTypeId).toBe('default')
         expect((await workspaceStore.get(unknown.id))?.defaultAgentTypeId).toBe('retired-seat')
         expect((await workspaceStore.get(otherAppLegacy.id))?.defaultAgentTypeId ?? null).toBeNull()

--- a/packages/core/src/server/db/__tests__/workspaceAgentSeats.migration.test.ts
+++ b/packages/core/src/server/db/__tests__/workspaceAgentSeats.migration.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const migrationPath = fileURLToPath(new URL(
+  '../../../../drizzle/0026_workspace_agent_seats.sql',
+  import.meta.url,
+))
+
+describe('0026 workspace Agent Seats migration', () => {
+  it('relaxes the old-writer default constraint before additive Seat DDL and backfill', () => {
+    const sql = readFileSync(migrationPath, 'utf8')
+    const relax = sql.indexOf('DROP CONSTRAINT IF EXISTS "workspaces_default_agent_type_id_required_check"')
+    const createSeats = sql.indexOf('CREATE TABLE "workspace_agent_seats"')
+    const backfill = sql.indexOf('INSERT INTO "workspace_agent_seats"')
+
+    expect(relax).toBeGreaterThanOrEqual(0)
+    expect(createSeats).toBeGreaterThan(relax)
+    expect(backfill).toBeGreaterThan(createSeats)
+    expect(sql).toContain('WHERE "default_agent_type_id" IS NOT NULL')
+    expect(sql).toContain("'migration-default'")
+    expect(sql).not.toMatch(/VALIDATE CONSTRAINT|SET NOT NULL/)
+  })
+})

--- a/packages/core/src/server/db/schema.ts
+++ b/packages/core/src/server/db/schema.ts
@@ -82,6 +82,45 @@ export const workspacesRelations = relations(workspaces, ({ one }) => ({
   }),
 }))
 
+export const workspaceAgentSeats = pgTable(
+  'workspace_agent_seats',
+  {
+    seatId: uuid('seat_id').default(sql`gen_random_uuid()`).primaryKey(),
+    workspaceId: uuid('workspace_id')
+      .notNull()
+      .references(() => workspaces.id, { onDelete: 'cascade' }),
+    agentTypeId: text('agent_type_id').notNull(),
+    source: text('source').notNull(),
+    enrolledByUserId: uuid('enrolled_by_user_id')
+      .references(() => users.id, { onDelete: 'set null' }),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex('workspace_agent_seats_workspace_agent_idx')
+      .on(table.workspaceId, table.agentTypeId),
+    index('workspace_agent_seats_workspace_id_idx').on(table.workspaceId),
+    check(
+      'workspace_agent_seats_agent_type_id_check',
+      sql`${table.agentTypeId} ~ '^[a-z][a-z0-9-]{0,62}$'`,
+    ),
+    check(
+      'workspace_agent_seats_source_check',
+      sql`${table.source} IN ('signup-intent', 'generic-default', 'user-add', 'migration-default', 'migration-session', 'operator')`,
+    ),
+  ],
+)
+
+export const workspaceAgentSeatsRelations = relations(workspaceAgentSeats, ({ one }) => ({
+  workspace: one(workspaces, {
+    fields: [workspaceAgentSeats.workspaceId],
+    references: [workspaces.id],
+  }),
+  enrolledBy: one(users, {
+    fields: [workspaceAgentSeats.enrolledByUserId],
+    references: [users.id],
+  }),
+}))
+
 export const workspaceMembers = pgTable(
   'workspace_members',
   {

--- a/packages/core/src/server/db/stores/LocalWorkspaceStore.ts
+++ b/packages/core/src/server/db/stores/LocalWorkspaceStore.ts
@@ -5,6 +5,8 @@ import type {
 } from '../../app/types.js'
 import type {
   Workspace,
+  WorkspaceAgentSeat,
+  WorkspaceAgentSeatSource,
   WorkspaceMember,
   WorkspaceInvite,
   WorkspaceRuntime,
@@ -29,6 +31,7 @@ function toWorkspace(workspace: Workspace): Workspace {
 
 export class LocalWorkspaceStore implements WorkspaceStore {
   private workspaces = new Map<string, Workspace>()
+  private agentSeats = new Map<string, WorkspaceAgentSeat>() // key: `${workspaceId}:${agentTypeId}`
   private members = new Map<string, WorkspaceMember>() // key: `${workspaceId}:${userId}`
   private invites = new Map<string, WorkspaceInvite>()
   private runtimes = new Map<string, WorkspaceRuntime>()
@@ -69,6 +72,14 @@ export class LocalWorkspaceStore implements WorkspaceStore {
       role: 'owner',
       createdAt: now,
     })
+    this.agentSeats.set(`${ws.id}:${defaultAgentTypeId}`, {
+      seatId: randomUUID(),
+      workspaceId: ws.id,
+      agentTypeId: defaultAgentTypeId,
+      source: opts.initialAgentSeatSource ?? 'generic-default',
+      enrolledByUserId: opts.enrolledByUserId ?? userId,
+      createdAt: now,
+    })
     this.runtimes.set(ws.id, {
       workspaceId: ws.id,
       spriteUrl: null,
@@ -107,6 +118,42 @@ export class LocalWorkspaceStore implements WorkspaceStore {
     return result
   }
 
+  async listAgentSeats(workspaceId: string): Promise<WorkspaceAgentSeat[]> {
+    return [...this.agentSeats.values()]
+      .filter((seat) => seat.workspaceId === workspaceId)
+      .sort((left, right) => left.createdAt.localeCompare(right.createdAt)
+        || left.agentTypeId.localeCompare(right.agentTypeId))
+      .map((seat) => ({ ...seat }))
+  }
+
+  async hasAgentSeat(workspaceId: string, agentTypeId: string): Promise<boolean> {
+    const parsedAgentTypeId = parseRequiredDefaultAgentTypeId(agentTypeId)
+    return this.agentSeats.has(`${workspaceId}:${parsedAgentTypeId}`)
+  }
+
+  async addAgentSeat(
+    workspaceId: string,
+    agentTypeId: string,
+    source: WorkspaceAgentSeatSource,
+    enrolledByUserId?: string,
+  ): Promise<WorkspaceAgentSeat> {
+    if (!this.workspaces.has(workspaceId)) throw new Error(`Workspace ${workspaceId} was not found`)
+    const parsedAgentTypeId = parseRequiredDefaultAgentTypeId(agentTypeId)
+    const key = `${workspaceId}:${parsedAgentTypeId}`
+    const existing = this.agentSeats.get(key)
+    if (existing) return { ...existing }
+    const seat: WorkspaceAgentSeat = {
+      seatId: randomUUID(),
+      workspaceId,
+      agentTypeId: parsedAgentTypeId,
+      source,
+      enrolledByUserId: enrolledByUserId ?? null,
+      createdAt: new Date().toISOString(),
+    }
+    this.agentSeats.set(key, seat)
+    return { ...seat }
+  }
+
   async countNullDefaultAgentTypeIds(appId: string): Promise<number> {
     let count = 0
     for (const workspace of this.workspaces.values()) {
@@ -121,6 +168,17 @@ export class LocalWorkspaceStore implements WorkspaceStore {
     for (const [id, workspace] of this.workspaces) {
       if (workspace.appId !== appId || workspace.defaultAgentTypeId != null) continue
       this.workspaces.set(id, { ...workspace, defaultAgentTypeId })
+      const seatKey = `${id}:${defaultAgentTypeId}`
+      if (!this.agentSeats.has(seatKey)) {
+        this.agentSeats.set(seatKey, {
+          seatId: randomUUID(),
+          workspaceId: id,
+          agentTypeId: defaultAgentTypeId,
+          source: 'migration-default',
+          enrolledByUserId: workspace.createdBy,
+          createdAt: new Date().toISOString(),
+        })
+      }
       updated += 1
     }
     return updated

--- a/packages/core/src/server/db/stores/PostgresWorkspaceStore.ts
+++ b/packages/core/src/server/db/stores/PostgresWorkspaceStore.ts
@@ -10,6 +10,8 @@ import type {
   MemberRole,
   User,
   Workspace,
+  WorkspaceAgentSeat,
+  WorkspaceAgentSeatSource,
   WorkspaceInvite,
   WorkspaceMember,
   WorkspaceRuntime,
@@ -28,6 +30,7 @@ import {
   userSettings,
   users,
   workspaces,
+  workspaceAgentSeats,
   workspaceInvites,
   workspaceMembers,
   workspaceRuntimeResources,
@@ -126,6 +129,17 @@ function toWorkspaceInvite(row: typeof workspaceInvites.$inferSelect): Workspace
   }
 }
 
+function toWorkspaceAgentSeat(row: typeof workspaceAgentSeats.$inferSelect): WorkspaceAgentSeat {
+  return {
+    seatId: row.seatId,
+    workspaceId: row.workspaceId,
+    agentTypeId: row.agentTypeId,
+    source: row.source as WorkspaceAgentSeatSource,
+    enrolledByUserId: row.enrolledByUserId,
+    createdAt: toIso(row.createdAt)!,
+  }
+}
+
 function toWorkspaceMember(row: typeof workspaceMembers.$inferSelect): WorkspaceMember {
   return {
     workspaceId: row.workspaceId,
@@ -207,6 +221,12 @@ export class PostgresWorkspaceStore implements WorkspaceStore {
           userId,
           role: 'owner',
         })
+        await tx.insert(workspaceAgentSeats).values({
+          workspaceId: row.id,
+          agentTypeId: defaultAgentTypeId,
+          source: opts.initialAgentSeatSource ?? 'generic-default',
+          enrolledByUserId: opts.enrolledByUserId ?? userId,
+        })
       }
 
       return toWorkspace(row)
@@ -230,6 +250,59 @@ export class PostgresWorkspaceStore implements WorkspaceStore {
     return rows.map((r) => toWorkspace(r.ws))
   }
 
+  async listAgentSeats(workspaceId: string): Promise<WorkspaceAgentSeat[]> {
+    const rows = await this.db
+      .select()
+      .from(workspaceAgentSeats)
+      .where(eq(workspaceAgentSeats.workspaceId, workspaceId))
+      .orderBy(workspaceAgentSeats.createdAt, workspaceAgentSeats.agentTypeId)
+    return rows.map(toWorkspaceAgentSeat)
+  }
+
+  async hasAgentSeat(workspaceId: string, agentTypeId: string): Promise<boolean> {
+    const parsedAgentTypeId = parseRequiredDefaultAgentTypeId(agentTypeId)
+    const rows = await this.db
+      .select({ seatId: workspaceAgentSeats.seatId })
+      .from(workspaceAgentSeats)
+      .where(and(
+        eq(workspaceAgentSeats.workspaceId, workspaceId),
+        eq(workspaceAgentSeats.agentTypeId, parsedAgentTypeId),
+      ))
+      .limit(1)
+    return rows.length > 0
+  }
+
+  async addAgentSeat(
+    workspaceId: string,
+    agentTypeId: string,
+    source: WorkspaceAgentSeatSource,
+    enrolledByUserId?: string,
+  ): Promise<WorkspaceAgentSeat> {
+    const parsedAgentTypeId = parseRequiredDefaultAgentTypeId(agentTypeId)
+    const inserted = await this.db
+      .insert(workspaceAgentSeats)
+      .values({
+        workspaceId,
+        agentTypeId: parsedAgentTypeId,
+        source,
+        enrolledByUserId: enrolledByUserId ?? null,
+      })
+      .onConflictDoNothing({
+        target: [workspaceAgentSeats.workspaceId, workspaceAgentSeats.agentTypeId],
+      })
+      .returning()
+    const row = inserted[0] ?? (await this.db
+      .select()
+      .from(workspaceAgentSeats)
+      .where(and(
+        eq(workspaceAgentSeats.workspaceId, workspaceId),
+        eq(workspaceAgentSeats.agentTypeId, parsedAgentTypeId),
+      ))
+      .limit(1))[0]
+    if (!row) throw new Error(`Agent Seat ${workspaceId}/${parsedAgentTypeId} was not created`)
+    return toWorkspaceAgentSeat(row)
+  }
+
   async countNullDefaultAgentTypeIds(appId: string): Promise<number> {
     const rows = await this.db
       .select({ count: sql<number>`count(*)::integer` })
@@ -240,12 +313,22 @@ export class PostgresWorkspaceStore implements WorkspaceStore {
 
   async compareAndSetNullDefaultAgentTypeId(appId: string, value: string): Promise<number> {
     const defaultAgentTypeId = parseRequiredDefaultAgentTypeId(value)
-    const rows = await this.db
-      .update(workspaces)
-      .set({ defaultAgentTypeId })
-      .where(and(eq(workspaces.appId, appId), isNull(workspaces.defaultAgentTypeId)))
-      .returning({ id: workspaces.id })
-    return rows.length
+    return await this.db.transaction(async (tx) => {
+      const rows = await tx
+        .update(workspaces)
+        .set({ defaultAgentTypeId })
+        .where(and(eq(workspaces.appId, appId), isNull(workspaces.defaultAgentTypeId)))
+        .returning({ id: workspaces.id, createdBy: workspaces.createdBy })
+      if (rows.length > 0) {
+        await tx.insert(workspaceAgentSeats).values(rows.map((row) => ({
+          workspaceId: row.id,
+          agentTypeId: defaultAgentTypeId,
+          source: 'migration-default',
+          enrolledByUserId: row.createdBy,
+        }))).onConflictDoNothing()
+      }
+      return rows.length
+    })
   }
 
   async get(id: string): Promise<Workspace | null> {

--- a/packages/core/src/server/db/stores/__tests__/PostgresWorkspaceStore.test.ts
+++ b/packages/core/src/server/db/stores/__tests__/PostgresWorkspaceStore.test.ts
@@ -751,24 +751,18 @@ describeWorkspaceStoreConformance(
       `
     },
     seedLegacyNullDefaultAgentTypeIds: async (_workspaceStore, workspaceIds) => {
-      // Production keeps the rolling-upgrade guard installed as NOT VALID: it
-      // permits historical NULL rows but blocks new legacy writes. Seed the
-      // complete historical cohort before reinstalling that barrier so store
-      // conformance can exercise the NULL-only CAS authentically.
+      // Seat rollout is additive: legacy writers may still create NULL
+      // defaults until the later enforcement cutover. Manufacture that cohort
+      // directly so conformance can exercise the NULL-only CAS.
       await sqlClient.begin(async (transaction) => {
         await transaction`
           ALTER TABLE workspaces
-          DROP CONSTRAINT workspaces_default_agent_type_id_required_check
+          DROP CONSTRAINT IF EXISTS workspaces_default_agent_type_id_required_check
         `
         await transaction`
           UPDATE workspaces
           SET default_agent_type_id = NULL
           WHERE id = ANY(${workspaceIds}::uuid[])
-        `
-        await transaction`
-          ALTER TABLE workspaces
-          ADD CONSTRAINT workspaces_default_agent_type_id_required_check
-          CHECK (default_agent_type_id IS NOT NULL) NOT VALID
         `
       })
     },

--- a/packages/core/src/shared/types.ts
+++ b/packages/core/src/shared/types.ts
@@ -29,6 +29,23 @@ export type Workspace = {
   readonly defaultAgentTypeId?: string | null
 }
 
+export type WorkspaceAgentSeatSource =
+  | 'signup-intent'
+  | 'generic-default'
+  | 'user-add'
+  | 'migration-default'
+  | 'migration-session'
+  | 'operator'
+
+export type WorkspaceAgentSeat = {
+  seatId: string
+  workspaceId: string
+  agentTypeId: string
+  source: WorkspaceAgentSeatSource
+  enrolledByUserId: string | null
+  createdAt: string
+}
+
 export type WorkspaceMember = {
   workspaceId: string
   userId: string


### PR DESCRIPTION
## Summary
- add the generic `workspace_agent_seats` relation and additive migration/backfill
- create each workspace default Seat atomically with workspace and owner membership
- add parity store APIs for list/has/idempotent add in Postgres and Local modes
- wire opt-in Core enforcement into the generic AgentHost policy from PR #1440
- evaluate Seat before app-owned acting-user entitlement
- resolve opaque Host scope claims back to the real workspace id
- add explicitly configured, owner/editor, add-only Seat management routes
- protect route scope against cross-workspace confused-deputy requests
- expose minimal entitlement-filtered Seat DTOs only
- keep compatibility mode unchanged until migration/census cutover

## Migration safety
- migration first relaxes the previous NOT VALID required-default constraint for old writers
- creates/backfills Seats only for non-null defaults
- NULL reconciliation atomically adds the migration-default Seat
- no removals, session changes, or lifecycle changes

## Validation
- 148 Local/Postgres store tests passed
- 3 focused Core Seat/policy/route/migration tests passed
- Agent package typecheck passed
- Core package typecheck is blocked locally by the unrelated main-branch Workspace `setArchived` generated-package ordering issue; CI builds in dependency order
- two fresh security reviews: all blockers resolved, SHIP
- `git diff --check`