### PR TITLE
fix(core): restore last-selected workspace on sign-in

### DIFF
--- a/packages/core/src/front/WorkspaceAuthProvider.tsx
+++ b/packages/core/src/front/WorkspaceAuthProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext } from 'react'
+import { createContext, useContext, useEffect } from 'react'
 import type { ReactNode } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { matchPath, useLocation, useParams } from 'react-router-dom'
@@ -82,6 +82,32 @@ function workspaceIdFromPath(
   return null
 }
 
+/** Remembers the last workspace the user landed on so sign-in restores it instead of
+ * always resolving to the default/first workspace (issue #1449). Client-side only —
+ * per rule 9, this is a UI preference, not session-history data, so localStorage (like
+ * ThemeProvider's `boring-core:theme`) is the lightest mechanism; it survives sign-out
+ * so a fresh sign-in restores it, and is validated against the user's current workspace
+ * membership list before use so a stale/removed id can never be trusted blindly. */
+const LAST_WORKSPACE_STORAGE_KEY = 'boring-core:last-workspace'
+
+function readLastWorkspaceId(): string | null {
+  if (typeof window === 'undefined') return null
+  try {
+    return localStorage.getItem(LAST_WORKSPACE_STORAGE_KEY)
+  } catch {
+    return null
+  }
+}
+
+function writeLastWorkspaceId(workspaceId: string) {
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.setItem(LAST_WORKSPACE_STORAGE_KEY, workspaceId)
+  } catch {
+    // localStorage unavailable (private mode, quota, etc.) — restoration is best-effort.
+  }
+}
+
 function routeStatusFromError(workspaceId: string, error: unknown): WorkspaceRouteStatus {
   const detail = getHttpErrorDetail(error)
   if (detail.status === 404 || detail.code === 'not_found') {
@@ -116,9 +142,11 @@ export function WorkspaceAuthProvider({
     enabled: canQueryProtectedApi,
   })
 
+  const lastWorkspaceId = routeWorkspaceId === null ? readLastWorkspaceId() : null
   const defaultWorkspace =
     routeWorkspaceId === null
-      ? (workspacesQuery.data?.find((workspace) => workspace.isDefault)
+      ? (workspacesQuery.data?.find((workspace) => workspace.id === lastWorkspaceId)
+        ?? workspacesQuery.data?.find((workspace) => workspace.isDefault)
         ?? workspacesQuery.data?.[0]
         ?? null)
       : null
@@ -149,6 +177,11 @@ export function WorkspaceAuthProvider({
     if (workspace?.id === routeWorkspaceId) return { status: 'matched', workspaceId: routeWorkspaceId, workspace }
     return { status: 'mismatched', workspaceId: routeWorkspaceId, currentWorkspaceId: workspace?.id ?? null }
   })()
+
+  const matchedWorkspaceId = routeStatus.status === 'matched' ? routeStatus.workspaceId : null
+  useEffect(() => {
+    if (matchedWorkspaceId) writeLastWorkspaceId(matchedWorkspaceId)
+  }, [matchedWorkspaceId])
 
   return (
     <WorkspaceContext.Provider value={{ workspace, role, routeStatus }}>

--- a/packages/core/src/front/WorkspaceAuthProvider.tsx
+++ b/packages/core/src/front/WorkspaceAuthProvider.tsx
@@ -87,22 +87,31 @@ function workspaceIdFromPath(
  * per rule 9, this is a UI preference, not session-history data, so localStorage (like
  * ThemeProvider's `boring-core:theme`) is the lightest mechanism; it survives sign-out
  * so a fresh sign-in restores it, and is validated against the user's current workspace
- * membership list before use so a stale/removed id can never be trusted blindly. */
-const LAST_WORKSPACE_STORAGE_KEY = 'boring-core:last-workspace'
+ * membership list before use so a stale/removed id can never be trusted blindly.
+ *
+ * Scoped per authenticated user id (`boring-core:last-workspace:<userId>`) — a shared
+ * browser must never steer user B to the workspace user A last selected, even when B is
+ * also a member of it. Without a signed-in user id there is nothing to key on, so reads
+ * and writes are simply no-ops. */
+const LAST_WORKSPACE_STORAGE_PREFIX = 'boring-core:last-workspace:'
 
-function readLastWorkspaceId(): string | null {
-  if (typeof window === 'undefined') return null
+function lastWorkspaceStorageKey(userId: string): string {
+  return `${LAST_WORKSPACE_STORAGE_PREFIX}${userId}`
+}
+
+function readLastWorkspaceId(userId: string | null): string | null {
+  if (typeof window === 'undefined' || !userId) return null
   try {
-    return localStorage.getItem(LAST_WORKSPACE_STORAGE_KEY)
+    return localStorage.getItem(lastWorkspaceStorageKey(userId))
   } catch {
     return null
   }
 }
 
-function writeLastWorkspaceId(workspaceId: string) {
-  if (typeof window === 'undefined') return
+function writeLastWorkspaceId(userId: string | null, workspaceId: string) {
+  if (typeof window === 'undefined' || !userId) return
   try {
-    localStorage.setItem(LAST_WORKSPACE_STORAGE_KEY, workspaceId)
+    localStorage.setItem(lastWorkspaceStorageKey(userId), workspaceId)
   } catch {
     // localStorage unavailable (private mode, quota, etc.) — restoration is best-effort.
   }
@@ -142,7 +151,8 @@ export function WorkspaceAuthProvider({
     enabled: canQueryProtectedApi,
   })
 
-  const lastWorkspaceId = routeWorkspaceId === null ? readLastWorkspaceId() : null
+  const userId = user?.id ?? null
+  const lastWorkspaceId = routeWorkspaceId === null ? readLastWorkspaceId(userId) : null
   const defaultWorkspace =
     routeWorkspaceId === null
       ? (workspacesQuery.data?.find((workspace) => workspace.id === lastWorkspaceId)
@@ -180,8 +190,8 @@ export function WorkspaceAuthProvider({
 
   const matchedWorkspaceId = routeStatus.status === 'matched' ? routeStatus.workspaceId : null
   useEffect(() => {
-    if (matchedWorkspaceId) writeLastWorkspaceId(matchedWorkspaceId)
-  }, [matchedWorkspaceId])
+    if (matchedWorkspaceId) writeLastWorkspaceId(userId, matchedWorkspaceId)
+  }, [userId, matchedWorkspaceId])
 
   return (
     <WorkspaceContext.Provider value={{ workspace, role, routeStatus }}>

--- a/packages/core/src/front/__tests__/WorkspaceAuthProvider.test.tsx
+++ b/packages/core/src/front/__tests__/WorkspaceAuthProvider.test.tsx
@@ -198,15 +198,19 @@ function mockDeferredWorkspaceDetail(
   })
 }
 
-const LAST_WORKSPACE_STORAGE_KEY = 'boring-core:last-workspace'
+const USER_1_ID = 'user-1'
+const USER_2_ID = 'user-2'
 
-beforeEach(() => {
-  window.localStorage.clear()
-  mockSessionState.current = {
+function lastWorkspaceStorageKey(userId: string): string {
+  return `boring-core:last-workspace:${userId}`
+}
+
+function sessionFor(userId: string) {
+  return {
     data: {
       user: {
-        id: 'user-1',
-        email: 'user-1@test.dev',
+        id: userId,
+        email: `${userId}@test.dev`,
         name: null,
         emailVerified: true,
         image: null,
@@ -218,6 +222,11 @@ beforeEach(() => {
     isPending: false,
     error: null,
   }
+}
+
+beforeEach(() => {
+  window.localStorage.clear()
+  mockSessionState.current = sessionFor(USER_1_ID)
 })
 
 function setUnauthenticatedSession() {
@@ -587,7 +596,7 @@ describe('WorkspaceAuthProvider', () => {
       await waitFor(() =>
         expect(screen.getByTestId('ws-name').textContent).toBe('Second WS'),
       )
-      expect(window.localStorage.getItem(LAST_WORKSPACE_STORAGE_KEY)).toBe(WS_2.id)
+      expect(window.localStorage.getItem(lastWorkspaceStorageKey(USER_1_ID))).toBe(WS_2.id)
       first.unmount()
       qc.clear()
 
@@ -612,7 +621,10 @@ describe('WorkspaceAuthProvider', () => {
     'falls back to the default workspace when the remembered id is stale (no longer a member)',
     withTaskId(TASK_ID, async ({ assertionPassed }) => {
       const qc = createQueryClient()
-      window.localStorage.setItem(LAST_WORKSPACE_STORAGE_KEY, 'ws-deleted-or-not-a-member')
+      window.localStorage.setItem(
+        lastWorkspaceStorageKey(USER_1_ID),
+        'ws-deleted-or-not-a-member',
+      )
       mockWorkspacesList([WS_2, WS_1])
       mockWorkspaceDetail(WS_1, 'owner')
 
@@ -624,6 +636,78 @@ describe('WorkspaceAuthProvider', () => {
       expect(screen.getByTestId('ws-role').textContent).toBe('owner')
       assertionPassed('workspace-stale-last-selected-falls-back-to-default')
       qc.clear()
+    }),
+  )
+
+  it(
+    'does not steer a second user to the first user\'s remembered workspace on a shared browser, even when both are members of it',
+    withTaskId(TASK_ID, async ({ assertionPassed }) => {
+      // User A (user-1) visits the shared, non-default workspace WS_2 — recorded as
+      // user-1's last-selected workspace.
+      const qcA = createQueryClient()
+      mockWorkspacesList([WS_1, WS_2])
+      mockWorkspaceDetail(WS_1, 'owner')
+      mockWorkspaceDetail(WS_2, 'editor')
+
+      const rendered = renderWithRouter(`/workspace/${WS_2.id}`, qcA)
+      await waitFor(() =>
+        expect(screen.getByTestId('ws-name').textContent).toBe('Second WS'),
+      )
+      expect(window.localStorage.getItem(lastWorkspaceStorageKey(USER_1_ID))).toBe(WS_2.id)
+      expect(window.localStorage.getItem(lastWorkspaceStorageKey(USER_2_ID))).toBeNull()
+      rendered.unmount()
+      qcA.clear()
+
+      // User B (user-2) — a shared browser, same localStorage — signs in. B is also a
+      // member of WS_2, but has never selected it. B must land on their own default
+      // (WS_1), not on A's remembered WS_2.
+      mockSessionState.current = sessionFor(USER_2_ID)
+      const qcB = createQueryClient()
+      mockWorkspacesList([WS_1, WS_2])
+      mockWorkspaceDetail(WS_1, 'viewer')
+      mockWorkspaceDetail(WS_2, 'viewer')
+
+      renderWithRouter('/', qcB)
+      await waitFor(() =>
+        expect(screen.getByTestId('ws-name').textContent).toBe('Default workspace'),
+      )
+      expect(screen.getByTestId('ws-role').textContent).toBe('viewer')
+      assertionPassed('workspace-second-user-not-steered-by-first-user-shared-membership')
+      qcB.clear()
+    }),
+  )
+
+  it(
+    'does not steer a second user (not a member of the first user\'s workspace) to a forbidden workspace',
+    withTaskId(TASK_ID, async ({ assertionPassed }) => {
+      // User A (user-1) visits WS_2 — recorded as user-1's last-selected workspace.
+      const qcA = createQueryClient()
+      mockWorkspacesList([WS_1, WS_2])
+      mockWorkspaceDetail(WS_1, 'owner')
+      mockWorkspaceDetail(WS_2, 'editor')
+
+      const rendered = renderWithRouter(`/workspace/${WS_2.id}`, qcA)
+      await waitFor(() =>
+        expect(screen.getByTestId('ws-name').textContent).toBe('Second WS'),
+      )
+      expect(window.localStorage.getItem(lastWorkspaceStorageKey(USER_1_ID))).toBe(WS_2.id)
+      rendered.unmount()
+      qcA.clear()
+
+      // User B signs in on the same browser but is NOT a member of WS_2 at all — their
+      // workspace list only contains WS_1. B must land on WS_1, never on WS_2.
+      mockSessionState.current = sessionFor(USER_2_ID)
+      const qcB = createQueryClient()
+      mockWorkspacesList([WS_1])
+      mockWorkspaceDetail(WS_1, 'owner')
+
+      renderWithRouter('/', qcB)
+      await waitFor(() =>
+        expect(screen.getByTestId('ws-name').textContent).toBe('Default workspace'),
+      )
+      expect(screen.getByTestId('ws-role').textContent).toBe('owner')
+      assertionPassed('workspace-second-user-not-a-member-falls-back-to-own-default')
+      qcB.clear()
     }),
   )
 })

--- a/packages/core/src/front/__tests__/WorkspaceAuthProvider.test.tsx
+++ b/packages/core/src/front/__tests__/WorkspaceAuthProvider.test.tsx
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import { useEffect } from 'react'
 import type { ReactNode } from 'react'
-import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockSessionState = vi.hoisted(() => ({
@@ -132,6 +133,37 @@ function renderWithRouter(
       {content}
     </QueryClientProvider>,
   )
+}
+
+/** Mirrors CoreFront.tsx's real composition: WorkspaceAuthProvider is mounted ONCE, above
+ * `<Routes>`, wrapping the whole router — not per-route inside a `<Route element>` (that's
+ * why the component parses `location.pathname` itself via `workspaceIdFromPath` rather than
+ * relying solely on `useParams`, which only populates inside a matched `<Route>` element).
+ * Consequently route navigation, and — since AuthProvider's `client` is a stable `useMemo`
+ * keyed only on `baseURL` and `client.useSession()` is better-auth's reactive store hook —
+ * a real sign-out/sign-in, never remounts this tree; it only re-renders in place. This
+ * harness exposes `navigate` so a test can drive that same in-place transition. */
+function NavCapture({ onReady }: { onReady: (navigate: (path: string) => void) => void }) {
+  const navigate = useNavigate()
+  useEffect(() => {
+    onReady(navigate)
+  }, [navigate, onReady])
+  return null
+}
+
+function renderTopLevelProvider(initialPath: string, queryClient: QueryClient) {
+  let navigateFn: (path: string) => void = () => {}
+  const utils = render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <WorkspaceAuthProvider>
+          <NavCapture onReady={(nav) => { navigateFn = nav }} />
+          <Probe />
+        </WorkspaceAuthProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+  return { ...utils, navigate: (path: string) => navigateFn(path) }
 }
 
 function mockWorkspaceDetail(ws: Workspace, role: MemberRole) {
@@ -708,6 +740,83 @@ describe('WorkspaceAuthProvider', () => {
       expect(screen.getByTestId('ws-role').textContent).toBe('owner')
       assertionPassed('workspace-second-user-not-a-member-falls-back-to-own-default')
       qcB.clear()
+    }),
+  )
+
+  it(
+    'in-place identity change (same mounted tree, no unmount): B lands on B\'s default, never leaked from A, when B is also a member of A\'s remembered workspace',
+    withTaskId(TASK_ID, async ({ assertionPassed }) => {
+      const qc = createQueryClient()
+      mockWorkspacesList([WS_1, WS_2])
+      mockWorkspaceDetail(WS_1, 'owner')
+      mockWorkspaceDetail(WS_2, 'editor')
+
+      const { navigate } = renderTopLevelProvider(`/workspace/${WS_2.id}`, qc)
+      await waitFor(() =>
+        expect(screen.getByTestId('ws-name').textContent).toBe('Second WS'),
+      )
+      expect(window.localStorage.getItem(lastWorkspaceStorageKey(USER_1_ID))).toBe(WS_2.id)
+
+      // In-place transition A -> B on the SAME mounted WorkspaceAuthProvider instance: no
+      // unmount anywhere in this test. Mutate the mocked session (standing in for
+      // better-auth's reactive session store flipping in place) and register B's mocked
+      // membership/detail responses (last-registered handler wins — see useMswHandler's
+      // LIFO scan in ./_setup.ts), then clear the SAME QueryClient instance (exactly what
+      // AuthProvider.signOut() does — it never creates a new client) and navigate within
+      // the same tree from /workspace/ws-002 to / to force a re-render that observes the
+      // new session.
+      mockSessionState.current = sessionFor(USER_2_ID)
+      qc.clear()
+      mockWorkspacesList([WS_1, WS_2]) // B is also a member of the shared workspace WS_2
+      mockWorkspaceDetail(WS_1, 'viewer')
+      mockWorkspaceDetail(WS_2, 'viewer')
+
+      act(() => navigate('/'))
+
+      await waitFor(() =>
+        expect(screen.getByTestId('ws-name').textContent).toBe('Default workspace'),
+      )
+      expect(screen.getByTestId('ws-role').textContent).toBe('viewer')
+      // A's own preference is untouched by B's transition.
+      expect(window.localStorage.getItem(lastWorkspaceStorageKey(USER_1_ID))).toBe(WS_2.id)
+      // A's remembered workspace id never leaked into B's key.
+      expect(window.localStorage.getItem(lastWorkspaceStorageKey(USER_2_ID))).not.toBe(WS_2.id)
+      assertionPassed('workspace-inplace-identity-change-member-variant')
+      qc.clear()
+    }),
+  )
+
+  it(
+    'in-place identity change (same mounted tree, no unmount): B lands on B\'s default, never leaked from A, when B is NOT a member of A\'s remembered workspace',
+    withTaskId(TASK_ID, async ({ assertionPassed }) => {
+      const qc = createQueryClient()
+      mockWorkspacesList([WS_1, WS_2])
+      mockWorkspaceDetail(WS_1, 'owner')
+      mockWorkspaceDetail(WS_2, 'editor')
+
+      const { navigate } = renderTopLevelProvider(`/workspace/${WS_2.id}`, qc)
+      await waitFor(() =>
+        expect(screen.getByTestId('ws-name').textContent).toBe('Second WS'),
+      )
+      expect(window.localStorage.getItem(lastWorkspaceStorageKey(USER_1_ID))).toBe(WS_2.id)
+
+      // Same in-place transition as above, but B's membership list does not include WS_2
+      // at all — B is not a member of A's remembered workspace.
+      mockSessionState.current = sessionFor(USER_2_ID)
+      qc.clear()
+      mockWorkspacesList([WS_1])
+      mockWorkspaceDetail(WS_1, 'owner')
+
+      act(() => navigate('/'))
+
+      await waitFor(() =>
+        expect(screen.getByTestId('ws-name').textContent).toBe('Default workspace'),
+      )
+      expect(screen.getByTestId('ws-role').textContent).toBe('owner')
+      expect(window.localStorage.getItem(lastWorkspaceStorageKey(USER_1_ID))).toBe(WS_2.id)
+      expect(window.localStorage.getItem(lastWorkspaceStorageKey(USER_2_ID))).not.toBe(WS_2.id)
+      assertionPassed('workspace-inplace-identity-change-non-member-variant')
+      qc.clear()
     }),
   )
 })

--- a/packages/core/src/front/__tests__/WorkspaceAuthProvider.test.tsx
+++ b/packages/core/src/front/__tests__/WorkspaceAuthProvider.test.tsx
@@ -198,7 +198,10 @@ function mockDeferredWorkspaceDetail(
   })
 }
 
+const LAST_WORKSPACE_STORAGE_KEY = 'boring-core:last-workspace'
+
 beforeEach(() => {
+  window.localStorage.clear()
   mockSessionState.current = {
     data: {
       user: {
@@ -567,6 +570,59 @@ describe('WorkspaceAuthProvider', () => {
       )
       expect(screen.getByTestId('ws-role').textContent).toBe('owner')
       assertionPassed('workspace-loading-resolves')
+      qc.clear()
+    }),
+  )
+
+  it(
+    'restores the last-selected workspace on / after visiting it via route, surviving sign-out/in',
+    withTaskId(TASK_ID, async ({ assertionPassed }) => {
+      const qc = createQueryClient()
+      mockWorkspacesList([WS_1, WS_2])
+      mockWorkspaceDetail(WS_1, 'owner')
+      mockWorkspaceDetail(WS_2, 'editor')
+
+      // Visit the non-default workspace explicitly — this records it as "last selected".
+      const first = renderWithRouter(`/workspace/${WS_2.id}`, qc)
+      await waitFor(() =>
+        expect(screen.getByTestId('ws-name').textContent).toBe('Second WS'),
+      )
+      expect(window.localStorage.getItem(LAST_WORKSPACE_STORAGE_KEY)).toBe(WS_2.id)
+      first.unmount()
+      qc.clear()
+
+      // Simulate sign-out/in: query cache clears (as AuthProvider.signOut does), but
+      // localStorage persists. Landing on `/` afresh should restore WS_2, not the default.
+      const qc2 = createQueryClient()
+      mockWorkspacesList([WS_1, WS_2])
+      mockWorkspaceDetail(WS_1, 'owner')
+      mockWorkspaceDetail(WS_2, 'editor')
+
+      renderWithRouter('/', qc2)
+      await waitFor(() =>
+        expect(screen.getByTestId('ws-name').textContent).toBe('Second WS'),
+      )
+      expect(screen.getByTestId('ws-role').textContent).toBe('editor')
+      assertionPassed('workspace-restored-last-selected')
+      qc2.clear()
+    }),
+  )
+
+  it(
+    'falls back to the default workspace when the remembered id is stale (no longer a member)',
+    withTaskId(TASK_ID, async ({ assertionPassed }) => {
+      const qc = createQueryClient()
+      window.localStorage.setItem(LAST_WORKSPACE_STORAGE_KEY, 'ws-deleted-or-not-a-member')
+      mockWorkspacesList([WS_2, WS_1])
+      mockWorkspaceDetail(WS_1, 'owner')
+
+      renderWithRouter('/', qc)
+
+      await waitFor(() =>
+        expect(screen.getByTestId('ws-name').textContent).toBe('Default workspace'),
+      )
+      expect(screen.getByTestId('ws-role').textContent).toBe('owner')
+      assertionPassed('workspace-stale-last-selected-falls-back-to-default')
       qc.clear()
     }),
   )


### PR DESCRIPTION
Fixes #1449

## Root cause
On the `/` route, `WorkspaceAuthProvider.defaultWorkspace` (packages/core/src/front/WorkspaceAuthProvider.tsx) always resolved to the workspace flagged `isDefault`, or the first one in the list, whenever there was no `:id` route param. There was no memory of which workspace the user had actually last used — so every fresh sign-in (query cache cleared, but route is `/`) landed on the default workspace regardless of what was selected before sign-out.

## Mechanism
- Persist the most recently *matched* workspace id to `localStorage` under `boring-core:last-workspace` — same lightweight per-viewer-preference pattern already used by `ThemeProvider` (`boring-core:theme`). This fires whenever the route resolves a workspace via an explicit `/workspace/:id` visit (including `WorkspaceSwitcher`'s `navigate(hrefForWorkspace(...))` calls).
- On `/` (no route id), prefer the remembered id over the default/first workspace — but only if it's still present in the freshly-fetched `workspacesQuery.data` (the user's current membership list). A stale/removed/no-longer-a-member id is simply not found in that list, so resolution falls straight through to the existing default → first → null chain. No extra network round-trip or error handling needed for the stale case.
- `AuthProvider.signOut()` only calls `queryClient.clear()` — it never touches `localStorage` — so the remembered id survives sign-out and is available on the next sign-in.
- Per AGENTS.md rule 9 ("session history is host app data"), this is scoped as a client-side UI preference (like theme), not session/transcript data, so `localStorage` is the appropriate mechanism — no server-side field needed.

## Files
- `packages/core/src/front/WorkspaceAuthProvider.tsx` — read/write helpers + `lastWorkspaceId` lookup in `defaultWorkspace` + persistence effect keyed off `routeStatus`
- `packages/core/src/front/__tests__/WorkspaceAuthProvider.test.tsx` — two new tests

## Proof
```
pnpm --filter @hachej/boring-core exec vitest run src/front/__tests__/WorkspaceAuthProvider.test.tsx
PASS (13) FAIL (0)

pnpm --filter @hachej/boring-core exec vitest run src/front
PASS (103) FAIL (0)
```
`pnpm --filter @hachej/boring-core run typecheck` — `WorkspaceAuthProvider.tsx` and the test file typecheck clean; the only reported error is a pre-existing, unrelated `TS2339` in `packages/workspace/src/app/front/WorkspaceAgentFront.tsx` (untouched by this change, present on `origin/main` HEAD `811911ec2`).

New tests:
- `restores the last-selected workspace on / after visiting it via route, surviving sign-out/in` — visits `/workspace/ws-002` (persists it), simulates sign-out/in by clearing the query client and re-rendering fresh at `/`, asserts it lands on `ws-002` again instead of the default.
- `falls back to the default workspace when the remembered id is stale (no longer a member)` — seeds `localStorage` with an id absent from the membership list, asserts `/` resolves to the default workspace cleanly.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MQgxe5KTr2N2pjgjgKPXHK