### PR TITLE
#1450 fix(core): carry invite context through the sign-in/sign-up handoff

### DIFF
--- a/packages/core/src/front/__tests__/SignInPage.test.tsx
+++ b/packages/core/src/front/__tests__/SignInPage.test.tsx
@@ -215,12 +215,16 @@ describe('SignInPage', () => {
   it(
     'derives invite_token for the Sign-up link from an invite-accept redirect path',
     withTaskId(EMAIL_AUTH_TASK_ID, async ({ assertionPassed }) => {
-      window.history.pushState({}, '', '/auth/signin?redirect=%2Finvites%2Ftok-abc')
+      window.history.pushState(
+        {},
+        '',
+        `/auth/signin?redirect=${encodeURIComponent('/invites/3fa85f64-5717-4562-b3fc-2c963f66afa6')}`,
+      )
 
       render(<SignInPage />, { wrapper: Wrapper })
 
       expect(screen.getByText(/sign up/i).closest('a')?.getAttribute('href')).toBe(
-        '/auth/signup?redirect=%2Finvites%2Ftok-abc&invite_token=tok-abc',
+        `/auth/signup?redirect=${encodeURIComponent('/invites/3fa85f64-5717-4562-b3fc-2c963f66afa6')}&invite_token=3fa85f64-5717-4562-b3fc-2c963f66afa6`,
       )
       assertionPassed('signin-derives-invite-token')
     }),

--- a/packages/core/src/front/__tests__/SignInPage.test.tsx
+++ b/packages/core/src/front/__tests__/SignInPage.test.tsx
@@ -195,6 +195,38 @@ describe('SignInPage', () => {
   )
 
   it(
+    'forwards redirect and invite_token query params through the Sign-up link',
+    withTaskId(EMAIL_AUTH_TASK_ID, async ({ assertionPassed }) => {
+      window.history.pushState(
+        {},
+        '',
+        '/auth/signin?redirect=%2Finvites%2Ftok-123&invite_token=tok-123',
+      )
+
+      render(<SignInPage />, { wrapper: Wrapper })
+
+      expect(screen.getByText(/sign up/i).closest('a')?.getAttribute('href')).toBe(
+        '/auth/signup?redirect=%2Finvites%2Ftok-123&invite_token=tok-123',
+      )
+      assertionPassed('signin-forwards-invite-context')
+    }),
+  )
+
+  it(
+    'derives invite_token for the Sign-up link from an invite-accept redirect path',
+    withTaskId(EMAIL_AUTH_TASK_ID, async ({ assertionPassed }) => {
+      window.history.pushState({}, '', '/auth/signin?redirect=%2Finvites%2Ftok-abc')
+
+      render(<SignInPage />, { wrapper: Wrapper })
+
+      expect(screen.getByText(/sign up/i).closest('a')?.getAttribute('href')).toBe(
+        '/auth/signup?redirect=%2Finvites%2Ftok-abc&invite_token=tok-abc',
+      )
+      assertionPassed('signin-derives-invite-token')
+    }),
+  )
+
+  it(
     'shows a helpful error when Google redirects back with an OAuth error',
     withTaskId(GOOGLE_AUTH_TASK_ID, async ({ assertionPassed }) => {
       window.history.pushState({}, '', '/auth/signin?error=access_denied&error_description=cancelled')

--- a/packages/core/src/front/__tests__/SignUpPage.test.tsx
+++ b/packages/core/src/front/__tests__/SignUpPage.test.tsx
@@ -196,6 +196,52 @@ describe('SignUpPage', () => {
   )
 
   it(
+    'derives invite_token from a redirect=/invites/:token param and hides Google sign-up',
+    withTaskId(GOOGLE_AUTH_TASK_ID, async ({ assertionPassed }) => {
+      mockUseOptionalConfig.mockReturnValue({ features: { googleOauth: true } })
+      mockSignUpEmail.mockResolvedValue({ data: { user: { id: 'u1' } }, error: null })
+      window.history.pushState({}, '', '/auth/signup?redirect=%2Finvites%2Ftok-xyz')
+
+      render(<SignUpPage />, { wrapper: Wrapper })
+
+      expect(screen.queryByRole('button', { name: /continue with google/i })).toBeNull()
+
+      const user = userEvent.setup()
+      await user.type(screen.getByLabelText(/name/i), 'Invited')
+      await user.type(screen.getByLabelText(/email/i), 'invited@example.com')
+      await user.type(screen.getByLabelText(/password/i), 'secret12345')
+      await user.click(screen.getByRole('button', { name: /sign up/i }))
+
+      await waitFor(() =>
+        expect(mockSignUpEmail).toHaveBeenCalledWith(
+          { email: 'invited@example.com', password: 'secret12345', name: 'Invited' },
+          { headers: { 'x-invite-token': 'tok-xyz' } },
+        ),
+      )
+      assertionPassed('signup-invite-token-from-redirect')
+    }),
+  )
+
+  it(
+    'forwards redirect and invite_token query params through the Sign-in link',
+    withTaskId(EMAIL_AUTH_TASK_ID, async ({ assertionPassed }) => {
+      window.history.pushState(
+        {},
+        '',
+        '/auth/signup?redirect=%2Finvites%2Ftok-123&invite_token=tok-123',
+      )
+
+      render(<SignUpPage />, { wrapper: Wrapper })
+
+      expect(screen.getByText(/already have an account/i).closest('div')
+        ?.querySelector('a')?.getAttribute('href')).toBe(
+        '/auth/signin?redirect=%2Finvites%2Ftok-123&invite_token=tok-123',
+      )
+      assertionPassed('signup-forwards-invite-context')
+    }),
+  )
+
+  it(
     'displays server error inline',
     withTaskId(EMAIL_AUTH_TASK_ID, async ({ assertionPassed }) => {
       mockSignUpEmail.mockResolvedValue({

--- a/packages/core/src/front/__tests__/SignUpPage.test.tsx
+++ b/packages/core/src/front/__tests__/SignUpPage.test.tsx
@@ -200,7 +200,11 @@ describe('SignUpPage', () => {
     withTaskId(GOOGLE_AUTH_TASK_ID, async ({ assertionPassed }) => {
       mockUseOptionalConfig.mockReturnValue({ features: { googleOauth: true } })
       mockSignUpEmail.mockResolvedValue({ data: { user: { id: 'u1' } }, error: null })
-      window.history.pushState({}, '', '/auth/signup?redirect=%2Finvites%2Ftok-xyz')
+      window.history.pushState(
+        {},
+        '',
+        `/auth/signup?redirect=${encodeURIComponent('/invites/3fa85f64-5717-4562-b3fc-2c963f66afa6')}`,
+      )
 
       render(<SignUpPage />, { wrapper: Wrapper })
 
@@ -215,10 +219,42 @@ describe('SignUpPage', () => {
       await waitFor(() =>
         expect(mockSignUpEmail).toHaveBeenCalledWith(
           { email: 'invited@example.com', password: 'secret12345', name: 'Invited' },
-          { headers: { 'x-invite-token': 'tok-xyz' } },
+          { headers: { 'x-invite-token': '3fa85f64-5717-4562-b3fc-2c963f66afa6' } },
         ),
       )
       assertionPassed('signup-invite-token-from-redirect')
+    }),
+  )
+
+  it(
+    'does not derive an invite_token header from a hostile redirect with a trailing segment',
+    withTaskId(GOOGLE_AUTH_TASK_ID, async ({ assertionPassed }) => {
+      mockUseOptionalConfig.mockReturnValue({ features: { googleOauth: true } })
+      mockSignUpEmail.mockResolvedValue({ data: { user: { id: 'u1' } }, error: null })
+      window.history.pushState(
+        {},
+        '',
+        `/auth/signup?redirect=${encodeURIComponent('/invites/3fa85f64-5717-4562-b3fc-2c963f66afa6/trailing')}`,
+      )
+
+      render(<SignUpPage />, { wrapper: Wrapper })
+
+      // No plausible-looking token was carried, so Google sign-up stays available.
+      expect(screen.queryByRole('button', { name: /continue with google/i })).toBeTruthy()
+
+      const user = userEvent.setup()
+      await user.type(screen.getByLabelText(/name/i), 'NotInvited')
+      await user.type(screen.getByLabelText(/email/i), 'not-invited@example.com')
+      await user.type(screen.getByLabelText(/password/i), 'secret12345')
+      await user.click(screen.getByRole('button', { name: /sign up/i }))
+
+      await waitFor(() =>
+        expect(mockSignUpEmail).toHaveBeenCalledWith(
+          { email: 'not-invited@example.com', password: 'secret12345', name: 'NotInvited' },
+          undefined,
+        ),
+      )
+      assertionPassed('signup-rejects-hostile-redirect-token')
     }),
   )
 
@@ -238,6 +274,41 @@ describe('SignUpPage', () => {
         '/auth/signin?redirect=%2Finvites%2Ftok-123&invite_token=tok-123',
       )
       assertionPassed('signup-forwards-invite-context')
+    }),
+  )
+
+  it(
+    'forwards a redirect-only (no invite_token) query param through the Sign-in link',
+    withTaskId(EMAIL_AUTH_TASK_ID, async ({ assertionPassed }) => {
+      window.history.pushState({}, '', '/auth/signup?redirect=%2Fw%2Fsome-workspace%2Fsettings')
+
+      render(<SignUpPage />, { wrapper: Wrapper })
+
+      const href = screen.getByText(/already have an account/i).closest('div')
+        ?.querySelector('a')?.getAttribute('href')
+      expect(href).toBe('/auth/signin?redirect=%2Fw%2Fsome-workspace%2Fsettings')
+      // A non-invite redirect must not fabricate an invite_token on the reverse link.
+      expect(href).not.toContain('invite_token')
+      assertionPassed('signup-forwards-redirect-only')
+    }),
+  )
+
+  it(
+    'derives invite_token for the Sign-in link from a redirect-only invite-accept path',
+    withTaskId(EMAIL_AUTH_TASK_ID, async ({ assertionPassed }) => {
+      window.history.pushState(
+        {},
+        '',
+        `/auth/signup?redirect=${encodeURIComponent('/invites/3fa85f64-5717-4562-b3fc-2c963f66afa6')}`,
+      )
+
+      render(<SignUpPage />, { wrapper: Wrapper })
+
+      expect(screen.getByText(/already have an account/i).closest('div')
+        ?.querySelector('a')?.getAttribute('href')).toBe(
+        `/auth/signin?redirect=${encodeURIComponent('/invites/3fa85f64-5717-4562-b3fc-2c963f66afa6')}&invite_token=3fa85f64-5717-4562-b3fc-2c963f66afa6`,
+      )
+      assertionPassed('signup-derives-invite-token-for-signin-link')
     }),
   )
 

--- a/packages/core/src/front/__tests__/utils.test.ts
+++ b/packages/core/src/front/__tests__/utils.test.ts
@@ -260,6 +260,13 @@ describe('extractInviteTokenFromRedirect', () => {
     ['too-short base64url-looking token', `/invites/${'a'.repeat(20)}`],
     ['too-long base64url-looking token', `/invites/${'a'.repeat(44)}`],
     ['UUID missing a hyphen', '3fa85f645717-4562-b3fc-2c963f66afa6'.replace(/^/, '/invites/')],
+    // randomUUID() can only emit version 4 with an RFC 4122 variant nibble. A
+    // syntactically UUID-shaped string with the wrong version or variant nibble is not a
+    // value randomUUID() can ever produce and must not be extracted as a token.
+    ['UUID with wrong version nibble (v1, not v4)', '/invites/3fa85f64-5717-1562-73fc-2c963f66afa6'],
+    ['UUID with wrong version nibble (v5, not v4)', '/invites/3fa85f64-5717-5562-b3fc-2c963f66afa6'],
+    ['UUID with wrong variant nibble (7, not 8/9/a/b)', '/invites/3fa85f64-5717-4562-73fc-2c963f66afa6'],
+    ['UUID with wrong variant nibble (c, not 8/9/a/b)', '/invites/3fa85f64-5717-4562-c3fc-2c963f66afa6'],
     ['whitespace padding', ` /invites/${'a'.repeat(43)} `],
     ['non-invite redirect target', '/w/some-workspace/settings'],
   ]

--- a/packages/core/src/front/__tests__/utils.test.ts
+++ b/packages/core/src/front/__tests__/utils.test.ts
@@ -11,6 +11,8 @@ import {
   getHttpErrorDetail,
   routes,
   routeHref,
+  extractInviteTokenFromRedirect,
+  withForwardedAuthParams,
 } from '../utils'
 import { HttpError } from '../../shared/errors'
 
@@ -217,5 +219,87 @@ describe('routes + routeHref', () => {
 
   it('routeHref substitutes params', () => {
     expect(routeHref('me', {})).toBe('/me')
+  })
+})
+
+describe('extractInviteTokenFromRedirect', () => {
+  const UUID_TOKEN = '3fa85f64-5717-4562-b3fc-2c963f66afa6'
+  const B64URL_TOKEN = 'dXaVMYAMLyQ_u2TWe6lSES-bxIX50QiETMxWiGl7CKE'
+
+  it('accepts a UUID invite token (LocalWorkspaceStore shape)', () => {
+    expect(extractInviteTokenFromRedirect(`/invites/${UUID_TOKEN}`)).toBe(UUID_TOKEN)
+  })
+
+  it('accepts a base64url invite token (PostgresWorkspaceStore shape)', () => {
+    expect(extractInviteTokenFromRedirect(`/invites/${B64URL_TOKEN}`)).toBe(B64URL_TOKEN)
+  })
+
+  it('accepts a percent-encoded-but-still-valid token unchanged after single decode', () => {
+    // '_' and '-' need no encoding, but a client could still send %5F/%2D for them.
+    const encoded = B64URL_TOKEN.replace(/_/g, '%5F').replace(/-/g, '%2D')
+    expect(extractInviteTokenFromRedirect(`/invites/${encoded}`)).toBe(B64URL_TOKEN)
+  })
+
+  const HOSTILE_CASES: Array<[string, string | null]> = [
+    ['null input', null],
+    ['empty string', ''],
+    ['bare route with no token', '/invites/'],
+    ['trailing segment appended', `/invites/${'a'.repeat(43)}/trailing`],
+    ['unrelated trailing path', `/invites/${'a'.repeat(43)}/../../admin`],
+    ['leading unrelated segment', `/foo/invites/${'a'.repeat(43)}`],
+    ['absolute URL, http', `http://evil.example/invites/${'a'.repeat(43)}`],
+    ['absolute URL, https', `https://evil.example/invites/${'a'.repeat(43)}`],
+    ['protocol-relative URL', `//evil.example/invites/${'a'.repeat(43)}`],
+    ['encoded separator smuggling a slash', '/invites/tok%2Fseparator-etc-etc-etc-etc-etc-x'],
+    ['double-encoded separator', '/invites/tok%252Fseparator-etc-etc-etc-etc-etc'],
+    ['malformed percent-escape', '/invites/%E0%A4%A'],
+    ['lone percent sign', '/invites/tok%en-not-a-real-escape-etc-etc-etc-x'],
+    ['query string smuggled into the segment', `/invites/${'a'.repeat(43)}?x=1`],
+    ['hash smuggled into the segment', `/invites/${'a'.repeat(43)}#frag`],
+    ['plausible-length but wrong alphabet', `/invites/${'!'.repeat(43)}`],
+    ['too-short base64url-looking token', `/invites/${'a'.repeat(20)}`],
+    ['too-long base64url-looking token', `/invites/${'a'.repeat(44)}`],
+    ['UUID missing a hyphen', '3fa85f645717-4562-b3fc-2c963f66afa6'.replace(/^/, '/invites/')],
+    ['whitespace padding', ` /invites/${'a'.repeat(43)} `],
+    ['non-invite redirect target', '/w/some-workspace/settings'],
+  ]
+
+  it.each(HOSTILE_CASES)('rejects: %s', (_label, input) => {
+    expect(extractInviteTokenFromRedirect(input)).toBeNull()
+  })
+})
+
+describe('withForwardedAuthParams', () => {
+  it('forwards redirect only when invite_token is absent and not derivable', () => {
+    expect(withForwardedAuthParams('/auth/signin', '?redirect=%2Fw%2Fsome-workspace%2Fsettings')).toBe(
+      '/auth/signin?redirect=%2Fw%2Fsome-workspace%2Fsettings',
+    )
+  })
+
+  it('forwards redirect only (reverse direction, sign-up -> sign-in)', () => {
+    expect(withForwardedAuthParams('/auth/signup', '?redirect=%2Fw%2Fsome-workspace%2Fsettings')).toBe(
+      '/auth/signup?redirect=%2Fw%2Fsome-workspace%2Fsettings',
+    )
+  })
+
+  it('derives and forwards invite_token from a redirect=/invites/:token path', () => {
+    const token = '3fa85f64-5717-4562-b3fc-2c963f66afa6'
+    const href = withForwardedAuthParams('/auth/signup', `?redirect=${encodeURIComponent(`/invites/${token}`)}`)
+    const params = new URLSearchParams(href.split('?')[1])
+    expect(params.get('redirect')).toBe(`/invites/${token}`)
+    expect(params.get('invite_token')).toBe(token)
+  })
+
+  it('does not fabricate an invite_token from a hostile redirect', () => {
+    const href = withForwardedAuthParams(
+      '/auth/signin',
+      `?redirect=${encodeURIComponent(`/invites/${'a'.repeat(43)}/trailing`)}`,
+    )
+    const params = new URLSearchParams(href.split('?')[1])
+    expect(params.get('invite_token')).toBeNull()
+  })
+
+  it('returns the bare path when neither param is present', () => {
+    expect(withForwardedAuthParams('/auth/signin', '')).toBe('/auth/signin')
   })
 })

--- a/packages/core/src/front/auth/SignInPage.tsx
+++ b/packages/core/src/front/auth/SignInPage.tsx
@@ -6,7 +6,7 @@ import { Button, Card, CardContent, CardDescription, CardFooter, CardHeader, Car
 import { useSignIn } from './AuthProvider.js'
 import { GoogleAuthButton } from './GoogleAuthButton.js'
 import { useOptionalConfig } from '../ConfigProvider.js'
-import { routes } from '../utils.js'
+import { routes, withForwardedAuthParams } from '../utils.js'
 
 const signInSchema = z.object({
   email: z.string().email('Please enter a valid email'),
@@ -23,6 +23,10 @@ function readGoogleAuthError(): string | null {
   return error ? DEFAULT_GOOGLE_SIGNIN_ERROR : null
 }
 
+function readSearch(): string {
+  return typeof window === 'undefined' ? '' : window.location.search
+}
+
 export function SignInPage() {
   const signIn = useSignIn()
   const config = useOptionalConfig()
@@ -30,6 +34,7 @@ export function SignInPage() {
   const [oauthError, setOauthError] = useState<string | null>(() => readGoogleAuthError())
   const [isSubmitting, setIsSubmitting] = useState(false)
   const showGoogleAuth = config?.features.googleOauth === true
+  const signupHref = withForwardedAuthParams(routes.signup, readSearch())
 
   const {
     register,
@@ -122,7 +127,7 @@ export function SignInPage() {
               <a href={routes.forgotPassword} className="text-muted-foreground hover:underline">
                 Forgot password?
               </a>
-              <a href={routes.signup} className="text-muted-foreground hover:underline">
+              <a href={signupHref} className="text-muted-foreground hover:underline">
                 Sign up
               </a>
             </div>

--- a/packages/core/src/front/auth/SignUpPage.tsx
+++ b/packages/core/src/front/auth/SignUpPage.tsx
@@ -8,7 +8,7 @@ import { useSignUp } from './AuthProvider.js'
 import { GoogleAuthButton } from './GoogleAuthButton.js'
 import { isRuntimeEmailVerificationEnabled } from '../../shared/authPolicy.js'
 import { useOptionalConfig } from '../ConfigProvider.js'
-import { routes } from '../utils.js'
+import { extractInviteTokenFromRedirect, routes, withForwardedAuthParams } from '../utils.js'
 
 const signUpSchema = z.object({
   name: z.string().min(1, 'Name is required'),
@@ -35,10 +35,14 @@ export function SignUpPage() {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [success, setSuccess] = useState(false)
 
-  const inviteToken = typeof window !== 'undefined'
-    ? new URLSearchParams(window.location.search).get('invite_token')
-    : null
+  const search = typeof window !== 'undefined' ? window.location.search : ''
+  const searchParams = new URLSearchParams(search)
+  // The invite-accept redirect (?redirect=/invites/:token) carries the token in the path.
+  // Fall back to that so invite context survives even when only `redirect` made it here.
+  const inviteToken = searchParams.get('invite_token')
+    ?? extractInviteTokenFromRedirect(searchParams.get('redirect'))
   const showGoogleAuth = config?.features.googleOauth === true && !inviteToken
+  const signinHref = withForwardedAuthParams(routes.signin, search)
 
   const {
     register,
@@ -86,7 +90,7 @@ export function SignUpPage() {
             </CardDescription>
           </CardHeader>
           <CardFooter>
-            <a href={routes.signin} className="text-sm text-muted-foreground hover:underline">
+            <a href={signinHref} className="text-sm text-muted-foreground hover:underline">
               Back to sign in
             </a>
           </CardFooter>
@@ -171,7 +175,7 @@ export function SignUpPage() {
             </Button>
             <div className="text-sm text-center">
               <span className="text-muted-foreground">Already have an account? </span>
-              <a href={routes.signin} className="hover:underline">
+              <a href={signinHref} className="hover:underline">
                 Sign in
               </a>
             </div>

--- a/packages/core/src/front/utils.ts
+++ b/packages/core/src/front/utils.ts
@@ -170,8 +170,14 @@ const INVITE_ACCEPT_PATH_RE = /^\/invites\/([^/?#]+)$/
 // `randomBytes(32).toString('base64url')`, 43 chars, unpadded). Only these two exact shapes
 // are accepted — anything else (including a decoded separator like `%2F`, which can only
 // ever decode to a `/`) is rejected rather than forwarded as a "close enough" token.
+//
+// The UUID branch is pinned to what `randomUUID()` can actually emit: version nibble `4`
+// (13th hex digit) and RFC 4122 variant nibble `8`/`9`/`a`/`b` (17th hex digit). A
+// syntactically UUID-shaped string with any other version/variant nibble (e.g. a v1 UUID)
+// is not a value `randomUUID()` can produce, so it is rejected rather than accepted as
+// "close enough".
 const INVITE_TOKEN_RE =
-  /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|[A-Za-z0-9_-]{43})$/
+  /^(?:[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|[A-Za-z0-9_-]{43})$/
 
 /**
  * The invite-accept redirect (`?redirect=/invites/:token`) carries the invite token in the

--- a/packages/core/src/front/utils.ts
+++ b/packages/core/src/front/utils.ts
@@ -158,3 +158,38 @@ export function routeHref(
   }
   return path
 }
+
+const INVITE_ACCEPT_PATH_RE = /^\/invites\/([^/?#]+)/
+
+/**
+ * The invite-accept redirect (`?redirect=/invites/:token`) carries the invite token in the
+ * path, not as an `invite_token` query param. Signup needs the raw token to send the
+ * `x-invite-token` header, so this recovers it when only `redirect` was forwarded.
+ */
+export function extractInviteTokenFromRedirect(redirect: string | null): string | null {
+  if (!redirect) return null
+  const match = INVITE_ACCEPT_PATH_RE.exec(redirect)
+  if (!match) return null
+  try {
+    return decodeURIComponent(match[1])
+  } catch {
+    return match[1]
+  }
+}
+
+/**
+ * Builds an href to another auth route that forwards `redirect` and `invite_token` from the
+ * current query string, so invite context survives switching between sign-in and sign-up.
+ */
+export function withForwardedAuthParams(path: string, search: string): string {
+  const params = new URLSearchParams(search)
+  const redirect = params.get('redirect')
+  const inviteToken = params.get('invite_token') ?? extractInviteTokenFromRedirect(redirect)
+
+  const forwarded = new URLSearchParams()
+  if (redirect) forwarded.set('redirect', redirect)
+  if (inviteToken) forwarded.set('invite_token', inviteToken)
+
+  const qs = forwarded.toString()
+  return qs ? `${path}?${qs}` : path
+}

--- a/packages/core/src/front/utils.ts
+++ b/packages/core/src/front/utils.ts
@@ -159,22 +159,44 @@ export function routeHref(
   return path
 }
 
-const INVITE_ACCEPT_PATH_RE = /^\/invites\/([^/?#]+)/
+// Matches the *entire* redirect value against a single-segment `/invites/:token` path: no
+// leading `//` (protocol-relative), no trailing segments, no `?`/`#` smuggled into the
+// captured segment. Anything else (absolute URLs, extra path parts, query/hash) fails to
+// match at all rather than being trimmed down to a plausible-looking prefix.
+const INVITE_ACCEPT_PATH_RE = /^\/invites\/([^/?#]+)$/
+
+// Invite tokens are generated server-side as either a v4 UUID (LocalWorkspaceStore's
+// `randomUUID()`) or a 32-byte base64url string (PostgresWorkspaceStore's
+// `randomBytes(32).toString('base64url')`, 43 chars, unpadded). Only these two exact shapes
+// are accepted — anything else (including a decoded separator like `%2F`, which can only
+// ever decode to a `/`) is rejected rather than forwarded as a "close enough" token.
+const INVITE_TOKEN_RE =
+  /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|[A-Za-z0-9_-]{43})$/
 
 /**
  * The invite-accept redirect (`?redirect=/invites/:token`) carries the invite token in the
  * path, not as an `invite_token` query param. Signup needs the raw token to send the
  * `x-invite-token` header, so this recovers it when only `redirect` was forwarded.
+ *
+ * Strict by construction: the redirect must be the complete, single-segment invite-accept
+ * path (no extra segments, no query/hash smuggled in), the segment is percent-decoded
+ * exactly once (a throw on malformed escapes yields `null`, never the raw/undecoded text),
+ * and the decoded result must match the invite token's actual character class. Anything
+ * that doesn't fully qualify returns `null` — never a fabricated or truncated token.
  */
 export function extractInviteTokenFromRedirect(redirect: string | null): string | null {
   if (!redirect) return null
   const match = INVITE_ACCEPT_PATH_RE.exec(redirect)
   if (!match) return null
+
+  let decoded: string
   try {
-    return decodeURIComponent(match[1])
+    decoded = decodeURIComponent(match[1])
   } catch {
-    return match[1]
+    return null
   }
+
+  return INVITE_TOKEN_RE.test(decoded) ? decoded : null
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fixes #1450: invite context (redirect/invite_token) was dropped by the bare `<a href={routes.signup}>` Sign-up link on `SignInPage`, and by the reverse Sign-in link on `SignUpPage`.
- Invitee-without-account repro: invite link -> InviteAcceptPage -> "Sign in to accept this invite" -> `/auth/signin?redirect=/invites/:token` -> Sign up link dropped everything -> signup had no `invite_token`, so `postSignupHook` never received `x-invite-token` and created an unwanted "Default workspace" alongside the invited workspace.
- `withForwardedAuthParams`/`extractInviteTokenFromRedirect` (packages/core/src/front/utils.ts) forward `redirect` and `invite_token` across the sign-in <-> sign-up links, and recover the invite token from a `redirect=/invites/:token` path shape (what `InviteAcceptPage` actually produces) when `invite_token` wasn't already present.
- `SignUpPage` now derives `inviteToken` from either source before calling `signUp.email`, so the `x-invite-token` header — and therefore `postSignupHook`'s default-workspace skip (already covered by existing server tests) — reliably fires for this flow.

## Test plan
- [x] `packages/core/src/front/__tests__/SignInPage.test.tsx` — new tests: Sign-up link forwards `redirect`/`invite_token`; derives `invite_token` from a `redirect=/invites/:token` path.
- [x] `packages/core/src/front/__tests__/SignUpPage.test.tsx` — new tests: derives `invite_token` from `redirect` and forwards it as the `x-invite-token` header on signup; Sign-in link forwards `redirect`/`invite_token`.
- [x] `pnpm exec vitest run src/front/__tests__/SignInPage.test.tsx src/front/__tests__/SignUpPage.test.tsx` — 24 passed.
- [x] `pnpm exec vitest run` (full core suite) — same 49 pre-existing failures with and without this change (Postgres-integration/env-dependent, unrelated files); confirmed via `git stash`/`stash pop` A-B comparison.
- [x] `tsc --noEmit` — same single pre-existing error in `packages/workspace/.../WorkspaceAgentFront.tsx` with and without this change; no new errors.

Fixes #1450

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQgxe5KTr2N2pjgjgKPXHK