### PR TITLE
Fix showcase route: seed a real backend session before enabling the composer

### DIFF
--- a/apps/workspace-playground/e2e/showcase.spec.ts
+++ b/apps/workspace-playground/e2e/showcase.spec.ts
@@ -33,10 +33,66 @@ test.describe("workspace-playground showcase route", () => {
     await expect(composer).toBeVisible()
     await expect(composer).toBeEnabled()
 
+    // The scripted harness marks its deterministic final reply with
+    // `PI_NATIVE_ASSISTANT_DONE:<agentTypeId>` (apps/workspace-playground/
+    // src/server/testing/scriptedPiHarness.ts). Waiting on that marker
+    // (rather than "any assistant message container") proves the turn
+    // actually completed streaming, not just that a message_start landed —
+    // the container renders before the final text does.
+    const meta = await (await page.request.get("/api/v1/workspace/meta")).json() as { defaultAgentTypeId: string }
+    const doneMarker = `PI_NATIVE_ASSISTANT_DONE:${meta.defaultAgentTypeId}`
+    const conversation = page.getByLabel("Agent conversation")
+
     const prompt = `showcase smoke ${Date.now()}`
     await composer.fill(prompt)
     await page.locator('[data-boring-agent-part="composer-submit"]').click()
-    await expect(page.getByLabel("Agent conversation").getByText(prompt)).toBeVisible()
-    await expect(page.locator('[data-boring-agent-message-role="assistant"]').last()).toBeVisible({ timeout: 30_000 })
+    await expect(conversation.getByText(prompt)).toBeVisible()
+    await expect(page.getByTestId("chat-working")).toBeVisible({ timeout: 10_000 })
+    await expect(conversation.getByText(doneMarker)).toBeVisible({ timeout: 30_000 })
+    await expect(page.getByTestId("chat-working")).toHaveCount(0, { timeout: 15_000 })
+    await expect(composer).toBeEnabled()
+  })
+
+  test("reuses the same backend session across a reload in the same tab", async ({ page }) => {
+    test.setTimeout(120_000)
+
+    await page.goto("/?showcase=1")
+    const chat = page.locator('[data-boring-agent-part="chat"]')
+    await chat.waitFor({ state: "visible", timeout: 40_000 })
+    await expect(chat).toHaveAttribute("data-pi-chat-connection", "connected", { timeout: 15_000 })
+    const firstSessionId = await chat.getAttribute("data-pi-chat-session-id")
+    expect(firstSessionId).toBeTruthy()
+
+    // Bounded-retention regression: a reload in the same tab must resume the
+    // already-booted (still-empty) session rather than minting a new durable
+    // one every time (gh-1458 review finding #3).
+    await page.reload({ waitUntil: "domcontentloaded" })
+    await chat.waitFor({ state: "visible", timeout: 40_000 })
+    await expect(chat).toHaveAttribute("data-pi-chat-connection", "connected", { timeout: 15_000 })
+    const secondSessionId = await chat.getAttribute("data-pi-chat-session-id")
+    expect(secondSessionId).toBe(firstSessionId)
+  })
+
+  test("switching to a decorative padding session materializes a real backend session", async ({ page }) => {
+    test.setTimeout(120_000)
+
+    // `sessions=3` pads the list with two client-only placeholder rows
+    // (gh-1458 review finding #2) — selecting one must not hand the chat
+    // pane an id that 404s the way the original SHOWCASE_SESSION_ID did.
+    await page.goto("/?showcase=1&sessions=3")
+    const chat = page.locator('[data-boring-agent-part="chat"]')
+    await chat.waitFor({ state: "visible", timeout: 40_000 })
+    await expect(chat).toHaveAttribute("data-pi-chat-connection", "connected", { timeout: 15_000 })
+
+    const decorativeRow = page.locator('[data-boring-workspace-part="app-session-row"][data-boring-session-id="__showcase__-2"]')
+    await decorativeRow.waitFor({ state: "visible", timeout: 10_000 })
+    await decorativeRow.locator("button").first().click()
+
+    await expect(page.getByText("session was not found")).toHaveCount(0)
+    await expect(chat).toHaveAttribute("data-pi-chat-connection", "connected", { timeout: 15_000 })
+    await expect(page.getByRole("textbox", { name: "Agent prompt" })).toBeEnabled()
+
+    const activeSessionId = await chat.getAttribute("data-pi-chat-session-id")
+    expect(activeSessionId).not.toBe("__showcase__-2")
   })
 })

--- a/apps/workspace-playground/e2e/showcase.spec.ts
+++ b/apps/workspace-playground/e2e/showcase.spec.ts
@@ -83,16 +83,32 @@ test.describe("workspace-playground showcase route", () => {
     const chat = page.locator('[data-boring-agent-part="chat"]')
     await chat.waitFor({ state: "visible", timeout: 40_000 })
     await expect(chat).toHaveAttribute("data-pi-chat-connection", "connected", { timeout: 15_000 })
+    // Captured before the click: the pre-existing boot session is already
+    // connected/enabled/error-free, so asserting only those properties after
+    // the click can pass while the row's async materialization POST is still
+    // in flight and the pane hasn't switched onto it at all. Waiting for the
+    // session id to actually change (and the placeholder row to disappear)
+    // proves the switch happened, not just that the old session was fine.
+    const bootSessionId = await chat.getAttribute("data-pi-chat-session-id")
+    expect(bootSessionId).toBeTruthy()
 
-    const decorativeRow = page.locator('[data-boring-workspace-part="app-session-row"][data-boring-session-id="__showcase__-2"]')
+    const placeholderId = "__showcase__-2"
+    const decorativeRow = page.locator(`[data-boring-workspace-part="app-session-row"][data-boring-session-id="${placeholderId}"]`)
     await decorativeRow.waitFor({ state: "visible", timeout: 10_000 })
     await decorativeRow.locator("button").first().click()
+
+    await expect.poll(
+      () => chat.getAttribute("data-pi-chat-session-id"),
+      { timeout: 15_000 },
+    ).not.toBe(bootSessionId)
+    await expect(page.locator(`[data-boring-workspace-part="app-session-row"][data-boring-session-id="${placeholderId}"]`)).toHaveCount(0)
 
     await expect(page.getByText("session was not found")).toHaveCount(0)
     await expect(chat).toHaveAttribute("data-pi-chat-connection", "connected", { timeout: 15_000 })
     await expect(page.getByRole("textbox", { name: "Agent prompt" })).toBeEnabled()
 
     const activeSessionId = await chat.getAttribute("data-pi-chat-session-id")
-    expect(activeSessionId).not.toBe("__showcase__-2")
+    expect(activeSessionId).not.toBe(placeholderId)
+    expect(activeSessionId).not.toBe(bootSessionId)
   })
 })

--- a/apps/workspace-playground/e2e/showcase.spec.ts
+++ b/apps/workspace-playground/e2e/showcase.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "@playwright/test"
+
+/**
+ * Regression for gh-1452: `?showcase=1` pre-seeded a client-side session id
+ * (SHOWCASE_SESSION_ID) that never had a matching backend session, so the
+ * chat pane's network hydrate always 404'd — a permanent "session was not
+ * found" banner and a composer that never enabled. The fix boots a real
+ * backend session before the chat panel renders, so the showcase route must
+ * come up connected with a working composer.
+ */
+
+test.describe("workspace-playground showcase route", () => {
+  test("boots a working session with no error banner and a live composer", async ({ page }) => {
+    test.setTimeout(120_000)
+
+    const pageErrors: string[] = []
+    page.on("pageerror", (error) => pageErrors.push(error.message))
+
+    await page.goto("/?showcase=1")
+
+    // Cold dev-server boot (first request ever, unbundled deps) can take a
+    // while beyond the usual per-assertion timeout — give it real headroom
+    // rather than flaking on a slow first compile.
+    const chat = page.locator('[data-boring-agent-part="chat"]')
+    await chat.waitFor({ state: "visible", timeout: 40_000 }).catch(() => {
+      throw new Error(`showcase chat panel did not render; page errors: ${pageErrors.join(" | ") || "none"}`)
+    })
+
+    await expect(page.getByText("session was not found")).toHaveCount(0)
+    await expect(chat).toHaveAttribute("data-pi-chat-connection", "connected", { timeout: 15_000 })
+
+    const composer = page.getByRole("textbox", { name: "Agent prompt" })
+    await expect(composer).toBeVisible()
+    await expect(composer).toBeEnabled()
+
+    const prompt = `showcase smoke ${Date.now()}`
+    await composer.fill(prompt)
+    await page.locator('[data-boring-agent-part="composer-submit"]').click()
+    await expect(page.getByLabel("Agent conversation").getByText(prompt)).toBeVisible()
+    await expect(page.locator('[data-boring-agent-message-role="assistant"]').last()).toBeVisible({ timeout: 30_000 })
+  })
+})

--- a/apps/workspace-playground/e2e/showcase.spec.ts
+++ b/apps/workspace-playground/e2e/showcase.spec.ts
@@ -1,4 +1,22 @@
+import { readFile } from "node:fs/promises"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
 import { expect, test } from "@playwright/test"
+
+// Matches playwright.config.ts's E2E_SESSION_ROOT default (this file's own
+// env has no BORING_AGENT_SESSION_ROOT — that var is only set on the
+// webServer child process's env via `env -i`).
+const E2E_SESSION_ROOT = join(dirname(fileURLToPath(import.meta.url)), "fixtures", "sessions")
+const SHOWCASE_REGISTRY_PATH = join(E2E_SESSION_ROOT, ".playground-showcase-session-ids.json")
+
+function decodeRegistryEntry(entry: string): { agentKey: string; workspaceId: string; sessionId: string } | undefined {
+  const parts = entry.split(REGISTRY_KEY_SEPARATOR)
+  if (parts.length !== 3) return undefined
+  const [agentKey, workspaceId, sessionId] = parts
+  return { agentKey, workspaceId, sessionId }
+}
+// Must match SHOWCASE_REGISTRY_KEY_SEPARATOR in scriptedPiHarness.ts (U+0001).
+const REGISTRY_KEY_SEPARATOR = ""
 
 /**
  * Regression for gh-1452: `?showcase=1` pre-seeded a client-side session id
@@ -110,5 +128,55 @@ test.describe("workspace-playground showcase route", () => {
     const activeSessionId = await chat.getAttribute("data-pi-chat-session-id")
     expect(activeSessionId).not.toBe(placeholderId)
     expect(activeSessionId).not.toBe(bootSessionId)
+  })
+
+  // gh-1458 review round 6: createWorkspaceAgentServer accepts TWO different
+  // values for `x-boring-workspace-id` — the canonical workspace scope id
+  // and `basename(workspaceRoot)` — and always resolves either one to the
+  // SAME canonical scope before a session record is ever created
+  // (trustedWorkspaceScopeId in createWorkspaceAgentServer.ts). The wrapper
+  // route used to key the showcase provenance registry by whichever raw
+  // header the client presented, so an allowed basename-selector request
+  // would create a session scoped to canonical while marking the registry
+  // under the basename — a permanent mismatch the sweep's full-match rule
+  // would never resolve (it deliberately never prunes an entry it can't
+  // positively verify). This drives the wrapper route directly with the
+  // basename selector and reads the on-disk registry to prove the entry is
+  // keyed by the canonical id regardless.
+  test("provenance registry keys by the canonical workspace scope, not whichever selector the client presented", async ({ page }) => {
+    test.setTimeout(60_000)
+
+    const meta = await (await page.request.get("/api/v1/workspace/meta")).json() as { workspaceId: string; defaultAgentTypeId: string }
+    // In local (non-remote-worker) mode, meta.workspaceId reflects
+    // basename(workspaceRoot) — the OTHER allowed selector, distinct from
+    // the canonical "default" scope this server actually resolves to.
+    const basenameSelector = meta.workspaceId
+    expect(basenameSelector).toBeTruthy()
+    expect(basenameSelector).not.toBe("default")
+
+    const response = await page.request.post("/api/v1/playground/showcase-sessions", {
+      headers: {
+        "content-type": "application/json",
+        "x-boring-workspace-id": basenameSelector,
+      },
+      data: {
+        agentTypeId: meta.defaultAgentTypeId,
+        title: "Basename selector parity check",
+      },
+    })
+    expect(response.status(), await response.text()).toBe(201)
+    const payload = await response.json() as { sessionId?: string }
+    expect(payload.sessionId).toBeTruthy()
+
+    const registryText = await readFile(SHOWCASE_REGISTRY_PATH, "utf8")
+    const registry = JSON.parse(registryText) as string[]
+    const decoded = registry.map(decodeRegistryEntry).filter((entry): entry is NonNullable<typeof entry> => Boolean(entry))
+    const matching = decoded.find((entry) => entry.sessionId === payload.sessionId)
+    expect(matching, `no registry entry found for session ${payload.sessionId}; decoded entries: ${JSON.stringify(decoded)}`).toBeTruthy()
+    // The registry key must be the canonical scope ("default"), never the
+    // basename selector the request presented — this is the belongsTo
+    // parity the review required.
+    expect(matching?.workspaceId).toBe("default")
+    expect(matching?.workspaceId).not.toBe(basenameSelector)
   })
 })

--- a/apps/workspace-playground/src/front/App.tsx
+++ b/apps/workspace-playground/src/front/App.tsx
@@ -8,6 +8,7 @@ import { diagramPlugin } from "@hachej/boring-diagram/front"
 import { createTasksPlugin } from "@hachej/boring-tasks/front"
 import { SHOWCASE_SESSION_ID } from "./showcaseMessages"
 import { LoadingStatesShowcase, type LoadingStateMode } from "./LoadingStatesShowcase"
+import { SHOWCASE_SESSION_TITLE_TAG } from "../shared/showcaseSession"
 
 function isShowcaseRoute(): boolean {
   if (typeof window === "undefined") return false
@@ -196,11 +197,15 @@ export function WorkspaceShell() {
   const liveShowcaseSessionIds = useRef(new Set<string>())
   // Tab-scoped reuse key: bounds session accumulation from repeated boots in
   // the same browser tab (reload, HMR) to one durable session instead of one
-  // per mount. sessionStorage (not localStorage) so it never outlives the
-  // tab. Cleared automatically once the reused session picks up its first
-  // turn — createSession only resumes empty (turnCount === 0) sessions
-  // server-side (embeddedGateway.ts), so a used session naturally falls
-  // through to creating a fresh one on the next reload.
+  // per mount. sessionStorage (not localStorage) so the *pointer* never
+  // outlives the tab. This alone does not bound the durable backend session
+  // itself — closing the tab discards only this reuse pointer, and a new
+  // tab/e2e context still creates its own session. Actual retention is
+  // bounded by two other layers: the pagehide cleanup below (best-effort,
+  // same boot) and the scripted dev server's boot-time sweep in
+  // scriptedPiHarness.ts (authoritative backstop — deletes every
+  // showcase-tagged session left empty by a *previous* boot, regardless of
+  // which tab/context created it). See SHOWCASE_SESSION_TITLE_TAG.
   const showcaseBootStorageKey = "boring-ui-v2:showcase:boot-session-id"
   const requestNewShowcaseSession = useCallback(async (
     title: string,
@@ -218,7 +223,13 @@ export function WorkspaceShell() {
           "x-boring-workspace-id": "default",
         },
         body: JSON.stringify({
-          title,
+          // The backend-stored title is tagged and never surfaced — this UI
+          // only ever renders the `title` this function returns below, taken
+          // from the controlled `sessions` prop it builds client-side (see
+          // ../shared/showcaseSession.ts). The tag lets the scripted dev
+          // server's boot-time sweep find and delete stale, still-empty
+          // showcase sessions without touching unrelated ones.
+          title: `${SHOWCASE_SESSION_TITLE_TAG}${title}`,
           ...(options.requestId ? { requestId: options.requestId } : {}),
           ...(options.resumeSessionId ? { resumeSessionId: options.resumeSessionId } : {}),
         }),
@@ -309,8 +320,20 @@ export function WorkspaceShell() {
   }, [])
   // Decorative rows (padding from `?sessions=N`) start with no backend
   // session behind them. Selecting one materializes a real session first —
-  // keyed by a stable per-row request id so a double-click can't create two
-  // — instead of ever handing the chat pane an id that will 404 (gh-1452).
+  // guarded against a double-click by the in-memory
+  // `materializingShowcaseSessionIds` set below — instead of ever handing
+  // the chat pane an id that will 404 (gh-1452).
+  //
+  // The request id is freshly random per attempt, NOT derived from the
+  // (fixed, deterministic) placeholder row id. A stable "showcase-row-<id>"
+  // request id looked idempotent-safe, but the placeholder id is the exact
+  // same string on every future page load/e2e run against this server —
+  // so a *second* click across a completely unrelated later visit would
+  // replay the ledger's very first receipt for it, handing back a stale
+  // session that a previous visit's pagehide cleanup may have already
+  // deleted. The `materializingShowcaseSessionIds` guard already prevents
+  // a genuine double-click within one page's lifetime, so no cross-visit
+  // request id is needed for that.
   const materializingShowcaseSessionIds = useRef(new Set<string>())
   const handleActiveSessionIdChange = useCallback(
     (sessionId: string | null) => {
@@ -322,7 +345,7 @@ export function WorkspaceShell() {
       if (materializingShowcaseSessionIds.current.has(sessionId)) return
       materializingShowcaseSessionIds.current.add(sessionId)
       const placeholderTitle = showcaseSessions.find((session) => session.id === sessionId)?.title ?? "New chat"
-      void requestNewShowcaseSession(placeholderTitle, { requestId: `showcase-row-${sessionId}`, timeoutMs: 8_000 })
+      void requestNewShowcaseSession(placeholderTitle, { requestId: randomId(), timeoutMs: 8_000 })
         .then((session) => {
           liveShowcaseSessionIds.current.add(session.id)
           setShowcaseSessions((current) => current.map((existing) => (existing.id === sessionId ? session : existing)))
@@ -338,6 +361,49 @@ export function WorkspaceShell() {
     },
     [requestNewShowcaseSession, showcase, showcaseSessions],
   )
+
+  // Best-effort client-side cleanup, layered on top of the server's
+  // boot-time sweep (scriptedPiHarness.ts): when the tab goes away, delete
+  // any showcase session this tab created that never got a real turn.
+  // `showcaseUsedSessionIds` is populated from `onPromptSubmitStarted`
+  // (wired below via chatParams) so a session the visitor actually used is
+  // never touched. `navigator.sendBeacon` cannot express this — it only
+  // ever sends a POST and cannot set the workspace header the delete route
+  // requires — so this uses `fetch` with `keepalive: true`, the documented
+  // sendBeacon-equivalent for non-POST/authenticated pagehide requests.
+  //
+  // `pagehide` fires on an in-tab reload too, not just a real tab close —
+  // deleting the reusable boot session here would race the *next* load's
+  // resumeSessionId lookup and defeat the reload-reuse behavior above,
+  // deleting a session the very next request expects to still exist. Skip
+  // whichever session id is currently the sessionStorage reuse pointer;
+  // its retention is already handled by that reuse path plus the server's
+  // boot-time sweep, so only the *other* (non-resumable) live sessions —
+  // decorative-row materializations, unused "New chat" clicks — need this
+  // pagehide sweep at all.
+  const showcaseUsedSessionIds = useRef(new Set<string>())
+  useEffect(() => {
+    if (!showcase) return
+    const handlePageHide = () => {
+      let resumePointerId: string | undefined
+      try {
+        resumePointerId = window.sessionStorage.getItem(showcaseBootStorageKey) ?? undefined
+      } catch {
+        /* sessionStorage unavailable — nothing to preserve for reuse */
+      }
+      for (const sessionId of liveShowcaseSessionIds.current) {
+        if (sessionId === resumePointerId) continue
+        if (showcaseUsedSessionIds.current.has(sessionId)) continue
+        void fetch(`/api/v1/agents/${encodeURIComponent(defaultAgentTypeId)}/sessions/${encodeURIComponent(sessionId)}`, {
+          method: "DELETE",
+          headers: { "x-boring-workspace-id": "default" },
+          keepalive: true,
+        }).catch(() => { /* best-effort — the boot-time sweep is the real backstop */ })
+      }
+    }
+    window.addEventListener("pagehide", handlePageHide)
+    return () => window.removeEventListener("pagehide", handlePageHide)
+  }, [defaultAgentTypeId, showcase])
 
   useEffect(() => {
     if (loadingShowcase) return
@@ -430,7 +496,12 @@ export function WorkspaceShell() {
       onCreateSession={showcase ? createShowcaseSession : undefined}
       onRenameSession={showcase ? renameShowcaseSession : undefined}
       plugins={workspacePlugins}
-      chatParams={{ thinkingControl: true }}
+      chatParams={showcase ? {
+        thinkingControl: true,
+        onPromptSubmitStarted: ({ sessionId }: { sessionId: string }) => {
+          showcaseUsedSessionIds.current.add(sessionId)
+        },
+      } : { thinkingControl: true }}
     />
   )
 }

--- a/apps/workspace-playground/src/front/App.tsx
+++ b/apps/workspace-playground/src/front/App.tsx
@@ -53,13 +53,17 @@ function showcaseSessionCount(): number {
   return Number.isFinite(requested) ? Math.min(100, Math.max(1, Math.floor(requested))) : 1
 }
 
+// Decorative-only entries used to pad the session list when `?sessions=N`
+// is requested (session-list volume/scroll demos). These never back a real
+// server session — only the boot-created session (below) is ever selected
+// by default, so they are never connected to.
 function createInitialShowcaseSessions() {
   const count = showcaseSessionCount()
   const now = Date.now()
-  return Array.from({ length: count }, (_, index) => ({
-    id: index === 0 ? SHOWCASE_SESSION_ID : `${SHOWCASE_SESSION_ID}-${index + 1}`,
-    title: showcaseSessionTitles[index % showcaseSessionTitles.length] ?? `Session ${index + 1}`,
-    updatedAt: now - index * 60_000,
+  return Array.from({ length: Math.max(0, count - 1) }, (_, index) => ({
+    id: `${SHOWCASE_SESSION_ID}-${index + 2}`,
+    title: showcaseSessionTitles[(index + 1) % showcaseSessionTitles.length] ?? `Session ${index + 2}`,
+    updatedAt: now - (index + 1) * 60_000,
   }))
 }
 
@@ -172,33 +176,79 @@ export function WorkspaceShell() {
   const [workspaceId, setWorkspaceId] = useState("Workspace")
   const [metaLoaded, setMetaLoaded] = useState(Boolean(loadingShowcase))
   const [metaError, setMetaError] = useState<string | null>(null)
-  const [showcaseActiveSessionId, setShowcaseActiveSessionId] = useState(SHOWCASE_SESSION_ID)
+  const [showcaseActiveSessionId, setShowcaseActiveSessionId] = useState<string | undefined>(undefined)
   const [showcaseSessions, setShowcaseSessions] = useState(createInitialShowcaseSessions)
+  // The showcase route pre-seeds a client-side session id, but the chat pane
+  // always talks to a real backend session (see packages/workspace's chat
+  // pane, which requires params.sessionId and hydrates it over the network).
+  // A session that only ever exists in localStorage 404s on hydrate, which is
+  // what previously produced the permanent "session was not found" banner
+  // and a disabled composer (gh-1452). `showcaseBootState` gates rendering
+  // the chat panel until a real backend session has been created.
+  const [showcaseBootState, setShowcaseBootState] = useState<"pending" | "ready" | "error">(showcase ? "pending" : "ready")
   const sessions = showcase ? showcaseSessions : undefined
   const liveShowcaseSessionIds = useRef(new Set<string>())
-  const createShowcaseSession = useCallback(async () => {
+  const requestNewShowcaseSession = useCallback(async (title: string) => {
     const response = await fetch(`/api/v1/agents/${encodeURIComponent(defaultAgentTypeId)}/sessions`, {
       method: "POST",
       headers: {
         "content-type": "application/json",
         "x-boring-workspace-id": "default",
       },
-      body: JSON.stringify({ title: "New chat" }),
+      body: JSON.stringify({ title }),
     })
     if (!response.ok) throw new Error(`showcase session create failed (${response.status})`)
     const payload = await response.json() as { agentTypeId?: string; sessionId?: string }
     if (!payload.sessionId) throw new Error("showcase session create returned no session id")
-    const session = {
+    return {
       id: payload.sessionId,
       agentTypeId: payload.agentTypeId ?? defaultAgentTypeId,
-      title: "New chat",
+      title,
       updatedAt: Date.now(),
     }
+  }, [defaultAgentTypeId])
+  const createShowcaseSession = useCallback(async () => {
+    const session = await requestNewShowcaseSession("New chat")
     liveShowcaseSessionIds.current.add(session.id)
     setShowcaseSessions((current) => [...current, session])
     setShowcaseActiveSessionId(session.id)
     return session
-  }, [defaultAgentTypeId])
+  }, [requestNewShowcaseSession])
+  // Boot the initial showcase session: create it on the real backend (with
+  // retries to ride out a cold dev-server boot) before the composer is ever
+  // shown, instead of pre-seeding a session id that never materializes
+  // server-side.
+  const showcaseBootStartedRef = useRef(false)
+  useEffect(() => {
+    if (!showcase || !metaLoaded || !defaultAgentTypeId) return
+    if (showcaseBootStartedRef.current) return
+    showcaseBootStartedRef.current = true
+    let cancelled = false
+    const maxAttempts = 5
+    const boot = async () => {
+      for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+        try {
+          const session = await requestNewShowcaseSession(showcaseSessionTitles[0] ?? "New chat")
+          if (cancelled) return
+          liveShowcaseSessionIds.current.add(session.id)
+          seedShowcase(session.id)
+          setShowcaseSessions((current) => [session, ...current])
+          setShowcaseActiveSessionId(session.id)
+          setShowcaseBootState("ready")
+          return
+        } catch {
+          if (cancelled) return
+          if (attempt === maxAttempts) {
+            setShowcaseBootState("error")
+            return
+          }
+          await new Promise((resolve) => setTimeout(resolve, 300 * attempt))
+        }
+      }
+    }
+    void boot()
+    return () => { cancelled = true }
+  }, [defaultAgentTypeId, metaLoaded, requestNewShowcaseSession, showcase])
   const renameShowcaseSession = useCallback((sessionId: string, title: string) => {
     setShowcaseSessions((current) => current.map((session) => (
       session.id === sessionId ? { ...session, title, updatedAt: Date.now() } : session
@@ -243,8 +293,6 @@ export function WorkspaceShell() {
     return () => { cancelled = true }
   }, [showcase, loadingShowcase])
 
-  if (showcase) seedShowcase(SHOWCASE_SESSION_ID)
-
   if (loadingShowcase) {
     return <LoadingStatesShowcase mode={loadingShowcase} />
   }
@@ -254,6 +302,19 @@ export function WorkspaceShell() {
       return (
         <div className="flex h-screen w-screen items-center justify-center bg-background p-6">
           <p role="alert" className="max-w-md text-center text-sm text-destructive">{metaError}</p>
+        </div>
+      )
+    }
+    return <div className="h-screen w-screen bg-background" />
+  }
+
+  if (showcase && showcaseBootState !== "ready") {
+    if (showcaseBootState === "error") {
+      return (
+        <div className="flex h-screen w-screen items-center justify-center bg-background p-6">
+          <p role="alert" className="max-w-md text-center text-sm text-destructive">
+            The showcase could not start its session. Reload to try again.
+          </p>
         </div>
       )
     }

--- a/apps/workspace-playground/src/front/App.tsx
+++ b/apps/workspace-playground/src/front/App.tsx
@@ -6,12 +6,17 @@ import { WorkspaceAgentFront, WorkspaceFullPagePanel, parseFullPagePanelLocation
 import { createAskUserPlugin } from "@hachej/boring-ask-user/front"
 import { diagramPlugin } from "@hachej/boring-diagram/front"
 import { createTasksPlugin } from "@hachej/boring-tasks/front"
-import { SHOWCASE_SESSION_ID, seedShowcase } from "./showcaseMessages"
+import { SHOWCASE_SESSION_ID } from "./showcaseMessages"
 import { LoadingStatesShowcase, type LoadingStateMode } from "./LoadingStatesShowcase"
 
 function isShowcaseRoute(): boolean {
   if (typeof window === "undefined") return false
   return new URLSearchParams(window.location.search).get("showcase") === "1"
+}
+
+function randomId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") return crypto.randomUUID()
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
 }
 
 const showcaseSessionTitles = [
@@ -53,10 +58,11 @@ function showcaseSessionCount(): number {
   return Number.isFinite(requested) ? Math.min(100, Math.max(1, Math.floor(requested))) : 1
 }
 
-// Decorative-only entries used to pad the session list when `?sessions=N`
-// is requested (session-list volume/scroll demos). These never back a real
-// server session — only the boot-created session (below) is ever selected
-// by default, so they are never connected to.
+// Decorative padding entries for the session list when `?sessions=N` is
+// requested (session-list volume/scroll demos). They start with no backend
+// session behind them — selecting one materializes a real session on demand
+// (see handleActiveSessionIdChange) instead of ever connecting the chat pane
+// to this placeholder id directly.
 function createInitialShowcaseSessions() {
   const count = showcaseSessionCount()
   const now = Date.now()
@@ -178,90 +184,159 @@ export function WorkspaceShell() {
   const [metaError, setMetaError] = useState<string | null>(null)
   const [showcaseActiveSessionId, setShowcaseActiveSessionId] = useState<string | undefined>(undefined)
   const [showcaseSessions, setShowcaseSessions] = useState(createInitialShowcaseSessions)
-  // The showcase route pre-seeds a client-side session id, but the chat pane
-  // always talks to a real backend session (see packages/workspace's chat
-  // pane, which requires params.sessionId and hydrates it over the network).
-  // A session that only ever exists in localStorage 404s on hydrate, which is
-  // what previously produced the permanent "session was not found" banner
-  // and a disabled composer (gh-1452). `showcaseBootState` gates rendering
-  // the chat panel until a real backend session has been created.
+  // The showcase route used to pre-seed a client-side session id, but the
+  // chat pane always talks to a real backend session (see packages/
+  // workspace's chat pane, which requires params.sessionId and hydrates it
+  // over the network). A session that only ever existed client-side 404'd on
+  // hydrate, which is what produced the permanent "session was not found"
+  // banner and a disabled composer (gh-1452). `showcaseBootState` gates
+  // rendering the chat panel until a real backend session has been created.
   const [showcaseBootState, setShowcaseBootState] = useState<"pending" | "ready" | "error">(showcase ? "pending" : "ready")
   const sessions = showcase ? showcaseSessions : undefined
   const liveShowcaseSessionIds = useRef(new Set<string>())
-  const requestNewShowcaseSession = useCallback(async (title: string) => {
-    const response = await fetch(`/api/v1/agents/${encodeURIComponent(defaultAgentTypeId)}/sessions`, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-boring-workspace-id": "default",
-      },
-      body: JSON.stringify({ title }),
-    })
-    if (!response.ok) throw new Error(`showcase session create failed (${response.status})`)
-    const payload = await response.json() as { agentTypeId?: string; sessionId?: string }
-    if (!payload.sessionId) throw new Error("showcase session create returned no session id")
-    return {
-      id: payload.sessionId,
-      agentTypeId: payload.agentTypeId ?? defaultAgentTypeId,
-      title,
-      updatedAt: Date.now(),
+  // Tab-scoped reuse key: bounds session accumulation from repeated boots in
+  // the same browser tab (reload, HMR) to one durable session instead of one
+  // per mount. sessionStorage (not localStorage) so it never outlives the
+  // tab. Cleared automatically once the reused session picks up its first
+  // turn — createSession only resumes empty (turnCount === 0) sessions
+  // server-side (embeddedGateway.ts), so a used session naturally falls
+  // through to creating a fresh one on the next reload.
+  const showcaseBootStorageKey = "boring-ui-v2:showcase:boot-session-id"
+  const requestNewShowcaseSession = useCallback(async (
+    title: string,
+    options: { requestId?: string; resumeSessionId?: string; timeoutMs?: number } = {},
+  ) => {
+    const controller = new AbortController()
+    const timeoutId = options.timeoutMs !== undefined
+      ? setTimeout(() => controller.abort(), options.timeoutMs)
+      : undefined
+    try {
+      const response = await fetch(`/api/v1/agents/${encodeURIComponent(defaultAgentTypeId)}/sessions`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-boring-workspace-id": "default",
+        },
+        body: JSON.stringify({
+          title,
+          ...(options.requestId ? { requestId: options.requestId } : {}),
+          ...(options.resumeSessionId ? { resumeSessionId: options.resumeSessionId } : {}),
+        }),
+        signal: controller.signal,
+      })
+      if (!response.ok) throw new Error(`showcase session create failed (${response.status})`)
+      const payload = await response.json() as { agentTypeId?: string; sessionId?: string }
+      if (!payload.sessionId) throw new Error("showcase session create returned no session id")
+      return {
+        id: payload.sessionId,
+        agentTypeId: payload.agentTypeId ?? defaultAgentTypeId,
+        title,
+        updatedAt: Date.now(),
+      }
+    } finally {
+      if (timeoutId !== undefined) clearTimeout(timeoutId)
     }
   }, [defaultAgentTypeId])
   const createShowcaseSession = useCallback(async () => {
-    const session = await requestNewShowcaseSession("New chat")
+    const session = await requestNewShowcaseSession("New chat", { requestId: randomId(), timeoutMs: 8_000 })
     liveShowcaseSessionIds.current.add(session.id)
     setShowcaseSessions((current) => [...current, session])
     setShowcaseActiveSessionId(session.id)
     return session
   }, [requestNewShowcaseSession])
-  // Boot the initial showcase session: create it on the real backend (with
-  // retries to ride out a cold dev-server boot) before the composer is ever
-  // shown, instead of pre-seeding a session id that never materializes
-  // server-side.
+  // Boot the initial showcase session: create it on the real backend (with a
+  // bounded, abort-timed retry to ride out a cold dev-server boot) before the
+  // composer is ever shown, instead of pre-seeding a session id that never
+  // materializes server-side. The request id is generated once and reused
+  // across every retry attempt so a committed-but-lost response can't create
+  // a second durable session (createSession is idempotent per requestId —
+  // embeddedGateway.ts replays the original receipt for a repeated id).
   const showcaseBootStartedRef = useRef(false)
+  const showcaseBootRequestIdRef = useRef<string | null>(null)
+  const showcaseBootCancelRef = useRef(false)
+  const bootShowcaseSession = useCallback(async () => {
+    showcaseBootCancelRef.current = false
+    showcaseBootStartedRef.current = true
+    setShowcaseBootState("pending")
+    if (!showcaseBootRequestIdRef.current) showcaseBootRequestIdRef.current = randomId()
+    const requestId = showcaseBootRequestIdRef.current
+    let resumeSessionId: string | undefined
+    try {
+      resumeSessionId = window.sessionStorage.getItem(showcaseBootStorageKey) ?? undefined
+    } catch {
+      /* sessionStorage unavailable (private mode, disabled storage) — always create fresh */
+    }
+    const maxAttempts = 5
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      if (showcaseBootCancelRef.current) return
+      try {
+        const session = await requestNewShowcaseSession(showcaseSessionTitles[0] ?? "New chat", {
+          requestId,
+          resumeSessionId,
+          timeoutMs: 8_000,
+        })
+        if (showcaseBootCancelRef.current) return
+        liveShowcaseSessionIds.current.add(session.id)
+        try { window.sessionStorage.setItem(showcaseBootStorageKey, session.id) } catch { /* noop */ }
+        setShowcaseSessions((current) => [session, ...current.filter((existing) => existing.id !== session.id)])
+        setShowcaseActiveSessionId(session.id)
+        setShowcaseBootState("ready")
+        return
+      } catch {
+        if (showcaseBootCancelRef.current) return
+        if (attempt === maxAttempts) {
+          setShowcaseBootState("error")
+          return
+        }
+        await new Promise((resolve) => setTimeout(resolve, 300 * attempt))
+      }
+    }
+  }, [requestNewShowcaseSession])
   useEffect(() => {
     if (!showcase || !metaLoaded || !defaultAgentTypeId) return
     if (showcaseBootStartedRef.current) return
-    showcaseBootStartedRef.current = true
-    let cancelled = false
-    const maxAttempts = 5
-    const boot = async () => {
-      for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-        try {
-          const session = await requestNewShowcaseSession(showcaseSessionTitles[0] ?? "New chat")
-          if (cancelled) return
-          liveShowcaseSessionIds.current.add(session.id)
-          seedShowcase(session.id)
-          setShowcaseSessions((current) => [session, ...current])
-          setShowcaseActiveSessionId(session.id)
-          setShowcaseBootState("ready")
-          return
-        } catch {
-          if (cancelled) return
-          if (attempt === maxAttempts) {
-            setShowcaseBootState("error")
-            return
-          }
-          await new Promise((resolve) => setTimeout(resolve, 300 * attempt))
-        }
-      }
-    }
-    void boot()
-    return () => { cancelled = true }
-  }, [defaultAgentTypeId, metaLoaded, requestNewShowcaseSession, showcase])
+    void bootShowcaseSession()
+    return () => { showcaseBootCancelRef.current = true }
+  }, [bootShowcaseSession, defaultAgentTypeId, metaLoaded, showcase])
+  const retryShowcaseBoot = useCallback(() => {
+    showcaseBootStartedRef.current = false
+    void bootShowcaseSession()
+  }, [bootShowcaseSession])
   const renameShowcaseSession = useCallback((sessionId: string, title: string) => {
     setShowcaseSessions((current) => current.map((session) => (
       session.id === sessionId ? { ...session, title, updatedAt: Date.now() } : session
     )))
   }, [])
+  // Decorative rows (padding from `?sessions=N`) start with no backend
+  // session behind them. Selecting one materializes a real session first —
+  // keyed by a stable per-row request id so a double-click can't create two
+  // — instead of ever handing the chat pane an id that will 404 (gh-1452).
+  const materializingShowcaseSessionIds = useRef(new Set<string>())
   const handleActiveSessionIdChange = useCallback(
     (sessionId: string | null) => {
-      if (showcase && sessionId) {
-        if (!liveShowcaseSessionIds.current.has(sessionId)) seedShowcase(sessionId)
+      if (!showcase || !sessionId) return
+      if (liveShowcaseSessionIds.current.has(sessionId)) {
         setShowcaseActiveSessionId(sessionId)
+        return
       }
+      if (materializingShowcaseSessionIds.current.has(sessionId)) return
+      materializingShowcaseSessionIds.current.add(sessionId)
+      const placeholderTitle = showcaseSessions.find((session) => session.id === sessionId)?.title ?? "New chat"
+      void requestNewShowcaseSession(placeholderTitle, { requestId: `showcase-row-${sessionId}`, timeoutMs: 8_000 })
+        .then((session) => {
+          liveShowcaseSessionIds.current.add(session.id)
+          setShowcaseSessions((current) => current.map((existing) => (existing.id === sessionId ? session : existing)))
+          setShowcaseActiveSessionId(session.id)
+        })
+        .catch(() => {
+          // Leave the active session untouched rather than switching into a
+          // placeholder id that is guaranteed to 404.
+        })
+        .finally(() => {
+          materializingShowcaseSessionIds.current.delete(sessionId)
+        })
     },
-    [showcase],
+    [requestNewShowcaseSession, showcase, showcaseSessions],
   )
 
   useEffect(() => {
@@ -311,10 +386,17 @@ export function WorkspaceShell() {
   if (showcase && showcaseBootState !== "ready") {
     if (showcaseBootState === "error") {
       return (
-        <div className="flex h-screen w-screen items-center justify-center bg-background p-6">
+        <div className="flex h-screen w-screen flex-col items-center justify-center gap-4 bg-background p-6">
           <p role="alert" className="max-w-md text-center text-sm text-destructive">
-            The showcase could not start its session. Reload to try again.
+            The showcase could not start its session.
           </p>
+          <button
+            type="button"
+            onClick={retryShowcaseBoot}
+            className="rounded-md border border-border bg-background px-3 py-1.5 text-sm font-medium text-foreground hover:bg-muted"
+          >
+            Retry
+          </button>
         </div>
       )
     }

--- a/apps/workspace-playground/src/front/App.tsx
+++ b/apps/workspace-playground/src/front/App.tsx
@@ -8,7 +8,7 @@ import { diagramPlugin } from "@hachej/boring-diagram/front"
 import { createTasksPlugin } from "@hachej/boring-tasks/front"
 import { SHOWCASE_SESSION_ID } from "./showcaseMessages"
 import { LoadingStatesShowcase, type LoadingStateMode } from "./LoadingStatesShowcase"
-import { SHOWCASE_SESSION_TITLE_TAG } from "../shared/showcaseSession"
+import { PLAYGROUND_SHOWCASE_SESSION_ROUTE } from "../shared/showcaseSession"
 
 function isShowcaseRoute(): boolean {
   if (typeof window === "undefined") return false
@@ -204,8 +204,8 @@ export function WorkspaceShell() {
   // bounded by two other layers: the pagehide cleanup below (best-effort,
   // same boot) and the scripted dev server's boot-time sweep in
   // scriptedPiHarness.ts (authoritative backstop — deletes every
-  // showcase-tagged session left empty by a *previous* boot, regardless of
-  // which tab/context created it). See SHOWCASE_SESSION_TITLE_TAG.
+  // showcase-created session left empty by a *previous* boot, regardless of
+  // which tab/context created it). See ../shared/showcaseSession.ts.
   const showcaseBootStorageKey = "boring-ui-v2:showcase:boot-session-id"
   const requestNewShowcaseSession = useCallback(async (
     title: string,
@@ -216,20 +216,20 @@ export function WorkspaceShell() {
       ? setTimeout(() => controller.abort(), options.timeoutMs)
       : undefined
     try {
-      const response = await fetch(`/api/v1/agents/${encodeURIComponent(defaultAgentTypeId)}/sessions`, {
+      // Every showcase session is created through this dev-only wrapper
+      // route, never the ordinary create-session endpoint directly — that
+      // is what marks a session as showcase-originated for the server's
+      // boot-time sweep (provenance-by-route, not by title content; see
+      // ../shared/showcaseSession.ts for why title tagging was dropped).
+      const response = await fetch(PLAYGROUND_SHOWCASE_SESSION_ROUTE, {
         method: "POST",
         headers: {
           "content-type": "application/json",
           "x-boring-workspace-id": "default",
         },
         body: JSON.stringify({
-          // The backend-stored title is tagged and never surfaced — this UI
-          // only ever renders the `title` this function returns below, taken
-          // from the controlled `sessions` prop it builds client-side (see
-          // ../shared/showcaseSession.ts). The tag lets the scripted dev
-          // server's boot-time sweep find and delete stale, still-empty
-          // showcase sessions without touching unrelated ones.
-          title: `${SHOWCASE_SESSION_TITLE_TAG}${title}`,
+          agentTypeId: defaultAgentTypeId,
+          title,
           ...(options.requestId ? { requestId: options.requestId } : {}),
           ...(options.resumeSessionId ? { resumeSessionId: options.resumeSessionId } : {}),
         }),

--- a/apps/workspace-playground/src/front/showcaseMessages.ts
+++ b/apps/workspace-playground/src/front/showcaseMessages.ts
@@ -3,9 +3,16 @@
  *
  * Renders one hand-crafted thread covering every message variant + tool
  * state + markdown pattern so we can iterate visual design without an LLM
- * in the loop. Hydrated into the Pi-native chat panel via localStorage.
- * picks it up on mount because the cache key matches the showcase
- * session id.
+ * in the loop.
+ *
+ * NOTE: `showcaseMessages` is not currently wired into the live chat panel.
+ * The Pi-native chat pane always hydrates a real backend session over the
+ * network (see App.tsx's boot flow), so there is no local-only render path
+ * left to feed this fixture into — a previous `localStorage` seeding
+ * mechanism that fed it was dead code (nothing read the key) and produced
+ * the gh-1452 "session was not found" regression, and has been removed.
+ * Kept here for reuse if/when the chat pane grows a local-fixture render
+ * mode again.
  *
  * Ported from the original agent shadcn showcase fixture.
  */
@@ -244,16 +251,3 @@ export const showcaseMessages = [
     ],
   },
 ] as const
-
-/**
- * Pre-seed the old showcase cache for archived demos.
- * Call once on mount in showcase mode; the fixture remains display-only
- * with no network round-trip.
- */
-export function seedShowcase(sessionId = SHOWCASE_SESSION_ID) {
-  try {
-    localStorage.setItem(`boring-agent:messages:${sessionId}`, JSON.stringify(showcaseMessages))
-  } catch {
-    /* noop — quota or disabled storage */
-  }
-}

--- a/apps/workspace-playground/src/server/dev.ts
+++ b/apps/workspace-playground/src/server/dev.ts
@@ -4,7 +4,8 @@ import { basename, dirname, resolve } from "node:path"
 import { createRemoteWorkerModeAdapter } from "@hachej/boring-agent/server"
 import { createReadonlyProjectionOperations } from "@hachej/boring-bash/server"
 import { createNodeWorkspace } from "@hachej/boring-sandbox/providers/node-workspace"
-import { createPersistedScriptedPiHarness } from "./testing/scriptedPiHarness"
+import { createPersistedScriptedPiHarness, markPlaygroundShowcaseSession } from "./testing/scriptedPiHarness"
+import { PLAYGROUND_SHOWCASE_SESSION_ROUTE } from "../shared/showcaseSession"
 import {
   SCRIPTED_ONE_AGENT,
   SCRIPTED_ONE_AGENT_CAPABILITY_PLUGINS,
@@ -132,6 +133,48 @@ export async function startPlaygroundServer(): Promise<void> {
         workspaceRoot,
         defaultAgentTypeId,
       }
+    })
+    // Dev-only wrapper the `?showcase=1` route creates every one of its
+    // sessions through (see PLAYGROUND_SHOWCASE_SESSION_ROUTE). It forwards
+    // to the ordinary create-session endpoint unchanged via `app.inject`
+    // (no extra network hop, no duplicated auth/validation logic) and then
+    // records the resulting id in the showcase provenance registry that
+    // scriptedPiHarness.ts's boot-time sweep reads. Provenance lives in
+    // *which route created the session*, not in title text — the ordinary
+    // session-creation UI never calls this route, so nothing a user types
+    // into a title can mark (or accidentally un-mark) a session here. See
+    // apps/workspace-playground/src/shared/showcaseSession.ts.
+    app.post(PLAYGROUND_SHOWCASE_SESSION_ROUTE, async (request, reply) => {
+      const body = (request.body ?? {}) as { agentTypeId?: unknown; title?: unknown; requestId?: unknown; resumeSessionId?: unknown }
+      const targetAgentTypeId = typeof body.agentTypeId === "string" && body.agentTypeId.trim() ? body.agentTypeId.trim() : defaultAgentTypeId
+      const forwardBody: Record<string, unknown> = {}
+      if (typeof body.title === "string") forwardBody.title = body.title
+      if (typeof body.requestId === "string") forwardBody.requestId = body.requestId
+      if (typeof body.resumeSessionId === "string") forwardBody.resumeSessionId = body.resumeSessionId
+      const workspaceIdHeader = request.headers["x-boring-workspace-id"]
+      const injected = await app.inject({
+        method: "POST",
+        url: `/api/v1/agents/${encodeURIComponent(targetAgentTypeId)}/sessions`,
+        headers: {
+          "content-type": "application/json",
+          ...(typeof workspaceIdHeader === "string" ? { "x-boring-workspace-id": workspaceIdHeader } : {}),
+        },
+        payload: JSON.stringify(forwardBody),
+      })
+      reply.code(injected.statusCode)
+      reply.header("content-type", injected.headers["content-type"] ?? "application/json")
+      if (injected.statusCode === 201) {
+        try {
+          const payload = JSON.parse(injected.body) as { sessionId?: unknown }
+          if (typeof payload.sessionId === "string") {
+            await markPlaygroundShowcaseSession(process.env.BORING_AGENT_SESSION_ROOT, payload.sessionId)
+          }
+        } catch {
+          // Response wasn't the expected shape — forward it as-is below;
+          // provenance just doesn't get recorded for this one.
+        }
+      }
+      return reply.send(injected.body)
     })
     await app.listen({ port: AGENT_API_PORT, host: "127.0.0.1" })
   })()

--- a/apps/workspace-playground/src/server/dev.ts
+++ b/apps/workspace-playground/src/server/dev.ts
@@ -153,17 +153,22 @@ export async function startPlaygroundServer(): Promise<void> {
       // `resumeSessionId` travels through the client's writable
       // sessionStorage (App.tsx) — a stale or manipulated value could
       // otherwise name an ordinary session this wrapper never created and
-      // marked, and the gateway would happily hand that session's ref back
+      // marked (or a showcase session belonging to a *different* agent
+      // type — scripted session ids are only unique within one agent
+      // namespace, so 'scripted-main' under `targetAgentTypeId` is a
+      // different session than 'scripted-main' under any other agent), and
+      // the gateway would happily hand that session's ref back
       // (embeddedGateway.ts createSession resumes any empty session it can
       // resolve, regardless of who created it). Only ever forward it when
-      // it already names a session this wrapper itself previously marked —
-      // an unrecognized id is silently dropped, not forwarded, so the boot
-      // flow just creates a brand-new (still perfectly valid) session
-      // instead. This is what keeps "which route created it" a guarantee
-      // instead of a suggestion.
+      // it already names a session this wrapper itself previously marked
+      // for THIS EXACT `targetAgentTypeId` — an unrecognized (agent, id)
+      // pair is silently dropped, not forwarded, so the boot flow just
+      // creates a brand-new (still perfectly valid) session instead. This
+      // is what keeps "which route created it, for which agent" a
+      // guarantee instead of a suggestion.
       if (
         typeof body.resumeSessionId === "string"
-        && await isPlaygroundShowcaseSession(process.env.BORING_AGENT_SESSION_ROOT, body.resumeSessionId)
+        && await isPlaygroundShowcaseSession(process.env.BORING_AGENT_SESSION_ROOT, targetAgentTypeId, body.resumeSessionId)
       ) {
         forwardBody.resumeSessionId = body.resumeSessionId
       }
@@ -183,7 +188,7 @@ export async function startPlaygroundServer(): Promise<void> {
         try {
           const payload = JSON.parse(injected.body) as { sessionId?: unknown }
           if (typeof payload.sessionId === "string") {
-            await markPlaygroundShowcaseSession(process.env.BORING_AGENT_SESSION_ROOT, payload.sessionId)
+            await markPlaygroundShowcaseSession(process.env.BORING_AGENT_SESSION_ROOT, targetAgentTypeId, payload.sessionId)
           }
         } catch {
           // Response wasn't the expected shape — forward it as-is below;

--- a/apps/workspace-playground/src/server/dev.ts
+++ b/apps/workspace-playground/src/server/dev.ts
@@ -147,19 +147,30 @@ export async function startPlaygroundServer(): Promise<void> {
     app.post(PLAYGROUND_SHOWCASE_SESSION_ROUTE, async (request, reply) => {
       const body = (request.body ?? {}) as { agentTypeId?: unknown; title?: unknown; requestId?: unknown; resumeSessionId?: unknown }
       const targetAgentTypeId = typeof body.agentTypeId === "string" && body.agentTypeId.trim() ? body.agentTypeId.trim() : defaultAgentTypeId
-      // The raw (unhashed) workspace id this exact request is scoped to.
-      // The scripted store's actual on-disk namespace additionally folds in
-      // a hash of the *internal* workspaceScopeId
-      // (sessionNamespaceForAgent in packages/agent), which this dev-only
-      // route has no business reproducing — a private algorithm in a
-      // different package. This raw id is what both this route and the
-      // store (via SessionCtx.workspaceId, the same field `belongsTo`
-      // scopes ordinary session visibility by) can derive identically
-      // without either side needing to know the hash: two different raw
-      // workspace ids always land in two different registry entries,
-      // tracking whichever partition the real hashed namespace produces.
+      // The registry must key by the CANONICAL workspace scope id
+      // (SessionCtx.workspaceId — what `belongsTo` actually compares
+      // against), not the raw header the client presented. createWorkspaceAgentServer
+      // accepts two DIFFERENT selectors for that same header —
+      // `workspaceScopeId` itself and `basename(workspaceRoot)`
+      // (createWorkspaceAgentServer.ts's `allowedWorkspaceSelectors`) — and
+      // `trustedWorkspaceScopeId` always resolves either one to the SAME
+      // canonical `workspaceScopeId` before it ever reaches a session
+      // record. Keying by the raw header instead would let an allowed
+      // basename-selector request create a session scoped to canonical
+      // while marking the registry under the basename, permanently
+      // orphaning that entry (the sweep's full-match rule intentionally
+      // never prunes a mismatch — see scriptedPiHarness.ts).
+      //
+      // Reproducing `trustedWorkspaceScopeId` itself isn't needed: for this
+      // server, `workspaceScopeId` is a SINGLE constant for the whole
+      // process lifetime — `opts.sessionId ?? "default"`
+      // (createWorkspaceAgentServer.ts) — computed once below from the
+      // exact same `remoteWorkerWorkspaceId` this file already passes as
+      // `sessionId` to `createWorkspaceAgentServer`. It does not vary per
+      // request, so it does not need to be derived from the header at all.
+      const canonicalWorkspaceScopeId = remoteWorkerWorkspaceId ?? "default"
+      const targetWorkspaceId = canonicalWorkspaceScopeId
       const workspaceIdHeader = request.headers["x-boring-workspace-id"]
-      const targetWorkspaceId = typeof workspaceIdHeader === "string" && workspaceIdHeader.trim() ? workspaceIdHeader.trim() : "default"
       const forwardBody: Record<string, unknown> = {}
       if (typeof body.title === "string") forwardBody.title = body.title
       if (typeof body.requestId === "string") forwardBody.requestId = body.requestId

--- a/apps/workspace-playground/src/server/dev.ts
+++ b/apps/workspace-playground/src/server/dev.ts
@@ -4,7 +4,7 @@ import { basename, dirname, resolve } from "node:path"
 import { createRemoteWorkerModeAdapter } from "@hachej/boring-agent/server"
 import { createReadonlyProjectionOperations } from "@hachej/boring-bash/server"
 import { createNodeWorkspace } from "@hachej/boring-sandbox/providers/node-workspace"
-import { createPersistedScriptedPiHarness, markPlaygroundShowcaseSession } from "./testing/scriptedPiHarness"
+import { createPersistedScriptedPiHarness, isPlaygroundShowcaseSession, markPlaygroundShowcaseSession } from "./testing/scriptedPiHarness"
 import { PLAYGROUND_SHOWCASE_SESSION_ROUTE } from "../shared/showcaseSession"
 import {
   SCRIPTED_ONE_AGENT,
@@ -150,7 +150,23 @@ export async function startPlaygroundServer(): Promise<void> {
       const forwardBody: Record<string, unknown> = {}
       if (typeof body.title === "string") forwardBody.title = body.title
       if (typeof body.requestId === "string") forwardBody.requestId = body.requestId
-      if (typeof body.resumeSessionId === "string") forwardBody.resumeSessionId = body.resumeSessionId
+      // `resumeSessionId` travels through the client's writable
+      // sessionStorage (App.tsx) — a stale or manipulated value could
+      // otherwise name an ordinary session this wrapper never created and
+      // marked, and the gateway would happily hand that session's ref back
+      // (embeddedGateway.ts createSession resumes any empty session it can
+      // resolve, regardless of who created it). Only ever forward it when
+      // it already names a session this wrapper itself previously marked —
+      // an unrecognized id is silently dropped, not forwarded, so the boot
+      // flow just creates a brand-new (still perfectly valid) session
+      // instead. This is what keeps "which route created it" a guarantee
+      // instead of a suggestion.
+      if (
+        typeof body.resumeSessionId === "string"
+        && await isPlaygroundShowcaseSession(process.env.BORING_AGENT_SESSION_ROOT, body.resumeSessionId)
+      ) {
+        forwardBody.resumeSessionId = body.resumeSessionId
+      }
       const workspaceIdHeader = request.headers["x-boring-workspace-id"]
       const injected = await app.inject({
         method: "POST",

--- a/apps/workspace-playground/src/server/dev.ts
+++ b/apps/workspace-playground/src/server/dev.ts
@@ -147,6 +147,19 @@ export async function startPlaygroundServer(): Promise<void> {
     app.post(PLAYGROUND_SHOWCASE_SESSION_ROUTE, async (request, reply) => {
       const body = (request.body ?? {}) as { agentTypeId?: unknown; title?: unknown; requestId?: unknown; resumeSessionId?: unknown }
       const targetAgentTypeId = typeof body.agentTypeId === "string" && body.agentTypeId.trim() ? body.agentTypeId.trim() : defaultAgentTypeId
+      // The raw (unhashed) workspace id this exact request is scoped to.
+      // The scripted store's actual on-disk namespace additionally folds in
+      // a hash of the *internal* workspaceScopeId
+      // (sessionNamespaceForAgent in packages/agent), which this dev-only
+      // route has no business reproducing — a private algorithm in a
+      // different package. This raw id is what both this route and the
+      // store (via SessionCtx.workspaceId, the same field `belongsTo`
+      // scopes ordinary session visibility by) can derive identically
+      // without either side needing to know the hash: two different raw
+      // workspace ids always land in two different registry entries,
+      // tracking whichever partition the real hashed namespace produces.
+      const workspaceIdHeader = request.headers["x-boring-workspace-id"]
+      const targetWorkspaceId = typeof workspaceIdHeader === "string" && workspaceIdHeader.trim() ? workspaceIdHeader.trim() : "default"
       const forwardBody: Record<string, unknown> = {}
       if (typeof body.title === "string") forwardBody.title = body.title
       if (typeof body.requestId === "string") forwardBody.requestId = body.requestId
@@ -154,25 +167,25 @@ export async function startPlaygroundServer(): Promise<void> {
       // sessionStorage (App.tsx) — a stale or manipulated value could
       // otherwise name an ordinary session this wrapper never created and
       // marked (or a showcase session belonging to a *different* agent
-      // type — scripted session ids are only unique within one agent
-      // namespace, so 'scripted-main' under `targetAgentTypeId` is a
-      // different session than 'scripted-main' under any other agent), and
+      // type or workspace scope — scripted session ids are only unique
+      // within one full storage namespace, so 'scripted-main' under
+      // `targetAgentTypeId`+`targetWorkspaceId` is a different session
+      // than 'scripted-main' under any other agent type or workspace), and
       // the gateway would happily hand that session's ref back
       // (embeddedGateway.ts createSession resumes any empty session it can
       // resolve, regardless of who created it). Only ever forward it when
       // it already names a session this wrapper itself previously marked
-      // for THIS EXACT `targetAgentTypeId` — an unrecognized (agent, id)
-      // pair is silently dropped, not forwarded, so the boot flow just
-      // creates a brand-new (still perfectly valid) session instead. This
-      // is what keeps "which route created it, for which agent" a
+      // for THIS EXACT (agent, workspace) pair — an unrecognized triple is
+      // silently dropped, not forwarded, so the boot flow just creates a
+      // brand-new (still perfectly valid) session instead. This is what
+      // keeps "which route created it, for which agent and workspace" a
       // guarantee instead of a suggestion.
       if (
         typeof body.resumeSessionId === "string"
-        && await isPlaygroundShowcaseSession(process.env.BORING_AGENT_SESSION_ROOT, targetAgentTypeId, body.resumeSessionId)
+        && await isPlaygroundShowcaseSession(process.env.BORING_AGENT_SESSION_ROOT, targetAgentTypeId, targetWorkspaceId, body.resumeSessionId)
       ) {
         forwardBody.resumeSessionId = body.resumeSessionId
       }
-      const workspaceIdHeader = request.headers["x-boring-workspace-id"]
       const injected = await app.inject({
         method: "POST",
         url: `/api/v1/agents/${encodeURIComponent(targetAgentTypeId)}/sessions`,
@@ -188,7 +201,7 @@ export async function startPlaygroundServer(): Promise<void> {
         try {
           const payload = JSON.parse(injected.body) as { sessionId?: unknown }
           if (typeof payload.sessionId === "string") {
-            await markPlaygroundShowcaseSession(process.env.BORING_AGENT_SESSION_ROOT, targetAgentTypeId, payload.sessionId)
+            await markPlaygroundShowcaseSession(process.env.BORING_AGENT_SESSION_ROOT, targetAgentTypeId, targetWorkspaceId, payload.sessionId)
           }
         } catch {
           // Response wasn't the expected shape — forward it as-is below;

--- a/apps/workspace-playground/src/server/testing/scriptedPiHarness.test.ts
+++ b/apps/workspace-playground/src/server/testing/scriptedPiHarness.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, readFile, readdir, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { createScriptedPiHarness } from './scriptedPiHarness'
+import { createScriptedPiHarness, markPlaygroundShowcaseSession } from './scriptedPiHarness'
 
 const runContext = (workdir: string) => ({
   abortSignal: new AbortController().signal,
@@ -106,5 +106,78 @@ describe('scripted Pi browser harness persistence', () => {
     const invalid = createScriptedPiHarness({ cwd: workspaceRoot, sessionRoot: isolatedRoot })
     await expect(invalid.sessions!.list(workspaceA)).resolves.toEqual([])
     await expect(invalid.sessions!.create(workspaceA)).resolves.toMatchObject({ id: 'scripted-main' })
+  })
+
+  // gh-1452 PR #1458 review: showcase-session provenance used to be a fixed
+  // title prefix, which an ordinary session's title could collide with (the
+  // create/rename HTTP schemas accept any title). Provenance is now a
+  // sidecar registry keyed by session id, marked only via
+  // `markPlaygroundShowcaseSession` (the dev-only wrapper route in dev.ts
+  // calls this — never reachable from the ordinary session-creation UI).
+  describe('showcase session provenance registry', () => {
+    it('sweeps a marked, still-empty session from a previous boot without touching an ordinary session even when its title copies the old removed tag text', async () => {
+      const workspaceRoot = await mkdtemp(join(tmpdir(), 'scripted-pi-showcase-workspace-'))
+      const sessionRoot = await mkdtemp(join(tmpdir(), 'scripted-pi-showcase-sessions-'))
+      const input = { cwd: workspaceRoot, sessionRoot }
+      const ctx = { workspaceId: 'workspace-a' }
+
+      const first = createScriptedPiHarness(input)
+      const showcaseSession = await first.sessions!.create(ctx, { title: 'Navigation polish review' })
+      await markPlaygroundShowcaseSession(sessionRoot, showcaseSession.id)
+
+      // A developer's own ordinary session, never marked, whose title
+      // happens to spell out the exact string the old (removed) title-tag
+      // mechanism used to look for. If provenance were still title-based,
+      // this would get swept — it must not be.
+      const collidingTitle = '[playground-showcase] my ordinary draft'
+      const ordinarySession = await first.sessions!.create(ctx, { title: collidingTitle })
+
+      // Simulate a process restart: a fresh store instance re-hydrates from
+      // disk and runs its boot-time sweep exactly once.
+      const restarted = createScriptedPiHarness(input)
+      const afterRestart = await restarted.sessions!.list(ctx, { includeEmpty: true })
+      const idsAfterRestart = afterRestart.map((session) => session.id)
+
+      expect(idsAfterRestart).not.toContain(showcaseSession.id)
+      expect(idsAfterRestart).toContain(ordinarySession.id)
+      expect(afterRestart.find((session) => session.id === ordinarySession.id)?.title).toBe(collidingTitle)
+    })
+
+    it('stops tracking (and never sweeps) a marked session once it has a real turn', async () => {
+      const workspaceRoot = await mkdtemp(join(tmpdir(), 'scripted-pi-showcase-used-workspace-'))
+      const sessionRoot = await mkdtemp(join(tmpdir(), 'scripted-pi-showcase-used-sessions-'))
+      const input = { cwd: workspaceRoot, sessionRoot }
+      const ctx = { workspaceId: 'workspace-a' }
+
+      const first = createScriptedPiHarness(input)
+      const session = await first.sessions!.create(ctx, { title: 'Navigation polish review' })
+      await markPlaygroundShowcaseSession(sessionRoot, session.id)
+      const adapter = await first.getPiSessionAdapter(
+        { sessionId: session.id, ctx },
+        runContext(workspaceRoot),
+      )
+      await adapter.prompt('a real turn')
+
+      const restarted = createScriptedPiHarness(input)
+      await expect(restarted.sessions!.list(ctx)).resolves.toContainEqual(
+        expect.objectContaining({ id: session.id, turnCount: 1 }),
+      )
+    })
+
+    it('leaves an unrelated registry entry alone when this store cannot find it (different session store)', async () => {
+      const workspaceRoot = await mkdtemp(join(tmpdir(), 'scripted-pi-showcase-foreign-workspace-'))
+      const sessionRoot = await mkdtemp(join(tmpdir(), 'scripted-pi-showcase-foreign-sessions-'))
+      const ctx = { workspaceId: 'workspace-a' }
+
+      // Mark an id that no session in this sessionRoot will ever create —
+      // standing in for an id that belongs to a different agent
+      // type/namespace's store sharing the same registry file.
+      await markPlaygroundShowcaseSession(sessionRoot, 'scripted-belongs-elsewhere')
+
+      const harness = createScriptedPiHarness({ cwd: workspaceRoot, sessionRoot })
+      // Hydration must not throw, and creating a real session must still
+      // work normally alongside the unresolvable registry entry.
+      await expect(harness.sessions!.create(ctx, { title: 'New chat' })).resolves.toMatchObject({ id: 'scripted-main' })
+    })
   })
 })

--- a/apps/workspace-playground/src/server/testing/scriptedPiHarness.test.ts
+++ b/apps/workspace-playground/src/server/testing/scriptedPiHarness.test.ts
@@ -2,7 +2,12 @@ import { mkdir, mkdtemp, readFile, readdir, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { createScriptedPiHarness, markPlaygroundShowcaseSession } from './scriptedPiHarness'
+import {
+  createScriptedPiHarness,
+  isPlaygroundShowcaseSession,
+  markPlaygroundShowcaseSession,
+  readPlaygroundShowcaseRegistryForTest,
+} from './scriptedPiHarness'
 
 const runContext = (workdir: string) => ({
   abortSignal: new AbortController().signal,
@@ -178,6 +183,64 @@ describe('scripted Pi browser harness persistence', () => {
       // Hydration must not throw, and creating a real session must still
       // work normally alongside the unresolvable registry entry.
       await expect(harness.sessions!.create(ctx, { title: 'New chat' })).resolves.toMatchObject({ id: 'scripted-main' })
+    })
+
+    // gh-1458 review round 3: the previous "unresolvable entry" test above
+    // proved hydration doesn't crash on a foreign id, but it left the entry
+    // in the registry forever — retention, not pruning. This test proves
+    // the actual exploit sequence the review described is closed: mark a
+    // session, delete it exactly the way the pagehide cleanup path does
+    // (through the ordinary delete route, i.e. `sessions.delete`), let a
+    // later ordinary session recycle the freed numeric id, and confirm a
+    // subsequent boot's sweep does NOT delete that unrelated ordinary
+    // session.
+    it('unmarks a session on delete, so its numeric id can be safely recycled by an ordinary session later', async () => {
+      const workspaceRoot = await mkdtemp(join(tmpdir(), 'scripted-pi-showcase-recycle-workspace-'))
+      const sessionRoot = await mkdtemp(join(tmpdir(), 'scripted-pi-showcase-recycle-sessions-'))
+      const input = { cwd: workspaceRoot, sessionRoot }
+      const ctx = { workspaceId: 'workspace-a' }
+
+      // Boot 1: create + mark a showcase session, then delete it — exactly
+      // what the pagehide cleanup does for a session that never got a turn.
+      const first = createScriptedPiHarness(input)
+      const showcaseSession = await first.sessions!.create(ctx, { title: 'Navigation polish review' })
+      expect(showcaseSession.id).toBe('scripted-main')
+      await markPlaygroundShowcaseSession(sessionRoot, showcaseSession.id)
+      await expect(readPlaygroundShowcaseRegistryForTest(sessionRoot)).resolves.toEqual(new Set(['scripted-main']))
+      await first.sessions!.delete(ctx, showcaseSession.id)
+
+      // Deletion must unmark immediately — not wait for a future sweep.
+      await expect(readPlaygroundShowcaseRegistryForTest(sessionRoot)).resolves.toEqual(new Set())
+
+      // Boot 2: createCount resets on hydrate, so an ordinary (unmarked)
+      // session recycles the now-free 'scripted-main' id.
+      const second = createScriptedPiHarness(input)
+      const ordinarySession = await second.sessions!.create(ctx, { title: 'A developer’s real draft' })
+      expect(ordinarySession.id).toBe('scripted-main')
+
+      // Boot 3: if the stale registry entry had survived, this sweep would
+      // now delete the ordinary session that happens to share its id.
+      const third = createScriptedPiHarness(input)
+      const afterBoot3 = await third.sessions!.list(ctx, { includeEmpty: true })
+      expect(afterBoot3.map((session) => session.id)).toContain(ordinarySession.id)
+      expect(afterBoot3.find((session) => session.id === ordinarySession.id)?.title).toBe('A developer’s real draft')
+    })
+
+    it('serializes concurrent marks so two overlapping requests both land in the registry', async () => {
+      const sessionRoot = await mkdtemp(join(tmpdir(), 'scripted-pi-showcase-concurrent-sessions-'))
+      await Promise.all(
+        Array.from({ length: 20 }, (_, index) => markPlaygroundShowcaseSession(sessionRoot, `scripted-concurrent-${index}`)),
+      )
+      const registry = await readPlaygroundShowcaseRegistryForTest(sessionRoot)
+      expect(registry).toEqual(new Set(Array.from({ length: 20 }, (_, index) => `scripted-concurrent-${index}`)))
+    })
+
+    it('isPlaygroundShowcaseSession only recognizes ids this wrapper actually marked', async () => {
+      const sessionRoot = await mkdtemp(join(tmpdir(), 'scripted-pi-showcase-known-sessions-'))
+      await expect(isPlaygroundShowcaseSession(sessionRoot, 'scripted-unmarked')).resolves.toBe(false)
+      await markPlaygroundShowcaseSession(sessionRoot, 'scripted-marked')
+      await expect(isPlaygroundShowcaseSession(sessionRoot, 'scripted-marked')).resolves.toBe(true)
+      await expect(isPlaygroundShowcaseSession(sessionRoot, 'scripted-unmarked')).resolves.toBe(false)
     })
   })
 })

--- a/apps/workspace-playground/src/server/testing/scriptedPiHarness.test.ts
+++ b/apps/workspace-playground/src/server/testing/scriptedPiHarness.test.ts
@@ -135,7 +135,7 @@ describe('scripted Pi browser harness persistence', () => {
 
       const first = createScriptedPiHarness(input)
       const showcaseSession = await first.sessions!.create(ctx, { title: 'Navigation polish review' })
-      await markPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, showcaseSession.id)
+      await markPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, ctx.workspaceId, showcaseSession.id)
 
       // A developer's own ordinary session, never marked, whose title
       // happens to spell out the exact string the old (removed) title-tag
@@ -163,7 +163,7 @@ describe('scripted Pi browser harness persistence', () => {
 
       const first = createScriptedPiHarness(input)
       const session = await first.sessions!.create(ctx, { title: 'Navigation polish review' })
-      await markPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, session.id)
+      await markPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, ctx.workspaceId, session.id)
       const adapter = await first.getPiSessionAdapter(
         { sessionId: session.id, ctx },
         runContext(workspaceRoot),
@@ -184,7 +184,7 @@ describe('scripted Pi browser harness persistence', () => {
       // Mark an id that no session in this sessionRoot will ever create —
       // standing in for an id that belongs to a different agent
       // type/namespace's store sharing the same registry file.
-      await markPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, 'scripted-belongs-elsewhere')
+      await markPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, ctx.workspaceId, 'scripted-belongs-elsewhere')
 
       const harness = createScriptedPiHarness({ cwd: workspaceRoot, sessionRoot })
       // Hydration must not throw, and creating a real session must still
@@ -212,13 +212,13 @@ describe('scripted Pi browser harness persistence', () => {
       const first = createScriptedPiHarness(input)
       const showcaseSession = await first.sessions!.create(ctx, { title: 'Navigation polish review' })
       expect(showcaseSession.id).toBe('scripted-main')
-      await markPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, showcaseSession.id)
-      await expect(isPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, showcaseSession.id)).resolves.toBe(true)
+      await markPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, ctx.workspaceId, showcaseSession.id)
+      await expect(isPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, ctx.workspaceId, showcaseSession.id)).resolves.toBe(true)
       await expect(readPlaygroundShowcaseRegistryForTest(sessionRoot)).resolves.toHaveProperty('size', 1)
       await first.sessions!.delete(ctx, showcaseSession.id)
 
       // Deletion must unmark immediately — not wait for a future sweep.
-      await expect(isPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, showcaseSession.id)).resolves.toBe(false)
+      await expect(isPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, ctx.workspaceId, showcaseSession.id)).resolves.toBe(false)
       await expect(readPlaygroundShowcaseRegistryForTest(sessionRoot)).resolves.toHaveProperty('size', 0)
 
       // Boot 2: createCount resets on hydrate, so an ordinary (unmarked)
@@ -238,21 +238,21 @@ describe('scripted Pi browser harness persistence', () => {
     it('serializes concurrent marks so two overlapping requests both land in the registry', async () => {
       const sessionRoot = await mkdtemp(join(tmpdir(), 'scripted-pi-showcase-concurrent-sessions-'))
       await Promise.all(
-        Array.from({ length: 20 }, (_, index) => markPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, `scripted-concurrent-${index}`)),
+        Array.from({ length: 20 }, (_, index) => markPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, 'workspace-a', `scripted-concurrent-${index}`)),
       )
       const registry = await readPlaygroundShowcaseRegistryForTest(sessionRoot)
       expect(registry.size).toBe(20)
       for (let index = 0; index < 20; index += 1) {
-        await expect(isPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, `scripted-concurrent-${index}`)).resolves.toBe(true)
+        await expect(isPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, 'workspace-a', `scripted-concurrent-${index}`)).resolves.toBe(true)
       }
     })
 
     it('isPlaygroundShowcaseSession only recognizes ids this wrapper actually marked', async () => {
       const sessionRoot = await mkdtemp(join(tmpdir(), 'scripted-pi-showcase-known-sessions-'))
-      await expect(isPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, 'scripted-unmarked')).resolves.toBe(false)
-      await markPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, 'scripted-marked')
-      await expect(isPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, 'scripted-marked')).resolves.toBe(true)
-      await expect(isPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, 'scripted-unmarked')).resolves.toBe(false)
+      await expect(isPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, 'workspace-a', 'scripted-unmarked')).resolves.toBe(false)
+      await markPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, 'workspace-a', 'scripted-marked')
+      await expect(isPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, 'workspace-a', 'scripted-marked')).resolves.toBe(true)
+      await expect(isPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, 'workspace-a', 'scripted-unmarked')).resolves.toBe(false)
     })
 
     // gh-1458 review round 4: scripted session ids are only unique WITHIN
@@ -280,7 +280,7 @@ describe('scripted Pi browser harness persistence', () => {
       })
       const alphaSession = await alphaHarness.sessions!.create(ctx, { title: 'Navigation polish review' })
       expect(alphaSession.id).toBe('scripted-main')
-      await markPlaygroundShowcaseSession(sessionRoot, 'alpha', alphaSession.id)
+      await markPlaygroundShowcaseSession(sessionRoot, 'alpha', ctx.workspaceId, alphaSession.id)
 
       const betaHarness = createScriptedPiHarness({
         cwd: betaWorkspaceRoot,
@@ -302,18 +302,82 @@ describe('scripted Pi browser harness persistence', () => {
 
       // The alpha mark is untouched by beta's hydration/sweep — it belongs
       // to a different agent key and beta's store never even looks at it.
-      await expect(isPlaygroundShowcaseSession(sessionRoot, 'alpha', alphaSession.id)).resolves.toBe(true)
-      await expect(isPlaygroundShowcaseSession(sessionRoot, 'beta', betaSession.id)).resolves.toBe(false)
+      await expect(isPlaygroundShowcaseSession(sessionRoot, 'alpha', ctx.workspaceId, alphaSession.id)).resolves.toBe(true)
+      await expect(isPlaygroundShowcaseSession(sessionRoot, 'beta', ctx.workspaceId, betaSession.id)).resolves.toBe(false)
     })
 
     it('resumeSessionId validation is scoped per agent key: a mark under one agent is not recognized under another', async () => {
       const sessionRoot = await mkdtemp(join(tmpdir(), 'scripted-pi-showcase-cross-namespace-resume-'))
-      await markPlaygroundShowcaseSession(sessionRoot, 'alpha', 'scripted-main')
-      await expect(isPlaygroundShowcaseSession(sessionRoot, 'alpha', 'scripted-main')).resolves.toBe(true)
+      await markPlaygroundShowcaseSession(sessionRoot, 'alpha', 'workspace-a', 'scripted-main')
+      await expect(isPlaygroundShowcaseSession(sessionRoot, 'alpha', 'workspace-a', 'scripted-main')).resolves.toBe(true)
       // Same bare session id, different agent key: must not be recognized —
       // this is exactly what dev.ts's wrapper route checks before ever
       // forwarding a client-supplied resumeSessionId for `targetAgentTypeId`.
-      await expect(isPlaygroundShowcaseSession(sessionRoot, 'beta', 'scripted-main')).resolves.toBe(false)
+      await expect(isPlaygroundShowcaseSession(sessionRoot, 'beta', 'workspace-a', 'scripted-main')).resolves.toBe(false)
+    })
+
+    // gh-1458 review round 5: agent-key scoping alone wasn't enough either.
+    // The store is scoped by the FULL storage namespace
+    // `<agentTypeId>--<hash(workspaceScopeId)>--...`, so the SAME agent
+    // type under two different workspace scopes ('alpha--hashA' vs
+    // 'alpha--hashB') is still two independent stores that each
+    // independently allocate their own 'scripted-main' — a collision
+    // agent-key-only scoping couldn't see. Reproduced directly: mark an
+    // empty session under 'alpha' for one raw workspace id, create an
+    // ordinary (unmarked, same-id) session under 'alpha' for a *different*
+    // raw workspace id sharing the same sessionRoot/registry file,
+    // rehydrate the second store, and confirm its unrelated draft survives.
+    it('does not let a mark for one workspace scope sweep a same-agent, same-id session in a different workspace scope', async () => {
+      const sessionRoot = await mkdtemp(join(tmpdir(), 'scripted-pi-showcase-cross-workspace-sessions-'))
+      const workspaceARoot = await mkdtemp(join(tmpdir(), 'scripted-pi-showcase-cross-workspace-a-workspace-'))
+      const workspaceBRoot = await mkdtemp(join(tmpdir(), 'scripted-pi-showcase-cross-workspace-b-workspace-'))
+      const ctxA = { workspaceId: 'workspace-A' }
+      const ctxB = { workspaceId: 'workspace-B' }
+
+      // Same agent type ('alpha'), two different workspace-scope hash
+      // suffixes — exactly what sessionNamespaceForAgent produces for the
+      // same agent serving two different workspaces.
+      const hashAHarness = createScriptedPiHarness({
+        cwd: workspaceARoot,
+        sessionRoot,
+        sessionNamespace: 'alpha--hashA',
+      })
+      const hashASession = await hashAHarness.sessions!.create(ctxA, { title: 'Navigation polish review' })
+      expect(hashASession.id).toBe('scripted-main')
+      await markPlaygroundShowcaseSession(sessionRoot, 'alpha', ctxA.workspaceId, hashASession.id)
+
+      const hashBHarness = createScriptedPiHarness({
+        cwd: workspaceBRoot,
+        sessionRoot,
+        sessionNamespace: 'alpha--hashB',
+      })
+      // Ordinary, never-marked session under the SAME agent type but a
+      // different workspace scope, independently allocating the same bare id.
+      const hashBSession = await hashBHarness.sessions!.create(ctxB, { title: "Workspace B's real draft" })
+      expect(hashBSession.id).toBe('scripted-main')
+
+      const hashBRestarted = createScriptedPiHarness({
+        cwd: workspaceBRoot,
+        sessionRoot,
+        sessionNamespace: 'alpha--hashB',
+      })
+      const hashBAfterRestart = await hashBRestarted.sessions!.list(ctxB, { includeEmpty: true })
+      expect(hashBAfterRestart).toContainEqual(expect.objectContaining({ id: hashBSession.id, title: "Workspace B's real draft" }))
+
+      // The workspace-A mark is untouched by workspace-B's hydration/sweep.
+      await expect(isPlaygroundShowcaseSession(sessionRoot, 'alpha', ctxA.workspaceId, hashASession.id)).resolves.toBe(true)
+      await expect(isPlaygroundShowcaseSession(sessionRoot, 'alpha', ctxB.workspaceId, hashBSession.id)).resolves.toBe(false)
+    })
+
+    it('resumeSessionId validation is scoped per workspace id too: a mark under one workspace is not recognized under another for the same agent', async () => {
+      const sessionRoot = await mkdtemp(join(tmpdir(), 'scripted-pi-showcase-cross-workspace-resume-'))
+      await markPlaygroundShowcaseSession(sessionRoot, 'alpha', 'workspace-A', 'scripted-main')
+      await expect(isPlaygroundShowcaseSession(sessionRoot, 'alpha', 'workspace-A', 'scripted-main')).resolves.toBe(true)
+      // Same agent key, same bare session id, different workspace id: must
+      // not be recognized — this is exactly what dev.ts's wrapper route
+      // checks (targetAgentTypeId + the raw x-boring-workspace-id header)
+      // before ever forwarding a client-supplied resumeSessionId.
+      await expect(isPlaygroundShowcaseSession(sessionRoot, 'alpha', 'workspace-B', 'scripted-main')).resolves.toBe(false)
     })
   })
 })

--- a/apps/workspace-playground/src/server/testing/scriptedPiHarness.test.ts
+++ b/apps/workspace-playground/src/server/testing/scriptedPiHarness.test.ts
@@ -7,7 +7,14 @@ import {
   isPlaygroundShowcaseSession,
   markPlaygroundShowcaseSession,
   readPlaygroundShowcaseRegistryForTest,
+  sessionNamespaceAgentKey,
 } from './scriptedPiHarness'
+
+// Matches what ScriptedSessionStore itself computes when no `sessionNamespace`
+// is passed (every existing test below, which predates agent-scoped
+// provenance) — keeping tests honest against the real derivation instead of
+// hardcoding the '(unscoped)' fallback string.
+const UNSCOPED_AGENT_KEY = sessionNamespaceAgentKey(undefined)
 
 const runContext = (workdir: string) => ({
   abortSignal: new AbortController().signal,
@@ -128,7 +135,7 @@ describe('scripted Pi browser harness persistence', () => {
 
       const first = createScriptedPiHarness(input)
       const showcaseSession = await first.sessions!.create(ctx, { title: 'Navigation polish review' })
-      await markPlaygroundShowcaseSession(sessionRoot, showcaseSession.id)
+      await markPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, showcaseSession.id)
 
       // A developer's own ordinary session, never marked, whose title
       // happens to spell out the exact string the old (removed) title-tag
@@ -156,7 +163,7 @@ describe('scripted Pi browser harness persistence', () => {
 
       const first = createScriptedPiHarness(input)
       const session = await first.sessions!.create(ctx, { title: 'Navigation polish review' })
-      await markPlaygroundShowcaseSession(sessionRoot, session.id)
+      await markPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, session.id)
       const adapter = await first.getPiSessionAdapter(
         { sessionId: session.id, ctx },
         runContext(workspaceRoot),
@@ -177,7 +184,7 @@ describe('scripted Pi browser harness persistence', () => {
       // Mark an id that no session in this sessionRoot will ever create —
       // standing in for an id that belongs to a different agent
       // type/namespace's store sharing the same registry file.
-      await markPlaygroundShowcaseSession(sessionRoot, 'scripted-belongs-elsewhere')
+      await markPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, 'scripted-belongs-elsewhere')
 
       const harness = createScriptedPiHarness({ cwd: workspaceRoot, sessionRoot })
       // Hydration must not throw, and creating a real session must still
@@ -205,12 +212,14 @@ describe('scripted Pi browser harness persistence', () => {
       const first = createScriptedPiHarness(input)
       const showcaseSession = await first.sessions!.create(ctx, { title: 'Navigation polish review' })
       expect(showcaseSession.id).toBe('scripted-main')
-      await markPlaygroundShowcaseSession(sessionRoot, showcaseSession.id)
-      await expect(readPlaygroundShowcaseRegistryForTest(sessionRoot)).resolves.toEqual(new Set(['scripted-main']))
+      await markPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, showcaseSession.id)
+      await expect(isPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, showcaseSession.id)).resolves.toBe(true)
+      await expect(readPlaygroundShowcaseRegistryForTest(sessionRoot)).resolves.toHaveProperty('size', 1)
       await first.sessions!.delete(ctx, showcaseSession.id)
 
       // Deletion must unmark immediately — not wait for a future sweep.
-      await expect(readPlaygroundShowcaseRegistryForTest(sessionRoot)).resolves.toEqual(new Set())
+      await expect(isPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, showcaseSession.id)).resolves.toBe(false)
+      await expect(readPlaygroundShowcaseRegistryForTest(sessionRoot)).resolves.toHaveProperty('size', 0)
 
       // Boot 2: createCount resets on hydrate, so an ordinary (unmarked)
       // session recycles the now-free 'scripted-main' id.
@@ -229,18 +238,82 @@ describe('scripted Pi browser harness persistence', () => {
     it('serializes concurrent marks so two overlapping requests both land in the registry', async () => {
       const sessionRoot = await mkdtemp(join(tmpdir(), 'scripted-pi-showcase-concurrent-sessions-'))
       await Promise.all(
-        Array.from({ length: 20 }, (_, index) => markPlaygroundShowcaseSession(sessionRoot, `scripted-concurrent-${index}`)),
+        Array.from({ length: 20 }, (_, index) => markPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, `scripted-concurrent-${index}`)),
       )
       const registry = await readPlaygroundShowcaseRegistryForTest(sessionRoot)
-      expect(registry).toEqual(new Set(Array.from({ length: 20 }, (_, index) => `scripted-concurrent-${index}`)))
+      expect(registry.size).toBe(20)
+      for (let index = 0; index < 20; index += 1) {
+        await expect(isPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, `scripted-concurrent-${index}`)).resolves.toBe(true)
+      }
     })
 
     it('isPlaygroundShowcaseSession only recognizes ids this wrapper actually marked', async () => {
       const sessionRoot = await mkdtemp(join(tmpdir(), 'scripted-pi-showcase-known-sessions-'))
-      await expect(isPlaygroundShowcaseSession(sessionRoot, 'scripted-unmarked')).resolves.toBe(false)
-      await markPlaygroundShowcaseSession(sessionRoot, 'scripted-marked')
-      await expect(isPlaygroundShowcaseSession(sessionRoot, 'scripted-marked')).resolves.toBe(true)
-      await expect(isPlaygroundShowcaseSession(sessionRoot, 'scripted-unmarked')).resolves.toBe(false)
+      await expect(isPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, 'scripted-unmarked')).resolves.toBe(false)
+      await markPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, 'scripted-marked')
+      await expect(isPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, 'scripted-marked')).resolves.toBe(true)
+      await expect(isPlaygroundShowcaseSession(sessionRoot, UNSCOPED_AGENT_KEY, 'scripted-unmarked')).resolves.toBe(false)
+    })
+
+    // gh-1458 review round 4: scripted session ids are only unique WITHIN
+    // one namespaced store — 'alpha--<hash>' and 'beta--<hash>' each
+    // independently allocate their own 'scripted-main'. A bare-id registry
+    // would let a mark for one agent's session be read as provenance for
+    // an unrelated session of the same id under a different agent. This is
+    // the review's deterministic repro, reproduced directly: mark an empty
+    // session under the 'alpha' namespace, create an ordinary (unmarked,
+    // same-id) session under the 'beta' namespace sharing the same
+    // sessionRoot (and therefore the same registry file), rehydrate the
+    // beta store, and confirm beta's unrelated draft survives — the sweep
+    // must never touch a different agent's records, no matter what bare id
+    // they share.
+    it('does not let a mark for one agent namespace sweep a same-id session in a different agent namespace', async () => {
+      const sessionRoot = await mkdtemp(join(tmpdir(), 'scripted-pi-showcase-cross-namespace-sessions-'))
+      const alphaWorkspaceRoot = await mkdtemp(join(tmpdir(), 'scripted-pi-showcase-cross-namespace-alpha-workspace-'))
+      const betaWorkspaceRoot = await mkdtemp(join(tmpdir(), 'scripted-pi-showcase-cross-namespace-beta-workspace-'))
+      const ctx = { workspaceId: 'workspace-a' }
+
+      const alphaHarness = createScriptedPiHarness({
+        cwd: alphaWorkspaceRoot,
+        sessionRoot,
+        sessionNamespace: 'alpha--scopehash',
+      })
+      const alphaSession = await alphaHarness.sessions!.create(ctx, { title: 'Navigation polish review' })
+      expect(alphaSession.id).toBe('scripted-main')
+      await markPlaygroundShowcaseSession(sessionRoot, 'alpha', alphaSession.id)
+
+      const betaHarness = createScriptedPiHarness({
+        cwd: betaWorkspaceRoot,
+        sessionRoot,
+        sessionNamespace: 'beta--scopehash',
+      })
+      // Ordinary, never-marked session that happens to independently
+      // allocate the exact same bare id as alpha's marked one.
+      const betaSession = await betaHarness.sessions!.create(ctx, { title: "Beta's real draft" })
+      expect(betaSession.id).toBe('scripted-main')
+
+      const betaRestarted = createScriptedPiHarness({
+        cwd: betaWorkspaceRoot,
+        sessionRoot,
+        sessionNamespace: 'beta--scopehash',
+      })
+      const betaAfterRestart = await betaRestarted.sessions!.list(ctx, { includeEmpty: true })
+      expect(betaAfterRestart).toContainEqual(expect.objectContaining({ id: betaSession.id, title: "Beta's real draft" }))
+
+      // The alpha mark is untouched by beta's hydration/sweep — it belongs
+      // to a different agent key and beta's store never even looks at it.
+      await expect(isPlaygroundShowcaseSession(sessionRoot, 'alpha', alphaSession.id)).resolves.toBe(true)
+      await expect(isPlaygroundShowcaseSession(sessionRoot, 'beta', betaSession.id)).resolves.toBe(false)
+    })
+
+    it('resumeSessionId validation is scoped per agent key: a mark under one agent is not recognized under another', async () => {
+      const sessionRoot = await mkdtemp(join(tmpdir(), 'scripted-pi-showcase-cross-namespace-resume-'))
+      await markPlaygroundShowcaseSession(sessionRoot, 'alpha', 'scripted-main')
+      await expect(isPlaygroundShowcaseSession(sessionRoot, 'alpha', 'scripted-main')).resolves.toBe(true)
+      // Same bare session id, different agent key: must not be recognized —
+      // this is exactly what dev.ts's wrapper route checks before ever
+      // forwarding a client-supplied resumeSessionId for `targetAgentTypeId`.
+      await expect(isPlaygroundShowcaseSession(sessionRoot, 'beta', 'scripted-main')).resolves.toBe(false)
     })
   })
 })

--- a/apps/workspace-playground/src/server/testing/scriptedPiHarness.ts
+++ b/apps/workspace-playground/src/server/testing/scriptedPiHarness.ts
@@ -220,7 +220,7 @@ class ScriptedSessionStore implements SessionStore {
     // session through this exact method (via the ordinary DELETE route), so
     // by the time its numeric id could ever be reused by an unrelated
     // ordinary session, the registry no longer references it at all.
-    await unmarkPlaygroundShowcaseSession(this.explicitSessionRoot, this.provenanceAgentKey, sessionId)
+    await unmarkPlaygroundShowcaseSession(this.explicitSessionRoot, this.provenanceAgentKey, record.workspaceId ?? '', sessionId)
   }
 
   async rename(_ctx: SessionCtx, sessionId: string, title: string): Promise<SessionSummary> {
@@ -352,22 +352,29 @@ class ScriptedSessionStore implements SessionStore {
       let registryChanged = false
       for (const entry of registry) {
         const decoded = decodeShowcaseRegistryEntry(entry)
-        // Bare session ids collide across namespaces — 'alpha--<hash>' and
-        // 'beta--<hash>' each independently allocate their own
-        // 'scripted-main'. The agent key is explicit in every entry now, so
-        // this is a definitive ownership check, not a guess: an entry for a
-        // different agent key is never this store's business, full stop —
-        // leave it untouched for whichever store owns that key.
+        // Bare session ids collide across namespaces — 'alpha--hashA' and
+        // 'alpha--hashB' (same agent type, different workspace scope) each
+        // independently allocate their own 'scripted-main', exactly like
+        // two different agent types do. The agent key AND workspace id are
+        // both explicit in every entry now, so this is a definitive
+        // ownership check, not a guess: an entry for a different agent key
+        // is never this store's business, full stop — leave it untouched
+        // for whichever store owns that key.
         if (!decoded || decoded.agentKey !== this.provenanceAgentKey) continue
-        const { sessionId } = decoded
+        const { workspaceId, sessionId } = decoded
         const record = this.records.get(sessionId)
-        // Already deleted (delete() unmarks eagerly, so this is mainly a
-        // safety net for an entry from before that fix existed).
-        if (!record) {
-          registry.delete(entry)
-          registryChanged = true
-          continue
-        }
+        // A record must exist under this exact id AND workspace id before
+        // this store treats the entry as its own. Critically, an entry that
+        // doesn't resolve here is left ALONE (never pruned) — it might
+        // belong to a *different* store that happens to share this agent
+        // key but a different workspace-scope hash (round 5's exact bug:
+        // 'alpha--hashA' and 'alpha--hashB' are different stores, and
+        // hashB's sweep must never guess about hashA's entries just
+        // because it also has a same-id record, or has none at all). The
+        // owning store's own `delete()` is what unmarks an entry once it's
+        // actually gone — sweep-time pruning here would risk deleting a
+        // still-valid mark for a store this one has no visibility into.
+        if (!record || record.workspaceId !== workspaceId) continue
         if (record.turnCount !== 0) {
           // Got a real turn since being marked — it's an ordinary session now
           // (kept like any other) and no longer needs tracking.
@@ -497,32 +504,51 @@ function defaultSessionDir(cwd: string, explicitRoot?: string): string {
 // location without needing to share a live object reference across the
 // HTTP boundary.
 //
-// Each entry is keyed by (agent key, session id), NOT bare session id —
-// round 4 review: scripted session ids ('scripted-main', 'scripted-1', ...)
-// are only unique WITHIN one namespaced store; two different agent types
-// each allocate their own 'scripted-main' independently. A bare-id registry
-// would let a mark for one agent's session be read as provenance for an
-// unrelated session of the same id under a different agent, and swept
-// accordingly. The agent key is the namespace's leading segment (see
-// `sessionNamespaceAgentKey`), which both this store (parsed from its own
-// `sessionNamespace`) and the dev-only wrapper route (the plain
-// `agentTypeId` the client requested) can derive identically without
-// sharing a live object reference.
+// Each entry is keyed by (agent key, workspace id, session id), NOT bare
+// session id — round 4 review: scripted session ids ('scripted-main',
+// 'scripted-1', ...) are only unique WITHIN one namespaced store; two
+// different agent types each allocate their own 'scripted-main'
+// independently, so a bare-id registry let a mark for one agent's session
+// be read as provenance for an unrelated session of the same id under a
+// different agent. Agent-key scoping alone still wasn't enough (round 5):
+// the store is scoped by the FULL storage namespace
+// `<agentTypeId>--<hash(workspaceScopeId)>--...`
+// (sessionNamespaceForAgent in packages/agent/.../sessionInventory.ts), so
+// the SAME agent type under two different workspace scopes
+// ('alpha--hashA' vs 'alpha--hashB') is still two independent stores that
+// each allocate their own 'scripted-main'. Reproducing that hash here
+// would require duplicating a private algorithm from a different package
+// (sha256 of an internal workspaceScopeId this store never even sees) —
+// fragile coupling for no real benefit. Instead, the workspace id
+// dimension is carried by the plain, unhashed id both sides already have
+// firsthand: this store receives it per-call as `SessionCtx.workspaceId`
+// (the same field `belongsTo` already scopes ordinary session visibility
+// by), and the dev-only wrapper route already has the raw
+// `x-boring-workspace-id` header it forwards on every request. Two
+// different raw workspace ids always land in two different registry
+// entries, exactly tracking whichever partition the real (hashed)
+// namespace would have produced — without ever needing to know the hash.
 const SHOWCASE_REGISTRY_FILENAME = '.playground-showcase-session-ids.json'
-// Neither an agent type id nor a scripted session id can ever contain this
-// character (session ids match SAFE_NATIVE_SESSION_ID; agent type ids are a
-// restricted identifier charset upstream), so it is a collision-proof
-// separator for the composite key.
+// Neither an agent type id, a raw workspace id, nor a scripted session id
+// can ever contain this character (session ids match SAFE_NATIVE_SESSION_ID;
+// agent type ids and workspace ids are restricted identifier charsets
+// upstream), so it is a collision-proof separator for the composite key.
 const SHOWCASE_REGISTRY_KEY_SEPARATOR = ''
 
-function encodeShowcaseRegistryEntry(agentKey: string, sessionId: string): string {
-  return `${agentKey}${SHOWCASE_REGISTRY_KEY_SEPARATOR}${sessionId}`
+function encodeShowcaseRegistryEntry(agentKey: string, workspaceId: string, sessionId: string): string {
+  return `${agentKey}${SHOWCASE_REGISTRY_KEY_SEPARATOR}${workspaceId}${SHOWCASE_REGISTRY_KEY_SEPARATOR}${sessionId}`
 }
 
-function decodeShowcaseRegistryEntry(entry: string): { agentKey: string; sessionId: string } | undefined {
-  const separatorIndex = entry.indexOf(SHOWCASE_REGISTRY_KEY_SEPARATOR)
-  if (separatorIndex < 0) return undefined
-  return { agentKey: entry.slice(0, separatorIndex), sessionId: entry.slice(separatorIndex + 1) }
+function decodeShowcaseRegistryEntry(entry: string): { agentKey: string; workspaceId: string; sessionId: string } | undefined {
+  const firstSeparator = entry.indexOf(SHOWCASE_REGISTRY_KEY_SEPARATOR)
+  if (firstSeparator < 0) return undefined
+  const secondSeparator = entry.indexOf(SHOWCASE_REGISTRY_KEY_SEPARATOR, firstSeparator + 1)
+  if (secondSeparator < 0) return undefined
+  return {
+    agentKey: entry.slice(0, firstSeparator),
+    workspaceId: entry.slice(firstSeparator + 1, secondSeparator),
+    sessionId: entry.slice(secondSeparator + 1),
+  }
 }
 
 function showcaseRegistryPath(explicitRoot?: string): string {
@@ -569,17 +595,18 @@ function queueShowcaseRegistry<T>(task: () => Promise<T>): Promise<T> {
 
 /**
  * Records that `sessionId` (under `agentKey`, e.g. the requested
- * `agentTypeId`) was created by the showcase route. Called only from the
- * dev-only wrapper route, never reachable from the ordinary
- * session-creation UI — that is what makes this provenance (as opposed to
- * the old title tag) immune to collision with a normal session. Keyed by
- * (agentKey, sessionId), not bare sessionId — see the registry comment
- * above for why bare ids collide across agent namespaces.
+ * `agentTypeId`, and `workspaceId`, the raw `x-boring-workspace-id`) was
+ * created by the showcase route. Called only from the dev-only wrapper
+ * route, never reachable from the ordinary session-creation UI — that is
+ * what makes this provenance (as opposed to the old title tag) immune to
+ * collision with a normal session. Keyed by (agentKey, workspaceId,
+ * sessionId), not bare sessionId — see the registry comment above for why
+ * bare ids collide across agent/workspace-scope namespaces.
  */
-export function markPlaygroundShowcaseSession(explicitRoot: string | undefined, agentKey: string, sessionId: string): Promise<void> {
+export function markPlaygroundShowcaseSession(explicitRoot: string | undefined, agentKey: string, workspaceId: string, sessionId: string): Promise<void> {
   return queueShowcaseRegistry(async () => {
     const entries = await readShowcaseRegistryUnsafe(explicitRoot)
-    const entry = encodeShowcaseRegistryEntry(agentKey, sessionId)
+    const entry = encodeShowcaseRegistryEntry(agentKey, workspaceId, sessionId)
     if (entries.has(entry)) return
     entries.add(entry)
     await writeShowcaseRegistryUnsafe(explicitRoot, entries)
@@ -587,19 +614,19 @@ export function markPlaygroundShowcaseSession(explicitRoot: string | undefined, 
 }
 
 /**
- * Removes the (agentKey, sessionId) entry from the registry, if present.
- * Called by `ScriptedSessionStore.delete` for every deletion
+ * Removes the (agentKey, workspaceId, sessionId) entry from the registry,
+ * if present. Called by `ScriptedSessionStore.delete` for every deletion
  * (showcase-originated or not — a no-op if the entry was never registered)
  * so a session no longer needs tracking the moment it stops existing,
  * instead of waiting for a future boot's sweep to notice. This is what
  * prevents a stale registry entry from surviving long enough for its
- * numeric id to be recycled by an unrelated ordinary session (in the same
- * or, without the agentKey scoping, even a different agent namespace).
+ * numeric id to be recycled by an unrelated ordinary session (in the same,
+ * or without this scoping, even a different agent/workspace namespace).
  */
-export function unmarkPlaygroundShowcaseSession(explicitRoot: string | undefined, agentKey: string, sessionId: string): Promise<void> {
+export function unmarkPlaygroundShowcaseSession(explicitRoot: string | undefined, agentKey: string, workspaceId: string, sessionId: string): Promise<void> {
   return queueShowcaseRegistry(async () => {
     const entries = await readShowcaseRegistryUnsafe(explicitRoot)
-    const entry = encodeShowcaseRegistryEntry(agentKey, sessionId)
+    const entry = encodeShowcaseRegistryEntry(agentKey, workspaceId, sessionId)
     if (!entries.has(entry)) return
     entries.delete(entry)
     await writeShowcaseRegistryUnsafe(explicitRoot, entries)
@@ -607,24 +634,25 @@ export function unmarkPlaygroundShowcaseSession(explicitRoot: string | undefined
 }
 
 /**
- * True only if (agentKey, sessionId) was previously marked by
+ * True only if (agentKey, workspaceId, sessionId) was previously marked by
  * `markPlaygroundShowcaseSession` and hasn't since been unmarked. Used by
  * the dev-only wrapper route to validate a client-supplied
  * `resumeSessionId` before ever forwarding it to the real create-session
- * endpoint, scoped to the REQUESTED `agentTypeId`: `resumeSessionId`
+ * endpoint, scoped to the REQUESTED `agentTypeId` and the raw
+ * `x-boring-workspace-id` of the current request: `resumeSessionId`
  * travels through writable `sessionStorage` (App.tsx), so a stale or
  * manipulated value could otherwise name an ordinary session (or a
- * showcase session belonging to a *different* agent type) the wrapper
- * never created for this agent. Refusing to honor (and thus never marking)
- * an unrecognized (agentKey, id) pair closes that off — the wrapper can
- * only ever resume an id it already vouched for itself, for that exact
- * agent type.
+ * showcase session belonging to a *different* agent type or workspace
+ * scope) the wrapper never created for this exact request. Refusing to
+ * honor (and thus never marking) an unrecognized (agentKey, workspaceId,
+ * id) triple closes that off — the wrapper can only ever resume an id it
+ * already vouched for itself, for that exact agent type and workspace.
  */
-export function isPlaygroundShowcaseSession(explicitRoot: string | undefined, agentKey: string, sessionId: string): Promise<boolean> {
-  return queueShowcaseRegistry(async () => (await readShowcaseRegistryUnsafe(explicitRoot)).has(encodeShowcaseRegistryEntry(agentKey, sessionId)))
+export function isPlaygroundShowcaseSession(explicitRoot: string | undefined, agentKey: string, workspaceId: string, sessionId: string): Promise<boolean> {
+  return queueShowcaseRegistry(async () => (await readShowcaseRegistryUnsafe(explicitRoot)).has(encodeShowcaseRegistryEntry(agentKey, workspaceId, sessionId)))
 }
 
-/** Test-only: the registry's current on-disk (agentKey, sessionId) entries, for asserting boundedness/scoping directly. */
+/** Test-only: the registry's current on-disk (agentKey, workspaceId, sessionId) entries, for asserting boundedness/scoping directly. */
 export function readPlaygroundShowcaseRegistryForTest(explicitRoot?: string): Promise<Set<string>> {
   return queueShowcaseRegistry(() => readShowcaseRegistryUnsafe(explicitRoot))
 }

--- a/apps/workspace-playground/src/server/testing/scriptedPiHarness.ts
+++ b/apps/workspace-playground/src/server/testing/scriptedPiHarness.ts
@@ -194,6 +194,13 @@ class ScriptedSessionStore implements SessionStore {
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
     }
+    // Deletion is the actual "no longer needs tracking" event for the
+    // showcase provenance registry — not just a future boot's sweep. This
+    // is what closes the id-reuse hole: the pagehide cleanup path deletes a
+    // session through this exact method (via the ordinary DELETE route), so
+    // by the time its numeric id could ever be reused by an unrelated
+    // ordinary session, the registry no longer references it at all.
+    await unmarkPlaygroundShowcaseSession(this.explicitSessionRoot, sessionId)
   }
 
   async rename(_ctx: SessionCtx, sessionId: string, title: string): Promise<SessionSummary> {
@@ -313,37 +320,45 @@ class ScriptedSessionStore implements SessionStore {
     await this.sweepStaleShowcaseSessions()
   }
 
-  private async sweepStaleShowcaseSessions(): Promise<void> {
-    const registry = await readShowcaseRegistry(this.explicitSessionRoot)
-    if (registry.size === 0) return
-    let registryChanged = false
-    for (const id of registry) {
-      const record = this.records.get(id)
-      // Not one of this store's sessions — could belong to a different
-      // agent type/namespace sharing the same registry file, or already
-      // deleted by an earlier sweep/pagehide cleanup. Never guess; leave
-      // it for whichever store (if any) actually owns it, rather than
-      // pruning an entry this store cannot positively verify.
-      if (!record) continue
-      if (record.turnCount !== 0) {
-        // Got a real turn since being marked — it's an ordinary session now
-        // (kept like any other) and no longer needs tracking.
+  private sweepStaleShowcaseSessions(): Promise<void> {
+    // The whole read-modify-write goes through the same queue mark/unmark
+    // use, as ONE task — not a read followed by a separately-queued write —
+    // so a mark/unmark landing between this sweep's read and its write
+    // can't be silently overwritten by the sweep's own (now stale) copy of
+    // the registry.
+    return queueShowcaseRegistry(async () => {
+      const registry = await readShowcaseRegistryUnsafe(this.explicitSessionRoot)
+      if (registry.size === 0) return
+      let registryChanged = false
+      for (const id of registry) {
+        const record = this.records.get(id)
+        // Not one of this store's sessions — could belong to a different
+        // agent type/namespace sharing the same registry file, or already
+        // deleted (which now unmarks eagerly via `delete()`, so in the
+        // common case this branch only fires for a genuinely different
+        // store's entry, not a stale leftover from this store). Never
+        // guess; leave it for whichever store (if any) actually owns it.
+        if (!record) continue
+        if (record.turnCount !== 0) {
+          // Got a real turn since being marked — it's an ordinary session now
+          // (kept like any other) and no longer needs tracking.
+          registry.delete(id)
+          registryChanged = true
+          continue
+        }
+        this.records.delete(id)
         registry.delete(id)
         registryChanged = true
-        continue
+        try {
+          const names = await readdir(this.sessionDir)
+          const match = names.find((name) => name === `${id}.jsonl` || name.endsWith(`_${id}.jsonl`))
+          if (match) await unlink(join(this.sessionDir, match))
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+        }
       }
-      this.records.delete(id)
-      registry.delete(id)
-      registryChanged = true
-      try {
-        const names = await readdir(this.sessionDir)
-        const match = names.find((name) => name === `${id}.jsonl` || name.endsWith(`_${id}.jsonl`))
-        if (match) await unlink(join(this.sessionDir, match))
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
-      }
-    }
-    if (registryChanged) await writeShowcaseRegistry(this.explicitSessionRoot, registry)
+      if (registryChanged) await writeShowcaseRegistryUnsafe(this.explicitSessionRoot, registry)
+    })
   }
 
   private takeNextSessionId(): string {
@@ -458,7 +473,7 @@ function showcaseRegistryPath(explicitRoot?: string): string {
   return join(sessionBaseDir(explicitRoot), SHOWCASE_REGISTRY_FILENAME)
 }
 
-async function readShowcaseRegistry(explicitRoot?: string): Promise<Set<string>> {
+async function readShowcaseRegistryUnsafe(explicitRoot?: string): Promise<Set<string>> {
   try {
     const text = await readFile(showcaseRegistryPath(explicitRoot), 'utf8')
     const parsed: unknown = JSON.parse(text)
@@ -471,10 +486,29 @@ async function readShowcaseRegistry(explicitRoot?: string): Promise<Set<string>>
   }
 }
 
-async function writeShowcaseRegistry(explicitRoot: string | undefined, ids: ReadonlySet<string>): Promise<void> {
+async function writeShowcaseRegistryUnsafe(explicitRoot: string | undefined, ids: ReadonlySet<string>): Promise<void> {
   const path = showcaseRegistryPath(explicitRoot)
   await mkdir(dirname(path), { recursive: true })
   await writeFile(path, JSON.stringify([...ids].sort()), 'utf8')
+}
+
+// Every read-modify-write of the registry file — mark, unmark, and the
+// boot-time sweep's own read+prune — is chained through this single
+// process-wide queue. `markPlaygroundShowcaseSession` is called from the
+// dev-only HTTP route handler (dev.ts), where two POSTs can genuinely
+// overlap (two tabs booting at once, a retry racing the original attempt);
+// an unlocked read-modify-write of the JSON file would let the second
+// write silently clobber the first write's addition. Node is
+// single-threaded, so serializing every access through one promise chain
+// is sufficient — no OS-level file lock needed for a same-process,
+// dev-only sidecar file.
+let showcaseRegistryQueue: Promise<unknown> = Promise.resolve()
+
+function queueShowcaseRegistry<T>(task: () => Promise<T>): Promise<T> {
+  const result = showcaseRegistryQueue.then(task, task)
+  // Never let one failed task poison the queue for later, unrelated calls.
+  showcaseRegistryQueue = result.catch(() => undefined)
+  return result
 }
 
 /**
@@ -483,11 +517,51 @@ async function writeShowcaseRegistry(explicitRoot: string | undefined, ids: Read
  * session-creation UI — that is what makes this provenance (as opposed to
  * the old title tag) immune to collision with a normal session.
  */
-export async function markPlaygroundShowcaseSession(explicitRoot: string | undefined, sessionId: string): Promise<void> {
-  const ids = await readShowcaseRegistry(explicitRoot)
-  if (ids.has(sessionId)) return
-  ids.add(sessionId)
-  await writeShowcaseRegistry(explicitRoot, ids)
+export function markPlaygroundShowcaseSession(explicitRoot: string | undefined, sessionId: string): Promise<void> {
+  return queueShowcaseRegistry(async () => {
+    const ids = await readShowcaseRegistryUnsafe(explicitRoot)
+    if (ids.has(sessionId)) return
+    ids.add(sessionId)
+    await writeShowcaseRegistryUnsafe(explicitRoot, ids)
+  })
+}
+
+/**
+ * Removes `sessionId` from the registry, if present. Called by
+ * `ScriptedSessionStore.delete` for every deletion (showcase-originated or
+ * not — a no-op if the id was never registered) so a session no longer
+ * needs tracking the moment it stops existing, instead of waiting for a
+ * future boot's sweep to notice. This is what prevents a stale registry
+ * entry from surviving long enough for its numeric id to be recycled by an
+ * unrelated ordinary session.
+ */
+export function unmarkPlaygroundShowcaseSession(explicitRoot: string | undefined, sessionId: string): Promise<void> {
+  return queueShowcaseRegistry(async () => {
+    const ids = await readShowcaseRegistryUnsafe(explicitRoot)
+    if (!ids.has(sessionId)) return
+    ids.delete(sessionId)
+    await writeShowcaseRegistryUnsafe(explicitRoot, ids)
+  })
+}
+
+/**
+ * True only if `sessionId` was previously marked by
+ * `markPlaygroundShowcaseSession` and hasn't since been unmarked. Used by
+ * the dev-only wrapper route to validate a client-supplied
+ * `resumeSessionId` before ever forwarding it to the real create-session
+ * endpoint: `resumeSessionId` travels through writable `sessionStorage`
+ * (App.tsx), so a stale or manipulated value could otherwise name an
+ * ordinary session the wrapper never created. Refusing to honor (and thus
+ * never marking) an unrecognized id closes that off — the wrapper can only
+ * ever resume an id it already vouched for itself.
+ */
+export function isPlaygroundShowcaseSession(explicitRoot: string | undefined, sessionId: string): Promise<boolean> {
+  return queueShowcaseRegistry(async () => (await readShowcaseRegistryUnsafe(explicitRoot)).has(sessionId))
+}
+
+/** Test-only: the registry's current on-disk contents, for asserting boundedness directly. */
+export function readPlaygroundShowcaseRegistryForTest(explicitRoot?: string): Promise<Set<string>> {
+  return queueShowcaseRegistry(() => readShowcaseRegistryUnsafe(explicitRoot))
 }
 
 class ScriptedPiSessionAdapter implements PiAgentSessionAdapter {

--- a/apps/workspace-playground/src/server/testing/scriptedPiHarness.ts
+++ b/apps/workspace-playground/src/server/testing/scriptedPiHarness.ts
@@ -38,6 +38,24 @@ interface SessionListOptions { includeId?: string; includeEmpty?: boolean }
 
 const persistedHarnesses = new Map<string, ScriptedPiHarness>()
 
+// Scripted session ids ('scripted-main', 'scripted-1', ...) are unique only
+// WITHIN one namespaced ScriptedSessionStore — each agent type gets its own
+// sessionDir and independently allocates the same short ids (gh-1458 review
+// round 4: 'alpha--<hash>/scripted-main' and 'beta--<hash>/scripted-main'
+// are different sessions that happen to share a bare id). Both this
+// response-marker text and the showcase provenance registry key below need
+// to identify "which agent type", so both derive it the same way: the
+// namespace's leading segment before the first '--' is always the raw
+// agentTypeId verbatim (see sessionNamespaceForAgent in
+// packages/agent/src/server/agent-host/sessionInventory.ts — the namespace
+// is built as `[agentTypeId, hash(workspaceScopeId), ns].join('--')` for
+// every agent type this app ever configures, none of which use the
+// DEFAULT_AGENT_TYPE_ID short-circuit).
+export function sessionNamespaceAgentKey(sessionNamespace?: string): string {
+  const agentTypeId = sessionNamespace?.split('--')[0]?.trim()
+  return agentTypeId || '(unscoped)'
+}
+
 function scriptedResponseMarker(sessionNamespace?: string): string {
   const agentTypeId = sessionNamespace?.split('--')[0]?.trim()
   return agentTypeId ? `PI_NATIVE_ASSISTANT_DONE:${agentTypeId}` : 'PI_NATIVE_ASSISTANT_DONE'
@@ -138,6 +156,7 @@ class ScriptedSessionStore implements SessionStore {
   private createCount = 0
   private readonly sessionDir: string
   private readonly explicitSessionRoot: string | undefined
+  private readonly provenanceAgentKey: string
   private hydration: Promise<void> | undefined
 
   constructor(input: AgentHarnessFactoryInput) {
@@ -145,6 +164,7 @@ class ScriptedSessionStore implements SessionStore {
       ? join(sessionBaseDir(input.sessionRoot), input.sessionNamespace)
       : defaultSessionDir(input.cwd, input.sessionRoot))
     this.explicitSessionRoot = input.sessionRoot
+    this.provenanceAgentKey = sessionNamespaceAgentKey(input.sessionNamespace)
   }
 
   async ensure(sessionId: string, ctx: SessionCtx): Promise<SessionSummary> {
@@ -200,7 +220,7 @@ class ScriptedSessionStore implements SessionStore {
     // session through this exact method (via the ordinary DELETE route), so
     // by the time its numeric id could ever be reused by an unrelated
     // ordinary session, the registry no longer references it at all.
-    await unmarkPlaygroundShowcaseSession(this.explicitSessionRoot, sessionId)
+    await unmarkPlaygroundShowcaseSession(this.explicitSessionRoot, this.provenanceAgentKey, sessionId)
   }
 
   async rename(_ctx: SessionCtx, sessionId: string, title: string): Promise<SessionSummary> {
@@ -330,28 +350,37 @@ class ScriptedSessionStore implements SessionStore {
       const registry = await readShowcaseRegistryUnsafe(this.explicitSessionRoot)
       if (registry.size === 0) return
       let registryChanged = false
-      for (const id of registry) {
-        const record = this.records.get(id)
-        // Not one of this store's sessions — could belong to a different
-        // agent type/namespace sharing the same registry file, or already
-        // deleted (which now unmarks eagerly via `delete()`, so in the
-        // common case this branch only fires for a genuinely different
-        // store's entry, not a stale leftover from this store). Never
-        // guess; leave it for whichever store (if any) actually owns it.
-        if (!record) continue
-        if (record.turnCount !== 0) {
-          // Got a real turn since being marked — it's an ordinary session now
-          // (kept like any other) and no longer needs tracking.
-          registry.delete(id)
+      for (const entry of registry) {
+        const decoded = decodeShowcaseRegistryEntry(entry)
+        // Bare session ids collide across namespaces — 'alpha--<hash>' and
+        // 'beta--<hash>' each independently allocate their own
+        // 'scripted-main'. The agent key is explicit in every entry now, so
+        // this is a definitive ownership check, not a guess: an entry for a
+        // different agent key is never this store's business, full stop —
+        // leave it untouched for whichever store owns that key.
+        if (!decoded || decoded.agentKey !== this.provenanceAgentKey) continue
+        const { sessionId } = decoded
+        const record = this.records.get(sessionId)
+        // Already deleted (delete() unmarks eagerly, so this is mainly a
+        // safety net for an entry from before that fix existed).
+        if (!record) {
+          registry.delete(entry)
           registryChanged = true
           continue
         }
-        this.records.delete(id)
-        registry.delete(id)
+        if (record.turnCount !== 0) {
+          // Got a real turn since being marked — it's an ordinary session now
+          // (kept like any other) and no longer needs tracking.
+          registry.delete(entry)
+          registryChanged = true
+          continue
+        }
+        this.records.delete(sessionId)
+        registry.delete(entry)
         registryChanged = true
         try {
           const names = await readdir(this.sessionDir)
-          const match = names.find((name) => name === `${id}.jsonl` || name.endsWith(`_${id}.jsonl`))
+          const match = names.find((name) => name === `${sessionId}.jsonl` || name.endsWith(`_${sessionId}.jsonl`))
           if (match) await unlink(join(this.sessionDir, match))
         } catch (error) {
           if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
@@ -458,7 +487,7 @@ function defaultSessionDir(cwd: string, explicitRoot?: string): string {
 // not durable provenance.
 //
 // Provenance now lives in a sidecar registry file instead: a plain JSON
-// array of session ids, written ONLY by the dev-only wrapper route
+// array of entries, written ONLY by the dev-only wrapper route
 // (`POST /api/v1/playground/showcase-sessions` in dev.ts) that the
 // showcase route's own session-creation calls go through — no title
 // content is ever inspected, so nothing an ordinary session's title says
@@ -467,7 +496,34 @@ function defaultSessionDir(cwd: string, explicitRoot?: string): string {
 // both dev.ts (writer) and this store (reader/pruner) agree on its
 // location without needing to share a live object reference across the
 // HTTP boundary.
+//
+// Each entry is keyed by (agent key, session id), NOT bare session id —
+// round 4 review: scripted session ids ('scripted-main', 'scripted-1', ...)
+// are only unique WITHIN one namespaced store; two different agent types
+// each allocate their own 'scripted-main' independently. A bare-id registry
+// would let a mark for one agent's session be read as provenance for an
+// unrelated session of the same id under a different agent, and swept
+// accordingly. The agent key is the namespace's leading segment (see
+// `sessionNamespaceAgentKey`), which both this store (parsed from its own
+// `sessionNamespace`) and the dev-only wrapper route (the plain
+// `agentTypeId` the client requested) can derive identically without
+// sharing a live object reference.
 const SHOWCASE_REGISTRY_FILENAME = '.playground-showcase-session-ids.json'
+// Neither an agent type id nor a scripted session id can ever contain this
+// character (session ids match SAFE_NATIVE_SESSION_ID; agent type ids are a
+// restricted identifier charset upstream), so it is a collision-proof
+// separator for the composite key.
+const SHOWCASE_REGISTRY_KEY_SEPARATOR = ''
+
+function encodeShowcaseRegistryEntry(agentKey: string, sessionId: string): string {
+  return `${agentKey}${SHOWCASE_REGISTRY_KEY_SEPARATOR}${sessionId}`
+}
+
+function decodeShowcaseRegistryEntry(entry: string): { agentKey: string; sessionId: string } | undefined {
+  const separatorIndex = entry.indexOf(SHOWCASE_REGISTRY_KEY_SEPARATOR)
+  if (separatorIndex < 0) return undefined
+  return { agentKey: entry.slice(0, separatorIndex), sessionId: entry.slice(separatorIndex + 1) }
+}
 
 function showcaseRegistryPath(explicitRoot?: string): string {
   return join(sessionBaseDir(explicitRoot), SHOWCASE_REGISTRY_FILENAME)
@@ -486,10 +542,10 @@ async function readShowcaseRegistryUnsafe(explicitRoot?: string): Promise<Set<st
   }
 }
 
-async function writeShowcaseRegistryUnsafe(explicitRoot: string | undefined, ids: ReadonlySet<string>): Promise<void> {
+async function writeShowcaseRegistryUnsafe(explicitRoot: string | undefined, entries: ReadonlySet<string>): Promise<void> {
   const path = showcaseRegistryPath(explicitRoot)
   await mkdir(dirname(path), { recursive: true })
-  await writeFile(path, JSON.stringify([...ids].sort()), 'utf8')
+  await writeFile(path, JSON.stringify([...entries].sort()), 'utf8')
 }
 
 // Every read-modify-write of the registry file — mark, unmark, and the
@@ -512,54 +568,63 @@ function queueShowcaseRegistry<T>(task: () => Promise<T>): Promise<T> {
 }
 
 /**
- * Records that `sessionId` was created by the showcase route. Called only
- * from the dev-only wrapper route, never reachable from the ordinary
+ * Records that `sessionId` (under `agentKey`, e.g. the requested
+ * `agentTypeId`) was created by the showcase route. Called only from the
+ * dev-only wrapper route, never reachable from the ordinary
  * session-creation UI — that is what makes this provenance (as opposed to
- * the old title tag) immune to collision with a normal session.
+ * the old title tag) immune to collision with a normal session. Keyed by
+ * (agentKey, sessionId), not bare sessionId — see the registry comment
+ * above for why bare ids collide across agent namespaces.
  */
-export function markPlaygroundShowcaseSession(explicitRoot: string | undefined, sessionId: string): Promise<void> {
+export function markPlaygroundShowcaseSession(explicitRoot: string | undefined, agentKey: string, sessionId: string): Promise<void> {
   return queueShowcaseRegistry(async () => {
-    const ids = await readShowcaseRegistryUnsafe(explicitRoot)
-    if (ids.has(sessionId)) return
-    ids.add(sessionId)
-    await writeShowcaseRegistryUnsafe(explicitRoot, ids)
+    const entries = await readShowcaseRegistryUnsafe(explicitRoot)
+    const entry = encodeShowcaseRegistryEntry(agentKey, sessionId)
+    if (entries.has(entry)) return
+    entries.add(entry)
+    await writeShowcaseRegistryUnsafe(explicitRoot, entries)
   })
 }
 
 /**
- * Removes `sessionId` from the registry, if present. Called by
- * `ScriptedSessionStore.delete` for every deletion (showcase-originated or
- * not — a no-op if the id was never registered) so a session no longer
- * needs tracking the moment it stops existing, instead of waiting for a
- * future boot's sweep to notice. This is what prevents a stale registry
- * entry from surviving long enough for its numeric id to be recycled by an
- * unrelated ordinary session.
+ * Removes the (agentKey, sessionId) entry from the registry, if present.
+ * Called by `ScriptedSessionStore.delete` for every deletion
+ * (showcase-originated or not — a no-op if the entry was never registered)
+ * so a session no longer needs tracking the moment it stops existing,
+ * instead of waiting for a future boot's sweep to notice. This is what
+ * prevents a stale registry entry from surviving long enough for its
+ * numeric id to be recycled by an unrelated ordinary session (in the same
+ * or, without the agentKey scoping, even a different agent namespace).
  */
-export function unmarkPlaygroundShowcaseSession(explicitRoot: string | undefined, sessionId: string): Promise<void> {
+export function unmarkPlaygroundShowcaseSession(explicitRoot: string | undefined, agentKey: string, sessionId: string): Promise<void> {
   return queueShowcaseRegistry(async () => {
-    const ids = await readShowcaseRegistryUnsafe(explicitRoot)
-    if (!ids.has(sessionId)) return
-    ids.delete(sessionId)
-    await writeShowcaseRegistryUnsafe(explicitRoot, ids)
+    const entries = await readShowcaseRegistryUnsafe(explicitRoot)
+    const entry = encodeShowcaseRegistryEntry(agentKey, sessionId)
+    if (!entries.has(entry)) return
+    entries.delete(entry)
+    await writeShowcaseRegistryUnsafe(explicitRoot, entries)
   })
 }
 
 /**
- * True only if `sessionId` was previously marked by
+ * True only if (agentKey, sessionId) was previously marked by
  * `markPlaygroundShowcaseSession` and hasn't since been unmarked. Used by
  * the dev-only wrapper route to validate a client-supplied
  * `resumeSessionId` before ever forwarding it to the real create-session
- * endpoint: `resumeSessionId` travels through writable `sessionStorage`
- * (App.tsx), so a stale or manipulated value could otherwise name an
- * ordinary session the wrapper never created. Refusing to honor (and thus
- * never marking) an unrecognized id closes that off — the wrapper can only
- * ever resume an id it already vouched for itself.
+ * endpoint, scoped to the REQUESTED `agentTypeId`: `resumeSessionId`
+ * travels through writable `sessionStorage` (App.tsx), so a stale or
+ * manipulated value could otherwise name an ordinary session (or a
+ * showcase session belonging to a *different* agent type) the wrapper
+ * never created for this agent. Refusing to honor (and thus never marking)
+ * an unrecognized (agentKey, id) pair closes that off — the wrapper can
+ * only ever resume an id it already vouched for itself, for that exact
+ * agent type.
  */
-export function isPlaygroundShowcaseSession(explicitRoot: string | undefined, sessionId: string): Promise<boolean> {
-  return queueShowcaseRegistry(async () => (await readShowcaseRegistryUnsafe(explicitRoot)).has(sessionId))
+export function isPlaygroundShowcaseSession(explicitRoot: string | undefined, agentKey: string, sessionId: string): Promise<boolean> {
+  return queueShowcaseRegistry(async () => (await readShowcaseRegistryUnsafe(explicitRoot)).has(encodeShowcaseRegistryEntry(agentKey, sessionId)))
 }
 
-/** Test-only: the registry's current on-disk contents, for asserting boundedness directly. */
+/** Test-only: the registry's current on-disk (agentKey, sessionId) entries, for asserting boundedness/scoping directly. */
 export function readPlaygroundShowcaseRegistryForTest(explicitRoot?: string): Promise<Set<string>> {
   return queueShowcaseRegistry(() => readShowcaseRegistryUnsafe(explicitRoot))
 }

--- a/apps/workspace-playground/src/server/testing/scriptedPiHarness.ts
+++ b/apps/workspace-playground/src/server/testing/scriptedPiHarness.ts
@@ -7,6 +7,7 @@ import type { AgentSessionEvent } from '@mariozechner/pi-coding-agent'
 import { CURRENT_SESSION_VERSION } from '@mariozechner/pi-coding-agent'
 import type { AgentCoreHarnessFactory, AgentHarness, RunContext, AgentSendInput } from '@hachej/boring-agent/shared'
 import type { SessionCtx, SessionDetail, SessionStore, SessionSummary } from '@hachej/boring-agent/shared'
+import { SHOWCASE_SESSION_TITLE_TAG } from '../../shared/showcaseSession'
 
 type RequiredAgentHarnessFactoryInput = Parameters<AgentCoreHarnessFactory>[0]
 type AgentHarnessFactoryInput = Omit<RequiredAgentHarnessFactoryInput, 'tools'> & {
@@ -297,6 +298,29 @@ class ScriptedSessionStore implements SessionStore {
       })
     }
     this.createCount = 0
+    // Boot-time retention sweep: everything just loaded above came from
+    // *before* this process started (this method only ever runs once per
+    // store, memoized by `ensureHydrated`/`this.hydration`). Delete any
+    // showcase-tagged session left empty by a prior boot — a real turn was
+    // never sent, so there is nothing to lose — instead of letting
+    // `?showcase=1` visits (one durable session per boot/tab/e2e context)
+    // accumulate on disk indefinitely. Non-showcase sessions and anything
+    // created during *this* boot are untouched (see SHOWCASE_SESSION_TITLE_TAG).
+    await this.sweepStaleShowcaseSessions()
+  }
+
+  private async sweepStaleShowcaseSessions(): Promise<void> {
+    for (const record of [...this.records.values()]) {
+      if (record.turnCount !== 0 || !record.title.startsWith(SHOWCASE_SESSION_TITLE_TAG)) continue
+      this.records.delete(record.id)
+      try {
+        const names = await readdir(this.sessionDir)
+        const match = names.find((name) => name === `${record.id}.jsonl` || name.endsWith(`_${record.id}.jsonl`))
+        if (match) await unlink(join(this.sessionDir, match))
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+      }
+    }
   }
 
   private takeNextSessionId(): string {

--- a/apps/workspace-playground/src/server/testing/scriptedPiHarness.ts
+++ b/apps/workspace-playground/src/server/testing/scriptedPiHarness.ts
@@ -1,13 +1,12 @@
 import { randomUUID } from 'node:crypto'
 import { mkdir, appendFile, readFile, readdir, unlink, writeFile } from 'node:fs/promises'
-import { join, resolve } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
 import { homedir } from 'node:os'
 import { setTimeout as sleep } from 'node:timers/promises'
 import type { AgentSessionEvent } from '@mariozechner/pi-coding-agent'
 import { CURRENT_SESSION_VERSION } from '@mariozechner/pi-coding-agent'
 import type { AgentCoreHarnessFactory, AgentHarness, RunContext, AgentSendInput } from '@hachej/boring-agent/shared'
 import type { SessionCtx, SessionDetail, SessionStore, SessionSummary } from '@hachej/boring-agent/shared'
-import { SHOWCASE_SESSION_TITLE_TAG } from '../../shared/showcaseSession'
 
 type RequiredAgentHarnessFactoryInput = Parameters<AgentCoreHarnessFactory>[0]
 type AgentHarnessFactoryInput = Omit<RequiredAgentHarnessFactoryInput, 'tools'> & {
@@ -138,12 +137,14 @@ class ScriptedSessionStore implements SessionStore {
   private readonly records = new Map<string, ScriptedSessionRecord>()
   private createCount = 0
   private readonly sessionDir: string
+  private readonly explicitSessionRoot: string | undefined
   private hydration: Promise<void> | undefined
 
   constructor(input: AgentHarnessFactoryInput) {
     this.sessionDir = input.sessionDir ?? (input.sessionNamespace
       ? join(sessionBaseDir(input.sessionRoot), input.sessionNamespace)
       : defaultSessionDir(input.cwd, input.sessionRoot))
+    this.explicitSessionRoot = input.sessionRoot
   }
 
   async ensure(sessionId: string, ctx: SessionCtx): Promise<SessionSummary> {
@@ -300,27 +301,49 @@ class ScriptedSessionStore implements SessionStore {
     this.createCount = 0
     // Boot-time retention sweep: everything just loaded above came from
     // *before* this process started (this method only ever runs once per
-    // store, memoized by `ensureHydrated`/`this.hydration`). Delete any
-    // showcase-tagged session left empty by a prior boot — a real turn was
-    // never sent, so there is nothing to lose — instead of letting
-    // `?showcase=1` visits (one durable session per boot/tab/e2e context)
-    // accumulate on disk indefinitely. Non-showcase sessions and anything
-    // created during *this* boot are untouched (see SHOWCASE_SESSION_TITLE_TAG).
+    // store, memoized by `ensureHydrated`/`this.hydration`), and the
+    // provenance registry (below) is read before this boot ever appends to
+    // it — so this only ever sweeps sessions the showcase route created on
+    // a *prior* boot and never sent a turn to. Delete those — there is
+    // nothing to lose — instead of letting `?showcase=1` visits (one
+    // durable session per boot/tab/e2e context) accumulate on disk
+    // indefinitely. Anything not in the registry (ordinary sessions, no
+    // matter what their title says) and anything created during *this*
+    // boot are untouched.
     await this.sweepStaleShowcaseSessions()
   }
 
   private async sweepStaleShowcaseSessions(): Promise<void> {
-    for (const record of [...this.records.values()]) {
-      if (record.turnCount !== 0 || !record.title.startsWith(SHOWCASE_SESSION_TITLE_TAG)) continue
-      this.records.delete(record.id)
+    const registry = await readShowcaseRegistry(this.explicitSessionRoot)
+    if (registry.size === 0) return
+    let registryChanged = false
+    for (const id of registry) {
+      const record = this.records.get(id)
+      // Not one of this store's sessions — could belong to a different
+      // agent type/namespace sharing the same registry file, or already
+      // deleted by an earlier sweep/pagehide cleanup. Never guess; leave
+      // it for whichever store (if any) actually owns it, rather than
+      // pruning an entry this store cannot positively verify.
+      if (!record) continue
+      if (record.turnCount !== 0) {
+        // Got a real turn since being marked — it's an ordinary session now
+        // (kept like any other) and no longer needs tracking.
+        registry.delete(id)
+        registryChanged = true
+        continue
+      }
+      this.records.delete(id)
+      registry.delete(id)
+      registryChanged = true
       try {
         const names = await readdir(this.sessionDir)
-        const match = names.find((name) => name === `${record.id}.jsonl` || name.endsWith(`_${record.id}.jsonl`))
+        const match = names.find((name) => name === `${id}.jsonl` || name.endsWith(`_${id}.jsonl`))
         if (match) await unlink(join(this.sessionDir, match))
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
       }
     }
+    if (registryChanged) await writeShowcaseRegistry(this.explicitSessionRoot, registry)
   }
 
   private takeNextSessionId(): string {
@@ -406,6 +429,65 @@ function defaultSessionDir(cwd: string, explicitRoot?: string): string {
   if (explicitRoot && cwd.trim().length === 0) return sessionBaseDir(explicitRoot)
   const safePath = `--${cwd.replace(/^[/\\]/, '').replace(/[/\\:]/g, '-')}--`
   return join(sessionBaseDir(explicitRoot), safePath)
+}
+
+// --- Showcase session provenance registry -----------------------------
+//
+// The playground's `?showcase=1` route needs a boot-time sweep of stale,
+// still-empty sessions it created (gh-1452 PR #1458 review). An earlier
+// version of this marked provenance with a fixed title prefix
+// (`SHOWCASE_SESSION_TITLE_TAG`) — but the create/rename HTTP schemas
+// accept any nonempty title up to 200 chars and forward it unchanged, so
+// an ordinary session a developer happened to title starting with that
+// exact prefix would be swept too. Title text is user-controlled data,
+// not durable provenance.
+//
+// Provenance now lives in a sidecar registry file instead: a plain JSON
+// array of session ids, written ONLY by the dev-only wrapper route
+// (`POST /api/v1/playground/showcase-sessions` in dev.ts) that the
+// showcase route's own session-creation calls go through — no title
+// content is ever inspected, so nothing an ordinary session's title says
+// can cause it to be swept. The file lives at a fixed, well-known path
+// derived the same way `sessionBaseDir` resolves the session root, so
+// both dev.ts (writer) and this store (reader/pruner) agree on its
+// location without needing to share a live object reference across the
+// HTTP boundary.
+const SHOWCASE_REGISTRY_FILENAME = '.playground-showcase-session-ids.json'
+
+function showcaseRegistryPath(explicitRoot?: string): string {
+  return join(sessionBaseDir(explicitRoot), SHOWCASE_REGISTRY_FILENAME)
+}
+
+async function readShowcaseRegistry(explicitRoot?: string): Promise<Set<string>> {
+  try {
+    const text = await readFile(showcaseRegistryPath(explicitRoot), 'utf8')
+    const parsed: unknown = JSON.parse(text)
+    return new Set(Array.isArray(parsed) ? parsed.filter((value): value is string => typeof value === 'string') : [])
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return new Set()
+    // A corrupt registry file must never crash session hydration — treat
+    // it as empty and let the next successful write repair it.
+    return new Set()
+  }
+}
+
+async function writeShowcaseRegistry(explicitRoot: string | undefined, ids: ReadonlySet<string>): Promise<void> {
+  const path = showcaseRegistryPath(explicitRoot)
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(path, JSON.stringify([...ids].sort()), 'utf8')
+}
+
+/**
+ * Records that `sessionId` was created by the showcase route. Called only
+ * from the dev-only wrapper route, never reachable from the ordinary
+ * session-creation UI — that is what makes this provenance (as opposed to
+ * the old title tag) immune to collision with a normal session.
+ */
+export async function markPlaygroundShowcaseSession(explicitRoot: string | undefined, sessionId: string): Promise<void> {
+  const ids = await readShowcaseRegistry(explicitRoot)
+  if (ids.has(sessionId)) return
+  ids.add(sessionId)
+  await writeShowcaseRegistry(explicitRoot, ids)
 }
 
 class ScriptedPiSessionAdapter implements PiAgentSessionAdapter {

--- a/apps/workspace-playground/src/shared/showcaseSession.ts
+++ b/apps/workspace-playground/src/shared/showcaseSession.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared between the playground front (`front/App.tsx`) and the scripted
+ * dev server (`server/testing/scriptedPiHarness.ts`).
+ *
+ * A stable, non-displayed prefix applied to the *backend* session title for
+ * every session the `?showcase=1` route creates. The showcase route always
+ * supplies its own client-side display title via the controlled `sessions`
+ * prop it hands `WorkspaceAgentFront` — the workspace shell never reads a
+ * showcase session's server-stored title back out — so this tag can ride
+ * along in that field without ever reaching a user.
+ *
+ * It exists so the scripted harness's boot-time sweep (see
+ * `sweepStaleShowcaseSessions` in scriptedPiHarness.ts) can scope itself to
+ * showcase-originated sessions and never touch an unrelated empty session a
+ * developer is mid-way through creating in the ordinary (non-showcase)
+ * playground route.
+ */
+export const SHOWCASE_SESSION_TITLE_TAG = "[playground-showcase] "

--- a/apps/workspace-playground/src/shared/showcaseSession.ts
+++ b/apps/workspace-playground/src/shared/showcaseSession.ts
@@ -1,18 +1,19 @@
 /**
- * Shared between the playground front (`front/App.tsx`) and the scripted
- * dev server (`server/testing/scriptedPiHarness.ts`).
+ * Shared between the playground front (`front/App.tsx`) and the dev server
+ * (`server/dev.ts`, `server/testing/scriptedPiHarness.ts`).
  *
- * A stable, non-displayed prefix applied to the *backend* session title for
- * every session the `?showcase=1` route creates. The showcase route always
- * supplies its own client-side display title via the controlled `sessions`
- * prop it hands `WorkspaceAgentFront` — the workspace shell never reads a
- * showcase session's server-stored title back out — so this tag can ride
- * along in that field without ever reaching a user.
+ * Every session the `?showcase=1` route creates goes through this dev-only
+ * wrapper route instead of the ordinary `/api/v1/agents/:agentTypeId/sessions`
+ * endpoint. The wrapper forwards the create request unchanged and then
+ * records the resulting session id in a provenance registry the scripted
+ * harness's boot-time sweep reads (see `markPlaygroundShowcaseSession` and
+ * `sweepStaleShowcaseSessions` in scriptedPiHarness.ts).
  *
- * It exists so the scripted harness's boot-time sweep (see
- * `sweepStaleShowcaseSessions` in scriptedPiHarness.ts) can scope itself to
- * showcase-originated sessions and never touch an unrelated empty session a
- * developer is mid-way through creating in the ordinary (non-showcase)
- * playground route.
+ * This route — not title text — is what marks a session as
+ * showcase-originated. An earlier version used a fixed title prefix, which
+ * an ordinary session could collide with (the create/rename HTTP schemas
+ * accept any title). Routing through a dedicated dev-only endpoint that the
+ * normal (non-showcase) session UI never calls makes that collision
+ * impossible: nothing a user types into a title can route a request here.
  */
-export const SHOWCASE_SESSION_TITLE_TAG = "[playground-showcase] "
+export const PLAYGROUND_SHOWCASE_SESSION_ROUTE = "/api/v1/playground/showcase-sessions"


### PR DESCRIPTION
## Summary
- `?showcase=1` pre-seeded a client-only `SHOWCASE_SESSION_ID` and wrote the fixture transcript into a `localStorage` key that nothing reads anymore.
- The chat pane always requires a real backend session id (`packages/workspace`'s built-in chat pane throws if `params.sessionId` is missing) and hydrates it over the network — that placeholder id 404'd on every load, producing a permanent "session was not found" banner and a composer that never enabled.
- `apps/workspace-playground/src/front/App.tsx` now boots a real backend session (stable-requestId + abort-timed bounded retry, explicit Retry action on terminal failure) and gates rendering the chat panel on that boot completing.
- Decorative padding rows (`?sessions=N`) never hand the chat pane a placeholder id — selecting one materializes a real backend session first.
- Every showcase session is created through a new dev-only wrapper route, `POST /api/v1/playground/showcase-sessions` (`apps/workspace-playground/src/server/dev.ts`), instead of the ordinary create-session endpoint — this is what marks a session as showcase-originated for the boot-time sweep. Provenance is *which route created the session*, never title text (see below).
- Added `apps/workspace-playground/e2e/showcase.spec.ts`: boot/banner/composer/scripted-reply regression, reload-reuse regression, decorative-materialization regression (with a real state-change poll, not just pre-existing-session properties).

**Showcase session retention rule** (`App.tsx`, `dev.ts`, `scriptedPiHarness.ts`): a showcase session lives until one of —
1. it gets a real turn, at which point it's a normal session kept like any other;
2. its tab goes away, and the `pagehide` best-effort cleanup deletes it (skipped only for the reload-reusable boot session, so a same-tab reload's `resumeSessionId` lookup isn't racing its own deletion);
3. failing both — a closed tab, a killed process, an isolated e2e context — the *next* dev-server boot sweeps it: the session store consults a sidecar provenance registry (populated only by the dev-only wrapper route above, never by title content) and deletes any registered, still-empty (`turnCount===0`) session left over from a prior boot.

Nothing showcase-created accumulates past one server boot, and nothing an ordinary session's title says can mark or un-mark it as showcase-originated.

Fixes #1452

## Test plan
- [x] `pnpm --filter workspace-playground run test` (29 passed)
- [x] `pnpm --filter workspace-playground run typecheck`
- [x] `pnpm --filter workspace-playground exec playwright test apps/workspace-playground/e2e/showcase.spec.ts` — multiple consecutive full runs against a reused dev server, all green.
- [x] `scriptedPiHarness.test.ts`: new registry-based sweep coverage — sweeps a marked+empty session from a prior boot, never touches an ordinary session even when its title reproduces the old removed tag text, stops tracking a session once it has a real turn, and doesn't crash on an unresolvable registry entry.
- [x] Live-drove the playground with Playwright against `?showcase=1`: no error banner, composer enabled, message sent, scripted assistant reply rendered.
- [x] Confirmed `apps/workspace-playground/e2e/cmd-effects.spec.ts`'s pre-existing "Focus Chat" flake reproduces identically with this branch's changes stashed out (unrelated to this fix).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

https://claude.ai/code/session_01MQgxe5KTr2N2pjgjgKPXHK