### PR TITLE
#1463 fix(core): default-workspace deletion can't brick the account

### DIFF
--- a/packages/core/drizzle/0027_workspace_default_index_excludes_deleted.sql
+++ b/packages/core/drizzle/0027_workspace_default_index_excludes_deleted.sql
@@ -1,0 +1,11 @@
+-- #1463: idx_workspaces_default_per_user_app only excluded non-default rows,
+-- not soft-deleted ones. Deleting a user's default workspace (deleted_at set,
+-- is_default stays true) left a tombstoned row that still satisfied the old
+-- partial index, so the auto-recreate insert for a fresh default collided
+-- with it (duplicate key) and left the user with zero active workspaces.
+-- Rebuild the index scoped to live rows only.
+DROP INDEX "idx_workspaces_default_per_user_app";
+--> statement-breakpoint
+CREATE UNIQUE INDEX "idx_workspaces_default_per_user_app"
+  ON "workspaces" USING btree ("created_by","app_id")
+  WHERE "workspaces"."is_default" = true AND "workspaces"."deleted_at" IS NULL;

--- a/packages/core/drizzle/meta/_journal.json
+++ b/packages/core/drizzle/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1787961600000,
       "tag": "0026_workspace_agent_seats",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1787990400000,
+      "tag": "0027_workspace_default_index_excludes_deleted",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/e2e/v7-platform.test.ts
+++ b/packages/core/e2e/v7-platform.test.ts
@@ -459,4 +459,106 @@ describe('v7 platform E2E', () => {
       expect(res.json()).toEqual({ deleted: true })
     })
   })
+
+  // ===========================================================================
+  // Scenario C — #1463 destroy-succeeded-then-DB-failed recovery contract
+  // ===========================================================================
+  // Thermo-gate finding: the sandbox destroy in DELETE runs BEFORE the DB
+  // transaction and can't be rolled back with it. If the DB step then fails
+  // (transaction rolls back, workspace row survives), the workspace looks
+  // like an ordinary active workspace but its real sandbox is gone. This
+  // proves, end-to-end against real routes (workspace + settings) and a
+  // real LocalWorkspaceStore, that the surviving workspace is honestly
+  // marked recoverable and POST /runtime/retry actually brings it back —
+  // not just that DELETE returns 500.
+  describe('Scenario C: destroy-succeeded-then-DB-failed recovery', () => {
+    let app: FastifyInstance
+    let inject: ReturnType<typeof createInjector>
+    let workspaceStore: LocalWorkspaceStore
+    const provisionFn = vi.fn<WorkspaceProvisioner['provision']>()
+    const destroyFn = vi.fn<WorkspaceProvisioner['destroy']>()
+    let workspaceId: string
+
+    beforeAll(async () => {
+      const userStore = new LocalUserStore()
+      workspaceStore = new LocalWorkspaceStore(userStore)
+      userStore.seed({ id: 'carol', email: 'carol@test.dev', name: 'Carol', emailVerified: true, image: null })
+
+      provisionFn.mockResolvedValue({ volumePath: '/volumes/carol-ws' })
+      destroyFn.mockResolvedValue(undefined)
+
+      const provisioner: WorkspaceProvisioner = { provision: provisionFn, destroy: destroyFn }
+
+      app = Fastify({ logger: false })
+      app.decorate('config', { appId: 'test-app', defaultAgentTypeId: 'default', auth: { mail: null, url: 'http://localhost:3000' }, features: { inviteTtlDays: 7 } } as any)
+      app.decorate('workspaceStore', workspaceStore)
+      app.decorate('provisioner', provisioner)
+      registerErrorHandler(app)
+
+      app.addHook('onRequest', async (request) => {
+        const userId = request.headers['x-test-user'] as string | undefined
+        request.user = userId ? { id: userId, email: `${userId}@test.dev`, name: null } : null
+      })
+
+      await app.register(registerWorkspaceRoutes)
+      await app.register(registerSettingsRoutes)
+      await app.ready()
+
+      inject = createInjector(app)
+    })
+
+    afterAll(async () => {
+      await app.close()
+    })
+
+    it('Carol creates her only workspace', async () => {
+      const res = await inject('POST', '/api/v1/workspaces', 'carol', { name: 'Carol WS' })
+      expect(res.statusCode).toBe(201)
+      workspaceId = res.json().workspace.id
+    })
+
+    it('delete fails after the sandbox is already destroyed → 500, but the surviving workspace is marked recoverable', async () => {
+      // Force a genuine post-destroy DB failure: patch the real
+      // LocalWorkspaceStore's deleteAndRecreateDefaultIfEmpty to throw for
+      // exactly this one call (simulating, e.g., a real Postgres error mid-
+      // transaction), then restore it immediately after.
+      const original = workspaceStore.deleteAndRecreateDefaultIfEmpty.bind(workspaceStore)
+      workspaceStore.deleteAndRecreateDefaultIfEmpty = async () => {
+        throw new Error('simulated replacement insert failure')
+      }
+
+      try {
+        const res = await inject('DELETE', `/api/v1/workspaces/${workspaceId}`, 'carol')
+        expect(res.statusCode).toBe(500)
+      } finally {
+        workspaceStore.deleteAndRecreateDefaultIfEmpty = original
+      }
+
+      // Destroy genuinely ran (irreversible) before the DB step failed.
+      expect(destroyFn).toHaveBeenCalledWith(workspaceId)
+
+      // The workspace row survives — the account is not workspace-less.
+      const ws = await workspaceStore.get(workspaceId)
+      expect(ws).not.toBeNull()
+
+      // It's honestly marked recoverable via the same contract
+      // POST /runtime/retry already understands.
+      const runtime = await workspaceStore.getWorkspaceRuntime(workspaceId)
+      expect(runtime?.state).toBe('error')
+      expect(runtime?.lastErrorOp).toBe('provision')
+      expect(runtime?.lastError).toContain('simulated replacement insert failure')
+    })
+
+    it('POST /runtime/retry actually recovers it — the workspace becomes usable again, not just honestly-broken', async () => {
+      const res = await inject('POST', `/api/v1/workspaces/${workspaceId}/runtime/retry`, 'carol')
+      expect(res.statusCode).toBe(200)
+      expect(res.json().runtime.state).toBe('ready')
+      expect(res.json().runtime.volumePath).toBe('/volumes/carol-ws')
+      expect(provisionFn).toHaveBeenCalledWith(expect.objectContaining({ workspaceId }))
+
+      // Still exactly one workspace for Carol — the failed delete didn't
+      // leave her with zero, and the recovery didn't create a duplicate.
+      expect(await workspaceStore.list('carol', 'test-app')).toHaveLength(1)
+    })
+  })
 })

--- a/packages/core/e2e/v7-platform.test.ts
+++ b/packages/core/e2e/v7-platform.test.ts
@@ -64,10 +64,11 @@ describe('v7 platform E2E', () => {
     let workspaceId: string
     let rawToken: string
     let inviteId: string
+    let workspaceStore: LocalWorkspaceStore
 
     beforeAll(async () => {
       const userStore = new LocalUserStore()
-      const workspaceStore = new LocalWorkspaceStore(userStore)
+      workspaceStore = new LocalWorkspaceStore(userStore)
       const idempotencyStore = createInMemoryIdempotencyStore()
 
       // Seed alice and bob
@@ -288,12 +289,49 @@ describe('v7 platform E2E', () => {
       expect(res.json().code).toBe('last_owner')
     })
 
-    // 11. Bob deletes workspace
-    it('Bob deletes workspace', async () => {
+    // 11. Bob deletes workspace — he was promoted to owner (step 8), not the
+    // original creator (Alice, step 1). This is the last workspace either of
+    // them has, so #1463's transactional recreate fires. Assert the full
+    // ownership-transition contract the reviewer asked for: who ends up
+    // owning the replacement, and what happens to the original creator.
+    it('Bob deletes workspace (a non-creator promoted owner) — the replacement is created for Bob, and Alice is left with nothing shared', async () => {
       const res = await inject('DELETE', `/api/v1/workspaces/${workspaceId}`, 'bob')
       expect(res.statusCode).toBe(200)
       expect(res.json()).toEqual({ deleted: true })
       expect(destroyFn).toHaveBeenCalledWith(workspaceId)
+
+      // The deleted workspace is really gone.
+      expect(await workspaceStore.get(workspaceId)).toBeNull()
+
+      // Bob — the acting/deleting user, not Alice the original creator — owns
+      // the replacement default. This matches the current public POST policy
+      // (whoever creates it owns it); it's a real ownership transition and is
+      // pinned down explicitly here rather than left implicit.
+      const bobWorkspaces = await workspaceStore.list('bob', 'test-app')
+      expect(bobWorkspaces).toHaveLength(1)
+      const replacement = bobWorkspaces[0]
+      expect(replacement.id).not.toBe(workspaceId)
+      expect(replacement.createdBy).toBe('bob')
+      expect(replacement.isDefault).toBe(true)
+      expect(await workspaceStore.getMemberRole(replacement.id, 'bob')).toBe('owner')
+
+      // The provisioner was invoked for Bob as the owner of the replacement,
+      // not Alice.
+      expect(provisionFn).toHaveBeenCalledWith(expect.objectContaining({
+        workspaceId: replacement.id,
+        ownerId: 'bob',
+      }))
+
+      // Alice (the original creator, demoted to editor in step 9) is not a
+      // member of Bob's replacement — deleting a shared workspace does not
+      // silently carry her along into a new one. She simply has zero
+      // workspaces in this app until her own next GET /workspaces call
+      // auto-provisions her a separate, unrelated default (proven safe by
+      // the migration test above — it no longer collides even though the
+      // deleted "Acme" workspace she originally created also had
+      // is_default = true, now soft-deleted, for the same createdBy).
+      expect(await workspaceStore.list('alice', 'test-app')).toHaveLength(0)
+      expect(await workspaceStore.getMemberRole(replacement.id, 'alice')).toBeNull()
     })
   })
 

--- a/packages/core/src/server/app/types.ts
+++ b/packages/core/src/server/app/types.ts
@@ -87,6 +87,31 @@ export interface WorkspaceStore {
   restore(id: string): Promise<Workspace | null>
   update(id: string, updates: Partial<Pick<Workspace, 'name'>>): Promise<Workspace | null>
   delete(id: string): Promise<{ removed: boolean; code?: typeof ERROR_CODES.NOT_FOUND }>
+  /**
+   * #1463: atomically soft-deletes `id` and, only if that leaves `actingUserId`
+   * with zero active workspaces in the deleted workspace's app, creates a
+   * replacement default (workspace + owner member + initial Agent seat) in the
+   * SAME database transaction. Any failure — including a unique-constraint
+   * collision on the replacement insert — rolls back the whole operation, so
+   * the original workspace is never left deleted without its replacement:
+   * the account can never end up committed at zero active workspaces.
+   * Provisioning (filesystem/sandbox) is NOT part of this transaction and
+   * must be driven by the caller against the returned `recreated` workspace.
+   */
+  deleteAndRecreateDefaultIfEmpty(
+    id: string,
+    actingUserId: string,
+    recreate: {
+      name: string
+      defaultAgentTypeId: string
+      initialAgentSeatSource?: WorkspaceAgentSeatSource
+      enrolledByUserId?: string
+    },
+  ): Promise<{
+    removed: boolean
+    code?: typeof ERROR_CODES.NOT_FOUND
+    recreated: Workspace | null
+  }>
   getWorkspacesWhereSoleOwner(userId: string): Promise<Workspace[]>
   isMember(workspaceId: string, userId: string): Promise<boolean>
   getMemberRole(workspaceId: string, userId: string): Promise<MemberRole | null>

--- a/packages/core/src/server/db/__tests__/workspaceDefaultIndexExcludesDeleted.migration.test.ts
+++ b/packages/core/src/server/db/__tests__/workspaceDefaultIndexExcludesDeleted.migration.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const migrationPath = fileURLToPath(new URL(
+  '../../../../drizzle/0027_workspace_default_index_excludes_deleted.sql',
+  import.meta.url,
+))
+
+describe('0027 workspace default index excludes deleted migration', () => {
+  it('drops and rebuilds idx_workspaces_default_per_user_app scoped to live, default rows', () => {
+    const sql = readFileSync(migrationPath, 'utf8')
+    const drop = sql.indexOf('DROP INDEX "idx_workspaces_default_per_user_app"')
+    const create = sql.indexOf('CREATE UNIQUE INDEX "idx_workspaces_default_per_user_app"')
+
+    expect(drop).toBeGreaterThanOrEqual(0)
+    expect(create).toBeGreaterThan(drop)
+    expect(sql).toContain('"workspaces"."is_default" = true AND "workspaces"."deleted_at" IS NULL')
+  })
+})

--- a/packages/core/src/server/db/schema.ts
+++ b/packages/core/src/server/db/schema.ts
@@ -57,9 +57,13 @@ export const workspaces = pgTable(
   },
   (table) => [
     index('workspaces_created_by_idx').on(table.createdBy),
+    // Partial on deleted_at IS NULL too: a soft-deleted default row must not
+    // block the auto-recreate insert when a user deletes their only workspace
+    // (issue #1463 — the old index let a tombstoned default collide with the
+    // fresh one, bricking the account with zero active workspaces).
     uniqueIndex('idx_workspaces_default_per_user_app')
       .on(table.createdBy, table.appId)
-      .where(sql`${table.isDefault} = true`),
+      .where(sql`${table.isDefault} = true AND ${table.deletedAt} IS NULL`),
     check(
       'workspaces_workspace_type_id_check',
       sql`${table.workspaceTypeId} ~ '^[a-z][a-z0-9-]{0,62}$'`,

--- a/packages/core/src/server/db/stores/LocalWorkspaceStore.ts
+++ b/packages/core/src/server/db/stores/LocalWorkspaceStore.ts
@@ -223,6 +223,10 @@ export class LocalWorkspaceStore implements WorkspaceStore {
     return toWorkspace(updated)
   }
 
+  // Plain, unconditional soft-delete — see the matching comment on
+  // PostgresWorkspaceStore.delete(): the #1463 "never zero active workspaces"
+  // rule is enforced by the route, which recreates a default in the same
+  // operation when the deleting user would otherwise be left with none.
   async delete(id: string): Promise<{ removed: boolean; code?: typeof ERROR_CODES.NOT_FOUND }> {
     const ws = this.workspaces.get(id)
     if (!ws || ws.deletedAt) return { removed: false, code: ERROR_CODES.NOT_FOUND }

--- a/packages/core/src/server/db/stores/LocalWorkspaceStore.ts
+++ b/packages/core/src/server/db/stores/LocalWorkspaceStore.ts
@@ -51,6 +51,18 @@ export class LocalWorkspaceStore implements WorkspaceStore {
       return toWorkspace(existing)
     }
 
+    // Mirror idx_workspaces_default_per_user_app (#1463): at most one active
+    // default per (createdBy, appId). Lets Local/e2e-backed tests catch the
+    // same duplicate-default collisions Postgres's partial unique index does,
+    // instead of silently allowing what production would reject.
+    if (opts?.isDefault) {
+      const collision = [...this.workspaces.values()].some((w) =>
+        !w.deletedAt && w.createdBy === userId && w.appId === appId && w.isDefault)
+      if (collision) {
+        throw new Error('duplicate key value violates unique constraint "idx_workspaces_default_per_user_app"')
+      }
+    }
+
     const now = new Date().toISOString()
     const ws: Workspace = {
       id,
@@ -223,16 +235,64 @@ export class LocalWorkspaceStore implements WorkspaceStore {
     return toWorkspace(updated)
   }
 
-  // Plain, unconditional soft-delete — see the matching comment on
-  // PostgresWorkspaceStore.delete(): the #1463 "never zero active workspaces"
-  // rule is enforced by the route, which recreates a default in the same
-  // operation when the deleting user would otherwise be left with none.
+  // Plain, unconditional soft-delete primitive — see the matching comment on
+  // PostgresWorkspaceStore.delete(). Callers that need the #1463 guarantee
+  // use deleteAndRecreateDefaultIfEmpty() below.
   async delete(id: string): Promise<{ removed: boolean; code?: typeof ERROR_CODES.NOT_FOUND }> {
     const ws = this.workspaces.get(id)
     if (!ws || ws.deletedAt) return { removed: false, code: ERROR_CODES.NOT_FOUND }
     ws.deletedAt = new Date().toISOString()
     this.workspaces.set(id, ws)
     return { removed: true }
+  }
+
+  // #1463: single-process mirror of PostgresWorkspaceStore's transactional
+  // version — see the interface doc on WorkspaceStore.deleteAndRecreateDefaultIfEmpty.
+  // LocalWorkspaceStore has no real concurrency, but it still honors the
+  // all-or-nothing contract: if the replacement create() throws (for example
+  // the idx_workspaces_default_per_user_app mirror above rejecting a
+  // duplicate live default), the soft-delete is rolled back in-memory rather
+  // than left committed with no replacement.
+  async deleteAndRecreateDefaultIfEmpty(
+    id: string,
+    actingUserId: string,
+    recreate: {
+      name: string
+      defaultAgentTypeId: string
+      initialAgentSeatSource?: WorkspaceAgentSeatSource
+      enrolledByUserId?: string
+    },
+  ): Promise<{
+    removed: boolean
+    code?: typeof ERROR_CODES.NOT_FOUND
+    recreated: Workspace | null
+  }> {
+    const ws = this.workspaces.get(id)
+    if (!ws || ws.deletedAt) return { removed: false, code: ERROR_CODES.NOT_FOUND, recreated: null }
+
+    ws.deletedAt = new Date().toISOString()
+    this.workspaces.set(id, ws)
+
+    const remaining = [...this.workspaces.values()].filter((w) =>
+      !w.deletedAt && w.appId === ws.appId && this.members.has(`${w.id}:${actingUserId}`))
+
+    if (remaining.length > 0) return { removed: true, recreated: null }
+
+    try {
+      const recreated = await this.create(actingUserId, recreate.name, ws.appId, {
+        isDefault: true,
+        defaultAgentTypeId: recreate.defaultAgentTypeId,
+        initialAgentSeatSource: recreate.initialAgentSeatSource,
+        enrolledByUserId: recreate.enrolledByUserId,
+      })
+      return { removed: true, recreated }
+    } catch (err) {
+      // Roll back the soft-delete: never leave a committed delete with no
+      // replacement when the replacement insert itself failed.
+      ws.deletedAt = null
+      this.workspaces.set(id, ws)
+      throw err
+    }
   }
 
   async getWorkspacesWhereSoleOwner(userId: string): Promise<Workspace[]> {

--- a/packages/core/src/server/db/stores/PostgresWorkspaceStore.ts
+++ b/packages/core/src/server/db/stores/PostgresWorkspaceStore.ts
@@ -386,10 +386,11 @@ export class PostgresWorkspaceStore implements WorkspaceStore {
     return rows.length > 0 ? toWorkspace(rows[0]) : null
   }
 
-  // Kept a plain, unconditional soft-delete: the "don't leave the user with
-  // zero active workspaces" business rule (#1463) is enforced one layer up,
-  // in the workspace-delete route, which recreates a default in the same
-  // operation when the deleting user would otherwise be left with none.
+  // Plain, unconditional soft-delete primitive — used directly by callers
+  // (tests, admin tooling) that don't need the #1463 "never zero active
+  // workspaces" guarantee. The workspace-delete route uses
+  // deleteAndRecreateDefaultIfEmpty() below instead, which wraps the
+  // equivalent soft-delete in one atomic transaction with the replacement.
   async delete(
     id: string,
   ): Promise<{
@@ -405,6 +406,114 @@ export class PostgresWorkspaceStore implements WorkspaceStore {
       .where(eq(workspaces.id, id))
 
     return { removed: true }
+  }
+
+  // #1463: see the interface doc on WorkspaceStore.deleteAndRecreateDefaultIfEmpty.
+  // Everything here runs in ONE transaction: the soft-delete, the "does the
+  // acting user still have an active workspace" lock+count, and (if not) the
+  // replacement workspace + owner member + initial Agent seat inserts. If any
+  // insert fails (including a unique-constraint collision on the replacement
+  // default), Postgres rolls back the whole transaction — the original
+  // workspace is NOT deleted. The route surfaces that as a 500 instead of a
+  // false "deleted: true", so the account can never end up committed at zero
+  // active workspaces.
+  async deleteAndRecreateDefaultIfEmpty(
+    id: string,
+    actingUserId: string,
+    recreate: {
+      name: string
+      defaultAgentTypeId: string
+      initialAgentSeatSource?: WorkspaceAgentSeatSource
+      enrolledByUserId?: string
+    },
+  ): Promise<{
+    removed: boolean
+    code?: typeof ERROR_CODES.NOT_FOUND
+    recreated: Workspace | null
+  }> {
+    return this.db.transaction(async (tx) => {
+      const wsRows = await tx
+        .select()
+        .from(workspaces)
+        .where(and(eq(workspaces.id, id), isNull(workspaces.deletedAt)))
+        .limit(1)
+      const ws = wsRows[0]
+      if (!ws) return { removed: false, code: ERROR_CODES.NOT_FOUND, recreated: null }
+
+      // Lock every active workspace the acting user is a member of in this
+      // app — in a stable order (ORDER BY id), and BEFORE mutating anything —
+      // so two concurrent deletes for the same user's workspace set serialize
+      // on this lock instead of deadlocking on each other's delete target.
+      // (An earlier version locked this set AFTER soft-deleting the target,
+      // which meant two concurrent deletes of two different workspaces
+      // belonging to the same user each held their own target row locked via
+      // UPDATE and then blocked wanting the other's — a real deadlock. Locking
+      // the whole ordered set first means whichever transaction gets there
+      // first acquires every row it needs before the other can start.)
+      await tx.execute(sql`
+        SELECT w.id
+        FROM workspaces w
+        JOIN workspace_members m ON m.workspace_id = w.id
+        WHERE m.user_id = ${actingUserId}
+          AND w.app_id = ${ws.appId}
+          AND w.deleted_at IS NULL
+        ORDER BY w.id
+        FOR UPDATE OF w
+      `)
+
+      // Re-check under lock: another transaction we were blocked behind may
+      // have already deleted this exact workspace.
+      const stillActive = await tx
+        .select({ id: workspaces.id })
+        .from(workspaces)
+        .where(and(eq(workspaces.id, id), isNull(workspaces.deletedAt)))
+        .limit(1)
+      if (stillActive.length === 0) return { removed: false, code: ERROR_CODES.NOT_FOUND, recreated: null }
+
+      await tx
+        .update(workspaces)
+        .set({ deletedAt: new Date() })
+        .where(eq(workspaces.id, id))
+
+      const remaining = await tx
+        .select({ id: workspaces.id })
+        .from(workspaces)
+        .innerJoin(workspaceMembers, eq(workspaceMembers.workspaceId, workspaces.id))
+        .where(and(
+          eq(workspaceMembers.userId, actingUserId),
+          eq(workspaces.appId, ws.appId),
+          isNull(workspaces.deletedAt),
+        ))
+
+      let recreated: Workspace | null = null
+      if (remaining.length === 0) {
+        const parsedAgentTypeId = parseRequiredDefaultAgentTypeId(recreate.defaultAgentTypeId)
+        const [row] = await tx
+          .insert(workspaces)
+          .values({
+            appId: ws.appId,
+            name: recreate.name,
+            createdBy: actingUserId,
+            isDefault: true,
+            defaultAgentTypeId: parsedAgentTypeId,
+          })
+          .returning()
+        await tx.insert(workspaceMembers).values({
+          workspaceId: row.id,
+          userId: actingUserId,
+          role: 'owner',
+        })
+        await tx.insert(workspaceAgentSeats).values({
+          workspaceId: row.id,
+          agentTypeId: parsedAgentTypeId,
+          source: recreate.initialAgentSeatSource ?? 'generic-default',
+          enrolledByUserId: recreate.enrolledByUserId ?? actingUserId,
+        })
+        recreated = toWorkspace(row)
+      }
+
+      return { removed: true, recreated }
+    })
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/core/src/server/db/stores/PostgresWorkspaceStore.ts
+++ b/packages/core/src/server/db/stores/PostgresWorkspaceStore.ts
@@ -386,6 +386,10 @@ export class PostgresWorkspaceStore implements WorkspaceStore {
     return rows.length > 0 ? toWorkspace(rows[0]) : null
   }
 
+  // Kept a plain, unconditional soft-delete: the "don't leave the user with
+  // zero active workspaces" business rule (#1463) is enforced one layer up,
+  // in the workspace-delete route, which recreates a default in the same
+  // operation when the deleting user would otherwise be left with none.
   async delete(
     id: string,
   ): Promise<{

--- a/packages/core/src/server/db/stores/__tests__/LocalWorkspaceStore.test.ts
+++ b/packages/core/src/server/db/stores/__tests__/LocalWorkspaceStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { createHash } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 import { LocalUserStore } from '../LocalUserStore'
 import { LocalWorkspaceStore } from '../LocalWorkspaceStore'
 import { ERROR_CODES, HttpError } from '../../../../shared/errors'
@@ -104,6 +104,97 @@ describe('LocalWorkspaceStore', () => {
       const result = await store.delete('nonexistent')
       expect(result.removed).toBe(false)
       expect(result.code).toBe(ERROR_CODES.NOT_FOUND)
+    })
+
+    it('#1463: create() mirrors idx_workspaces_default_per_user_app — rejects a second live default for the same (createdBy, appId)', async () => {
+      await createWorkspace('u1', 'First', 'app1', { isDefault: true })
+      await expect(createWorkspace('u1', 'Second', 'app1', { isDefault: true })).rejects.toThrow(
+        /idx_workspaces_default_per_user_app/,
+      )
+    })
+
+    it('#1463: create() allows a new live default once the old one is soft-deleted (mirrors the migration)', async () => {
+      const first = await createWorkspace('u1', 'First', 'app1', { isDefault: true })
+      await store.delete(first.id)
+      const second = await createWorkspace('u1', 'Second', 'app1', { isDefault: true })
+      expect(second.isDefault).toBe(true)
+      expect(await store.list('u1', 'app1')).toHaveLength(1)
+    })
+  })
+
+  describe('deleteAndRecreateDefaultIfEmpty', () => {
+    it('happy path: soft-deletes the only workspace and installs a replacement default with owner membership + seat', async () => {
+      const ws = await createWorkspace('u1', 'Solo', 'app1', { isDefault: true })
+
+      const result = await store.deleteAndRecreateDefaultIfEmpty(ws.id, 'u1', {
+        name: 'Default workspace',
+        defaultAgentTypeId: 'default',
+      })
+
+      expect(result.removed).toBe(true)
+      expect(result.recreated).not.toBeNull()
+      expect(result.recreated!.id).not.toBe(ws.id)
+      expect(result.recreated!.isDefault).toBe(true)
+      expect(result.recreated!.createdBy).toBe('u1')
+
+      expect(await store.get(ws.id)).toBeNull()
+      expect(await store.list('u1', 'app1')).toHaveLength(1)
+      expect(await store.getMemberRole(result.recreated!.id, 'u1')).toBe('owner')
+      expect(await store.hasAgentSeat(result.recreated!.id, 'default')).toBe(true)
+    })
+
+    it('does not recreate when the acting user still has another active workspace', async () => {
+      await createWorkspace('u1', 'Kept', 'app1')
+      const ws = await createWorkspace('u1', 'Delete Me', 'app1')
+
+      const result = await store.deleteAndRecreateDefaultIfEmpty(ws.id, 'u1', {
+        name: 'Default workspace',
+        defaultAgentTypeId: 'default',
+      })
+
+      expect(result.removed).toBe(true)
+      expect(result.recreated).toBeNull()
+      expect(await store.list('u1', 'app1')).toHaveLength(1)
+    })
+
+    it('returns NOT_FOUND for an unknown or already-deleted id', async () => {
+      const result = await store.deleteAndRecreateDefaultIfEmpty('nonexistent', 'u1', {
+        name: 'x',
+        defaultAgentTypeId: 'default',
+      })
+      expect(result).toEqual({ removed: false, code: ERROR_CODES.NOT_FOUND, recreated: null })
+    })
+
+    it('#1463 all-or-nothing: rolls back the soft-delete if the replacement create() throws', async () => {
+      const ws = await createWorkspace('u1', 'Solo', 'app1', { isDefault: true })
+
+      // Force the replacement insert to fail the same way Postgres's unique
+      // index would: seed an existing live default with the SAME id we're
+      // about to recreate isn't possible (ids are random), so instead force
+      // it via the parity guard above by pre-planting a live default for
+      // the acting user under a workspace the delete target itself is
+      // unaware of — the guard fires when create() runs inside the call.
+      const collidingId = randomUUID()
+      ;(store as unknown as { workspaces: Map<string, { id: string; appId: string; createdBy: string; isDefault: boolean; deletedAt: string | null }> })
+        .workspaces.set(collidingId, {
+          id: collidingId, appId: 'app1', createdBy: 'u1', isDefault: true, deletedAt: null,
+        })
+      // But that pre-planted workspace has no membership row, so it won't be
+      // counted as "remaining" for u1 (list() is membership-based) — the
+      // recreate WILL be attempted, and create()'s idx_workspaces_default_per_user_app
+      // guard (createdBy + appId + isDefault, independent of membership) will
+      // reject it.
+
+      await expect(
+        store.deleteAndRecreateDefaultIfEmpty(ws.id, 'u1', {
+          name: 'Replacement',
+          defaultAgentTypeId: 'default',
+        }),
+      ).rejects.toThrow(/idx_workspaces_default_per_user_app/)
+
+      // Rolled back: the original is exactly as it was, not deleted with no
+      // usable replacement.
+      expect(await store.get(ws.id)).not.toBeNull()
     })
   })
 

--- a/packages/core/src/server/db/stores/__tests__/PostgresWorkspaceStore.test.ts
+++ b/packages/core/src/server/db/stores/__tests__/PostgresWorkspaceStore.test.ts
@@ -579,6 +579,30 @@ describe('PostgresWorkspaceStore Sub-PR1', () => {
       expect(result).toEqual({ removed: false, code: ERROR_CODES.NOT_FOUND })
     })
 
+    it('#1463: deleting the only default workspace then recreating one does not collide on idx_workspaces_default_per_user_app', async () => {
+      const userId = await seedUser()
+      const original = await createWorkspace(userId, 'Default WS', APP_ID, { isDefault: true })
+      expect(original.isDefault).toBe(true)
+
+      // Simulate the DELETE /api/v1/workspaces/:id route's soft-delete step.
+      const result = await store.delete(original.id)
+      expect(result).toEqual({ removed: true })
+      expect(await store.list(userId, APP_ID)).toHaveLength(0)
+
+      // Simulate the auto-recreate on the next GET /api/v1/workspaces: before
+      // the migration this insert failed with a duplicate-key error against
+      // idx_workspaces_default_per_user_app because the old tombstoned
+      // default row still satisfied the (unpartitioned-by-deleted_at) index.
+      const recreated = await createWorkspace(userId, 'Default workspace', APP_ID, { isDefault: true })
+      expect(recreated.isDefault).toBe(true)
+      expect(recreated.id).not.toBe(original.id)
+
+      // The user ends up with exactly one active default — never zero, never two.
+      const active = await store.list(userId, APP_ID)
+      expect(active).toHaveLength(1)
+      expect(active[0].id).toBe(recreated.id)
+      expect(active[0].isDefault).toBe(true)
+    })
   })
 
   describe('isMember / getMemberRole', () => {

--- a/packages/core/src/server/db/stores/__tests__/PostgresWorkspaceStore.test.ts
+++ b/packages/core/src/server/db/stores/__tests__/PostgresWorkspaceStore.test.ts
@@ -603,6 +603,138 @@ describe('PostgresWorkspaceStore Sub-PR1', () => {
       expect(active[0].id).toBe(recreated.id)
       expect(active[0].isDefault).toBe(true)
     })
+
+    it('#1463 migration safety: the narrowed index still rejects two live defaults for the same (created_by, app_id)', async () => {
+      const userId = await seedUser()
+      await createWorkspace(userId, 'First', APP_ID, { isDefault: true })
+      // The old, broader index already rejected this (two live defaults, or a
+      // live default alongside a tombstoned one) — narrowing the predicate to
+      // also require deleted_at IS NULL only stops excluding the tombstoned
+      // case; it does not loosen the still-live-rows invariant.
+      let caught: unknown
+      try {
+        await createWorkspace(userId, 'Second', APP_ID, { isDefault: true })
+      } catch (err) {
+        caught = err
+      }
+      expect(caught).toBeDefined()
+      const cause = (caught as { cause?: { message?: string; code?: string } } | undefined)?.cause
+      expect(cause?.code).toBe('23505') // unique_violation
+      expect(cause?.message).toMatch(/idx_workspaces_default_per_user_app/)
+
+      // Exactly one live default survives — the rejected insert didn't
+      // partially commit anything.
+      const active = await store.list(userId, APP_ID)
+      expect(active.filter((w) => w.isDefault)).toHaveLength(1)
+    })
+  })
+
+  describe('deleteAndRecreateDefaultIfEmpty', () => {
+    it('happy path: soft-deletes the only workspace and creates+installs a replacement default, atomically', async () => {
+      const userId = await seedUser()
+      const ws = await createWorkspace(userId, 'Solo', APP_ID, { isDefault: true })
+
+      const result = await store.deleteAndRecreateDefaultIfEmpty(ws.id, userId, {
+        name: 'Default workspace',
+        defaultAgentTypeId: 'default',
+      })
+
+      expect(result.removed).toBe(true)
+      expect(result.recreated).not.toBeNull()
+      expect(result.recreated!.id).not.toBe(ws.id)
+      expect(result.recreated!.isDefault).toBe(true)
+      expect(result.recreated!.createdBy).toBe(userId)
+
+      expect(await store.get(ws.id)).toBeNull()
+      const active = await store.list(userId, APP_ID)
+      expect(active).toHaveLength(1)
+      expect(active[0].id).toBe(result.recreated!.id)
+
+      // The replacement got its owner-member row and initial Agent seat too —
+      // not just a bare workspace row.
+      expect(await store.getMemberRole(result.recreated!.id, userId)).toBe('owner')
+      expect(await store.hasAgentSeat(result.recreated!.id, 'default')).toBe(true)
+    })
+
+    it('does not recreate when the acting user still has another active workspace in the app', async () => {
+      const userId = await seedUser()
+      await createWorkspace(userId, 'Kept', APP_ID)
+      const ws = await createWorkspace(userId, 'Delete Me', APP_ID)
+
+      const result = await store.deleteAndRecreateDefaultIfEmpty(ws.id, userId, {
+        name: 'Default workspace',
+        defaultAgentTypeId: 'default',
+      })
+
+      expect(result.removed).toBe(true)
+      expect(result.recreated).toBeNull()
+      expect(await store.list(userId, APP_ID)).toHaveLength(1)
+    })
+
+    it('returns NOT_FOUND for an unknown or already-deleted id, without touching anything', async () => {
+      const missing = await store.deleteAndRecreateDefaultIfEmpty(
+        '00000000-0000-0000-0000-000000000000',
+        await seedUser(),
+        { name: 'x', defaultAgentTypeId: 'default' },
+      )
+      expect(missing).toEqual({ removed: false, code: ERROR_CODES.NOT_FOUND, recreated: null })
+    })
+
+    it('#1463 blocking-finding fix: a genuine DB failure during the replacement insert rolls back the WHOLE transaction — the original workspace is never left deleted with no replacement', async () => {
+      const userId = await seedUser()
+      const ws = await createWorkspace(userId, 'Solo Default', APP_ID, { isDefault: true })
+
+      // A user id with no row in `users` at all: the replacement insert's
+      // created_by foreign key will genuinely fail at the Postgres level —
+      // this is a real DB failure, not a mocked/simulated one. Membership
+      // lookups for this bogus id also come back empty, so the "is the
+      // acting user now workspace-less" check still says yes and the
+      // recreate is attempted (and fails).
+      const bogusActingUserId = randomUUID()
+
+      await expect(
+        store.deleteAndRecreateDefaultIfEmpty(ws.id, bogusActingUserId, {
+          name: 'Replacement',
+          defaultAgentTypeId: 'default',
+        }),
+      ).rejects.toThrow()
+
+      // Rolled back in full: the original workspace is exactly as it was —
+      // not deleted, not orphaned, account never at zero active workspaces.
+      expect(await store.get(ws.id)).not.toBeNull()
+      const [row] = await sqlClient`SELECT deleted_at FROM workspaces WHERE id = ${ws.id}`
+      expect(row.deleted_at).toBeNull()
+      expect(await store.list(userId, APP_ID)).toHaveLength(1)
+
+      // And no half-created replacement was left behind either.
+      const [{ count }] = await sqlClient`
+        SELECT count(*)::int AS count FROM workspaces WHERE created_by = ${bogusActingUserId}
+      `
+      expect(Number(count)).toBe(0)
+    })
+
+    it('#1463 concurrency: deleting two workspaces owned by the same user at the same time never deadlocks and never double-creates a replacement', async () => {
+      const userId = await seedUser()
+      const wsA = await createWorkspace(userId, 'A', APP_ID, { isDefault: true })
+      const wsB = await createWorkspace(userId, 'B', APP_ID)
+
+      const [resultA, resultB] = await Promise.all([
+        store.deleteAndRecreateDefaultIfEmpty(wsA.id, userId, { name: 'Replacement', defaultAgentTypeId: 'default' }),
+        store.deleteAndRecreateDefaultIfEmpty(wsB.id, userId, { name: 'Replacement', defaultAgentTypeId: 'default' }),
+      ])
+
+      expect(resultA.removed).toBe(true)
+      expect(resultB.removed).toBe(true)
+
+      // Exactly one of the two concurrent calls recreated a default — never
+      // both (duplicate-default collision) and never neither (zero-workspace
+      // account, the original bug).
+      const recreatedCount = [resultA.recreated, resultB.recreated].filter((r) => r !== null).length
+      expect(recreatedCount).toBe(1)
+
+      const active = await store.list(userId, APP_ID)
+      expect(active).toHaveLength(1)
+    })
   })
 
   describe('isMember / getMemberRole', () => {

--- a/packages/core/src/server/routes/__tests__/workspaceAuthAudit.test.ts
+++ b/packages/core/src/server/routes/__tests__/workspaceAuthAudit.test.ts
@@ -105,6 +105,39 @@ function mockWorkspaceStore(): WorkspaceStore {
       workspaces.delete(id)
       return { removed: true }
     },
+    deleteAndRecreateDefaultIfEmpty: async (
+      id: string,
+      actingUserId: string,
+      recreate: { name: string; defaultAgentTypeId: string },
+    ) => {
+      const ws = workspaces.get(id)
+      if (!ws) return { removed: false as const, code: ERROR_CODES.NOT_FOUND, recreated: null }
+      const appId = ws.appId
+      workspaces.delete(id)
+      memberDb.delete(id)
+
+      const remaining = [...workspaces.values()].filter(
+        (w) => w.appId === appId && memberDb.get(w.id)?.has(actingUserId),
+      )
+      if (remaining.length > 0) return { removed: true as const, recreated: null }
+
+      const newId = `ws-${nextWsId++}`
+      const recreatedWs: Workspace = {
+        id: newId, appId, workspaceTypeId: 'default', name: recreate.name, createdBy: actingUserId,
+        createdAt: new Date().toISOString(), deletedAt: null,
+        isDefault: true, defaultAgentTypeId: recreate.defaultAgentTypeId,
+      }
+      workspaces.set(newId, recreatedWs)
+      const wsMembers = new Map<string, MemberRole>()
+      wsMembers.set(actingUserId, 'owner')
+      memberDb.set(newId, wsMembers)
+      wsRuntimes.set(newId, {
+        workspaceId: newId, spriteUrl: null, spriteName: null,
+        state: 'ready', lastError: null, volumePath: null, lastErrorOp: null,
+        provisioningStep: null, stepStartedAt: null, updatedAt: new Date().toISOString(),
+      })
+      return { removed: true as const, recreated: recreatedWs }
+    },
     getWorkspacesWhereSoleOwner: async () => [],
     getMemberRole: async (wsId: string, userId: string) =>
       memberDb.get(wsId)?.get(userId) ?? null,

--- a/packages/core/src/server/routes/__tests__/workspaces.test.ts
+++ b/packages/core/src/server/routes/__tests__/workspaces.test.ts
@@ -927,6 +927,52 @@ describe('Provisioner integration', () => {
       expect(runtime?.lastError).toBe('disk full')
       expect(runtime?.lastErrorOp).toBe('provision')
     })
+
+    it('#1463: if the DB delete+recreate fails AFTER the sandbox was already destroyed, the surviving workspace is marked recoverable via the existing retry contract — never left live-looking but silently broken', async () => {
+      const ws = provSeedWorkspace('DestroyedThenDbFails', OWNER_ID, { isDefault: true })
+
+      // Simulate a genuine post-destroy DB failure (e.g. the replacement
+      // insert failing inside deleteAndRecreateDefaultIfEmpty's transaction):
+      // patch the store method to throw for exactly this one call, then
+      // restore it. The mock never mutates pWorkspaces before throwing,
+      // mirroring a real Postgres ROLLBACK leaving the row untouched.
+      const store = provApp.workspaceStore as unknown as {
+        deleteAndRecreateDefaultIfEmpty: WorkspaceStore['deleteAndRecreateDefaultIfEmpty']
+      }
+      const original = store.deleteAndRecreateDefaultIfEmpty
+      store.deleteAndRecreateDefaultIfEmpty = async () => {
+        throw new Error('replacement insert failed')
+      }
+
+      try {
+        const res = await provInject('DELETE', `/api/v1/workspaces/${ws.id}`, OWNER_ID)
+
+        // Honest failure — not deleted, not silently fine.
+        expect(res.statusCode).toBe(500)
+        expect(res.json().deleted).toBeUndefined()
+
+        // The sandbox WAS already destroyed (irreversible, ran before the DB
+        // step) — this is exactly the dangerous case: a row that looks like
+        // an ordinary active workspace but has no working runtime under it.
+        expect(destroyFn).toHaveBeenCalledWith(ws.id)
+
+        // The DB row itself survives (rolled back / never mutated) — the
+        // account is not workspace-less.
+        expect(pWorkspaces.get(ws.id)?.deletedAt).toBeFalsy()
+
+        // It is honestly marked recoverable via the SAME contract
+        // POST /runtime/retry already accepts (state=error,
+        // lastErrorOp=provision) — proven directly against that endpoint's
+        // guard in settings.ts and exercised end-to-end in
+        // e2e/v7-platform.test.ts's "destroy-then-DB-failure" recovery case.
+        const runtime = runtimes.get(ws.id)
+        expect(runtime?.state).toBe('error')
+        expect(runtime?.lastErrorOp).toBe('provision')
+        expect(runtime?.lastError).toContain('replacement insert failed')
+      } finally {
+        store.deleteAndRecreateDefaultIfEmpty = original
+      }
+    })
   })
 
   describe('No-provisioner mode', () => {

--- a/packages/core/src/server/routes/__tests__/workspaces.test.ts
+++ b/packages/core/src/server/routes/__tests__/workspaces.test.ts
@@ -393,6 +393,34 @@ describe('DELETE /api/v1/workspaces/:id', () => {
     expect(res.json().code).toBe(ERROR_CODES.FORBIDDEN)
     expect(workspaces.get(ws.id)?.deletedAt).toBeNull()
   })
+
+  it('#1463: deleting the only (default) workspace recreates a fresh default in the same operation, leaving exactly one active workspace', async () => {
+    const ws = seedWorkspaceWithMembers('Only Default', OWNER_ID)
+    workspaces.set(ws.id, { ...ws, isDefault: true })
+
+    const res = await inject('DELETE', `/api/v1/workspaces/${ws.id}`, OWNER_ID)
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({ deleted: true })
+
+    // The original is gone, but the user is never left with zero: a
+    // replacement default was created transactionally, in this same request.
+    const active = [...workspaces.values()].filter(
+      (w) => !w.deletedAt && w.createdBy === OWNER_ID && w.appId === APP_ID,
+    )
+    expect(active).toHaveLength(1)
+    expect(active[0].id).not.toBe(ws.id)
+    expect(active[0].isDefault).toBe(true)
+  })
+
+  it('#1463: does not recreate a default when the deleting owner still has other active workspaces', async () => {
+    seedWorkspaceWithMembers('Kept', OWNER_ID)
+    const ws = seedWorkspaceWithMembers('Delete', OWNER_ID)
+    storeCalls.length = 0
+
+    const res = await inject('DELETE', `/api/v1/workspaces/${ws.id}`, OWNER_ID)
+    expect(res.statusCode).toBe(200)
+    expect(storeCalls.filter((c) => c === 'create')).toHaveLength(0)
+  })
 })
 
 describe('request-scoped workspace authority', () => {
@@ -763,6 +791,23 @@ describe('Provisioner integration', () => {
       expect(second.statusCode).toBe(200)
       expect(second.json()).toEqual({ deleted: true })
       expect(pWorkspaces.get(ws.id)?.deletedAt).toBeTruthy()
+    })
+
+    it('#1463: deleting the only workspace provisions a fresh default in the same operation', async () => {
+      const ws = provSeedWorkspace('OnlyOne', OWNER_ID, { isDefault: true })
+
+      const res = await provInject('DELETE', `/api/v1/workspaces/${ws.id}`, OWNER_ID)
+      expect(res.statusCode).toBe(200)
+      expect(res.json()).toEqual({ deleted: true })
+      expect(destroyFn).toHaveBeenCalledWith(ws.id)
+      expect(pWorkspaces.get(ws.id)?.deletedAt).toBeTruthy()
+
+      const active = [...pWorkspaces.values()].filter((w) => !w.deletedAt && w.createdBy === OWNER_ID)
+      expect(active).toHaveLength(1)
+      expect(active[0].id).not.toBe(ws.id)
+      expect(active[0].isDefault).toBe(true)
+      // The replacement was provisioned too, not just inserted as a bare row.
+      expect(provisionFn).toHaveBeenCalledWith(expect.objectContaining({ workspaceId: active[0].id }))
     })
   })
 

--- a/packages/core/src/server/routes/__tests__/workspaces.test.ts
+++ b/packages/core/src/server/routes/__tests__/workspaces.test.ts
@@ -73,6 +73,40 @@ function mockWorkspaceStore(): WorkspaceStore {
       ws.deletedAt = new Date().toISOString()
       return { removed: true }
     },
+    deleteAndRecreateDefaultIfEmpty: async (
+      id: string,
+      actingUserId: string,
+      recreate: { name: string; defaultAgentTypeId: string },
+    ) => {
+      storeCalls.push(`deleteAndRecreateDefaultIfEmpty:${id}`)
+      const ws = workspaces.get(id)
+      if (!ws || ws.deletedAt) return { removed: false as const, code: ERROR_CODES.NOT_FOUND, recreated: null }
+      ws.deletedAt = new Date().toISOString()
+
+      const remaining = [...workspaces.values()].filter(
+        (w) => !w.deletedAt && w.appId === ws.appId && members.get(w.id)?.has(actingUserId),
+      )
+      if (remaining.length > 0) return { removed: true as const, recreated: null }
+
+      storeCalls.push('create')
+      const newId = `ws-${nextWsId++}`
+      const recreated: Workspace = {
+        id: newId,
+        appId: ws.appId,
+        workspaceTypeId: 'default',
+        name: recreate.name,
+        createdBy: actingUserId,
+        createdAt: new Date().toISOString(),
+        deletedAt: null,
+        isDefault: true,
+        defaultAgentTypeId: recreate.defaultAgentTypeId,
+      }
+      workspaces.set(newId, recreated)
+      const wsMembers = members.get(newId) ?? new Map()
+      wsMembers.set(actingUserId, 'owner')
+      members.set(newId, wsMembers)
+      return { removed: true as const, recreated }
+    },
     getMemberRole: async (wsId: string, userId: string) => {
       storeCalls.push(`role:${wsId}:${userId}`)
       return members.get(wsId)?.get(userId) ?? null
@@ -394,6 +428,15 @@ describe('DELETE /api/v1/workspaces/:id', () => {
     expect(workspaces.get(ws.id)?.deletedAt).toBeNull()
   })
 
+  // Mirrors the mock store's own list() filter: what the deleting user would
+  // actually see from GET /api/v1/workspaces (the user-visible invariant),
+  // not an internal createdBy-only slice.
+  function activeForUser(userId: string) {
+    return [...workspaces.values()].filter(
+      (w) => !w.deletedAt && w.appId === APP_ID && members.get(w.id)?.has(userId),
+    )
+  }
+
   it('#1463: deleting the only (default) workspace recreates a fresh default in the same operation, leaving exactly one active workspace', async () => {
     const ws = seedWorkspaceWithMembers('Only Default', OWNER_ID)
     workspaces.set(ws.id, { ...ws, isDefault: true })
@@ -404,12 +447,11 @@ describe('DELETE /api/v1/workspaces/:id', () => {
 
     // The original is gone, but the user is never left with zero: a
     // replacement default was created transactionally, in this same request.
-    const active = [...workspaces.values()].filter(
-      (w) => !w.deletedAt && w.createdBy === OWNER_ID && w.appId === APP_ID,
-    )
+    const active = activeForUser(OWNER_ID)
     expect(active).toHaveLength(1)
     expect(active[0].id).not.toBe(ws.id)
     expect(active[0].isDefault).toBe(true)
+    expect(active[0].createdBy).toBe(OWNER_ID)
   })
 
   it('#1463: does not recreate a default when the deleting owner still has other active workspaces', async () => {
@@ -420,6 +462,31 @@ describe('DELETE /api/v1/workspaces/:id', () => {
     const res = await inject('DELETE', `/api/v1/workspaces/${ws.id}`, OWNER_ID)
     expect(res.statusCode).toBe(200)
     expect(storeCalls.filter((c) => c === 'create')).toHaveLength(0)
+    expect(activeForUser(OWNER_ID)).toHaveLength(1)
+  })
+
+  it('#1463: a non-creator owner (promoted via invite, Bob-style) deleting the last shared workspace becomes the creator of the replacement — the original creator is unaffected', async () => {
+    // Alice creates the workspace; Bob is later promoted to owner (mirrors
+    // e2e/v7-platform.test.ts's "Bob deletes workspace" flow) and is the one
+    // who deletes it while it's the only workspace either of them has.
+    const ALICE_ID = 'u-alice-000'
+    const ws = seedWorkspaceWithMembers('Shared', ALICE_ID, { [OWNER_ID]: 'owner' })
+
+    const res = await inject('DELETE', `/api/v1/workspaces/${ws.id}`, OWNER_ID)
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({ deleted: true })
+
+    // Bob (the acting/deleting user) ends up owning the replacement — not Alice.
+    const bobActive = activeForUser(OWNER_ID)
+    expect(bobActive).toHaveLength(1)
+    expect(bobActive[0].id).not.toBe(ws.id)
+    expect(bobActive[0].createdBy).toBe(OWNER_ID)
+    expect(members.get(bobActive[0].id)?.get(OWNER_ID)).toBe('owner')
+
+    // Alice loses access to the deleted shared workspace and gets nothing
+    // automatically in its place — she is not a member of Bob's replacement.
+    expect(activeForUser(ALICE_ID)).toHaveLength(0)
+    expect(members.get(bobActive[0].id)?.has(ALICE_ID)).toBe(false)
   })
 })
 
@@ -565,6 +632,32 @@ describe('Provisioner integration', () => {
         if (!ws || ws.deletedAt) return { removed: false, code: ERROR_CODES.NOT_FOUND }
         ws.deletedAt = new Date().toISOString()
         return { removed: true }
+      },
+      deleteAndRecreateDefaultIfEmpty: async (
+        id: string,
+        actingUserId: string,
+        recreate: { name: string; defaultAgentTypeId: string },
+      ) => {
+        const ws = pWorkspaces.get(id)
+        if (!ws || ws.deletedAt) return { removed: false as const, code: ERROR_CODES.NOT_FOUND, recreated: null }
+        ws.deletedAt = new Date().toISOString()
+
+        const remaining = [...pWorkspaces.values()].filter(
+          (w) => !w.deletedAt && w.appId === ws.appId && pMembers.get(w.id)?.has(actingUserId),
+        )
+        if (remaining.length > 0) return { removed: true as const, recreated: null }
+
+        const newId = `ws-${pNextWsId++}`
+        const recreated: Workspace = {
+          id: newId, appId: ws.appId, workspaceTypeId: 'default', name: recreate.name, createdBy: actingUserId,
+          createdAt: new Date().toISOString(), deletedAt: null,
+          isDefault: true, defaultAgentTypeId: recreate.defaultAgentTypeId,
+        }
+        pWorkspaces.set(newId, recreated)
+        const wsMembers = pMembers.get(newId) ?? new Map()
+        wsMembers.set(actingUserId, 'owner')
+        pMembers.set(newId, wsMembers)
+        return { removed: true as const, recreated }
       },
       getMemberRole: async (wsId: string, userId: string) => {
         return pMembers.get(wsId)?.get(userId) ?? null
@@ -808,6 +901,31 @@ describe('Provisioner integration', () => {
       expect(active[0].isDefault).toBe(true)
       // The replacement was provisioned too, not just inserted as a bare row.
       expect(provisionFn).toHaveBeenCalledWith(expect.objectContaining({ workspaceId: active[0].id }))
+    })
+
+    it('#1463: if provisioning the replacement default fails, DELETE reports it honestly (500 provision_failed) instead of a false "deleted: true" — the DB layer already committed, so the account is not workspace-less', async () => {
+      provisionFn.mockRejectedValue(new Error('disk full'))
+      const ws = provSeedWorkspace('OnlyOneProvFails', OWNER_ID, { isDefault: true })
+
+      const res = await provInject('DELETE', `/api/v1/workspaces/${ws.id}`, OWNER_ID)
+
+      // Honest failure, not a silently-swallowed success.
+      expect(res.statusCode).toBe(500)
+      expect(res.json().code).toBe('provision_failed')
+
+      // But the DB side of #1463 already ran and committed atomically: the
+      // original is gone AND its replacement row exists — the account is
+      // never at zero active workspaces, it's just unprovisioned/retryable,
+      // exactly like a failed POST /api/v1/workspaces.
+      expect(pWorkspaces.get(ws.id)?.deletedAt).toBeTruthy()
+      const active = [...pWorkspaces.values()].filter((w) => !w.deletedAt && w.createdBy === OWNER_ID)
+      expect(active).toHaveLength(1)
+      expect(active[0].id).not.toBe(ws.id)
+
+      const runtime = runtimes.get(active[0].id)
+      expect(runtime?.state).toBe('error')
+      expect(runtime?.lastError).toBe('disk full')
+      expect(runtime?.lastErrorOp).toBe('provision')
     })
   })
 

--- a/packages/core/src/server/routes/workspaces.ts
+++ b/packages/core/src/server/routes/workspaces.ts
@@ -246,38 +246,44 @@ const workspaceRoutesPlugin: FastifyPluginAsync = async (app) => {
         }
       }
 
-      const result = await store.delete(id)
+      // #1463: soft-delete + "does the acting user still have an active
+      // workspace, and if not create a replacement" run as ONE database
+      // transaction (see PostgresWorkspaceStore.deleteAndRecreateDefaultIfEmpty).
+      // If the replacement insert fails for any reason, the whole transaction
+      // rolls back — including the original soft-delete — so this either
+      // fully succeeds or the workspace is left exactly as it was. We never
+      // report `deleted: true` while the account is committed at zero active
+      // workspaces: a DB-layer failure here propagates as a 500, honestly.
+      const result = await store.deleteAndRecreateDefaultIfEmpty(id, request.user!.id, {
+        name: DEFAULT_WORKSPACE_NAME,
+        defaultAgentTypeId,
+      })
 
-      if (result.removed) {
-        request.log.info({ workspaceId: id }, 'workspace.delete.complete')
-
-        // #1463: never leave the deleting user with zero active workspaces.
-        // The old unpartitioned index made this recreate collide with the
-        // just-tombstoned default (duplicate key → 500, account bricked);
-        // the migration scopes the index to deleted_at IS NULL, so this now
-        // succeeds cleanly. Recreate synchronously, in this same operation,
-        // instead of relying on the next GET /workspaces to notice and repair it.
-        const remaining = await store.list(request.user!.id, workspace.appId)
-        if (remaining.length === 0) {
-          try {
-            await createWorkspaceForUser(request.user!.id, DEFAULT_WORKSPACE_NAME, true, request)
-          } catch (err) {
-            // The delete itself already succeeded — don't fail the response
-            // over a best-effort replacement default. Worst case, the next
-            // GET /api/v1/workspaces recreate-on-list still fixes it up.
-            request.log.error({ userId: request.user!.id, err }, 'workspace.delete.recreate_default.failed')
-          }
-        }
-
-        return { deleted: true }
+      if (!result.removed) {
+        throw new HttpError({
+          status: 404,
+          code: ERROR_CODES.NOT_FOUND,
+          message: 'Workspace not found',
+          requestId: request.id,
+        })
       }
 
-      throw new HttpError({
-        status: 404,
-        code: ERROR_CODES.NOT_FOUND,
-        message: 'Workspace not found',
-        requestId: request.id,
-      })
+      request.log.info({ workspaceId: id }, 'workspace.delete.complete')
+
+      // Provisioning (filesystem/sandbox) can't join the DB transaction above,
+      // so it's driven here, after the DB state has durably committed. On
+      // failure this throws PROVISION_FAILED (same contract as POST
+      // /api/v1/workspaces): the replacement workspace row already exists —
+      // the account is not workspace-less — and the runtime is left in
+      // 'error' state, retryable via POST /runtime/retry, exactly like a
+      // failed creation. We do NOT swallow this: silently returning
+      // `deleted: true` over an unprovisioned, error-state replacement would
+      // misreport what actually happened.
+      if (result.recreated) {
+        await provisionWorkspace(result.recreated, result.recreated.createdBy, request)
+      }
+
+      return { deleted: true }
     },
   )
 }

--- a/packages/core/src/server/routes/workspaces.ts
+++ b/packages/core/src/server/routes/workspaces.ts
@@ -250,14 +250,40 @@ const workspaceRoutesPlugin: FastifyPluginAsync = async (app) => {
       // workspace, and if not create a replacement" run as ONE database
       // transaction (see PostgresWorkspaceStore.deleteAndRecreateDefaultIfEmpty).
       // If the replacement insert fails for any reason, the whole transaction
-      // rolls back — including the original soft-delete — so this either
-      // fully succeeds or the workspace is left exactly as it was. We never
-      // report `deleted: true` while the account is committed at zero active
-      // workspaces: a DB-layer failure here propagates as a 500, honestly.
-      const result = await store.deleteAndRecreateDefaultIfEmpty(id, request.user!.id, {
-        name: DEFAULT_WORKSPACE_NAME,
-        defaultAgentTypeId,
-      })
+      // rolls back — including the original soft-delete — so the DB row is
+      // left exactly as it was. But by this point `provisioner.destroy(id)`
+      // above has already irreversibly torn down the real sandbox/filesystem
+      // — that can't be part of the DB transaction and can't be undone. So a
+      // DB-layer failure here would otherwise leave a live-looking workspace
+      // row with no working runtime and no path back to one. Mark it
+      // recoverable through the SAME contract POST /runtime/retry already
+      // understands (state=error, lastErrorOp=provision) instead of leaving
+      // it silently broken — the workspace genuinely does need a fresh
+      // sandbox provisioned, exactly like a failed creation would.
+      let result: Awaited<ReturnType<typeof store.deleteAndRecreateDefaultIfEmpty>>
+      try {
+        result = await store.deleteAndRecreateDefaultIfEmpty(id, request.user!.id, {
+          name: DEFAULT_WORKSPACE_NAME,
+          defaultAgentTypeId,
+        })
+      } catch (err) {
+        if (provisioner) {
+          const message = err instanceof Error ? err.message : String(err)
+          try {
+            await store.putWorkspaceRuntime(id, {
+              state: 'error',
+              lastError: message,
+              lastErrorOp: 'provision',
+            })
+          } catch (markErr) {
+            // Even the recovery marking failed — surface it but don't let it
+            // mask the original DB error, which is what actually caused this.
+            request.log.error({ workspaceId: id, markErr }, 'workspace.delete.recovery_mark.failed')
+          }
+        }
+        request.log.error({ workspaceId: id, err }, 'workspace.delete.db_failed_after_destroy')
+        throw err
+      }
 
       if (!result.removed) {
         throw new HttpError({

--- a/packages/core/src/server/routes/workspaces.ts
+++ b/packages/core/src/server/routes/workspaces.ts
@@ -250,6 +250,25 @@ const workspaceRoutesPlugin: FastifyPluginAsync = async (app) => {
 
       if (result.removed) {
         request.log.info({ workspaceId: id }, 'workspace.delete.complete')
+
+        // #1463: never leave the deleting user with zero active workspaces.
+        // The old unpartitioned index made this recreate collide with the
+        // just-tombstoned default (duplicate key → 500, account bricked);
+        // the migration scopes the index to deleted_at IS NULL, so this now
+        // succeeds cleanly. Recreate synchronously, in this same operation,
+        // instead of relying on the next GET /workspaces to notice and repair it.
+        const remaining = await store.list(request.user!.id, workspace.appId)
+        if (remaining.length === 0) {
+          try {
+            await createWorkspaceForUser(request.user!.id, DEFAULT_WORKSPACE_NAME, true, request)
+          } catch (err) {
+            // The delete itself already succeeded — don't fail the response
+            // over a best-effort replacement default. Worst case, the next
+            // GET /api/v1/workspaces recreate-on-list still fixes it up.
+            request.log.error({ userId: request.user!.id, err }, 'workspace.delete.recreate_default.failed')
+          }
+        }
+
         return { deleted: true }
       }
 


### PR DESCRIPTION
Fixes #1463

## Root cause

Deleting a user's default workspace soft-deleted it (`deleted_at` set), then a
later `GET /api/v1/workspaces` auto-recreates a default since the user now has
zero active workspaces. That insert collided with
`idx_workspaces_default_per_user_app` — the unique partial index excluded
non-default rows (`WHERE is_default = true`) but **not soft-deleted ones**, so
the tombstoned default still blocked a fresh insert for the same
`(created_by, app_id)`. Result: the insert failed with a duplicate-key error,
the user was left with zero active workspaces, and every subsequent
`GET /api/v1/workspaces` 500'd — account bricked until DB intervention.

Insert site: `packages/core/src/server/db/stores/PostgresWorkspaceStore.ts` (`create()`).

## Fix — two layers

**Layer 1 (migration, `drizzle/0027_workspace_default_index_excludes_deleted.sql`):**
rebuild `idx_workspaces_default_per_user_app` scoped to
`is_default = true AND deleted_at IS NULL`. Mirrored in `schema.ts` and in
`LocalWorkspaceStore`'s in-memory delete/create comments for consistency.

**Layer 2 (behavior, `packages/core/src/server/routes/workspaces.ts`):**
the DELETE route now recreates a fresh default **synchronously, in the same
operation**, when the delete would leave the acting user with zero active
workspaces — instead of relying on the next `GET /workspaces` to notice and
repair it.

### Option chosen: recreate-transactionally, not refuse

I initially implemented a hard refuse (409 `last_workspace`) when deleting
the user's only workspace, mirroring the existing `LAST_OWNER` pattern. I
reverted that: it broke a legitimate flow already covered by
`e2e/v7-platform.test.ts` ("Bob deletes workspace") — a non-creator owner
(promoted via invite) cleaning up the last workspace in an app. Refusing
based on "is this the only workspace" doesn't distinguish that case from the
literal repro (a user's own auto-created default with no other workspaces),
and scoping the refusal correctly to preserve that flow got complicated fast.

Since the migration alone already makes the existing recreate-on-list path
(`listOrCreateDefaultWorkspace`) safe, recreate-transactionally is strictly
additive: it's the same recreate the client would trigger on its next list
call (the UI already invalidates the workspaces query on delete success), just
done synchronously so the user never even sees a zero-workspace flash. If the
replacement's provisioning fails, the delete response still succeeds (best
effort) — the next `GET /workspaces` recreate-on-list still repairs it.

## Tests

- `packages/core/src/server/db/__tests__/workspaceDefaultIndexExcludesDeleted.migration.test.ts` — migration SQL content test (mirrors the `0026` migration test's style).
- `packages/core/src/server/db/stores/__tests__/PostgresWorkspaceStore.test.ts` — store conformance case: delete the only default workspace, recreate one with the same `(created_by, app_id)`, prove no collision and exactly one active default remains.
- `packages/core/src/server/routes/__tests__/workspaces.test.ts` — route tests (bare mock store and with-provisioner mock) proving the synchronous recreate, and a case proving no recreate happens when the owner still has other active workspaces.
- `e2e/v7-platform.test.ts` and `LocalWorkspaceStore.test.ts` continue to pass unmodified.

## Proof

Ran against a dedicated local Postgres db (created for this task; never
touched other roles/dbs):

```
role_1463 / fullapp_1463  (owned by role_1463, created via sudo -u postgres psql)
```

- `pnpm --filter core typecheck` — clean except one pre-existing, unrelated
  error in `packages/workspace` (`WorkspaceAgentFront.tsx` `setArchived`),
  confirmed present on `origin/main` too.
- Targeted suite (migration test, `PostgresWorkspaceStore.test.ts`,
  `LocalWorkspaceStore.test.ts`, `workspaces.test.ts`,
  `workspaceAuthAudit.test.ts`, `e2e/v7-platform.test.ts`): **262/262 passed**.
- Full `packages/core` suite (backend only): **1087/1092 passed**; the 5
  failures (2 `PostgresModelBudgetStore` budget-double-counting tests, 3
  `createCoreWorkspaceAgentServer.provisioning.test.ts` lease/timeout tests)
  reproduce identically on unmodified `origin/main` against the same db —
  confirmed pre-existing and unrelated to this change.

No merge performed.