### PR TITLE
Fix: focus session created via 'Start new chat with <Agent>'

### DIFF
--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -1807,12 +1807,28 @@ export function WorkspaceAgentFront<
       if (remoteSessionsPending && current.ids.length > 0 && !pendingCreatedId) return current
       const currentActiveRef = current.activeId ? workspaceSessionRefFromKey(current.activeId) : undefined
       const activeOwnerIsExplicit = Boolean(effectiveActiveSessionAgentTypeId)
-      const currentMatchesControlledSession = activeOwnerIsExplicit
+      // #1472 review: a fleet create's addressed-Agent switch and its pane
+      // update land in the same tick, but the newly addressed Agent's OWN
+      // session snapshot (`addressedFleetSessions.tsx`'s `snapshots` map)
+      // only catches up a render or two later, via that Agent's session
+      // source publishing through its own passive effect. In the gap,
+      // `chatSessionKey` still names the Agent's PREVIOUS active session, so
+      // without this the optimistic pane got judged "uncontrolled" and
+      // replaced by that stale session — a `new → stale → new` visible stomp.
+      // Trust an optimistically-created pane over the (possibly stale)
+      // controlled session until its own key is cleared from the ref above
+      // (once the real session list actually contains it).
+      const currentIsOptimisticCreate = Boolean(current.activeId && optimisticCreatedPaneKeysRef.current.has(current.activeId))
+      const currentMatchesControlledSession = currentIsOptimisticCreate || (activeOwnerIsExplicit
         ? current.activeId === chatSessionKey
-        : currentActiveRef?.sessionId === chatSessionId
+        : currentActiveRef?.sessionId === chatSessionId)
       const resolvedDesiredSessionId = !pendingCreatedId
         && current.activeId
-        && (!canPruneMissingSessions || resolvedSessionsByKey.has(current.activeId))
+        // An optimistic create bypasses the "known session" gate too: it is
+        // by definition not in `resolvedSessionsByKey` yet (that is what
+        // "optimistic" means here), so requiring membership would undo the
+        // protection `currentMatchesControlledSession` just granted it.
+        && (!canPruneMissingSessions || resolvedSessionsByKey.has(current.activeId) || currentIsOptimisticCreate)
         && currentMatchesControlledSession
         ? current.activeId
         : desiredSessionId

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -2022,6 +2022,17 @@ export function WorkspaceAgentFront<
         if (createdAgentTypeId) rawSwitch(id, createdAgentTypeId)
         else rawSwitch(id)
       }
+      // A fleet create can target an Agent OTHER than the one currently
+      // addressed (#1470: the New chat Agent picker retargets independently
+      // of the addressed selection). The pane-reconciliation effect below
+      // resolves its desired session from the ADDRESSED Agent's own session
+      // API, so without this the new pane got immediately stomped back to
+      // whatever the previously addressed chat was — created, but never
+      // shown. Address the created Agent so every creation entry point (the
+      // rail "+", the card, and the picker alike) opens on what it just made.
+      if (fleetModeEnabled && createdAgentTypeId && createdAgentTypeId !== addressedAgents.selectedAgentTypeId) {
+        addressedAgents.selectAgentTypeId(createdAgentTypeId)
+      }
       scheduleActiveAgentComposerFocus()
     }).catch(() => {
       settleIfOwner()
@@ -2029,7 +2040,7 @@ export function WorkspaceAgentFront<
       // transaction only owns clearing its pending state.
     })
     return created
-  }, [chatSessionKey, rawSwitch, resolvedCreate, resolvedSessions, selectedAgentTypeId, sessionApi, workspaceId])
+  }, [addressedAgents.selectAgentTypeId, addressedAgents.selectedAgentTypeId, chatSessionKey, fleetModeEnabled, rawSwitch, resolvedCreate, resolvedSessions, selectedAgentTypeId, sessionApi, workspaceId])
 
   useEffect(() => {
     const pending = pendingCreatePaneRef.current

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -463,6 +463,14 @@ function useStoredNullableStringState(
 const EMPTY_HEADERS: Record<string, string> = {}
 const EMPTY_STRING_LIST: string[] = []
 const PREPARING_WARMUP_STATUS: WorkspaceWarmupStatus = { status: "preparing" }
+// An optimistically-created pane loses its protection once its owning
+// Agent's session snapshot acknowledges it (the normal, fast path). This is
+// the terminal fallback for the abnormal one: the session was deleted (in
+// app or out of band) or a provider returned an id that never materializes,
+// so no snapshot will EVER acknowledge it. Past this window the key is
+// dropped and reconciliation falls back to the real authoritative session
+// instead of protecting a pane that may no longer exist.
+export const OPTIMISTIC_CREATE_ACK_WINDOW_MS = 10_000
 const useIsomorphicLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect
 
 function sessionCreateProtocolError(message: string): SessionCreateProtocolError {
@@ -1485,7 +1493,28 @@ export function WorkspaceAgentFront<
   const autoCreateSessionRef = useRef(false)
   const pendingLastSessionDeleteRef = useRef<Set<string>>(new Set())
   const pendingCreatePaneRef = useRef<PendingCreatePane | null>(null)
-  const optimisticCreatedPaneKeysRef = useRef<Set<string>>(new Set())
+  // Maps an optimistically-created pane key to the time it was created, so a
+  // never-acknowledged create (deleted before its Agent's first snapshot
+  // observed it, or a phantom id a provider never materializes) can be aged
+  // out instead of protecting a pane forever. See OPTIMISTIC_CREATE_ACK_WINDOW_MS.
+  const optimisticCreatedPaneKeysRef = useRef<Map<string, number>>(new Map())
+  // Nothing else re-renders once a create's ack window merely elapses (no
+  // session list changed, no user action happened) — this tick forces the
+  // reconciliation effect below to re-run so the aged-out key is actually
+  // dropped and reconciliation falls back to the real session.
+  const [optimisticCreateAckTick, setOptimisticCreateAckTick] = useState(0)
+  const optimisticCreateAckTimersRef = useRef<Set<ReturnType<typeof window.setTimeout>>>(new Set())
+  useEffect(() => () => {
+    for (const timer of optimisticCreateAckTimersRef.current) window.clearTimeout(timer)
+    optimisticCreateAckTimersRef.current.clear()
+  }, [])
+  // A workspace/source switch resets chatPaneState to empty (see the
+  // chatPaneSourceIdentity effect above) and abandons whatever pane a create
+  // was protecting — any leftover optimistic keys belong to a pane that no
+  // longer exists on screen, so nothing should still be aging them out.
+  useEffect(() => {
+    optimisticCreatedPaneKeysRef.current.clear()
+  }, [chatPaneSourceIdentity, workspaceId])
   const surfaceOpenRef = useRef(surfaceOpen)
   const surfaceKeyRef = useRef(resolvedSurfaceStorageKey)
   const surfaceRef = useRef<{ key: string; api: SurfaceShellApi } | null>(null)
@@ -1765,8 +1794,15 @@ export function WorkspaceAgentFront<
       pendingCreatePaneRef.current = null
       if (ownedPendingCreatePane.placementDirection) setChatPaneSplitPending(false)
     }
-    for (const key of optimisticCreatedPaneKeysRef.current) {
-      if (resolvedSessionsByKey.has(key)) optimisticCreatedPaneKeysRef.current.delete(key)
+    const optimisticCreateDeadline = Date.now() - OPTIMISTIC_CREATE_ACK_WINDOW_MS
+    for (const [key, createdAt] of optimisticCreatedPaneKeysRef.current) {
+      // Acknowledged (the normal path): the owning Agent's session snapshot
+      // now contains it. Aged out (the abnormal path this review flagged):
+      // deleted before ever being observed, or a phantom id that never
+      // materializes — stop protecting a pane that may no longer exist.
+      if (resolvedSessionsByKey.has(key) || createdAt <= optimisticCreateDeadline) {
+        optimisticCreatedPaneKeysRef.current.delete(key)
+      }
     }
     const newlyObservedSession = pendingCreatePane
       ? resolvedSessions.find((session) => !pendingCreatePane.knownIds.has(workspaceSessionKeyFor(session)))
@@ -1864,7 +1900,7 @@ export function WorkspaceAgentFront<
       ) return previous
       return { workspaceId, ids: nextIds, activeId: nextActiveId }
     })
-  }, [autoSubmitSessionId, chatSessionId, chatSessionKey, effectiveActiveSessionAgentTypeId, remoteSessionsPending, remoteSessionsTransitioning, resolvedSessions, resolvedSessionsByKey, sessionListAuthoritative, workspaceId])
+  }, [autoSubmitSessionId, chatSessionId, chatSessionKey, effectiveActiveSessionAgentTypeId, optimisticCreateAckTick, remoteSessionsPending, remoteSessionsTransitioning, resolvedSessions, resolvedSessionsByKey, sessionListAuthoritative, workspaceId])
   const [initialHydrationPromptStarted, setInitialHydrationPromptStarted] = useState<{ workspaceId: string; ids: Set<string> }>(() => ({
     workspaceId,
     ids: new Set(),
@@ -2025,7 +2061,17 @@ export function WorkspaceAgentFront<
       const nextState = { workspaceId, ids: nextIds, activeId: createdKey }
 
       if (!settleIfOwner()) return
-      optimisticCreatedPaneKeysRef.current.add(createdKey)
+      optimisticCreatedPaneKeysRef.current.set(createdKey, Date.now())
+      if (typeof window !== "undefined") {
+        const timer = window.setTimeout(() => {
+          optimisticCreateAckTimersRef.current.delete(timer)
+          // Force the reconciliation effect to re-evaluate even if nothing
+          // else changed in the meantime — that is exactly the abnormal case
+          // (deleted/never-materialized) this window exists to catch.
+          setOptimisticCreateAckTick((tick) => tick + 1)
+        }, OPTIMISTIC_CREATE_ACK_WINDOW_MS)
+        optimisticCreateAckTimersRef.current.add(timer)
+      }
       chatPaneStateRef.current = nextState
       setChatPaneState(nextState)
       if (placementDirection) {
@@ -2101,6 +2147,10 @@ export function WorkspaceAgentFront<
 
   const deleteSessionAndPane = useCallback((sessionId: string, sessionAgentTypeId?: string) => {
     const sessionKey = workspaceSessionKey(sessionId, sessionAgentTypeId)
+    // We know FOR CERTAIN this session is gone — no need to wait out the ack
+    // window. Deleting an optimistic key we never created is a harmless
+    // no-op, so this is safe to call unconditionally.
+    optimisticCreatedPaneKeysRef.current.delete(sessionKey)
     const current = chatPaneState.workspaceId === workspaceId
       ? chatPaneState
       : { workspaceId, ids: [chatSessionKey], activeId: chatSessionKey }

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -1503,9 +1503,9 @@ export function WorkspaceAgentFront<
   // reconciliation effect below to re-run so the aged-out key is actually
   // dropped and reconciliation falls back to the real session.
   const [optimisticCreateAckTick, setOptimisticCreateAckTick] = useState(0)
-  const optimisticCreateAckTimersRef = useRef<Set<ReturnType<typeof window.setTimeout>>>(new Set())
+  const optimisticCreateAckTimersRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set())
   useEffect(() => () => {
-    for (const timer of optimisticCreateAckTimersRef.current) window.clearTimeout(timer)
+    for (const timer of optimisticCreateAckTimersRef.current) clearTimeout(timer)
     optimisticCreateAckTimersRef.current.clear()
   }, [])
   // A workspace/source switch resets chatPaneState to empty (see the
@@ -2063,7 +2063,7 @@ export function WorkspaceAgentFront<
       if (!settleIfOwner()) return
       optimisticCreatedPaneKeysRef.current.set(createdKey, Date.now())
       if (typeof window !== "undefined") {
-        const timer = window.setTimeout(() => {
+        const timer = setTimeout(() => {
           optimisticCreateAckTimersRef.current.delete(timer)
           // Force the reconciliation effect to re-evaluate even if nothing
           // else changed in the meantime — that is exactly the abnormal case

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -788,6 +788,78 @@ describe("WorkspaceAgentFront", () => {
     expect(within(unifiedDetailsOverlay as HTMLElement).queryByRole("tab")).not.toBeInTheDocument()
   }, 30_000)
 
+  // #1470: "Start new chat with <Agent>" (the New chat Agent picker) creates
+  // the session but must land the main pane on it too, exactly like the
+  // per-Agent card's "New chat with <Agent>" button does.
+  it("focuses the session created via the New chat Agent picker", async () => {
+    const user = userEvent.setup()
+    const agents = [
+      { agentTypeId: "alpha", label: "Alpha" },
+      { agentTypeId: "beta", label: "Beta" },
+    ]
+    const useAgentSelection = () => {
+      const [selectedAgentTypeId, setSelectedAgentTypeId] = useState("alpha")
+      return {
+        agents,
+        selectedAgentTypeId,
+        loading: false,
+        error: undefined,
+        selectAgentTypeId: setSelectedAgentTypeId,
+      }
+    }
+    const useFleetSessions: AttestedWorkspaceAgentFrontProps<WorkspaceAgentSession>["useSessions"] = (options) => {
+      const owner = options.agentTypeId
+      const [owned, setOwned] = useState(() => [{
+        id: `${owner}-one`,
+        agentTypeId: owner,
+        title: `${owner} one`,
+        updatedAt: 1,
+      }])
+      return {
+        sessions: owned,
+        loading: false,
+        activeSessionId: owned[0]?.id,
+        activeSessionAgentTypeId: owner,
+        activeSession: owned[0],
+        workspaceId: options.workspaceId,
+        switch: vi.fn(),
+        create: async () => {
+          const session = { id: `${owner}-new`, agentTypeId: owner, title: `${owner} new`, updatedAt: 2 }
+          setOwned((current) => [session, ...current])
+          return session
+        },
+        delete: vi.fn(),
+      }
+    }
+
+    render(
+      <WorkspaceAgentFront
+        workspaceId="picker-focus"
+        workspaceLayout="plugin-tabs"
+        chatPanel={SessionIdChatPanel}
+        addressedAgentSelection
+        useAddressedAgentSelection={useAgentSelection}
+        useSessions={useFleetSessions}
+        persistenceEnabled={false}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-pane")).toHaveAttribute("data-agent-type-id", "alpha")
+      expect(screen.getByTestId("chat-pane")).toHaveAttribute("data-session-id", "alpha-one")
+    })
+
+    // Retarget the picker to Beta without ever addressing/opening a Beta chat.
+    await user.click(await screen.findByRole("button", { name: "Choose Agent for new chat" }))
+    await user.click(await screen.findByRole("menuitem", { name: "Beta" }))
+    await user.click(await screen.findByRole("button", { name: "Start new chat with Beta" }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-pane")).toHaveAttribute("data-agent-type-id", "beta")
+      expect(screen.getByTestId("chat-pane")).toHaveAttribute("data-session-id", "beta-new")
+    })
+  })
+
   it("initializes a controlled colliding id to its explicit active owner", () => {
     localStorage.setItem("boring-workspace:chat-panes:explicit-active-owner", JSON.stringify({
       version: 2,

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -11,6 +11,7 @@ import { requestAppLeftOverlay } from "../../../shared/plugins/appLeftOverlay"
 import { definePlugin } from "../../../shared/plugins/frontFactory"
 import type { PluginProviderProps } from "../../../shared/plugins/types"
 import {
+  OPTIMISTIC_CREATE_ACK_WINDOW_MS,
   WorkspaceAgentFront as RawWorkspaceAgentFront,
   type UseWorkspaceAgentSessions,
   type WorkspaceAgentFrontProps,
@@ -915,6 +916,107 @@ describe("WorkspaceAgentFront", () => {
     // waitFor on the settled state alone cannot catch a corrected frame.
     expect(observed).not.toContain("beta:beta-one")
     expect(observed).toEqual(["alpha:alpha-one", "beta:beta-new"])
+  })
+
+  // #1472 review: optimisticCreatedPaneKeysRef's ONLY removal path used to be
+  // "the owning Agent's session snapshot contains the key" — the normal,
+  // fast-acknowledgment case the previous test covers. If the created
+  // session is instead deleted before that ever happens (or a provider
+  // returns an id that never materializes — indistinguishable from
+  // reconciliation's point of view: the key just never appears in
+  // resolvedSessionsByKey), the key never cleared, the stale flag kept
+  // bypassing both the controlled-session and inventory gates forever, and
+  // the nonexistent optimistic pane stayed active indefinitely — the phantom
+  // pane suppressed legitimate reconciliation to the real session sitting
+  // right there. This proves the bounded ack-window fallback actually fires
+  // and hands the pane back to a real, authoritative session.
+  it("ages out a never-acknowledged optimistic create and falls back to a real session", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      const user = userEvent.setup({ delay: null, advanceTimers: vi.advanceTimersByTime })
+      const agents = [
+        { agentTypeId: "alpha", label: "Alpha" },
+        { agentTypeId: "beta", label: "Beta" },
+      ]
+      const useAgentSelection = () => {
+        const [selectedAgentTypeId, setSelectedAgentTypeId] = useState("alpha")
+        return {
+          agents,
+          selectedAgentTypeId,
+          loading: false,
+          error: undefined,
+          selectAgentTypeId: setSelectedAgentTypeId,
+        }
+      }
+      const { ObservingChatPanel } = makeObservingChatPanel()
+      const useFleetSessions: AttestedWorkspaceAgentFrontProps<WorkspaceAgentSession>["useSessions"] = (options) => {
+        const owner = options.agentTypeId
+        const [owned] = useState(() => (
+          owner === "alpha" ? [{ id: "alpha-one", agentTypeId: "alpha", title: "alpha one", updatedAt: 1 }] : []
+        ))
+        return {
+          sessions: owned,
+          loading: false,
+          activeSessionId: owned[0]?.id,
+          activeSessionAgentTypeId: owner,
+          activeSession: owned[0],
+          workspaceId: options.workspaceId,
+          switch: vi.fn(),
+          create: async () => (
+            // Beta's create() resolves — the transaction gets a real id and
+            // addresses Beta — but Beta's OWN session list never comes to
+            // include it: a session deleted (in app or out of band) before
+            // its first acknowledgment, or a phantom id a provider never
+            // materializes, looks IDENTICAL from here.
+            { id: "beta-phantom", agentTypeId: "beta", title: "beta phantom", updatedAt: 2 }
+          ),
+          delete: vi.fn(),
+        }
+      }
+
+      render(
+        <WorkspaceAgentFront
+          workspaceId="picker-phantom"
+          workspaceLayout="plugin-tabs"
+          chatPanel={ObservingChatPanel}
+          addressedAgentSelection
+          useAddressedAgentSelection={useAgentSelection}
+          useSessions={useFleetSessions}
+          persistenceEnabled={false}
+        />,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId("chat-pane")).toHaveAttribute("data-session-id", "alpha-one")
+      })
+
+      await user.click(await screen.findByRole("button", { name: "Choose Agent for new chat" }))
+      await user.click(await screen.findByRole("menuitem", { name: "Beta" }))
+      await user.click(await screen.findByRole("button", { name: "Start new chat with Beta" }))
+
+      // Optimistic protection holds: the phantom pane is shown and stays put
+      // well within the ack window, since nothing ever acknowledges it.
+      await waitFor(() => {
+        expect(screen.getByTestId("chat-pane")).toHaveAttribute("data-session-id", "beta-phantom")
+      })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(OPTIMISTIC_CREATE_ACK_WINDOW_MS - 1_000)
+      })
+      expect(screen.getByTestId("chat-pane")).toHaveAttribute("data-session-id", "beta-phantom")
+
+      // Past the ack window: the never-acknowledged key ages out and
+      // reconciliation falls back to the real authoritative session
+      // (Alpha's, the only one that actually exists) instead of leaving the
+      // phantom pane active forever.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2_000)
+      })
+      await waitFor(() => {
+        expect(screen.getByTestId("chat-pane")).toHaveAttribute("data-session-id", "alpha-one")
+      })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it("initializes a controlled colliding id to its explicit active owner", () => {

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -72,6 +72,20 @@ function visibleChatSessionIds(): string[] {
   return screen.getAllByTestId("chat-pane").map((node) => node.getAttribute("data-session-id") ?? "")
 }
 
+/** Records every distinct (agentTypeId, sessionId) the single active chat
+ * pane renders with, across every commit — not just the final settled one.
+ * A `waitFor` on the end state cannot see a value that appears and then gets
+ * corrected before the assertion runs; this catches it. */
+function makeObservingChatPanel() {
+  const observed: string[] = []
+  function ObservingChatPanel(props: WorkspaceChatPanelProps) {
+    const key = `${props.agentTypeId}:${props.sessionId}`
+    if (observed[observed.length - 1] !== key) observed.push(key)
+    return <div data-testid="chat-pane" data-agent-type-id={props.agentTypeId} data-session-id={props.sessionId}>Chat pane {props.sessionId}</div>
+  }
+  return { ObservingChatPanel, observed }
+}
+
 function addressedSession(sessionId: string, title: string) {
   return {
     ref: { agentTypeId: "default", sessionId },
@@ -807,6 +821,18 @@ describe("WorkspaceAgentFront", () => {
         selectAgentTypeId: setSelectedAgentTypeId,
       }
     }
+    const { ObservingChatPanel, observed } = makeObservingChatPanel()
+    // Deliberately decouples "the create() promise the transaction awaits
+    // resolves" from "Beta's OWN session snapshot catches up" — exactly the
+    // ordering `addressedFleetSessions.tsx` cannot guarantee: its per-Agent
+    // `FleetSessionSource` only republishes an updated controller from a
+    // passive effect, a render or more after this hook's own state update,
+    // while `createChatPaneTransaction`'s success callback (which flips the
+    // addressed Agent) runs off the SAME resolved promise. Holding this gate
+    // open reproduces the worst case deterministically instead of hoping a
+    // microtask-count race lands the same way twice.
+    let releaseBetaSnapshot: (() => void) | undefined
+    const betaSnapshotGate = new Promise<void>((resolve) => { releaseBetaSnapshot = resolve })
     const useFleetSessions: AttestedWorkspaceAgentFrontProps<WorkspaceAgentSession>["useSessions"] = (options) => {
       const owner = options.agentTypeId
       const [owned, setOwned] = useState(() => [{
@@ -825,7 +851,14 @@ describe("WorkspaceAgentFront", () => {
         switch: vi.fn(),
         create: async () => {
           const session = { id: `${owner}-new`, agentTypeId: owner, title: `${owner} new`, updatedAt: 2 }
-          setOwned((current) => [session, ...current])
+          if (owner === "beta") {
+            // The transaction sees the created session and addresses Beta
+            // immediately; Beta's own controller only reflects it once this
+            // gate is released, below.
+            void betaSnapshotGate.then(() => setOwned((current) => [session, ...current]))
+          } else {
+            setOwned((current) => [session, ...current])
+          }
           return session
         },
         delete: vi.fn(),
@@ -836,7 +869,7 @@ describe("WorkspaceAgentFront", () => {
       <WorkspaceAgentFront
         workspaceId="picker-focus"
         workspaceLayout="plugin-tabs"
-        chatPanel={SessionIdChatPanel}
+        chatPanel={ObservingChatPanel}
         addressedAgentSelection
         useAddressedAgentSelection={useAgentSelection}
         useSessions={useFleetSessions}
@@ -850,14 +883,38 @@ describe("WorkspaceAgentFront", () => {
     })
 
     // Retarget the picker to Beta without ever addressing/opening a Beta chat.
+    // Beta already owns an untouched "beta-one" session at this point — the
+    // ONLY way it can appear below is the addressed-Agent switch racing
+    // ahead of Beta's own session snapshot and getting judged "uncontrolled".
     await user.click(await screen.findByRole("button", { name: "Choose Agent for new chat" }))
     await user.click(await screen.findByRole("menuitem", { name: "Beta" }))
     await user.click(await screen.findByRole("button", { name: "Start new chat with Beta" }))
+
+    // Mid-race: the addressed Agent has already flipped to Beta and the
+    // create() promise has resolved, but Beta's own snapshot is still
+    // deliberately held back (gate not yet released). This is the exact
+    // frame the reviewer flagged — assert it directly, not just the eventual
+    // settled state a `waitFor` would otherwise paper over.
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-pane")).toHaveAttribute("data-agent-type-id", "beta")
+    })
+    expect(screen.getByTestId("chat-pane")).toHaveAttribute("data-session-id", "beta-new")
+
+    await act(async () => {
+      releaseBetaSnapshot?.()
+      await betaSnapshotGate
+    })
 
     await waitFor(() => {
       expect(screen.getByTestId("chat-pane")).toHaveAttribute("data-agent-type-id", "beta")
       expect(screen.getByTestId("chat-pane")).toHaveAttribute("data-session-id", "beta-new")
     })
+
+    // Sequence-sensitive: the picker's Beta chat must never have painted as
+    // "beta-one" (Beta's PREVIOUS session) on its way to "beta-new". A final
+    // waitFor on the settled state alone cannot catch a corrected frame.
+    expect(observed).not.toContain("beta:beta-one")
+    expect(observed).toEqual(["alpha:alpha-one", "beta:beta-new"])
   })
 
   it("initializes a controlled colliding id to its explicit active owner", () => {


### PR DESCRIPTION
Fixes #1470

## Summary
- The New chat Agent picker ("Choose Agent for new chat" → pick another agent → "Start new chat with <Agent>") retargets creation to a different Agent than the one currently addressed, but never updated the addressed selection itself.
- The pane-reconciliation effect resolves its desired session from the ADDRESSED Agent's own session API, so the freshly created pane was immediately stomped back to whatever chat was previously open — the session was created (visible in the sidebar) but never focused.
- Fix lives in the single shared creation transaction (`createChatPaneTransaction` in `WorkspaceAgentFront.tsx`) used by every creation entry point (rail "+", agent card "+", and the picker), so the fix applies uniformly rather than special-casing the picker.

## Change
- `packages/workspace/src/app/front/WorkspaceAgentFront.tsx`: after a fleet-mode session is created for an Agent other than the currently addressed one, call `addressedAgents.selectAgentTypeId(createdAgentTypeId)` so the addressed selection follows the newly created session.
- `packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx`: added a regression test — retarget the picker to Beta without ever addressing Beta, click "Start new chat with Beta", assert the rendered chat pane's `data-agent-type-id`/`data-session-id` now point at the new Beta session.

## Test plan
- [x] `pnpm -C packages/workspace vitest run src/app/front/__tests__/WorkspaceAgentFront.test.tsx` — 100/100 pass (new test included)
- [x] `pnpm -C packages/workspace vitest run src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx` — 41/41 pass
- [x] `pnpm -C packages/workspace tsc --noEmit` — clean
- [x] `pnpm -C packages/agent tsc --noEmit` — clean (package untouched by this fix)
- Full monorepo `vitest run` shows some failures in unrelated server-side/agent suites under full-parallel load; verified these are pre-existing/environmental (reproduced in isolation without this change touching those files, and they pass when run in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQgxe5KTr2N2pjgjgKPXHK