### PR TITLE
fix(full-app): automatic JSX runtime in dev for cross-package sources (#1444)

### DIFF
--- a/apps/full-app/src/server/__tests__/devJsxRuntime.test.ts
+++ b/apps/full-app/src/server/__tests__/devJsxRuntime.test.ts
@@ -1,0 +1,59 @@
+import { execFileSync } from 'node:child_process'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+// Regression test for #1444: the full-app *dev* harness (tsx, launched with
+// cwd=apps/full-app) crashed rendering the verification email with "React is
+// not defined", even though PR #1439 (#1438) fixed the *build*. Root cause:
+// tsx resolves whether a discovered tsconfig applies to a given source file
+// by checking that file against the tsconfig's `include` globs — not just by
+// aliasing it via `paths`. apps/full-app/tsconfig.json's `paths` map
+// `@hachej/boring-core/server` etc. to `../../packages/core/src/...`, but its
+// `include` only covered `src/**/*` inside apps/full-app itself. Any
+// cross-package .tsx file reached through those aliases (e.g. the mail
+// templates under packages/core/src/server/mail/templates) therefore fell
+// outside the resolved tsconfig's scope and got esbuild's default *classic*
+// JSX transform instead of the automatic runtime the whole monorepo assumes
+// — hence "React is not defined" at SSR.
+//
+// A vitest unit test that imports the templates directly (like
+// templates.test.ts in packages/core) cannot catch this: vitest applies its
+// own automatic-jsx transform regardless of tsx's cwd-scoped tsconfig
+// resolution. This test instead runs the exact same command the dev harness
+// runs — `node --import tsx` with cwd=apps/full-app — as a real subprocess,
+// so it exercises tsx's actual tsconfig-applicability check. Before the fix
+// (apps/full-app/tsconfig.json's `include` not covering the aliased package
+// src dirs), this reproduces the crash; after the fix it renders cleanly.
+
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
+
+function renderCrossPackageTemplateViaDevTsx(): string {
+  const script = `
+    import('../../packages/core/src/server/mail/templates/index.ts').then(async (templates) => {
+      const email = await templates.renderVerifyEmail({
+        to: 'devjsx-guard@example.test',
+        verifyUrl: 'https://app.test/verify?token=abc',
+        appName: 'GuardTest',
+        expiresInHours: 24,
+      })
+      process.stdout.write(email.subject)
+    }).catch((error) => {
+      console.error(error.stack)
+      process.exit(1)
+    })
+  `
+
+  return execFileSync(process.execPath, ['--import', 'tsx', '-e', script], {
+    cwd: appRoot,
+    encoding: 'utf8',
+    timeout: 30_000,
+  })
+}
+
+describe('full-app dev harness JSX resolution for cross-package sources (#1444)', () => {
+  it('renders a cross-package mail template (packages/core/src/server/mail/templates) via the real dev tsx invocation, cwd=apps/full-app', () => {
+    const subject = renderCrossPackageTemplateViaDevTsx()
+    expect(subject).toContain('Verify your GuardTest email address')
+  })
+})

--- a/apps/full-app/tsconfig.json
+++ b/apps/full-app/tsconfig.json
@@ -53,10 +53,24 @@
   "include": [
     "src/**/*",
     "scripts/**/*.ts",
-    "vite.config.ts"
+    "vite.config.ts",
+    "../../packages/agent/src/**/*",
+    "../../packages/boring-bash/src/**/*",
+    "../../packages/boring-sandbox/src/**/*",
+    "../../packages/core/src/**/*",
+    "../../packages/workspace/src/**/*",
+    "../../plugins/boring-automation/src/**/*",
+    "../../plugins/boring-governance/src/**/*",
+    "../../plugins/boring-mcp/src/**/*"
   ],
   "exclude": [
     "node_modules",
-    "dist"
+    "dist",
+    "../../packages/*/src/**/__tests__/**",
+    "../../packages/*/src/**/eval/**",
+    "../../packages/*/host/**",
+    "../../packages/*/test-host/**",
+    "../../plugins/*/src/**/__tests__/**",
+    "../../plugins/*/src/**/eval/**"
   ]
 }


### PR DESCRIPTION
## Root cause

apps/full-app's dev harness (`tsx`) crashed rendering the signup verification email with `React is not defined`, even after #1439 fixed the *dist* build.

`tsx` decides whether a discovered tsconfig applies to a given source file by checking that file against the tsconfig's `include` globs — not just by resolving it via `paths`. `apps/full-app/tsconfig.json` aliases `@hachej/boring-core/server` (and other cross-package imports) to `../../packages/core/src/...`, but its `include` only covered `apps/full-app`'s own `src/**/*`. Any cross-package `.tsx` file reached through those aliases — e.g. `packages/core/src/server/mail/templates/VerifyEmail.tsx` — fell outside the resolved tsconfig's scope and got esbuild's default **classic** JSX transform instead of the automatic runtime the whole monorepo assumes for `.tsx` files. Hence `React is not defined` at SSR.

Confirmed via a minimal repro: `node --import tsx` importing the mail template with `cwd=packages/core` succeeds; the identical import with `cwd=apps/full-app` (the real dev harness's cwd) fails — and crucially, even pointing `TSX_TSCONFIG_PATH` explicitly at `apps/full-app/tsconfig.json` (which already declares `"jsx": "react-jsx"`) still failed, until `include` was widened to cover the aliased package source dir. That isolates the bug to the `include`-glob applicability check, not simple cwd tsconfig discovery.

## Option chosen + trade-off

Chose **(a)-adjacent**: widen `apps/full-app/tsconfig.json`'s `include` to cover every package/plugin `src/` dir reachable via its `paths` aliases (agent, boring-bash, boring-sandbox, core, workspace, boring-automation, boring-governance, boring-mcp), with matching `exclude` entries for `__tests__`/`eval`/`host`/`test-host` dirs so `tsc --noEmit` doesn't pull in test-only files that assume a different tsconfig (vitest globals, `@agent-test-host` path alias, etc.).

Rejected **(b)** (point full-app dev aliases at core's dist, like workspace-playground): that would match prod semantics for module resolution, but core's dist is per-package tsup output while full-app's SSR mail templates need live edits during dev without a rebuild step — the DX cost (core edit → rebuild → restart) doesn't match this repo's dev-loop conventions, and full-app's own tsconfig already declares the correct `jsx: react-jsx` for every one of these files (they just weren't in scope). Widening `include` keeps dev DX intact (edit `packages/core/src` → tsx picks it up immediately) **and** matches prod semantics exactly, since the JSX mode itself was never the problem — only which files tsx considered "covered" by that mode.

Verified this adds **zero new typecheck errors**: `tsc --noEmit` before and after the change both report the same single pre-existing, unrelated error in `packages/workspace/src/app/front/WorkspaceAgentFront.tsx:568` (missing `setArchived` on `UsePiSessionsResult`) — confirmed present on `origin/main` too.

## Guard against regression

Added `apps/full-app/src/server/__tests__/devJsxRuntime.test.ts`, which spawns the *actual* dev-harness command (`node --import tsx`, `cwd=apps/full-app`) as a subprocess and renders `VerifyEmail` through the real cross-package alias resolution path. A vitest-native import test can't catch this class of bug — vitest applies its own automatic-JSX transform regardless of tsx's cwd-scoped tsconfig resolution (same reasoning as `jsxRuntimeBuild.test.ts` in packages/core for the build-side fix). Confirmed the guard fails with `React is not defined` when the `tsconfig.json` fix is reverted, and passes with it applied.

## End-to-end proof

Booted full-app dev (`pnpm run build:deps && pnpm run dev:app`) against a dedicated Postgres role/database (`smoke1444` / `fullapp_smoke_1444`, since dropped) with `MAIL_TRANSPORT_URL=console://`, `PORT=4444`, `FRONTEND_PORT=5460`.

1. `POST /auth/sign-up/email` → **200 OK**.
2. The rendered verification email printed to the console transport in full (no crash):
   ```
   [mail:console] {"type":"mail_sent",...,"subject":"Verify your Seneca AI email address",
   "html":"...<a href=\"http://localhost:4444/auth/verify-email?token=...\">Verify email</a>...",
   "text":"...Verify email http://localhost:4444/auth/verify-email?token=...","timestamp":"..."}
   ```
3. Followed the verify link through the real Vite dev frontend (port 5460, proxying `/auth` to the API like the actual dev harness) in a headless browser, clicked "Continue", and landed on `/workspace/<id>` — **zero DB intervention**. `email_verified` flipped to `t` in Postgres from the auth flow alone.
4. Screenshot of the landed workspace (sidebar "Default workspace", chat panel, "Smoke Continue" account) was captured locally during this session at `04-workspace-landed.png` — not attached here since it's not committed to the repo; available on request.
5. Full `apps/full-app` vitest suite: **47 tests passed (6 files)**, including the new guard.

Fixes #1444.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQgxe5KTr2N2pjgjgKPXHK