### PR TITLE
fix(core): leave navigates away; settings route honors membership guard

### DIFF
--- a/packages/core/src/app/front/CoreWorkspaceAgentFront.tsx
+++ b/packages/core/src/app/front/CoreWorkspaceAgentFront.tsx
@@ -10,6 +10,7 @@ import {
   useCurrentWorkspace,
   useSession,
   useWorkspaceRouteStatus,
+  WorkspaceRouteErrorPage,
   type CoreFrontAuthPagesOverride,
   type CoreFrontCompanyAdminOptions,
 } from '../../front/index.js'
@@ -226,22 +227,6 @@ function HomeRedirect<TSession extends WorkspaceAgentSession = WorkspaceAgentSes
   }
   if (!workspace) return <>{resolvedLoadingFallback}</>
   return <Navigate to={workspaceHref(workspace.id)} replace />
-}
-
-function WorkspaceRouteErrorPage({ status, message }: { status: 'not-found' | 'forbidden' | 'switch-failed'; message: string }) {
-  const title = status === 'not-found'
-    ? 'Workspace not found'
-    : status === 'forbidden'
-      ? 'Workspace unavailable'
-      : 'Workspace failed to open'
-  return (
-    <div className="flex h-screen min-h-0 items-center justify-center bg-background px-6 text-foreground">
-      <div className="w-full max-w-md rounded-2xl border border-border bg-card p-6 text-center shadow-sm">
-        <h1 className="text-lg font-semibold">{title}</h1>
-        <p className="mt-2 text-sm text-muted-foreground">{message}</p>
-      </div>
-    </div>
-  )
 }
 
 function WorkspaceRoute<

--- a/packages/core/src/app/front/CoreWorkspaceAgentFront.tsx
+++ b/packages/core/src/app/front/CoreWorkspaceAgentFront.tsx
@@ -10,10 +10,16 @@ import {
   useCurrentWorkspace,
   useSession,
   useWorkspaceRouteStatus,
-  WorkspaceRouteErrorPage,
   type CoreFrontAuthPagesOverride,
   type CoreFrontCompanyAdminOptions,
 } from '../../front/index.js'
+// Imported directly from its module (not the `../../front/index.js` barrel):
+// this is a pure presentational component with no hooks/context, and
+// CoreWorkspaceAgentFront.test.tsx replaces the whole barrel with a manual
+// mock. Routing it through the barrel would silently render `undefined`
+// under that mock instead of the real terminal-route screen the test
+// (added by #1435) asserts on.
+import { WorkspaceRouteErrorPage } from '../../front/workspace/WorkspaceRouteErrorPage.js'
 import {
   parseFullPagePanelLocation,
   WorkspaceAgentFront,

--- a/packages/core/src/front/__tests__/MembersPage.leaveIntegration.test.tsx
+++ b/packages/core/src/front/__tests__/MembersPage.leaveIntegration.test.tsx
@@ -1,0 +1,263 @@
+// @vitest-environment jsdom
+//
+// Integration regression for the self-leave -> "/" redirect, using the real
+// WorkspaceAuthProvider (unmocked) instead of MembersPage.test.tsx's mocked
+// provider. This is the only way to catch the race a thermo review flagged:
+// invalidateQueries() alone does not clear the *current* cached workspaces
+// list/detail before navigate('/') runs, so WorkspaceAuthProvider (which
+// resolves "/" synchronously off whatever is already cached) can redirect
+// straight back into the workspace the user just left.
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { useEffect } from 'react'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { withTaskId } from '../../server/__tests__/_setup'
+import type { Workspace } from '../../shared/types'
+import { MembersPage } from '../workspace/MembersPage'
+import { useCurrentWorkspace, WorkspaceAuthProvider } from '../WorkspaceAuthProvider'
+import { useMswHandler } from './_setup'
+
+const TASK_ID = 'boring-ui-v2-lv1n'
+
+const OWNER_ID = 'user-owner'
+const EDITOR_ID = 'user-editor'
+
+const WS_1: Workspace = {
+  id: 'ws-001',
+  appId: 'test-app',
+  workspaceTypeId: 'default',
+  name: 'Workspace One',
+  createdBy: OWNER_ID,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  deletedAt: null,
+  isDefault: true,
+}
+
+const WS_2: Workspace = {
+  id: 'ws-002',
+  appId: 'test-app',
+  workspaceTypeId: 'default',
+  name: 'Workspace Two',
+  createdBy: OWNER_ID,
+  createdAt: '2026-01-02T00:00:00.000Z',
+  deletedAt: null,
+  isDefault: false,
+}
+
+const mockSessionState = {
+  current: {
+    data: { user: { id: EDITOR_ID, email: 'editor@test.dev' } },
+    isPending: false,
+    error: null,
+  } as any,
+}
+
+vi.mock('../auth/AuthProvider', () => ({
+  useSession: () => mockSessionState.current,
+}))
+
+beforeAll(() => {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false
+  }
+  if (!Element.prototype.setPointerCapture) {
+    Element.prototype.setPointerCapture = () => undefined
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => undefined
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => undefined
+  }
+})
+
+afterEach(() => {
+  mockSessionState.current = {
+    data: { user: { id: EDITOR_ID, email: 'editor@test.dev' } },
+    isPending: false,
+    error: null,
+  }
+  vi.restoreAllMocks()
+})
+
+function extractUrl(input: RequestInfo | URL): string {
+  if (typeof input === 'string') return input
+  if (input instanceof URL) return input.toString()
+  return input.url
+}
+
+// Records every workspace name/id the Home probe observes, in render order,
+// including transient renders that a plain `waitFor` on the final state
+// would never surface.
+const observedHomeWorkspaces: Array<string | null> = []
+
+function HomeProbe() {
+  const workspace = useCurrentWorkspace()
+  useEffect(() => {
+    observedHomeWorkspaces.push(workspace?.id ?? null)
+  })
+  return <div data-testid="home-route">{workspace?.name ?? 'resolving…'}</div>
+}
+
+function Wrapper({ initialPath }: { initialPath: string }) {
+  return (
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route
+          path="/workspace/:id/members"
+          element={
+            <WorkspaceAuthProvider>
+              <MembersPage />
+            </WorkspaceAuthProvider>
+          }
+        />
+        <Route
+          path="/"
+          element={
+            <WorkspaceAuthProvider>
+              <HomeProbe />
+            </WorkspaceAuthProvider>
+          }
+        />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+describe('MembersPage leave -> "/" redirect (integration, real WorkspaceAuthProvider)', () => {
+  it(
+    'self-leave never redirects back into the just-left workspace, and resolves the next one',
+    withTaskId(TASK_ID, async ({ assertionPassed }) => {
+      const qc = new QueryClient({
+        defaultOptions: { queries: { retry: false, staleTime: 60_000 } },
+      })
+      observedHomeWorkspaces.length = 0
+
+      // Server-side ground truth: EDITOR_ID starts as a member of both
+      // workspaces; leaving ws-001 removes it from subsequent /workspaces
+      // and /workspaces/ws-001 responses, exactly like a real backend.
+      let leftWorkspace = false
+      let deleteCalled = false
+
+      // The *first* GET /workspaces (initial page load) resolves normally.
+      // Every subsequent call -- i.e. the invalidateQueries()-triggered
+      // refetch that fires from the leave mutation's onSuccess -- is held
+      // open on a deferred promise the test controls explicitly. This is
+      // what makes the test meaningful: with a real backend, that refetch's
+      // network round trip does not complete synchronously/instantly, so a
+      // fix that relies on it to correct the cache (rather than updating
+      // the cache atomically before navigating) would race a real redirect.
+      // A same-tick-resolving mock fetch would hide exactly that race.
+      let workspacesCallCount = 0
+      const deferredWorkspacesRefetch: { release: (() => void) | null } = { release: null }
+
+      useMswHandler(async (input, init) => {
+        const url = extractUrl(input)
+
+        if (url.endsWith('/api/v1/workspaces')) {
+          workspacesCallCount += 1
+          if (workspacesCallCount > 1) {
+            await new Promise<void>((resolve) => {
+              deferredWorkspacesRefetch.release = resolve
+            })
+          }
+          const workspaces = leftWorkspace ? [WS_2] : [WS_1, WS_2]
+          return new Response(JSON.stringify({ workspaces }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          })
+        }
+        if (url.endsWith('/api/v1/workspaces/ws-001')) {
+          if (leftWorkspace) {
+            return new Response(
+              JSON.stringify({ code: 'forbidden', message: 'Not a member of this workspace' }),
+              { status: 403, headers: { 'content-type': 'application/json' } },
+            )
+          }
+          return new Response(JSON.stringify({ workspace: WS_1, role: 'editor' }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          })
+        }
+        if (url.endsWith('/api/v1/workspaces/ws-002')) {
+          return new Response(JSON.stringify({ workspace: WS_2, role: 'editor' }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          })
+        }
+        if (url.endsWith('/api/v1/workspaces/ws-001/members')) {
+          return new Response(
+            JSON.stringify({
+              members: [
+                { workspaceId: WS_1.id, role: 'owner', createdAt: WS_1.createdAt, userId: OWNER_ID, user: { id: OWNER_ID, email: 'owner@test.dev', name: 'Owner', image: null } },
+                { workspaceId: WS_1.id, role: 'editor', createdAt: WS_1.createdAt, userId: EDITOR_ID, user: { id: EDITOR_ID, email: 'editor@test.dev', name: 'Editor', image: null } },
+              ],
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          )
+        }
+        if (url.endsWith(`/api/v1/workspaces/ws-001/members/${EDITOR_ID}`) && init?.method === 'DELETE') {
+          deleteCalled = true
+          leftWorkspace = true
+          return new Response(JSON.stringify({ removed: true }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          })
+        }
+        return undefined
+      })
+
+      render(
+        <QueryClientProvider client={qc}>
+          <Wrapper initialPath="/workspace/ws-001/members" />
+        </QueryClientProvider>,
+      )
+
+      await waitFor(() => expect(screen.getByTestId('members-list')).toBeTruthy())
+
+      const leaveBtn = screen.getByTestId(`remove-${EDITOR_ID}`)
+      expect(leaveBtn.textContent).toBe('Leave')
+      fireEvent.click(leaveBtn)
+
+      await waitFor(() => expect(screen.getByTestId('confirm-remove')).toBeTruthy())
+      fireEvent.click(screen.getByTestId('confirm-remove'))
+
+      await waitFor(() => expect(deleteCalled).toBe(true))
+      // Wait for the invalidate-triggered second GET /workspaces to actually
+      // be in flight (and parked on the deferred promise) before asserting
+      // anything -- this proves the assertions below run *before* that
+      // network round trip has any chance to resolve.
+      await waitFor(() => expect(workspacesCallCount).toBeGreaterThan(1))
+      await waitFor(() => expect(deferredWorkspacesRefetch.release).not.toBeNull())
+
+      // Directly proves atomicity of the fix: by the time the mutation's
+      // onSuccess callback has run, the cached workspaces list must already
+      // exclude ws-001 -- synchronously, with no network round trip needed
+      // -- so "/" can never observe a stale list containing it.
+      const cachedWorkspaces = qc.getQueryData<Workspace[]>(['workspaces'])
+      expect(cachedWorkspaces?.some((w) => w.id === WS_1.id)).toBe(false)
+
+      // The redirect target must already be correct *before* the deferred
+      // refetch resolves -- i.e. it does not depend on that network round
+      // trip to avoid landing back on the just-left workspace.
+      await waitFor(() =>
+        expect(screen.getByTestId('home-route').textContent).toBe('Workspace Two'),
+      )
+      expect(observedHomeWorkspaces).not.toContain(WS_1.id)
+
+      // Now let the deferred refetch resolve and confirm the outcome is
+      // stable (no flip, in either direction).
+      deferredWorkspacesRefetch.release?.()
+      await waitFor(() =>
+        expect(screen.getByTestId('home-route').textContent).toBe('Workspace Two'),
+      )
+      expect(observedHomeWorkspaces).not.toContain(WS_1.id)
+      expect(observedHomeWorkspaces[observedHomeWorkspaces.length - 1]).toBe(WS_2.id)
+
+      assertionPassed('self-leave-no-redirect-back-resolves-next-workspace')
+      qc.clear()
+    }),
+  )
+})

--- a/packages/core/src/front/__tests__/MembersPage.test.tsx
+++ b/packages/core/src/front/__tests__/MembersPage.test.tsx
@@ -68,6 +68,7 @@ const mockSession = {
 vi.mock('../WorkspaceAuthProvider.js', () => ({
   useCurrentWorkspace: () => mockWorkspace.current,
   useWorkspaceRole: () => mockRole.current,
+  WORKSPACES_QUERY_KEY: ['workspaces'],
 }))
 
 vi.mock('../auth/AuthProvider.js', () => ({
@@ -86,6 +87,7 @@ function Wrapper({ children, qc }: { children: ReactNode; qc: QueryClient }) {
       <MemoryRouter initialEntries={[`/w/${WS_ID}/members`]}>
         <Routes>
           <Route path="/w/:id/members" element={children} />
+          <Route path="/" element={<div data-testid="home-route">home</div>} />
         </Routes>
       </MemoryRouter>
     </QueryClientProvider>
@@ -322,8 +324,65 @@ describe('MembersPage', () => {
       fireEvent.click(screen.getByTestId('confirm-remove'))
 
       await waitFor(() => expect(deletedUserId).toBe(EDITOR_ID))
+      await waitFor(() => expect(screen.getByTestId('home-route')).toBeTruthy())
 
       assertionPassed('leave-workspace-self')
+      qc.clear()
+    }),
+  )
+
+  it(
+    'leave workspace as non-owner: navigates away and does not refetch the now-forbidden members list',
+    withTaskId(TASK_ID, async ({ assertionPassed }) => {
+      const qc = createQueryClient()
+      mockRole.current = 'editor'
+      mockSession.current = {
+        data: { user: { id: EDITOR_ID, email: 'editor@test.dev' } },
+        isPending: false,
+        error: null,
+      }
+      let membersFetchCount = 0
+
+      useMswHandler(async (input, init) => {
+        const url = extractUrl(input)
+        if (url.endsWith(`/api/v1/workspaces/${WS_ID}/members`)) {
+          membersFetchCount += 1
+          return new Response(JSON.stringify({ members: [OWNER_MEMBER, EDITOR_MEMBER] }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          })
+        }
+        const deleteMatch = url.match(/\/members\/(user-[^/]+)$/)
+        if (deleteMatch && init?.method === 'DELETE') {
+          return new Response(JSON.stringify({ removed: true }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          })
+        }
+        return undefined
+      })
+
+      render(
+        <Wrapper qc={qc}>
+          <MembersPage />
+        </Wrapper>,
+      )
+
+      await waitFor(() => expect(screen.getByTestId('members-list')).toBeTruthy())
+      const fetchCountAfterInitialLoad = membersFetchCount
+
+      fireEvent.click(screen.getByTestId(`remove-${EDITOR_ID}`))
+      await waitFor(() => expect(screen.getByTestId('confirm-remove')).toBeTruthy())
+      fireEvent.click(screen.getByTestId('confirm-remove'))
+
+      // Navigates to "/" instead of staying on a page whose data (and Leave
+      // button) is now stale/forbidden.
+      await waitFor(() => expect(screen.getByTestId('home-route')).toBeTruthy())
+      expect(screen.queryByText('Failed to load members.')).toBeNull()
+      // The now-forbidden members query must not be refetched after leaving.
+      expect(membersFetchCount).toBe(fetchCountAfterInitialLoad)
+
+      assertionPassed('leave-workspace-navigates-no-stale-refetch')
       qc.clear()
     }),
   )

--- a/packages/core/src/front/__tests__/WorkspaceSettingsPage.test.tsx
+++ b/packages/core/src/front/__tests__/WorkspaceSettingsPage.test.tsx
@@ -33,10 +33,15 @@ const mockWorkspace = {
 }
 
 const mockNavigate = vi.fn()
+const mockRole = { current: 'owner' as string | null }
+const mockRouteStatus = {
+  current: { status: 'matched', workspaceId: WS_ID, workspace: mockWorkspace.current } as any,
+}
 
 vi.mock('../WorkspaceAuthProvider.js', () => ({
   useCurrentWorkspace: () => mockWorkspace.current,
-  useWorkspaceRole: () => 'owner',
+  useWorkspaceRole: () => mockRole.current,
+  useWorkspaceRouteStatus: () => mockRouteStatus.current,
   WORKSPACES_QUERY_KEY: ['workspaces'],
   workspaceQueryKey: (id: string) => ['workspace', id],
 }))
@@ -96,6 +101,8 @@ afterEach(() => {
     deletedAt: null,
     isDefault: true,
   }
+  mockRole.current = 'owner'
+  mockRouteStatus.current = { status: 'matched', workspaceId: WS_ID, workspace: mockWorkspace.current }
   mockNavigate.mockReset()
   vi.restoreAllMocks()
 })
@@ -486,6 +493,76 @@ describe('WorkspaceSettingsPage', () => {
       expect(mockNavigate).not.toHaveBeenCalled()
 
       assertionPassed('delete-failure-inline-error')
+      qc.clear()
+    }),
+  )
+
+  it(
+    'non-member (forbidden route status): shows access-denied screen, no settings shell',
+    withTaskId(TASK_ID, async ({ assertionPassed }) => {
+      const qc = createQueryClient()
+      mockRouteStatus.current = {
+        status: 'forbidden',
+        workspaceId: WS_ID,
+        message: 'Not a member of this workspace',
+      }
+
+      render(
+        <Wrapper qc={qc}>
+          <WorkspaceSettingsPage />
+        </Wrapper>,
+      )
+
+      await waitFor(() => expect(screen.getByText('Workspace unavailable')).toBeTruthy())
+      expect(screen.getByText('Not a member of this workspace')).toBeTruthy()
+      expect(screen.queryByTestId('delete-workspace')).toBeNull()
+      expect(screen.queryByTestId('danger-zone')).toBeNull()
+
+      assertionPassed('forbidden-shows-access-denied')
+      qc.clear()
+    }),
+  )
+
+  it(
+    'route status not yet matched (loading role): no settings shell, no Delete button',
+    withTaskId(TASK_ID, async ({ assertionPassed }) => {
+      const qc = createQueryClient()
+      mockRouteStatus.current = { status: 'loading', workspaceId: WS_ID }
+      mockRole.current = null
+
+      render(
+        <Wrapper qc={qc}>
+          <WorkspaceSettingsPage />
+        </Wrapper>,
+      )
+
+      await waitFor(() => expect(screen.getByTestId('workspace-settings-loading')).toBeTruthy())
+      expect(screen.queryByTestId('delete-workspace')).toBeNull()
+      expect(screen.queryByTestId('danger-zone')).toBeNull()
+
+      assertionPassed('loading-hides-delete-button')
+      qc.clear()
+    }),
+  )
+
+  it(
+    'matched but role not owner: Delete button rendered but disabled',
+    withTaskId(TASK_ID, async ({ assertionPassed }) => {
+      const qc = createQueryClient()
+      mockRole.current = 'editor'
+      setupRuntimeHandler(null)
+
+      render(
+        <Wrapper qc={qc}>
+          <WorkspaceSettingsPage />
+        </Wrapper>,
+      )
+
+      await waitFor(() => expect(screen.getByTestId('danger-zone')).toBeTruthy())
+      const deleteBtn = screen.getByTestId('delete-workspace') as HTMLButtonElement
+      expect(deleteBtn.disabled).toBe(true)
+
+      assertionPassed('non-owner-delete-disabled')
       qc.clear()
     }),
   )

--- a/packages/core/src/front/index.ts
+++ b/packages/core/src/front/index.ts
@@ -87,6 +87,8 @@ export { InvitesPage } from './workspace/InvitesPage.js'
 export { MembersPage } from './workspace/MembersPage.js'
 export { WorkspaceSettingsPage } from './workspace/WorkspaceSettingsPage.js'
 export { CompanyAdminPage } from './workspace/CompanyAdminPage.js'
+export { WorkspaceRouteErrorPage } from './workspace/WorkspaceRouteErrorPage.js'
+export type { WorkspaceRouteErrorStatus } from './workspace/WorkspaceRouteErrorPage.js'
 export { getWorkspaceCommands } from './workspace/commands.js'
 export type { WorkspaceCommand } from './workspace/commands.js'
 

--- a/packages/core/src/front/workspace/MembersPage.tsx
+++ b/packages/core/src/front/workspace/MembersPage.tsx
@@ -34,7 +34,7 @@ import { useSession } from '../auth/AuthProvider.js'
 import { useWorkspaceMembers } from '../hooks/useWorkspaceMembers.js'
 import type { EnrichedMember } from '../hooks/useWorkspaceMembers.js'
 import { apiFetch, getHttpErrorDetail } from '../utils.js'
-import type { MemberRole } from '../../shared/types.js'
+import type { MemberRole, Workspace } from '../../shared/types.js'
 
 const ROLE_OPTIONS: MemberRole[] = ['owner', 'editor', 'viewer']
 
@@ -95,13 +95,21 @@ export function MembersPage() {
     onSuccess: ({ userId }) => {
       setConfirmTarget(null)
       if (userId === currentUserId) {
-        // We just removed ourselves: there is nothing left to show on this
-        // page, and this workspace's members list is now forbidden to us.
-        // Leave immediately instead of refetching it — invalidating (rather
-        // than removing) the cache means an observer still mounted for one
-        // more tick won't trigger a doomed refetch. Invalidate the
-        // workspaces list too, so the picker on "/" resolves the next
-        // available workspace instead of a stale/removed one.
+        // We just removed ourselves. WorkspaceAuthProvider stays mounted
+        // across this navigation and resolves "/" synchronously from
+        // whatever is already in the query cache — an invalidate-only
+        // update races that resolution: the still-cached workspaces list
+        // (with this workspace as isDefault/first, plus its still-cached
+        // detail) can redirect straight back into the workspace we just
+        // left, before the invalidated refetch lands. Filter this
+        // workspace out of the cached list atomically, in this same
+        // callback, so "/" never observes a list that still contains it.
+        // (invalidateQueries afterward still reconciles with the server
+        // in the background, e.g. if another workspace was also removed
+        // concurrently.)
+        queryClient.setQueryData<Workspace[]>(WORKSPACES_QUERY_KEY, (existing) =>
+          existing ? existing.filter((w) => w.id !== workspaceId) : existing,
+        )
         queryClient.invalidateQueries({ queryKey: WORKSPACES_QUERY_KEY })
         navigate('/', { replace: true })
         return

--- a/packages/core/src/front/workspace/MembersPage.tsx
+++ b/packages/core/src/front/workspace/MembersPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
 import {
   AlertDialog,
   AlertDialogCancel,
@@ -24,7 +25,11 @@ import {
   LoadingState,
   Notice,
 } from '@hachej/boring-ui-kit'
-import { useCurrentWorkspace, useWorkspaceRole } from '../WorkspaceAuthProvider.js'
+import {
+  useCurrentWorkspace,
+  useWorkspaceRole,
+  WORKSPACES_QUERY_KEY,
+} from '../WorkspaceAuthProvider.js'
 import { useSession } from '../auth/AuthProvider.js'
 import { useWorkspaceMembers } from '../hooks/useWorkspaceMembers.js'
 import type { EnrichedMember } from '../hooks/useWorkspaceMembers.js'
@@ -38,6 +43,7 @@ export function MembersPage() {
   const myRole = useWorkspaceRole()
   const session = useSession()
   const queryClient = useQueryClient()
+  const navigate = useNavigate()
 
   const workspaceId = workspace?.id ?? ''
   const currentUserId = session.data?.user?.id ?? ''
@@ -84,10 +90,23 @@ export function MembersPage() {
         `/api/v1/workspaces/${encodedWorkspaceId}/members/${encodeURIComponent(userId)}`,
         { method: 'DELETE' },
       )
+      return { userId }
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['members', workspaceId] })
+    onSuccess: ({ userId }) => {
       setConfirmTarget(null)
+      if (userId === currentUserId) {
+        // We just removed ourselves: there is nothing left to show on this
+        // page, and this workspace's members list is now forbidden to us.
+        // Leave immediately instead of refetching it — invalidating (rather
+        // than removing) the cache means an observer still mounted for one
+        // more tick won't trigger a doomed refetch. Invalidate the
+        // workspaces list too, so the picker on "/" resolves the next
+        // available workspace instead of a stale/removed one.
+        queryClient.invalidateQueries({ queryKey: WORKSPACES_QUERY_KEY })
+        navigate('/', { replace: true })
+        return
+      }
+      queryClient.invalidateQueries({ queryKey: ['members', workspaceId] })
     },
     onError: (err: unknown) => {
       const detail = getHttpErrorDetail(err)

--- a/packages/core/src/front/workspace/WorkspaceRouteErrorPage.tsx
+++ b/packages/core/src/front/workspace/WorkspaceRouteErrorPage.tsx
@@ -1,0 +1,24 @@
+export type WorkspaceRouteErrorStatus = 'not-found' | 'forbidden' | 'switch-failed'
+
+/**
+ * Shared terminal state for a workspace-scoped route whose route status
+ * resolved to something other than `matched` (not-found / forbidden /
+ * switch-failed). Every workspace route (the main `/workspace/:id` shell,
+ * members, settings, ...) renders this instead of its own content so a
+ * non-member never sees a stale or half-loaded interactive shell.
+ */
+export function WorkspaceRouteErrorPage({ status, message }: { status: WorkspaceRouteErrorStatus; message: string }) {
+  const title = status === 'not-found'
+    ? 'Workspace not found'
+    : status === 'forbidden'
+      ? 'Workspace unavailable'
+      : 'Workspace failed to open'
+  return (
+    <div className="flex h-screen min-h-0 items-center justify-center bg-background px-6 text-foreground">
+      <div className="w-full max-w-md rounded-2xl border border-border bg-card p-6 text-center shadow-sm">
+        <h1 className="text-lg font-semibold">{title}</h1>
+        <p className="mt-2 text-sm text-muted-foreground">{message}</p>
+      </div>
+    </div>
+  )
+}

--- a/packages/core/src/front/workspace/WorkspaceSettingsPage.tsx
+++ b/packages/core/src/front/workspace/WorkspaceSettingsPage.tsx
@@ -29,11 +29,16 @@ import {
   ShieldAlert,
   Trash2,
 } from 'lucide-react'
-import { useCurrentWorkspace, useWorkspaceRole } from '../WorkspaceAuthProvider.js'
+import {
+  useCurrentWorkspace,
+  useWorkspaceRole,
+  useWorkspaceRouteStatus,
+} from '../WorkspaceAuthProvider.js'
 import { WORKSPACES_QUERY_KEY, workspaceQueryKey } from '../WorkspaceAuthProvider.js'
 import { useOptionalConfig } from '../ConfigProvider.js'
 import { apiFetch, apiFetchJson, getHttpErrorDetail } from '../utils.js'
 import type { WorkspaceRuntime } from '../../shared/types.js'
+import { WorkspaceRouteErrorPage } from './WorkspaceRouteErrorPage.js'
 
 export interface WorkspaceSettingsPageProps {
   topBar?: ReactNode
@@ -147,6 +152,7 @@ type WorkspaceFileSettings = {
 export function WorkspaceSettingsPage({ topBar }: WorkspaceSettingsPageProps = {}) {
   const workspace = useCurrentWorkspace()
   const role = useWorkspaceRole()
+  const routeStatus = useWorkspaceRouteStatus()
   const queryClient = useQueryClient()
   const navigate = useNavigate()
 
@@ -315,7 +321,9 @@ export function WorkspaceSettingsPage({ topBar }: WorkspaceSettingsPageProps = {
   const fileSettingsChanged = imageUploadDirValue !== null && imageUploadDirValue.trim() !== currentImageUploadDir
   const nameChanged = nameValue !== null && nameValue.trim() !== workspace?.name
   const canEditName = role !== 'viewer'
-  const canDeleteWorkspace = role === 'owner' || role === null
+  // Destructive controls must never render "enabled by default" while role is
+  // unresolved: only an explicitly confirmed owner may delete a workspace.
+  const canDeleteWorkspace = role === 'owner'
   const workspaceName = workspace?.name ?? 'Workspace'
   const workspaceInitial = (workspace?.name?.trim()?.[0] ?? 'W').toUpperCase()
   const topBarNode = topBar === undefined
@@ -326,6 +334,32 @@ export function WorkspaceSettingsPage({ topBar }: WorkspaceSettingsPageProps = {
     if (item.href === '#files') return hasFileSettings
     return true
   })
+
+  // Same membership guard as the other workspace routes (/workspace/:id,
+  // /members): a non-member (or a not-found/switch-failed workspace) never
+  // sees the settings shell — including its destructive Delete control.
+  if (
+    routeStatus.status === 'not-found'
+    || routeStatus.status === 'forbidden'
+    || routeStatus.status === 'switch-failed'
+  ) {
+    return <WorkspaceRouteErrorPage status={routeStatus.status} message={routeStatus.message} />
+  }
+
+  // Role/workspace still resolving: render nothing interactive (in
+  // particular, no Delete button) until membership is confirmed.
+  if (routeStatus.status !== 'matched') {
+    return (
+      <main className="boring-settings-shell" data-testid="workspace-settings-loading">
+        {topBarNode}
+        <div className="boring-settings-scroll">
+          <div className="flex min-h-[40vh] items-center justify-center px-6">
+            <p className="text-sm text-muted-foreground">Loading workspace settings…</p>
+          </div>
+        </div>
+      </main>
+    )
+  }
 
   return (
     <main className="boring-settings-shell">


### PR DESCRIPTION
Fixes #1466

## Summary
- MembersPage: on a successful self-leave, invalidate the workspaces query and navigate to `/` instead of refetching the now-forbidden members list — fixes the stale list / "Failed to load members." / dead Leave button after leaving as a non-owner.
- WorkspaceSettingsPage: apply the same route-status membership guard used by the main `/workspace/:id` shell (extracted the shared `WorkspaceRouteErrorPage` out of `CoreWorkspaceAgentFront` into `packages/core/src/front/workspace/`). A non-member now sees the "Not a member" 403 screen instead of a stuck "Loading role" settings shell, and the whole shell (including Delete) is withheld until the route status is `matched`.
- Fixed `canDeleteWorkspace = role === 'owner' || role === null` → `role === 'owner'`: this bug is what let the Delete workspace button render enabled while role was still unresolved (or forbidden).

Server authz for both cases was already correct — these are pure UI-guard fixes.

## Test plan
- [x] `pnpm -C packages/core exec vitest run src/front --no-file-parallelism` — 33 files / 240 tests passed, including new coverage:
  - MembersPage: self-leave navigates to `/`, no stale refetch of the forbidden members query
  - WorkspaceSettingsPage: forbidden route status → access-denied screen, no shell; non-matched route status → no Delete button rendered; matched-but-non-owner → Delete button rendered but disabled
- [x] `pnpm -C packages/core run typecheck` — no new errors (one pre-existing, unrelated error in `packages/workspace/src/app/front/WorkspaceAgentFront.tsx` also present on `origin/main`)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

https://claude.ai/code/session_01MQgxe5KTr2N2pjgjgKPXHK