### PR TITLE
Resolve trusted initial Agent Seat intents

### DIFF
--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -88,6 +88,7 @@ import {
   createAuth,
   type BetterAuthInstance,
   type CoreDynamicAuthBaseURL,
+  type ResolveInitialAgentSeat,
 } from '../../server/auth/index.js'
 import {
   authorizeRequestScopedWorkspace,
@@ -325,6 +326,8 @@ export interface CreateCoreWorkspaceAgentServerOptions {
   appRoot?: string
   /** Opt into host-local auth callback URLs for an exact host allowlist. */
   authBaseURL?: CoreDynamicAuthBaseURL
+  /** Trusted app-owned server resolver for initial signup Seat intent. */
+  resolveInitialAgentSeat?: ResolveInitialAgentSeat
   config?: CoreConfig
   loadConfigOptions?: LoadConfigOptions
   plugins?: CoreWorkspacePluginEntry[]
@@ -1031,6 +1034,7 @@ async function createCoreRuntime(
   customTelemetry?: TelemetrySink,
   requestScopeResolver?: CoreRequestScopeResolver,
   authBaseURL?: CoreDynamicAuthBaseURL,
+  resolveInitialAgentSeat?: ResolveInitialAgentSeat,
 ): Promise<{
   app: CoreWorkspaceAgentServer
   sql: postgres.Sql
@@ -1067,6 +1071,7 @@ async function createCoreRuntime(
     logger: app.log,
     telemetry,
     disableDefaultWorkspaceCreation: requestScopeResolver !== undefined,
+    resolveInitialAgentSeat,
   })
 
   app.decorate('db', db)
@@ -1165,6 +1170,7 @@ export async function createCoreWorkspaceAgentServer(
     options.telemetry,
     options.requestScopeResolver,
     options.authBaseURL,
+    options.resolveInitialAgentSeat,
   )
   const appRoot = options.appRoot
   const serveFrontend =

--- a/packages/core/src/server/__tests__/signupAgentDefaults.test.ts
+++ b/packages/core/src/server/__tests__/signupAgentDefaults.test.ts
@@ -244,6 +244,53 @@ describe('signup-domain default-agent initialization (Decision 28 hook)', () => 
     })
   })
 
+  it('prefers a trusted app-resolved signup intent over hostname and boot defaults', async () => {
+    const config = makeConfig()
+    const { store, create } = makeFakeStore()
+    const resolveInitialAgentSeat = vi.fn(async ({ context }: { context: PostSignupContext | null }) => {
+      expect(context?.getHeader?.('cookie')).toBe('agent-intent=opaque')
+      return { agentTypeId: 'charlotteledoux', source: 'signup-intent' as const }
+    })
+    const hook = createPostSignupHook({
+      config,
+      signupAgentDefaults: compileSignupAgentDefaults(
+        config.signupAgentDefaults,
+        ['boring-v2', 'legal', 'charlotteledoux'],
+        config.security?.trustedProxy,
+      ),
+      workspaceStore: store,
+      transport: null,
+      resolveInitialAgentSeat,
+    })
+
+    await hook(user, ctxWithHeaders({
+      cookie: 'agent-intent=opaque',
+      [TRUSTED_SIGNUP_HOSTNAME_HEADER]: 'legal.example',
+    }))
+
+    expect(resolveInitialAgentSeat).toHaveBeenCalledOnce()
+    expect(create).toHaveBeenCalledWith(user.id, 'Default workspace', 'test-app', {
+      isDefault: true,
+      defaultAgentTypeId: 'charlotteledoux',
+      initialAgentSeatSource: 'signup-intent',
+      enrolledByUserId: user.id,
+    })
+  })
+
+  it('fails closed before workspace creation when the trusted intent resolver fails', async () => {
+    const config = makeConfig()
+    const { store, create } = makeFakeStore()
+    const hook = createPostSignupHook({
+      config,
+      workspaceStore: store,
+      transport: null,
+      resolveInitialAgentSeat: async () => { throw new Error('intent store unavailable') },
+    })
+
+    await expect(hook(user, null)).rejects.toThrow('intent store unavailable')
+    expect(create).not.toHaveBeenCalled()
+  })
+
   it('normalizes the host (case/port) before the exact lookup', async () => {
     const { create } = await runSignup({ headers: { [TRUSTED_SIGNUP_HOSTNAME_HEADER]: 'Legal.Example:443' } })
     expect(create.mock.calls[0]![3]).toEqual({

--- a/packages/core/src/server/auth/createAuth.ts
+++ b/packages/core/src/server/auth/createAuth.ts
@@ -15,7 +15,7 @@ import {
   renderResetPassword,
   renderMagicLink,
 } from '../mail/templates/index.js'
-import { createPostSignupHook } from './postSignupHook.js'
+import { createPostSignupHook, type ResolveInitialAgentSeat } from './postSignupHook.js'
 import { isCoreEmailVerificationEnabled } from '../../shared/authPolicy.js'
 import { safeCapture, noopTelemetry, type TelemetrySink } from '../../shared/telemetry.js'
 import type { ValidatedSignupAgentDefaults } from '../signupAgentDefaults.js'
@@ -121,6 +121,7 @@ export interface CreateAuthOptions {
   /** Telemetry sink for auth.signed_up / auth.session_started (defaults to noop). */
   telemetry?: TelemetrySink
   disableDefaultWorkspaceCreation?: boolean
+  resolveInitialAgentSeat?: ResolveInitialAgentSeat
 }
 
 async function createReplayableRequest(request: Request): Promise<Request> {
@@ -209,6 +210,7 @@ export function createAuth(config: CoreConfig, db: Database, opts?: CreateAuthOp
         transport,
         logger: opts.logger,
         disableDefaultWorkspaceCreation: opts.disableDefaultWorkspaceCreation,
+        resolveInitialAgentSeat: opts.resolveInitialAgentSeat,
       })
     : undefined
 

--- a/packages/core/src/server/auth/index.ts
+++ b/packages/core/src/server/auth/index.ts
@@ -5,7 +5,12 @@ export type {
   CreateAuthOptions,
 } from './createAuth.js'
 export { createPostSignupHook } from './postSignupHook.js'
-export type { PostSignupHookDeps } from './postSignupHook.js'
+export type {
+  InitialAgentSeatResolution,
+  PostSignupHookDeps,
+  ResolveInitialAgentSeat,
+  ResolveInitialAgentSeatInput,
+} from './postSignupHook.js'
 export { authHook } from './authHook.js'
 export type { AuthHookOptions } from './authHook.js'
 export { requireWorkspaceMember } from './requireWorkspaceMember.js'

--- a/packages/core/src/server/auth/postSignupHook.ts
+++ b/packages/core/src/server/auth/postSignupHook.ts
@@ -35,6 +35,21 @@ type InviteFailureCode =
   | 'invite_already_accepted'
   | 'invite_email_mismatch'
 
+export interface InitialAgentSeatResolution {
+  agentTypeId: string
+  source: 'signup-intent' | 'generic-default'
+}
+
+export interface ResolveInitialAgentSeatInput {
+  user: PostSignupUser
+  context: PostSignupContext | null
+  applicationDefaultAgentTypeId: string
+}
+
+export type ResolveInitialAgentSeat = (
+  input: ResolveInitialAgentSeatInput,
+) => InitialAgentSeatResolution | undefined | Promise<InitialAgentSeatResolution | undefined>
+
 export interface PostSignupHookDeps {
   config: CoreConfig
   /** Boot-compiled, fleet-validated map. Raw CoreConfig is never consumed. */
@@ -43,6 +58,8 @@ export interface PostSignupHookDeps {
   transport: MailTransport | null
   logger?: { warn: (obj: Record<string, unknown>, msg: string) => void }
   disableDefaultWorkspaceCreation?: boolean
+  /** Trusted app resolver for a server-issued signup intent. */
+  resolveInitialAgentSeat?: ResolveInitialAgentSeat
 }
 
 function readHeader(ctx: PostSignupContext | null, name: string): string | null {
@@ -73,6 +90,7 @@ export function createPostSignupHook(deps: PostSignupHookDeps) {
     transport,
     logger,
     disableDefaultWorkspaceCreation,
+    resolveInitialAgentSeat,
   } = deps
   const applicationDefaultAgentTypeId = parseRequiredDefaultAgentTypeId(config.defaultAgentTypeId)
 
@@ -118,16 +136,25 @@ export function createPostSignupHook(deps: PostSignupHookDeps) {
       // The hostname is read once and matched exactly against boot-validated
       // trusted host configuration; only the resolved Agent id and source are
       // persisted.
+      const resolvedIntent = await resolveInitialAgentSeat?.({
+        user,
+        context: ctx,
+        applicationDefaultAgentTypeId,
+      })
       const signupHostname = normalizeSignupHostname(
         readHeader(ctx, TRUSTED_SIGNUP_HOSTNAME_HEADER),
       )
       const signupSeat = resolveSignupDefaultAgentTypeId(signupAgentDefaults, signupHostname)
-      const initialSeat = signupSeat ?? applicationDefaultAgentTypeId
+      const initialSeat = parseRequiredDefaultAgentTypeId(
+        resolvedIntent?.agentTypeId ?? signupSeat ?? applicationDefaultAgentTypeId,
+      )
+      const initialSeatSource = resolvedIntent?.source
+        ?? (signupSeat ? 'signup-intent' : 'generic-default')
       await workspaceStore.create(user.id, 'Default workspace', config.appId, {
         isDefault: true,
         // Decision 28: every initialized Workspace persists a real default.
         defaultAgentTypeId: initialSeat,
-        initialAgentSeatSource: signupSeat ? 'signup-intent' : 'generic-default',
+        initialAgentSeatSource: initialSeatSource,
         enrolledByUserId: user.id,
       })
     }


### PR DESCRIPTION
## Summary
- add an optional server-composition-only initial Agent Seat resolver
- invoke it before trusted-host and application-default fallback
- validate the returned Agent id grammar
- preserve invite and generic signup behavior when no intent resolves
- fail closed before workspace creation when the resolver is unavailable
- keep workspace, owner membership, default Agent, and Seat creation atomic

The embedding app remains responsible for cryptographically validating its opaque signup intent; client headers are not trusted by Core.

## Validation
- 29 focused signup and request-scope tests passed
- Agent typecheck passed
- fresh security review: SHIP
- `git diff --check`