### PR TITLE
fix(workspace): Tasks panel gets non-zero size when editor tabs open

### DIFF
--- a/apps/workspace-playground/e2e/tasks-panel-width.spec.ts
+++ b/apps/workspace-playground/e2e/tasks-panel-width.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "@playwright/test"
+
+/**
+ * #1451: opening a file (editor tab) put the workbench at its persisted
+ * default width (680px). On a medium desktop viewport that left too little
+ * room for the chat column once the Tasks overlay forced it back open —
+ * ChatLayout deliberately skips its narrow-viewport chat-auto-collapse
+ * whenever a chat overlay is active, so the overlay's flex wrapper was the
+ * thing left computing to ~0 width instead. See ChatLayout.tsx's
+ * `chatOverlayReserve` / measured `rowWidth`.
+ */
+test.describe("Tasks panel width with editor tabs open", () => {
+  test.use({ viewport: { width: 1024, height: 800 } })
+
+  test("Tasks overlay stays visible and non-zero width after opening a file", async ({ page }) => {
+    await page.goto("/?fresh=1")
+
+    const filesButton = page.locator('[aria-label="Files"]').first()
+    await expect(filesButton).toBeVisible({ timeout: 15_000 })
+    await filesButton.click()
+
+    await page.getByText("README.md", { exact: true }).first().click()
+    await expect(page.getByRole("tab", { name: /README\.md/ })).toBeVisible({ timeout: 10_000 })
+
+    await page.getByRole("button", { name: "Tasks" }).click()
+
+    const overlay = page.locator('[data-boring-workspace-part="tasks-overlay"]')
+    await expect(overlay).toBeVisible()
+
+    const box = await overlay.boundingBox()
+    expect(box).not.toBeNull()
+    // Pre-fix this collapsed to ~63px — effectively invisible/unusable. The
+    // fix reserves a real minimum for the chat column whenever it must host
+    // an overlay, so the board stays legible.
+    expect(box!.width).toBeGreaterThan(200)
+    expect(box!.height).toBeGreaterThan(200)
+
+    await expect(page.getByText("Tasks", { exact: true }).first()).toBeVisible()
+  })
+})

--- a/apps/workspace-playground/e2e/tasks-panel-width.spec.ts
+++ b/apps/workspace-playground/e2e/tasks-panel-width.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test"
+import { expect, test, type Locator } from "@playwright/test"
 
 /**
  * #1451: opening a file (editor tab) put the workbench at its persisted
@@ -9,6 +9,39 @@ import { expect, test } from "@playwright/test"
  * thing left computing to ~0 width instead. See ChatLayout.tsx's
  * `chatOverlayReserve` / measured `rowWidth`.
  */
+
+/**
+ * The workbench and the overlay's chat column both animate their width over
+ * 280ms (`transition-[...,width,...] duration-[280ms]` in ChatLayout.tsx).
+ * A single `boundingBox()` sample right after the overlay becomes visible
+ * can land mid-transition and read an intermediate, pre-fix-like width —
+ * visible does not mean geometry has settled (#1457 review finding 3).
+ * Poll until two consecutive samples, spaced further apart than a single
+ * animation frame, report the same box.
+ */
+async function waitForStableBoundingBox(locator: Locator, timeoutMs = 5_000) {
+  let previous: Awaited<ReturnType<Locator["boundingBox"]>> = null
+  await expect
+    .poll(
+      async () => {
+        const current = await locator.boundingBox()
+        const stable = current !== null
+          && previous !== null
+          && current.width === previous.width
+          && current.height === previous.height
+          && current.x === previous.x
+          && current.y === previous.y
+        previous = current
+        return stable
+      },
+      { timeout: timeoutMs, intervals: [50, 50, 100, 100, 200] },
+    )
+    .toBe(true)
+  const box = await locator.boundingBox()
+  if (!box) throw new Error("element has no bounding box after it stabilized")
+  return box
+}
+
 test.describe("Tasks panel width with editor tabs open", () => {
   test.use({ viewport: { width: 1024, height: 800 } })
 
@@ -27,13 +60,13 @@ test.describe("Tasks panel width with editor tabs open", () => {
     const overlay = page.locator('[data-boring-workspace-part="tasks-overlay"]')
     await expect(overlay).toBeVisible()
 
-    const box = await overlay.boundingBox()
-    expect(box).not.toBeNull()
-    // Pre-fix this collapsed to ~63px — effectively invisible/unusable. The
-    // fix reserves a real minimum for the chat column whenever it must host
-    // an overlay, so the board stays legible.
-    expect(box!.width).toBeGreaterThan(200)
-    expect(box!.height).toBeGreaterThan(200)
+    // Pre-fix this settled at ~63px — mounted but effectively
+    // invisible/unusable. The fix reserves a real minimum for the chat
+    // column whenever it must host an overlay, so the board stays legible
+    // once its (and the sibling workbench's) width transition settles.
+    const box = await waitForStableBoundingBox(overlay)
+    expect(box.width).toBeGreaterThan(200)
+    expect(box.height).toBeGreaterThan(200)
 
     await expect(page.getByText("Tasks", { exact: true }).first()).toBeVisible()
   })

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -255,14 +255,28 @@ export function ChatLayout(props: ChatLayoutProps) {
   // is armed one frame *later*, in this separate effect — never in the same
   // commit as a width correction — so "transition turns on" and "width
   // changes" can never be the same style recalculation.
+  //
+  // The gate's source of truth is `surfaceTransitionEnabled` alone — no
+  // separate "armed" ref. An earlier version set a ref to `true` *before*
+  // scheduling the frame, then never reset it if that frame's schedule was
+  // cancelled (e.g. a second, distinct `measuredRowWidth` arrives before the
+  // first frame runs — the effect's cleanup cancels the pending callback,
+  // but the ref stayed `true`, so the next effect run bailed out at its
+  // first line and never rescheduled — `surfaceTransitionEnabled` then
+  // stayed `false` for the component's entire lifetime, permanently
+  // disabling this transition for every later legitimate change too:
+  // collapse/restore, fullscreen, drag-resize, a genuine host-chrome
+  // resize). Gating on the state value itself instead means every effect
+  // run that hasn't yet enabled it will (re)schedule a frame — including
+  // one whose predecessor's frame was cancelled — and once
+  // `surfaceTransitionEnabled` flips `true` the guard's own dependency stops
+  // any further scheduling. See #1457.
   const [surfaceTransitionEnabled, setSurfaceTransitionEnabled] = useState(false)
-  const surfaceTransitionArmedRef = useRef(false)
   useEffect(() => {
-    if (surfaceTransitionArmedRef.current) return
+    if (surfaceTransitionEnabled) return
     // No real measurement yet, and one is still possible — wait for it
     // rather than arming against the unmeasured estimate.
     if (measuredRowWidth === null && typeof ResizeObserver !== "undefined") return
-    surfaceTransitionArmedRef.current = true
     const raf = typeof requestAnimationFrame === "function"
       ? requestAnimationFrame(() => setSurfaceTransitionEnabled(true))
       : (setTimeout(() => setSurfaceTransitionEnabled(true), 0) as unknown as number)
@@ -270,7 +284,7 @@ export function ChatLayout(props: ChatLayoutProps) {
       if (typeof cancelAnimationFrame === "function") cancelAnimationFrame(raf)
       else clearTimeout(raf as unknown as ReturnType<typeof setTimeout>)
     }
-  }, [measuredRowWidth])
+  }, [measuredRowWidth, surfaceTransitionEnabled])
   const navIsTopDrawer = navOpen && (mobileShell || !sidebarOpen)
   const sidebarIsTopDrawer = sidebarOpen && !navIsTopDrawer
   useModalDrawer({ active: navIsTopDrawer, containerRef: navDrawerRef, onDismiss: closeNav, focusFallback: scheduleLocalComposerFocus, lifecycleKey: sidebarOpen })

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore, type ComponentType } from "react"
+import { Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore, type ComponentType } from "react"
 import { IconButton, LoadingState, ResizeHandle as UiResizeHandle } from "@hachej/boring-ui-kit"
 import { Maximize2, MessageSquare, Minimize2, PanelRightClose, PanelRightOpen } from "lucide-react"
 import { cn } from "../lib/utils"
@@ -150,8 +150,14 @@ export function ChatLayout(props: ChatLayoutProps) {
   // in their own persistent chrome (e.g. the plugin-tabs shell's app-left
   // rail/pane) consume some of that width before ChatLayout's own row ever
   // starts, so `viewport` overstates how much room the chat+workbench row
-  // actually has — `rowWidth` (measured off this component's own root,
-  // populated below) is the real figure and is preferred once available.
+  // actually has. `rowWidth` is the real figure: it prefers a live
+  // measurement of ChatLayout's own chat+workbench row (`rowRef`, attached
+  // below to the flex row that actually holds `<main>`/`<aside>` — NOT the
+  // outer shell, which also contains the session/workbench-left drawers and
+  // so overstates the row just as much as `viewport` did) and falls back,
+  // before that measurement lands, to `viewport` minus this component's own
+  // known drawer widths (nav + workbench-left), which are already known
+  // synchronously from persisted state on the very first render.
   // `surfaceMax`/`effectiveSurfaceWidth` used to size the workbench purely
   // off `viewport`, so on medium desktop widths a wide persisted workbench
   // could consume the entire real row, squeezing the chat column (and any
@@ -161,7 +167,10 @@ export function ChatLayout(props: ChatLayoutProps) {
   // is active, so the overlay's flex wrapper was the thing left computing
   // to ~0 width. See #1451.
   const [measuredRowWidth, setMeasuredRowWidth] = useState<number | null>(null)
-  const rowWidth = measuredRowWidth ?? viewport
+  const rowWidthEstimate = mobileShell
+    ? viewport
+    : Math.max(0, viewport - (navOpen ? effectiveNavWidth : 0) - (sidebarOpen ? effectiveSidebarWidth : 0))
+  const rowWidth = measuredRowWidth ?? rowWidthEstimate
   const MIN_CHAT_OVERLAY_WIDTH = 280
   const chatOverlayReserve = !mobileShell && props.chatOverlay && surfaceOpen && !chatCollapsed
     ? MIN_CHAT_OVERLAY_WIDTH
@@ -188,25 +197,46 @@ export function ChatLayout(props: ChatLayoutProps) {
     ? chatPanes.find((pane) => pane.id === props.activeChatPaneId) ?? chatPanes[0]
     : undefined
   const shellRef = useRef<HTMLDivElement | null>(null)
+  const rowRef = useRef<HTMLDivElement | null>(null)
   const navDrawerRef = useRef<HTMLElement | null>(null)
   const sidebarDrawerRef = useRef<HTMLElement | null>(null)
   const scheduleLocalComposerFocus = useCallback(() => {
     const shell = shellRef.current
     if (shell) scheduleComposerFocus(shell)
   }, [])
-  // Feeds `measuredRowWidth` above with this component's own real content
-  // width — see the #1451 note at its declaration for why `viewport` alone
-  // is not a safe basis for sizing the workbench column.
-  useEffect(() => {
-    const el = shellRef.current
-    if (!el || typeof ResizeObserver === "undefined") return
-    const observer = new ResizeObserver((entries) => {
-      const width = entries[0]?.contentRect.width
-      if (typeof width !== "number") return
+  // Feeds `measuredRowWidth` above with the chat+workbench row's real
+  // content width — see the #1451 note at its declaration. Attached to
+  // `rowRef` (the flex row that directly holds `<main>`/`<aside>` below),
+  // not `shellRef` (the outer shell, which also contains the session and
+  // workbench-left drawers and so overstates the row width by however much
+  // of those is open).
+  //
+  // `useLayoutEffect`, not `useEffect`: this measurement feeds a width that
+  // is itself rendered as a fixed CSS px value a few lines down, so reading
+  // it after paint (as a passive effect would) can let the browser paint one
+  // frame at the stale/estimated width before snapping to the measured one
+  // — most visible on first mount with a wide persisted workbench width and
+  // an overlay already open. Layout effects run synchronously after DOM
+  // mutations but before the browser paints, so the corrected width is what
+  // actually reaches the screen.
+  useLayoutEffect(() => {
+    const el = rowRef.current
+    if (!el) return
+    const measure = () => {
+      const width = el.getBoundingClientRect().width
+      // A real, mounted, visible row is never legitimately 0px wide. Treat 0
+      // as "no usable measurement yet" (environments with no real layout —
+      // jsdom's ResizeObserver polyfill is a no-op that never calls back, and
+      // `getBoundingClientRect` always reports zeros — or a momentarily
+      // display:none ancestor) rather than let it override `rowWidthEstimate`
+      // with a value that would floor every width computation below at 200.
+      if (width <= 0) return
       setMeasuredRowWidth((previous) => (previous === width ? previous : width))
-    })
+    }
+    measure()
+    if (typeof ResizeObserver === "undefined") return
+    const observer = new ResizeObserver(() => measure())
     observer.observe(el)
-    setMeasuredRowWidth(el.getBoundingClientRect().width)
     return () => observer.disconnect()
   }, [])
   const navIsTopDrawer = navOpen && (mobileShell || !sidebarOpen)
@@ -621,7 +651,7 @@ export function ChatLayout(props: ChatLayoutProps) {
         ) : null}
       </aside>
 
-      <div className="relative flex h-full min-h-0 min-w-0 flex-1 overflow-hidden bg-background">
+      <div ref={rowRef} data-boring-workspace-part="chat-workbench-row" className="relative flex h-full min-h-0 min-w-0 flex-1 overflow-hidden bg-background">
         <main
           data-boring-workspace-part="chat-stage"
           data-boring-state={chatHidden ? "collapsed" : "expanded"}

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -145,8 +145,33 @@ export function ChatLayout(props: ChatLayoutProps) {
   // hard-floored the nav drawer at 280px, overflowing any narrower host.
   const effectiveNavWidth = clamp(navWidth, 200, 360)
   const effectiveSidebarWidth = clamp(sidebarWidth, 200, Math.max(240, Math.floor(viewport * 0.5)))
-  const surfaceMax = mobileShell ? viewport : Math.max(480, Math.floor(viewport * 0.72))
-  const effectiveSurfaceWidth = mobileShell ? viewport : clamp(surfaceWidth, 480, surfaceMax)
+  const sidebarOpen = Boolean(props.sidebar)
+  // `viewport` is the full browser window width. Hosts that wrap ChatLayout
+  // in their own persistent chrome (e.g. the plugin-tabs shell's app-left
+  // rail/pane) consume some of that width before ChatLayout's own row ever
+  // starts, so `viewport` overstates how much room the chat+workbench row
+  // actually has — `rowWidth` (measured off this component's own root,
+  // populated below) is the real figure and is preferred once available.
+  // `surfaceMax`/`effectiveSurfaceWidth` used to size the workbench purely
+  // off `viewport`, so on medium desktop widths a wide persisted workbench
+  // could consume the entire real row, squeezing the chat column (and any
+  // mandatory chat overlay like Tasks/Skills) down toward 0 width while
+  // editor tabs stayed open — ChatLayout deliberately skips the
+  // auto-collapse-chat-on-narrow-viewport effect below whenever an overlay
+  // is active, so the overlay's flex wrapper was the thing left computing
+  // to ~0 width. See #1451.
+  const [measuredRowWidth, setMeasuredRowWidth] = useState<number | null>(null)
+  const rowWidth = measuredRowWidth ?? viewport
+  const MIN_CHAT_OVERLAY_WIDTH = 280
+  const chatOverlayReserve = !mobileShell && props.chatOverlay && surfaceOpen && !chatCollapsed
+    ? MIN_CHAT_OVERLAY_WIDTH
+    : 0
+  const surfaceMax = mobileShell
+    ? viewport
+    : Math.max(480, Math.floor(rowWidth * 0.72))
+  const effectiveSurfaceWidth = mobileShell
+    ? viewport
+    : Math.max(200, Math.min(clamp(surfaceWidth, 480, surfaceMax), rowWidth - chatOverlayReserve))
   const uiSurface = getFunction<() => SurfaceShellApi | null>(props.centerParams, "getSurface")
   const uiIsWorkbenchOpen = getFunction<() => boolean>(props.centerParams, "isWorkbenchOpen")
   const uiOpenWorkbench = getFunction<() => void>(props.centerParams, "openWorkbench")
@@ -162,13 +187,27 @@ export function ChatLayout(props: ChatLayoutProps) {
   const activeMobileChatPane = hasChatPanes
     ? chatPanes.find((pane) => pane.id === props.activeChatPaneId) ?? chatPanes[0]
     : undefined
-  const sidebarOpen = Boolean(props.sidebar)
   const shellRef = useRef<HTMLDivElement | null>(null)
   const navDrawerRef = useRef<HTMLElement | null>(null)
   const sidebarDrawerRef = useRef<HTMLElement | null>(null)
   const scheduleLocalComposerFocus = useCallback(() => {
     const shell = shellRef.current
     if (shell) scheduleComposerFocus(shell)
+  }, [])
+  // Feeds `measuredRowWidth` above with this component's own real content
+  // width — see the #1451 note at its declaration for why `viewport` alone
+  // is not a safe basis for sizing the workbench column.
+  useEffect(() => {
+    const el = shellRef.current
+    if (!el || typeof ResizeObserver === "undefined") return
+    const observer = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width
+      if (typeof width !== "number") return
+      setMeasuredRowWidth((previous) => (previous === width ? previous : width))
+    })
+    observer.observe(el)
+    setMeasuredRowWidth(el.getBoundingClientRect().width)
+    return () => observer.disconnect()
   }, [])
   const navIsTopDrawer = navOpen && (mobileShell || !sidebarOpen)
   const sidebarIsTopDrawer = sidebarOpen && !navIsTopDrawer

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -239,6 +239,38 @@ export function ChatLayout(props: ChatLayoutProps) {
     observer.observe(el)
     return () => observer.disconnect()
   }, [])
+  // #1457 finding-2 follow-up: `useLayoutEffect` guarantees no *painted*
+  // frame shows the pre-measurement estimate, but it does not guarantee no
+  // *animated* one. `measure()` above reads `getBoundingClientRect()`,
+  // which forces a synchronous layout/style pass against whatever style is
+  // on the DOM at that instant (the first render's `effectiveSurfaceWidth`,
+  // computed from `rowWidthEstimate` — which cannot see host chrome outside
+  // this component, e.g. the plugin-tabs app-left pane). If the corrected
+  // width is applied in the same commit as a `transition-duration` that is
+  // already active on that property, the browser can still treat the
+  // forced-layout value as the transition's start point and animate through
+  // it, even though it was never actually painted. So the workbench's width
+  // transition is intentionally withheld (`surfaceTransitionEnabled` below,
+  // gated in the JSX) until a real measurement has landed, and even then it
+  // is armed one frame *later*, in this separate effect — never in the same
+  // commit as a width correction — so "transition turns on" and "width
+  // changes" can never be the same style recalculation.
+  const [surfaceTransitionEnabled, setSurfaceTransitionEnabled] = useState(false)
+  const surfaceTransitionArmedRef = useRef(false)
+  useEffect(() => {
+    if (surfaceTransitionArmedRef.current) return
+    // No real measurement yet, and one is still possible — wait for it
+    // rather than arming against the unmeasured estimate.
+    if (measuredRowWidth === null && typeof ResizeObserver !== "undefined") return
+    surfaceTransitionArmedRef.current = true
+    const raf = typeof requestAnimationFrame === "function"
+      ? requestAnimationFrame(() => setSurfaceTransitionEnabled(true))
+      : (setTimeout(() => setSurfaceTransitionEnabled(true), 0) as unknown as number)
+    return () => {
+      if (typeof cancelAnimationFrame === "function") cancelAnimationFrame(raf)
+      else clearTimeout(raf as unknown as ReturnType<typeof setTimeout>)
+    }
+  }, [measuredRowWidth])
   const navIsTopDrawer = navOpen && (mobileShell || !sidebarOpen)
   const sidebarIsTopDrawer = sidebarOpen && !navIsTopDrawer
   useModalDrawer({ active: navIsTopDrawer, containerRef: navDrawerRef, onDismiss: closeNav, focusFallback: scheduleLocalComposerFocus, lifecycleKey: sidebarOpen })
@@ -748,7 +780,14 @@ export function ChatLayout(props: ChatLayoutProps) {
                     "relative",
                     // Collapsed workbench fills available width; otherwise it is a side panel.
                     chatCollapsed && surfaceOpen ? "min-w-0 flex-1" : "shrink-0",
-                    "transition-[flex-grow,flex-basis,width,min-width,max-width] duration-[280ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
+                    // Withheld until `surfaceTransitionEnabled` arms (see the
+                    // effect above) so the very first width correction —
+                    // driven by a real `rowRef` measurement replacing the
+                    // pre-measurement `rowWidthEstimate` — never animates.
+                    // Legitimate later changes (drag-resize, collapse
+                    // toggle, a real host-chrome resize) do animate, same as
+                    // before.
+                    surfaceTransitionEnabled && "transition-[flex-grow,flex-basis,width,min-width,max-width] duration-[280ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
                     surfaceOpen && "border-l border-border",
                   ),
             )}

--- a/packages/workspace/src/front/layout/__tests__/presets.test.tsx
+++ b/packages/workspace/src/front/layout/__tests__/presets.test.tsx
@@ -1040,6 +1040,94 @@ describe("ChatLayout component", () => {
     ro.restore()
   })
 
+  function workbenchTransitionClassPresent(): boolean {
+    return screen.getByRole("complementary", { name: "Workbench" }).className
+      .includes("transition-[flex-grow,flex-basis,width,min-width,max-width]")
+  }
+
+  it("arms the workbench width transition once the row settles (#1457 lifecycle)", async () => {
+    const ro = installControllableResizeObserver()
+    setViewport(1024)
+    const storageKey = "chat-layout-1457-transition-arm-basic"
+
+    const { container } = renderWithRegistry(
+      <ChatLayout
+        center="chat"
+        nav={null}
+        storageKey={storageKey}
+        surface="artifact-surface"
+        surfaceParams={{ onClose: vi.fn() }}
+      />,
+      ["chat", "artifact-surface"],
+    )
+
+    const row = container.querySelector('[data-boring-workspace-part="chat-workbench-row"]')
+    expect(row).toBeTruthy()
+
+    // Not armed yet: no real measurement has landed (jsdom's real
+    // `getBoundingClientRect` is always 0, guarded away by the 0-width
+    // check).
+    expect(workbenchTransitionClassPresent()).toBe(false)
+
+    vi.spyOn(row as Element, "getBoundingClientRect").mockReturnValue({ width: 900 } as DOMRect)
+    ro.fire()
+
+    // Still not armed the instant the value lands — arming is deliberately
+    // deferred to a later frame so "transition on" and "width changed" are
+    // never the same commit (see #1457 finding 2).
+    expect(workbenchTransitionClassPresent()).toBe(false)
+
+    await act(async () => { await new Promise((resolve) => setTimeout(resolve, 100)) })
+    expect(workbenchTransitionClassPresent()).toBe(true)
+
+    ro.restore()
+  })
+
+  it("still arms the workbench width transition when an earlier schedule is cancelled by a superseding measurement (#1457 cleanup-safety)", async () => {
+    const ro = installControllableResizeObserver()
+    setViewport(1024)
+    const storageKey = "chat-layout-1457-transition-arm-reschedule"
+
+    const { container } = renderWithRegistry(
+      <ChatLayout
+        center="chat"
+        nav={null}
+        storageKey={storageKey}
+        surface="artifact-surface"
+        surfaceParams={{ onClose: vi.fn() }}
+      />,
+      ["chat", "artifact-surface"],
+    )
+
+    const row = container.querySelector('[data-boring-workspace-part="chat-workbench-row"]')
+    expect(row).toBeTruthy()
+    expect(workbenchTransitionClassPresent()).toBe(false)
+
+    // Reproduces the reported repro exactly: a *second, distinct*
+    // `measuredRowWidth` update lands before the first arming frame has a
+    // chance to run. The effect's cleanup cancels the first schedule — a
+    // buggy "armed" ref set *before* scheduling (rather than by the frame
+    // actually firing) would stay `true` from the first run and make the
+    // second effect run bail out without rescheduling, permanently
+    // disabling this transition (not just for the plugin-tabs case — for
+    // every later legitimate change too: collapse/restore, fullscreen,
+    // drag-resize, a genuine host-chrome resize).
+    vi.spyOn(row as Element, "getBoundingClientRect").mockReturnValue({ width: 900 } as DOMRect)
+    ro.fire()
+    vi.spyOn(row as Element, "getBoundingClientRect").mockReturnValue({ width: 901 } as DOMRect)
+    ro.fire()
+
+    expect(workbenchTransitionClassPresent()).toBe(false) // pre-settle, as above
+
+    // The rescheduled frame must still fire and arm the transition — it
+    // must not have been silently dropped by the first schedule's
+    // cancellation.
+    await act(async () => { await new Promise((resolve) => setTimeout(resolve, 100)) })
+    expect(workbenchTransitionClassPresent()).toBe(true)
+
+    ro.restore()
+  })
+
   it("owns collapsed, split, fullscreen, restore, and collapse transitions at the ChatLayout host", async () => {
     const panelRegistry = new PanelRegistry()
     panelRegistry.register("chat", { title: "Chat", lazy: false, component: DummyPanel })

--- a/packages/workspace/src/front/layout/__tests__/presets.test.tsx
+++ b/packages/workspace/src/front/layout/__tests__/presets.test.tsx
@@ -927,6 +927,119 @@ describe("ChatLayout component", () => {
     expect(workbench.style.width).toBe("680px")
   })
 
+  // #1457 re-review probes. The reviewer judged both non-blocking from code
+  // reading alone and flagged that the global `ResizeObserver` mock (a
+  // no-op) leaves this behavior untested. These install a *controllable*
+  // `ResizeObserver` for the duration of one test so the row's real
+  // measurement callback can be fired on demand, closing that gap with
+  // actual evidence instead of just re-reading the source.
+  function installControllableResizeObserver() {
+    let deliver: (() => void) | null = null
+    class ControllableResizeObserver {
+      constructor(callback: () => void) { deliver = callback }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    const original = globalThis.ResizeObserver
+    vi.stubGlobal("ResizeObserver", ControllableResizeObserver)
+    return {
+      fire: () => act(() => { deliver?.() }),
+      restore: () => vi.stubGlobal("ResizeObserver", original),
+    }
+  }
+
+  it("ignores a transient 0-width row sample and recovers on the next positive one (#1457 probe 1)", () => {
+    const ro = installControllableResizeObserver()
+    setViewport(1024)
+    const storageKey = "chat-layout-1457-zero-guard"
+    window.localStorage.setItem(`${storageKey}:surfaceWidth`, "680")
+
+    const { container } = renderWithRegistry(
+      <ChatLayout
+        center="chat"
+        nav={null}
+        storageKey={storageKey}
+        surface="artifact-surface"
+        surfaceParams={{ onClose: vi.fn() }}
+        chatOverlay={<div>Tasks overlay</div>}
+      />,
+      ["chat", "artifact-surface"],
+    )
+
+    const row = container.querySelector('[data-boring-workspace-part="chat-workbench-row"]')
+    expect(row).toBeTruthy()
+    const workbenchWidth = () => screen.getByRole("complementary", { name: "Workbench" }).style.width
+
+    // Mount already exercised the 0-guard once (jsdom's real
+    // getBoundingClientRect is always zero), landing on the pre-measurement
+    // estimate. This is the value a legitimate collapse-to-0 must not
+    // disturb.
+    const beforeCollapse = workbenchWidth()
+
+    // A row that is legitimately, fully squeezed (or behind a momentary
+    // `display:none` ancestor) reports 0 — this must not be treated as "the
+    // real width is now 0" and propagated into sizing math.
+    vi.spyOn(row as Element, "getBoundingClientRect").mockReturnValue({ width: 0 } as DOMRect)
+    ro.fire()
+    expect(workbenchWidth()).toBe(beforeCollapse)
+
+    // Recovery: the next positive sample is applied normally — the guard
+    // does not get "stuck" ignoring real data after a 0 reading.
+    vi.spyOn(row as Element, "getBoundingClientRect").mockReturnValue({ width: 744 } as DOMRect)
+    ro.fire()
+    // 744 row, 280 chatOverlay reserve, persisted surfaceWidth 680 clamped
+    // to surfaceMax = max(480, floor(744*0.72)) = 535 → min(535, 744-280) = 464.
+    expect(workbenchWidth()).toBe("464px")
+    expect(workbenchWidth()).not.toBe(beforeCollapse)
+
+    ro.restore()
+  })
+
+  it("dedupes an identical resize sample: no further geometry change reaches the DOM (#1457 probe 2)", async () => {
+    const ro = installControllableResizeObserver()
+    setViewport(1024)
+    const storageKey = "chat-layout-1457-dedupe"
+
+    const { container } = renderWithRegistry(
+      <ChatLayout
+        center="chat"
+        nav={null}
+        storageKey={storageKey}
+        surface="artifact-surface"
+        surfaceParams={{ onClose: vi.fn() }}
+      />,
+      ["chat", "artifact-surface"],
+    )
+
+    const row = container.querySelector('[data-boring-workspace-part="chat-workbench-row"]')
+    expect(row).toBeTruthy()
+    vi.spyOn(row as Element, "getBoundingClientRect").mockReturnValue({ width: 900 } as DOMRect)
+    const workbenchWidth = () => screen.getByRole("complementary", { name: "Workbench" }).style.width
+
+    // First real sample changes the measured width (0 → 900): a real
+    // geometry change lands in the DOM.
+    ro.fire()
+    await act(async () => { await new Promise((resolve) => setTimeout(resolve, 50)) })
+    const widthAfterFirstSample = workbenchWidth()
+    expect(widthAfterFirstSample).not.toBe("")
+
+    // Second delivery reports the *identical* width. React's own docs note
+    // that returning the same value from a state updater can still let the
+    // owning component "render" once more before bailing out of
+    // committing — so a raw render/commit-count assertion here would be an
+    // implementation-detail-sensitive, not-quite-accurate proxy (verified:
+    // an earlier version of this test asserting zero additional commits via
+    // a `Profiler` was flaky against exactly that documented behavior). What
+    // the reviewer's finding was actually about — and what matters for
+    // correctness — is that no *second geometry update* reaches the DOM.
+    ro.fire()
+    await act(async () => { await new Promise((resolve) => setTimeout(resolve, 50)) })
+    expect(workbenchWidth()).toBe(widthAfterFirstSample)
+
+    ro.restore()
+  })
+
   it("owns collapsed, split, fullscreen, restore, and collapse transitions at the ChatLayout host", async () => {
     const panelRegistry = new PanelRegistry()
     panelRegistry.register("chat", { title: "Chat", lazy: false, component: DummyPanel })

--- a/packages/workspace/src/front/layout/__tests__/presets.test.tsx
+++ b/packages/workspace/src/front/layout/__tests__/presets.test.tsx
@@ -846,6 +846,87 @@ describe("ChatLayout component", () => {
     expect(screen.queryByRole("button", { name: "Close workbench" })).not.toBeInTheDocument()
   })
 
+  // #1457 review findings 1 & 2. jsdom has no real layout: the vitest-wide
+  // `ResizeObserver` polyfill (vitest.setup.ts) is a no-op that never calls
+  // back, and `getBoundingClientRect` always reports zeros, which ChatLayout
+  // now treats as "no usable measurement yet" rather than letting it zero
+  // out sizing. That makes jsdom exercise exactly the pre-measurement
+  // fallback path (`rowWidthEstimate`) end to end — never a value the
+  // ResizeObserver later corrects — which is the right target for both
+  // findings: (1) the estimate must account for ChatLayout's own open
+  // drawers (not just the raw viewport), and (2) that estimate must already
+  // be the safe, reserved value on the very first render, with no
+  // intermediate frame at the old unclamped width.
+  it("reserves room for a chat overlay on first render, accounting for an open workbench-left drawer (#1451/#1457)", () => {
+    setViewport(1024)
+    const storageKey = "chat-layout-1457-initial-reserve"
+    window.localStorage.setItem(`${storageKey}:surfaceWidth`, "680")
+
+    renderWithRegistry(
+      <ChatLayout
+        center="chat"
+        nav={null}
+        storageKey={storageKey}
+        surface="artifact-surface"
+        surfaceParams={{ onClose: vi.fn() }}
+        sidebar="workbench-left"
+        sidebarParams={{ onClose: vi.fn() }}
+        chatOverlay={<div>Tasks overlay</div>}
+      />,
+      ["chat", "artifact-surface", "workbench-left"],
+    )
+
+    // Reproduces finding 1's example: nav closed, a 280px workbench-left
+    // drawer open, 1024px viewport → a 744px row. Pre-fix, the width budget
+    // was computed off the *outer shell* (or, before that, the raw
+    // viewport), which does not subtract the open workbench-left drawer —
+    // so the workbench could be sized as if it owned the whole row and the
+    // chat/overlay column got squeezed to near 0. Post-fix the estimate
+    // subtracts the drawer, so the workbench is capped well under its
+    // persisted 680px width, leaving the reserved 280px for the overlay.
+    const workbench = screen.getByRole("complementary", { name: "Workbench" })
+    const width = Number(workbench.style.width.replace("px", ""))
+    expect(Number.isFinite(width)).toBe(true)
+    expect(width).toBeLessThan(680) // shrank off the persisted width
+    expect(width).toBeLessThanOrEqual(744 - 280) // left >= the overlay reserve
+    expect(workbench.style.width).toBe(workbench.style.minWidth)
+    expect(workbench.style.width).toBe(workbench.style.maxWidth)
+
+    // No later correction changes it: this IS the first-render value (no
+    // `act`/`waitFor` beyond what `render` itself flushes), so there was no
+    // intermediate frame at the old, unclamped width for the browser to
+    // paint before a passive effect fixed it up.
+    expect(screen.getByRole("complementary", { name: "Workbench" }).style.width).toBe(workbench.style.width)
+  })
+
+  it("does not widen the workbench to fill the whole row when no chat overlay is open (#1457)", () => {
+    // Wide enough (>= CHAT_AUTOCOLLAPSE_MAX_WIDTH) that ChatLayout's separate
+    // narrow-viewport auto-collapse effect does not also kick in here — this
+    // test is only about the reserve/estimate math, not that unrelated
+    // behavior (which the 1024px-viewport test above deliberately keeps
+    // out of play by supplying a chatOverlay).
+    setViewport(1280)
+    const storageKey = "chat-layout-1457-no-overlay"
+    window.localStorage.setItem(`${storageKey}:surfaceWidth`, "680")
+
+    renderWithRegistry(
+      <ChatLayout
+        center="chat"
+        nav={null}
+        storageKey={storageKey}
+        surface="artifact-surface"
+        surfaceParams={{ onClose: vi.fn() }}
+      />,
+      ["chat", "artifact-surface"],
+    )
+
+    // No sidebar drawer open and no chatOverlay: the persisted 680px width
+    // fits inside the row untouched — the reserve/estimate logic must not
+    // shrink the workbench when nothing needs the room.
+    const workbench = screen.getByRole("complementary", { name: "Workbench" })
+    expect(workbench.style.width).toBe("680px")
+  })
+
   it("owns collapsed, split, fullscreen, restore, and collapse transitions at the ChatLayout host", async () => {
     const panelRegistry = new PanelRegistry()
     panelRegistry.register("chat", { title: "Chat", lazy: false, component: DummyPanel })


### PR DESCRIPTION
## Summary
- `ChatLayout` sized the workbench (editor tabs) purely off `window.innerWidth`, ignoring how much width the host's own chrome (e.g. the plugin-tabs app-left rail) had already consumed, and never reserved room for a mandatory chat overlay (Tasks/Skills) that is deliberately kept open beside the workbench.
- On a medium desktop viewport with an editor tab open, the persisted workbench width (default 680px) could consume the entire real row, leaving the Tasks overlay's flex wrapper computing to a few px wide — mounted but invisible/unusable.
- Fix: measure `ChatLayout`'s own root width via `ResizeObserver` instead of trusting the full window viewport, and reserve a minimum width (280px) for the chat column whenever a chat overlay is open beside the workbench.

## Root cause
- `packages/workspace/src/front/layout/ChatLayout.tsx`: `surfaceMax`/`effectiveSurfaceWidth` (the workbench's width) were computed from `useViewportWidth()` (full window width), not the actual space available to `ChatLayout`'s own flex row. In the plugin-tabs layout, the app-left rail/pane sits *outside* `ChatLayout` and consumes real width that `ChatLayout` never subtracted.
- Separately, `ChatLayout` deliberately skips its narrow-viewport chat-auto-collapse effect whenever a chat overlay (e.g. Tasks) is active (so the overlay stays visible), but nothing then constrained the workbench's width to leave the chat column any room — so the fixed-width workbench pane could squeeze the chat/overlay column down to near-zero.

## Fix
- Added a `ResizeObserver` on `ChatLayout`'s root (`shellRef`) to measure `rowWidth`, the real available width for the chat+workbench row.
- `surfaceMax` and `effectiveSurfaceWidth` are now derived from `rowWidth`, not `viewport`.
- Added `chatOverlayReserve` (280px) subtracted from the workbench's width budget whenever a chat overlay is open beside an open workbench, so the overlay always gets a legible minimum width instead of computing to ~0.

## Proof
Reproduced against a live playground dev server (`origin/main` @ 465f521c6, viewport 1024×800): opening `README.md`, then clicking Tasks in the left rail.
- **Before fix:** `[data-boring-workspace-part="tasks-overlay"]` bounding box = `{ width: 63, height: 800 }` — mounted, effectively invisible.
- **After fix:** same flow → `{ width: 278, height: 800 }` — visible and usable; workbench width auto-shrinks from 680px to 465px to make room. At a wide viewport (1280px) behavior is unchanged (`width: 319`).

## Test plan
- [x] Added `apps/workspace-playground/e2e/tasks-panel-width.spec.ts` — opens a file, clicks Tasks, asserts the overlay's bounding box has width/height > 200px, at a 1024×800 viewport that reproduces the bug pre-fix.
- [x] `pnpm -C packages/workspace exec vitest run` — 129/129 tests pass in `src/front/layout/**` (one unrelated suite fails to resolve `@hachej/boring-bash/shared`, a pre-existing unbuilt-dependency issue in this fresh checkout, not caused by this change).
- [x] `pnpm -C packages/workspace run typecheck` — only a pre-existing, unrelated error in `WorkspaceAgentFront.tsx` (confirmed present with this diff reverted).
- [ ] CI: full `apps/workspace-playground` e2e suite (needs `build:deps`, not run locally due to time).

Fixes #1451

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MQgxe5KTr2N2pjgjgKPXHK