### PR TITLE
Fix composer permanently disabled for sessions without a stored model

### DIFF
--- a/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
+++ b/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
@@ -1411,6 +1411,61 @@ describe('PiChatPanel sandbox shell', () => {
     })))
   })
 
+  test('unlocks the composer and submits with the server default model for a pre-seeded session with no stored model (#1469)', async () => {
+    // A session created outside the primary new-chat flow (pre-seeded scripted
+    // session, or one created via a direct POST .../sessions call) hydrates
+    // with no currentModel and is not "new" (remoteState()'s default already
+    // carries a committed message). Live server-side model discovery (not the
+    // availableModels/serverResourcesEnabled=false shortcut most tests use)
+    // must still resolve a model so the composer isn't disabled forever, and
+    // the resolved model must be the server's own default — never a leftover
+    // browser-storage choice.
+    const staleBrowserModel = { provider: 'anthropic', id: 'claude-haiku' } as const
+    const serverDefault = { provider: 'anthropic', id: 'claude-opus' } as const
+    const persisted = storage({
+      [scopedComposerStorageKey('workspace-a', 'model')]: JSON.stringify(staleBrowserModel),
+      [scopedComposerStorageKey('workspace-a', 'model:user-selected')]: '1',
+    })
+    const remote = new FakeRemotePiSession(remoteState())
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url
+      if (url.includes('/models')) {
+        return new Response(JSON.stringify({
+          models: [
+            { ...staleBrowserModel, label: 'Haiku', available: true },
+            { ...serverDefault, label: 'Opus', available: true },
+          ],
+          defaultModel: serverDefault,
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      return jsonResponse([session('pi-1')])
+    })
+
+    render(
+      <PiChatPanel
+        storageScope="workspace-a"
+        storage={persisted}
+        fetch={fetchMock as unknown as typeof fetch}
+        createRemoteSession={remoteFactory(remote)}
+      />,
+    )
+
+    const textarea = await screen.findByLabelText('Agent prompt')
+    await waitFor(() => expect((textarea as HTMLTextAreaElement).disabled).toBe(false))
+    expect((screen.getByRole('button', { name: 'Submit' }) as HTMLButtonElement).disabled).toBe(false)
+
+    fireEvent.change(textarea, { target: { value: 'pre-seeded prompt' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+    await waitFor(() => expect(remote.prompt).toHaveBeenCalledWith(expect.objectContaining({
+      message: 'pre-seeded prompt',
+      model: serverDefault,
+    })))
+  })
+
   test('opens model and thinking pickers from slash commands', async () => {
     const remote = new FakeRemotePiSession(remoteState({ committedMessages: [], history: { mode: 'full', messageCount: 0 } }))
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse([session('pi-1')]))

--- a/packages/agent/src/front/hooks/__tests__/useChatModelSelection.test.tsx
+++ b/packages/agent/src/front/hooks/__tests__/useChatModelSelection.test.tsx
@@ -147,6 +147,37 @@ describe('useChatModelSelection', () => {
     expect(result.current.model).toBeNull()
   })
 
+  it('resolves the agent default model for a pre-seeded/directly-created session with no stored model (#1469)', async () => {
+    // Sessions created outside the primary new-chat flow (pre-seeded scripted
+    // sessions, sessions created via a direct POST .../sessions call) hydrate
+    // with no session.currentModel and are never "new" (sessionIsNew is false
+    // once the session already carries history/queue state or was created
+    // out of band). Composer authority must still resolve a model from the
+    // agent's server-side default so the composer isn't disabled forever.
+    const defaultModel = { provider: 'anthropic', id: 'claude-sonnet' } as const
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      models: [
+        { provider: 'anthropic', id: 'claude-sonnet', label: 'Sonnet', available: true },
+      ],
+      defaultModel,
+    }))) as unknown as typeof fetch
+
+    const store = storage()
+    const { result } = renderHook(() => useChatModelSelection({
+      sessionId: 'pre-seeded-no-model',
+      sessionHydrated: true,
+      sessionIsNew: false,
+      storageScope: 'scope-a',
+      storage: store,
+      fetch: fetchImpl,
+      enabled: true,
+    }))
+
+    await waitFor(() => expect(result.current.loaded).toBe(true))
+    await waitFor(() => expect(result.current.model).toEqual(defaultModel))
+    expect(result.current.sessionModel).toBeUndefined()
+  })
+
   it('normalizes discovered model metadata before storing a prompt selection', async () => {
     const store = storage()
     const { result } = renderHook(() => useChatModelSelection({

--- a/packages/agent/src/front/hooks/__tests__/useChatModelSelection.test.tsx
+++ b/packages/agent/src/front/hooks/__tests__/useChatModelSelection.test.tsx
@@ -178,6 +178,91 @@ describe('useChatModelSelection', () => {
     expect(result.current.sessionModel).toBeUndefined()
   })
 
+  it('never trusts a leftover browser-stored default over the server default for an existing session with no stored model (#1469 review)', async () => {
+    // Regression for a review finding on the #1469 fix: a prior tab/session in
+    // this storage scope left model A selected in browser storage. A is still
+    // a valid, available model per discovery — so the old "already available,
+    // keep it" shortcut would happily resolve to A. But this session has no
+    // sessionModel of its own (sessionIsNew: false), so A is not this
+    // session's model; it is unrelated leftover state. The server's own
+    // default (B) must win, never a coincidentally-available browser choice.
+    const browserStoredModelA = { provider: 'anthropic', id: 'claude-haiku' } as const
+    const serverDefaultB = { provider: 'anthropic', id: 'claude-opus' } as const
+    const store = storage({
+      [scopedComposerStorageKey('scope-a', 'model')]: JSON.stringify(browserStoredModelA),
+      [scopedComposerStorageKey('scope-a', 'model:user-selected')]: '1',
+    })
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      models: [
+        { provider: 'anthropic', id: 'claude-haiku', label: 'Haiku', available: true },
+        { provider: 'anthropic', id: 'claude-opus', label: 'Opus', available: true },
+      ],
+      defaultModel: serverDefaultB,
+    }))) as unknown as typeof fetch
+
+    const { result } = renderHook(() => useChatModelSelection({
+      sessionId: 'pre-seeded-with-stale-browser-default',
+      sessionHydrated: true,
+      sessionIsNew: false,
+      storageScope: 'scope-a',
+      storage: store,
+      fetch: fetchImpl,
+      enabled: true,
+    }))
+
+    await waitFor(() => expect(result.current.loaded).toBe(true))
+    await waitFor(() => expect(result.current.model).toEqual(serverDefaultB))
+    expect(result.current.model).not.toEqual(browserStoredModelA)
+    expect(result.current.sessionModel).toBeUndefined()
+  })
+
+  it('does not expose or submit the local/server default while a session with a stored model is still hydrating, even after discovery completes first (#1319 ordering)', async () => {
+    // Regression for a review finding: discovery can complete before an
+    // existing session finishes hydrating. sessionAuthorityReady must stay
+    // gated on sessionHydrated so a session that WILL report a stored model
+    // never briefly presents (or could submit with) the discovery default in
+    // that window — canonical hydration assigns currentModel and
+    // hydrated:true atomically, so there is no intermediate "hydrated with no
+    // model yet" state for such a session, but the hook must not race ahead
+    // of hydration to guess one anyway.
+    const localDefault = { provider: 'anthropic', id: 'claude-local-default' } as const
+    const storedSessionModel = { provider: 'openai-codex', id: 'gpt-5.6-sol' } as const
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      models: [
+        { provider: 'anthropic', id: 'claude-local-default', label: 'Local default', available: true },
+        { provider: 'openai-codex', id: 'gpt-5.6-sol', label: 'Sol', available: true },
+      ],
+      defaultModel: localDefault,
+    }))) as unknown as typeof fetch
+    const store = storage()
+
+    const { result, rerender } = renderHook(
+      ({ sessionHydrated, sessionModel }) => useChatModelSelection({
+        sessionId: 'deferred-hydration-existing',
+        sessionHydrated,
+        sessionIsNew: false,
+        sessionModel,
+        storageScope: 'scope-a',
+        storage: store,
+        fetch: fetchImpl,
+        enabled: true,
+      }),
+      { initialProps: { sessionHydrated: false, sessionModel: undefined as ModelSelection | undefined } },
+    )
+
+    // Discovery finishes while the session is still unhydrated.
+    await waitFor(() => expect(result.current.loaded).toBe(true))
+    // Authority must not be ready yet: no model to display, nothing a caller
+    // could submit with.
+    expect(result.current.model).toBeNull()
+
+    // Hydration lands atomically with the session's real stored model.
+    rerender({ sessionHydrated: true, sessionModel: storedSessionModel })
+
+    await waitFor(() => expect(result.current.model).toEqual(storedSessionModel))
+    expect(result.current.model).not.toEqual(localDefault)
+  })
+
   it('normalizes discovered model metadata before storing a prompt selection', async () => {
     const store = storage()
     const { result } = renderHook(() => useChatModelSelection({

--- a/packages/agent/src/front/hooks/useChatModelSelection.ts
+++ b/packages/agent/src/front/hooks/useChatModelSelection.ts
@@ -140,21 +140,24 @@ export function useChatModelSelection({
         setAvailableModels(models)
         setSelection((current) => {
           const selected = current.pendingOverride ?? sessionModel ?? current.localDefault
-          if (availableModel(models, selected)) return current
-          if (sessionModel) return { ...current, pendingOverride: undefined }
-          // An existing session without a stored model (pre-seeded/directly-created
-          // sessions) has no authoritative model of its own. Resolve one from the
-          // server's discovery response (agent default, or first available) instead
-          // of leaving localDefault null forever — a null default here is what kept
-          // sessionAuthorityReady from ever becoming true for such sessions, which
-          // permanently disabled the composer (#1469).
-          const firstAvailable = models.find((candidate) => candidate.available)
-          return {
-            ...current,
-            pendingOverride: undefined,
-            localDefault: payload.defaultModel
-              ?? (firstAvailable ? { provider: firstAvailable.provider, id: firstAvailable.id } : null),
+          if (sessionModel) {
+            if (availableModel(models, selected)) return current
+            return { ...current, pendingOverride: undefined }
           }
+          const firstAvailable = models.find((candidate) => candidate.available)
+          const serverDefault = payload.defaultModel
+            ?? (firstAvailable ? { provider: firstAvailable.provider, id: firstAvailable.id } : null)
+          if (sessionId && !sessionIsNew) {
+            // An existing session without a stored model (pre-seeded/directly-created
+            // sessions) has no authoritative model of its own. Never trust a leftover
+            // browser-storage default here even if it happens to still be "available" —
+            // a stale/uncoordinated local choice surviving discovery would let this
+            // session submit with the wrong model. Always resolve exclusively from the
+            // server's own default/first-available model instead (#1469 review finding).
+            return { ...current, pendingOverride: undefined, localDefault: serverDefault }
+          }
+          if (availableModel(models, selected)) return current
+          return { ...current, pendingOverride: undefined, localDefault: serverDefault }
         })
         setLoadedDiscoveryKey(discoveryKey)
         setLoaded(true)

--- a/packages/agent/src/front/hooks/useChatModelSelection.ts
+++ b/packages/agent/src/front/hooks/useChatModelSelection.ts
@@ -142,7 +142,12 @@ export function useChatModelSelection({
           const selected = current.pendingOverride ?? sessionModel ?? current.localDefault
           if (availableModel(models, selected)) return current
           if (sessionModel) return { ...current, pendingOverride: undefined }
-          if (sessionId && !sessionIsNew) return { ...current, pendingOverride: undefined, localDefault: null }
+          // An existing session without a stored model (pre-seeded/directly-created
+          // sessions) has no authoritative model of its own. Resolve one from the
+          // server's discovery response (agent default, or first available) instead
+          // of leaving localDefault null forever — a null default here is what kept
+          // sessionAuthorityReady from ever becoming true for such sessions, which
+          // permanently disabled the composer (#1469).
           const firstAvailable = models.find((candidate) => candidate.available)
           return {
             ...current,
@@ -180,7 +185,13 @@ export function useChatModelSelection({
     && selection.storageScope === storageScope
   const pendingOverride = selectionBelongsToSession ? selection.pendingOverride : undefined
   const isOverride = Boolean(pendingOverride && sessionModel && !sameModel(pendingOverride, sessionModel))
-  const sessionAuthorityReady = !sessionId || (sessionHydrated && (sessionModel !== undefined || sessionIsNew))
+  // Discovery must have actually run (not just be vacuously "loaded" because
+  // it's disabled) before we trust localDefault as an existing session's
+  // resolved model — otherwise an untouched/stale browser-storage default
+  // could leak into a session that never selected one.
+  const discoveryVetted = enabled && currentDiscoveryLoaded
+  const sessionAuthorityReady = !sessionId
+    || (sessionHydrated && (sessionModel !== undefined || sessionIsNew || discoveryVetted))
   const model = currentDiscoveryLoaded && sessionAuthorityReady
     ? pendingOverride ?? sessionModel ?? selection.localDefault
     : null


### PR DESCRIPTION
## Summary
- Fixes #1469: sessions not created via the primary new-chat flow (pre-seeded scripted sessions, sessions created via a direct `POST /api/v1/agents/:id/sessions` call) hydrate with `sessionModel === undefined` and `sessionIsNew === false`. `useChatModelSelection`'s `sessionAuthorityReady` never became true for that combination, so `model` stayed `null` forever, `serverModelSelectionUnavailable`/`serverModelSelectionReady` in `PiChatPanel.tsx` never cleared, `policy` stayed `undefined`, and the composer textarea was permanently disabled.
- `sessionAuthorityReady` now also becomes ready once discovery has genuinely run (`enabled && currentDiscoveryLoaded`) for a hydrated, non-new session with no stored model — not just for sessions with a stored model or brand-new sessions.
- The discovery-success handler's existing-session branch no longer blanks `localDefault` to `null` when the session has no model; it now resolves the server's `defaultModel` (or first available model) the same way a new session does — this is what actually gives such a session a model.
- `useChatModelSelection`'s "does not fall back to local storage for a non-new session whose model authority is unavailable" test still passes unmodified: with `enabled: false` (discovery never runs), authority correctly stays unready, so a stale local-storage default is never trusted for an existing session — only a server-vetted default is now trusted.
- PR #1319's behavior (composer shows the session's actual model when one is stored) is untouched: `sessionModel !== undefined` still short-circuits `sessionAuthorityReady` immediately.

## Root cause confirmation
- `packages/agent/src/front/hooks/useChatModelSelection.ts:183` (old): `sessionAuthorityReady = !sessionId || (sessionHydrated && (sessionModel !== undefined || sessionIsNew))` — permanently `false` for a hydrated, non-new session with no stored model.
- `packages/agent/src/front/chat/PiChatPanel.tsx:788`: `policy` is `undefined` unless `serverModelSelectionReady`, which requires `selectedModelAuthorizedByDiscovery`, which requires a non-null `selectedModel` — so `model` staying `null` forever cascades into `policy === undefined` forever, and `disabled = !policy || ...` is permanently `true`.

## Test proof
- New unit test `resolves the agent default model for a pre-seeded/directly-created session with no stored model (#1469)` in `packages/agent/src/front/hooks/__tests__/useChatModelSelection.test.tsx`, verified failing against pre-fix code (`expected null to deeply equal { provider: 'anthropic', ... }`) and passing after the fix.
- `packages/agent/src/front/hooks/__tests__/useChatModelSelection.test.tsx`: 13/13 pass.
- Full agent front suite: 64 files / 662 tests pass, 0 type errors (`pnpm exec vitest run src/front`).
- `pnpm run typecheck` (packages/agent): clean.

## e2e finding
- Booted `apps/workspace-playground` with `BORING_AGENT_E2E_SCRIPTED_PI=1 BORING_AGENT_MODE=direct ANTHROPIC_API_KEY=scripted-e2e-not-a-real-key` and ran `apps/workspace-playground/e2e/multi-agent-addressed-ui.spec.ts` directly. With the fix applied, the composer resolves a model and both the pre-seeded "alpha" session (created via direct `POST .../sessions`) and the "beta" session become interactive — prompts submit and `PI_NATIVE_ASSISTANT_DONE` renders for both, confirming the composer-disabled bug is fixed.
- The spec still times out (180s) at a *different*, pre-existing step: `page.getByRole('menuitem', { name: 'Open in new chat pane' })` never resolves, because `AppSessionActionsMenu.tsx`'s "Chat actions for …" menu has no such item (only Pin/Copy/Rename/Archive/Delete). That menu item appears to have been removed by the #1169 left-pane redesign (`eac1f8e02`, 2026-08-08) without updating this spec — unrelated to #1469, out of scope here.

## CI-coverage finding
- CI's `e2e` job runs `pnpm e2e` → `pnpm --filter @hachej/boring-agent run test:e2e` → `playwright test -c e2e/playwright.config.ts`, whose config is `testDir: '.'` / `testMatch: '*.spec.ts'` scoped to `packages/agent/e2e/`.
- `apps/workspace-playground/e2e/multi-agent-addressed-ui.spec.ts` is only matched by `apps/workspace-playground/playwright.config.ts` (`testMatch: apps/workspace-playground/e2e/**/*.spec.ts`), which is never invoked by any script CI actually runs (`apps/workspace-playground/package.json`'s own `test:e2e` isn't called from the root `e2e` script or any workflow step). The `changes` job's path filter watches `apps/workspace-playground/**` to *gate whether the e2e job runs at all*, but the job body still only executes `boring-agent`'s narrower suite — so this spec (and its stale "Open in new chat pane" assertion) has never actually run in CI, which is why the hang was never caught.

## Test plan
- [x] `pnpm exec vitest run src/front/hooks/__tests__/useChatModelSelection.test.tsx` (packages/agent) — repro test fails pre-fix, passes post-fix
- [x] `pnpm exec vitest run src/front` (packages/agent) — 662/662 pass
- [x] `pnpm run typecheck` (packages/agent) — clean
- [x] `apps/workspace-playground/e2e/multi-agent-addressed-ui.spec.ts` run directly — composer-disabled symptom confirmed fixed; times out later on an unrelated pre-existing stale-selector defect (documented above, not fixed by this PR)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MQgxe5KTr2N2pjgjgKPXHK