### PR TITLE
feat(sandbox): own bounded runsc sandbox roots

### DIFF
--- a/packages/boring-sandbox/src/providers/runsc/index.ts
+++ b/packages/boring-sandbox/src/providers/runsc/index.ts
@@ -128,11 +128,17 @@ export {
   FixedQuotaHelperCommandRunnerV1,
   assertHostReserveWritable,
   requiredHostReserveBytes,
+  validateCanonicalQuotaWorkspaceId,
   validateQuotaWorkspaceId,
   type QuotaHelperCommandResultV1,
   type QuotaHelperCommandRunnerV1,
   type QuotaHelperOperationV1,
 } from "./runtime/quota";
+export {
+  RunscSandboxRootLifecycleV1,
+  type RunscSandboxRootLifecycleOptionsV1,
+} from "./runtime/sandboxRootLifecycle";
+export type { CompositeRunscSessionRetirementV1 } from "./runtime/sessionRetirement";
 export {
   RunscSessionRuntimeV1,
   type CreateRunscSessionInputV1,

--- a/packages/boring-sandbox/src/providers/runsc/runtime/__tests__/quota.test.ts
+++ b/packages/boring-sandbox/src/providers/runsc/runtime/__tests__/quota.test.ts
@@ -7,17 +7,22 @@ import {
   FixedProjectQuotaManagerV1,
   assertHostReserveWritable,
   requiredHostReserveBytes,
+  validateCanonicalQuotaWorkspaceId,
 } from "../quota";
 
 const workspaceId = "00000000-0000-4000-8000-000000000001";
+const workspaceRoot = "/srv/boring/workspaces";
 
 describe("fixed project quota contract", () => {
-  test("passes only validated workspace id and the fixed profile to the helper", async () => {
+  test("passes only a canonical workspace id and the fixed profile to the helper", async () => {
     const run = vi.fn(async () => ({ exitCode: 0, timedOut: false }));
-    await new FixedProjectQuotaManagerV1({ run }).apply(workspaceId.toUpperCase());
+    await new FixedProjectQuotaManagerV1({ run }, workspaceRoot).apply(
+      workspaceId,
+    );
     expect(run).toHaveBeenCalledWith({
       argv: ["apply", workspaceId, RUNSC_WORKSPACE_QUOTA_PROFILE_V1.profileId],
       timeoutMs: 120_000,
+      workspaceRoot,
     });
   });
 
@@ -26,7 +31,7 @@ describe("fixed project quota contract", () => {
     async (untrusted) => {
       const run = vi.fn();
       await expect(
-        new FixedProjectQuotaManagerV1({ run }).apply(untrusted),
+        new FixedProjectQuotaManagerV1({ run }, workspaceRoot).apply(untrusted),
       ).rejects.toMatchObject({
         code: REMOTE_WORKER_ERROR_CODES_V1.requestInvalid,
       });
@@ -34,14 +39,32 @@ describe("fixed project quota contract", () => {
     },
   );
 
+  test("preserves legacy normalization and optional-root runner inputs", async () => {
+    const run = vi.fn(async () => ({ exitCode: 0, timedOut: false }));
+    const upper = `  ${workspaceId.toUpperCase()}  `;
+    await new FixedProjectQuotaManagerV1({ run }).apply(upper);
+    expect(run).toHaveBeenCalledWith({
+      argv: ["apply", workspaceId, RUNSC_WORKSPACE_QUOTA_PROFILE_V1.profileId],
+      timeoutMs: 120_000,
+    });
+    expect(() => validateCanonicalQuotaWorkspaceId(upper)).toThrowError(
+      expect.objectContaining({
+        code: REMOTE_WORKER_ERROR_CODES_V1.requestInvalid,
+      }),
+    );
+  });
+
   test("maps all quota exhaustion to one stable failure", async () => {
     await expect(
-      new FixedProjectQuotaManagerV1({
-        run: async () => ({
-          exitCode: RUNSC_QUOTA_HELPER_EXCEEDED_EXIT,
-          timedOut: false,
-        }),
-      }).check(workspaceId),
+      new FixedProjectQuotaManagerV1(
+        {
+          run: async () => ({
+            exitCode: RUNSC_QUOTA_HELPER_EXCEEDED_EXIT,
+            timedOut: false,
+          }),
+        },
+        workspaceRoot,
+      ).check(workspaceId),
     ).rejects.toMatchObject({
       code: REMOTE_WORKER_ERROR_CODES_V1.quotaExceeded,
     });

--- a/packages/boring-sandbox/src/providers/runsc/runtime/__tests__/sandboxRootLifecycle.test.ts
+++ b/packages/boring-sandbox/src/providers/runsc/runtime/__tests__/sandboxRootLifecycle.test.ts
@@ -1,0 +1,523 @@
+import {
+  chmod,
+  lstat,
+  mkdir,
+  readFile,
+  rename,
+  rm,
+  rmdir,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mkdtemp } from "node:fs/promises";
+
+import { describe, expect, test, vi } from "vitest";
+
+import { REMOTE_WORKER_ERROR_CODES_V1 } from "../../../../shared/remoteWorkerProtocolV1";
+import { RUNSC_RUNTIME_LIMITS_V1 } from "../limits";
+import {
+  FixedProjectQuotaManagerV1,
+  RUNSC_QUOTA_LOCK_NAME,
+} from "../quota";
+import { RunscSandboxRootLifecycleV1 } from "../sandboxRootLifecycle";
+
+const workspaceA = "00000000-0000-4000-8000-000000000001";
+const workspaceB = "00000000-0000-4000-8000-000000000002";
+const aliasWorkspace = "abcdef00-0000-4000-8000-000000000003";
+
+async function lifecycle() {
+  const parent = await mkdtemp(join(tmpdir(), "boring-runsc-roots-"));
+  const root = join(parent, "sandboxes");
+  await mkdir(root, { mode: 0o750 });
+  const quota = {
+    workspaceRoot: root,
+    apply: vi.fn(async () => undefined),
+    check: vi.fn(async () => undefined),
+  };
+  return {
+    root,
+    quota,
+    roots: new RunscSandboxRootLifecycleV1({
+      sandboxRoot: root,
+      prepareOwnership: async () => undefined,
+      trustedOwnerUid: process.getuid?.() ?? 0,
+    }),
+  };
+}
+
+describe("runsc per-sandbox root lifecycle", () => {
+  test("creates exact workspace+sandbox children and removes only one", async () => {
+    const { root, roots, quota } = await lifecycle();
+    const sourceA = await roots.prepare(workspaceA, "sandbox-a", quota);
+    const sourceB = await roots.prepare(workspaceA, "sandbox-b", quota);
+    await writeFile(join(String(sourceA), "state"), "a");
+    await writeFile(join(String(sourceB), "state"), "b");
+
+    await roots.dispose(sourceA);
+
+    await expect(lstat(String(sourceA))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(
+      readFile(join(String(sourceB), "state"), "utf8"),
+    ).resolves.toBe("b");
+    await expect(lstat(root)).resolves.toMatchObject({});
+  });
+
+  test("fails closed on aliased identities, existing leaves, and symlinked parents", async () => {
+    const { root, roots, quota } = await lifecycle();
+    await expect(
+      roots.prepare(aliasWorkspace.toUpperCase(), "sandbox-upper", quota),
+    ).rejects.toMatchObject({ code: "REMOTE_WORKER_REQUEST_INVALID" });
+    await expect(
+      roots.prepare(` ${workspaceA}`, "sandbox-spaced", quota),
+    ).rejects.toMatchObject({ code: "REMOTE_WORKER_REQUEST_INVALID" });
+    await roots.prepare(workspaceA, "sandbox-a", quota);
+    await expect(
+      roots.prepare(workspaceA, "sandbox-a", quota),
+    ).rejects.toMatchObject({
+      code: "REMOTE_WORKER_PATH_UNSAFE",
+    });
+    await expect(
+      lstat(join(root, workspaceA, "sandbox-a")),
+    ).resolves.toMatchObject({});
+
+    await symlink(join(root, workspaceA), join(root, workspaceB));
+    await expect(
+      roots.prepare(workspaceB, "sandbox-b", quota),
+    ).rejects.toMatchObject({
+      code: "REMOTE_WORKER_PATH_UNSAFE",
+    });
+  });
+
+  test.each(["retry", "close", "startup"] as const)(
+    "retains failed prepare cleanup authority until %s converges",
+    async (convergence) => {
+      const parent = await mkdtemp(join(tmpdir(), "boring-runsc-roots-"));
+      const root = join(parent, "sandboxes");
+      await mkdir(root, { mode: 0o750 });
+      let removeAttempts = 0;
+      const roots = new RunscSandboxRootLifecycleV1({
+        sandboxRoot: root,
+        prepareOwnership: async () => {
+          throw new Error("ownership failed");
+        },
+        removeSandboxRoot: async (path) => {
+          removeAttempts += 1;
+          if (removeAttempts === 1) throw new Error("injected remove failure");
+          await rm(path, { recursive: true, force: true });
+        },
+        trustedOwnerUid: process.getuid?.() ?? 0,
+      });
+      const quota = {
+        workspaceRoot: root,
+        apply: vi.fn(async () => undefined),
+        check: vi.fn(async () => undefined),
+      };
+      const sandboxRoot = join(root, workspaceA, "sandbox-a");
+
+      await expect(
+        roots.prepare(workspaceA, "sandbox-a", quota),
+      ).rejects.toMatchObject({
+        code: "REMOTE_WORKER_INCOMPLETE_CLEANUP",
+        message: "remote-worker sandbox root cleanup is incomplete",
+      });
+      await expect(lstat(sandboxRoot)).resolves.toMatchObject({});
+      expect(roots.pendingCleanupCount).toBe(1);
+
+      if (convergence === "retry") {
+        await expect(roots.retryPendingCleanup()).resolves.toBe(1);
+      } else if (convergence === "close") {
+        await expect(roots.close()).resolves.toBeUndefined();
+      } else {
+        await expect(roots.startupSweep()).resolves.toBe(1);
+      }
+      expect(removeAttempts).toBe(2);
+      expect(roots.pendingCleanupCount).toBe(0);
+      await expect(lstat(sandboxRoot)).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    },
+  );
+
+  test("retains pending authority through ambiguous parent cleanup then ENOENT retry", async () => {
+    const parent = await mkdtemp(join(tmpdir(), "boring-runsc-roots-"));
+    const root = join(parent, "sandboxes");
+    await mkdir(root, { mode: 0o750 });
+    let parentAttempts = 0;
+    const roots = new RunscSandboxRootLifecycleV1({
+      sandboxRoot: root,
+      prepareOwnership: async () => {
+        throw new Error("ownership failed");
+      },
+      removeWorkspaceRoot: async (path) => {
+        parentAttempts += 1;
+        await rmdir(path);
+        if (parentAttempts === 1) throw new Error("parent response lost");
+      },
+      trustedOwnerUid: process.getuid?.() ?? 0,
+    });
+    const quota = {
+      workspaceRoot: root,
+      apply: vi.fn(async () => undefined),
+      check: vi.fn(async () => undefined),
+    };
+    await expect(
+      roots.prepare(workspaceA, "sandbox-a", quota),
+    ).rejects.toMatchObject({
+      code: "REMOTE_WORKER_INCOMPLETE_CLEANUP",
+    });
+    expect(roots.pendingCleanupCount).toBe(1);
+    await expect(
+      lstat(join(root, workspaceA, "sandbox-a")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(roots.retryPendingCleanup()).resolves.toBe(1);
+    expect(roots.pendingCleanupCount).toBe(0);
+    expect(parentAttempts).toBe(1);
+  });
+
+  test("retains failed-prepare parent cleanup after a permission error", async () => {
+    const parent = await mkdtemp(join(tmpdir(), "boring-runsc-roots-"));
+    const root = join(parent, "sandboxes");
+    await mkdir(root, { mode: 0o750 });
+    let parentAttempts = 0;
+    const roots = new RunscSandboxRootLifecycleV1({
+      sandboxRoot: root,
+      prepareOwnership: async () => {
+        throw new Error("ownership failed");
+      },
+      removeWorkspaceRoot: async (path) => {
+        parentAttempts += 1;
+        if (parentAttempts === 1) {
+          throw Object.assign(new Error("permission uncertain"), {
+            code: "EACCES",
+          });
+        }
+        await rmdir(path);
+      },
+      trustedOwnerUid: process.getuid?.() ?? 0,
+    });
+    const quota = {
+      workspaceRoot: root,
+      apply: vi.fn(async () => undefined),
+      check: vi.fn(async () => undefined),
+    };
+
+    await expect(
+      roots.prepare(workspaceA, "sandbox-a", quota),
+    ).rejects.toMatchObject({
+      code: REMOTE_WORKER_ERROR_CODES_V1.incompleteCleanup,
+    });
+    expect(roots.pendingCleanupCount).toBe(1);
+    await expect(
+      lstat(join(root, workspaceA, "sandbox-a")),
+    ).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(lstat(join(root, workspaceA))).resolves.toMatchObject({});
+
+    await expect(roots.retryPendingCleanup()).resolves.toBe(1);
+    expect(parentAttempts).toBe(2);
+    expect(roots.pendingCleanupCount).toBe(0);
+    await expect(lstat(join(root, workspaceA))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  test("retries ambiguous parent removal after the leaf is already absent", async () => {
+    const parent = await mkdtemp(join(tmpdir(), "boring-runsc-roots-"));
+    const root = join(parent, "sandboxes");
+    await mkdir(root, { mode: 0o750 });
+    let parentAttempts = 0;
+    const roots = new RunscSandboxRootLifecycleV1({
+      sandboxRoot: root,
+      prepareOwnership: async () => undefined,
+      removeWorkspaceRoot: async (path) => {
+        parentAttempts += 1;
+        if (parentAttempts === 1) {
+          throw Object.assign(new Error("permission uncertain"), {
+            code: "EACCES",
+          });
+        }
+        await rmdir(path);
+      },
+      trustedOwnerUid: process.getuid?.() ?? 0,
+    });
+    const quota = {
+      workspaceRoot: root,
+      apply: vi.fn(async () => undefined),
+      check: vi.fn(async () => undefined),
+    };
+    const source = await roots.prepare(workspaceA, "sandbox-a", quota);
+
+    await expect(roots.dispose(source)).rejects.toMatchObject({
+      code: "REMOTE_WORKER_INCOMPLETE_CLEANUP",
+    });
+    await expect(lstat(String(source))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(lstat(join(root, workspaceA))).resolves.toMatchObject({});
+
+    await expect(roots.dispose(source)).resolves.toBeUndefined();
+    expect(parentAttempts).toBe(2);
+    await expect(lstat(join(root, workspaceA))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  test("converges when an owned parent is already absent", async () => {
+    const parent = await mkdtemp(join(tmpdir(), "boring-runsc-roots-"));
+    const root = join(parent, "sandboxes");
+    await mkdir(root, { mode: 0o750 });
+    const roots = new RunscSandboxRootLifecycleV1({
+      sandboxRoot: root,
+      prepareOwnership: async () => {
+        throw new Error("ownership failed");
+      },
+      removeWorkspaceRoot: async (path) => {
+        await rmdir(path);
+        throw Object.assign(new Error("already absent"), { code: "ENOENT" });
+      },
+      trustedOwnerUid: process.getuid?.() ?? 0,
+    });
+    const quota = {
+      workspaceRoot: root,
+      apply: vi.fn(async () => undefined),
+      check: vi.fn(async () => undefined),
+    };
+    await expect(
+      roots.prepare(workspaceA, "sandbox-a", quota),
+    ).rejects.toMatchObject({
+      code: "REMOTE_WORKER_PATH_UNSAFE",
+    });
+    await expect(roots.retryPendingCleanup()).resolves.toBe(0);
+    await expect(lstat(join(root, workspaceA))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  test("converges when retry observes ENOENT after an after-effect removal failure", async () => {
+    const parent = await mkdtemp(join(tmpdir(), "boring-runsc-roots-"));
+    const root = join(parent, "sandboxes");
+    await mkdir(root, { mode: 0o750 });
+    let removeAttempts = 0;
+    const roots = new RunscSandboxRootLifecycleV1({
+      sandboxRoot: root,
+      prepareOwnership: async () => undefined,
+      removeSandboxRoot: async (path) => {
+        removeAttempts += 1;
+        await rm(path, { recursive: true, force: true });
+        throw new Error("response lost after removal");
+      },
+      trustedOwnerUid: process.getuid?.() ?? 0,
+    });
+    const quota = {
+      workspaceRoot: root,
+      apply: vi.fn(async () => undefined),
+      check: vi.fn(async () => undefined),
+    };
+    const source = await roots.prepare(workspaceA, "sandbox-a", quota);
+    await expect(roots.dispose(source)).rejects.toMatchObject({
+      code: "REMOTE_WORKER_INCOMPLETE_CLEANUP",
+    });
+    await expect(roots.dispose(source)).resolves.toBeUndefined();
+    expect(removeAttempts).toBe(1);
+
+    const pendingRoots = new RunscSandboxRootLifecycleV1({
+      sandboxRoot: root,
+      prepareOwnership: async () => {
+        throw new Error("ownership failed");
+      },
+      removeSandboxRoot: async (path) => {
+        await rm(path, { recursive: true, force: true });
+        throw new Error("response lost after removal");
+      },
+      trustedOwnerUid: process.getuid?.() ?? 0,
+    });
+    await expect(
+      pendingRoots.prepare(workspaceB, "sandbox-b", quota),
+    ).rejects.toMatchObject({ code: "REMOTE_WORKER_INCOMPLETE_CLEANUP" });
+    await expect(pendingRoots.retryPendingCleanup()).resolves.toBe(1);
+  });
+
+  test("serializes retry and sweep behind an in-flight prepare", async () => {
+    const parent = await mkdtemp(join(tmpdir(), "boring-runsc-roots-"));
+    const root = join(parent, "sandboxes");
+    await mkdir(root, { mode: 0o750 });
+    let releaseOwnership: (() => void) | undefined;
+    const ownershipGate = new Promise<void>((resolve) => {
+      releaseOwnership = resolve;
+    });
+    const roots = new RunscSandboxRootLifecycleV1({
+      sandboxRoot: root,
+      prepareOwnership: async () => await ownershipGate,
+      trustedOwnerUid: process.getuid?.() ?? 0,
+    });
+    const quota = {
+      workspaceRoot: root,
+      apply: vi.fn(async () => undefined),
+      check: vi.fn(async () => undefined),
+    };
+
+    const preparing = roots.prepare(workspaceA, "sandbox-a", quota);
+    await vi.waitFor(async () =>
+      expect(lstat(join(root, workspaceA, "sandbox-a"))).resolves.toMatchObject(
+        {},
+      ),
+    );
+    let retrySettled = false;
+    const retry = roots.retryPendingCleanup().then((count) => {
+      retrySettled = true;
+      return count;
+    });
+    let sweepSettled = false;
+    const sweep = roots.startupSweep().then((count) => {
+      sweepSettled = true;
+      return count;
+    });
+    await Promise.resolve();
+    expect(retrySettled).toBe(false);
+    expect(sweepSettled).toBe(false);
+    await expect(lstat(join(root, workspaceA, "sandbox-a"))).resolves.toMatchObject(
+      {},
+    );
+
+    releaseOwnership?.();
+    const source = await preparing;
+    await expect(retry).resolves.toBe(0);
+    await expect(sweep).resolves.toBe(1);
+    await expect(lstat(String(source))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  test("excludes the fixed quota lock and admits exactly sweepable distinct roots", async () => {
+    const { root, roots, quota } = await lifecycle();
+    const lockPath = join(root, RUNSC_QUOTA_LOCK_NAME);
+    await writeFile(lockPath, "lock");
+    await chmod(lockPath, 0o600);
+    const rootCount = Math.floor(
+      RUNSC_RUNTIME_LIMITS_V1.maxStartupSweepContainers / 2,
+    );
+    for (let index = 1; index <= rootCount; index += 1) {
+      const suffix = index.toString(16).padStart(12, "0");
+      await roots.prepare(
+        `00000000-0000-4000-8000-${suffix}`,
+        `sandbox-${index}`,
+        quota,
+      );
+    }
+    expect(roots.ownedRecoveryEntryCount).toBe(
+      RUNSC_RUNTIME_LIMITS_V1.maxStartupSweepContainers,
+    );
+    await expect(
+      roots.prepare(workspaceA, "over-capacity", quota),
+    ).rejects.toMatchObject({
+      code: REMOTE_WORKER_ERROR_CODES_V1.pathUnsafe,
+    });
+
+    const restarted = new RunscSandboxRootLifecycleV1({
+      sandboxRoot: root,
+      prepareOwnership: async () => undefined,
+      trustedOwnerUid: process.getuid?.() ?? 0,
+    });
+    await expect(restarted.startupSweep()).resolves.toBe(rootCount);
+    await expect(lstat(lockPath)).resolves.toMatchObject({});
+  }, 30_000);
+
+  test("bounded startup sweep removes owned leaves beneath the dedicated root", async () => {
+    const { roots, quota } = await lifecycle();
+    const sourceA = await roots.prepare(workspaceA, "sandbox-a", quota);
+    const sourceB = await roots.prepare(workspaceB, "sandbox-b", quota);
+
+    await expect(roots.startupSweep()).resolves.toBe(2);
+    await expect(lstat(String(sourceA))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(lstat(String(sourceB))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  test("composes the fixed quota manager once before leaves and checks it on reuse/restart", async () => {
+    const { root, roots } = await lifecycle();
+    const run = vi.fn(
+      async (_input: {
+        readonly argv: readonly ["apply" | "check", string, string];
+        readonly timeoutMs: number;
+      }) => ({ exitCode: 0, timedOut: false }),
+    );
+    const quota = new FixedProjectQuotaManagerV1({ run }, root);
+    await roots.prepare(workspaceA, "sandbox-a", quota);
+    await roots.prepare(workspaceA, "sandbox-b", quota);
+    expect(run.mock.calls.map(([input]) => input.argv[0])).toEqual([
+      "apply",
+      "check",
+    ]);
+
+    const restarted = new RunscSandboxRootLifecycleV1({
+      sandboxRoot: root,
+      prepareOwnership: async () => undefined,
+      trustedOwnerUid: process.getuid?.() ?? 0,
+    });
+    await restarted.prepare(workspaceA, "sandbox-c", quota);
+    expect(run.mock.calls.map(([input]) => input.argv[0])).toEqual([
+      "apply",
+      "check",
+      "check",
+    ]);
+  });
+
+  test("removes a newly-created workspace parent when quota preparation fails", async () => {
+    const { root, roots } = await lifecycle();
+    const quota = {
+      workspaceRoot: root,
+      apply: vi.fn(async () => {
+        throw new Error("quota unavailable");
+      }),
+      check: vi.fn(async () => undefined),
+    };
+    await expect(roots.prepare(workspaceA, "sandbox-a", quota)).rejects.toThrow(
+      "quota unavailable",
+    );
+    await expect(lstat(join(root, workspaceA))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  test("bounds workspace parents as well as sandbox leaves during startup", async () => {
+    const { root, roots } = await lifecycle();
+    for (
+      let index = 1;
+      index <= RUNSC_RUNTIME_LIMITS_V1.maxStartupSweepContainers + 1;
+      index += 1
+    ) {
+      const suffix = index.toString(16).padStart(12, "0");
+      await mkdir(join(root, `00000000-0000-4000-8000-${suffix}`), {
+        mode: 0o750,
+      });
+    }
+    await expect(roots.startupSweep()).rejects.toMatchObject({
+      code: "REMOTE_WORKER_PATH_UNSAFE",
+    });
+  });
+
+  test("rejects a replaced trusted root and a symlink swapped before cleanup", async () => {
+    const { root, roots, quota } = await lifecycle();
+    const source = await roots.prepare(workspaceA, "sandbox-a", quota);
+    const outside = await mkdtemp(join(tmpdir(), "boring-runsc-outside-"));
+    await rm(String(source), { recursive: true });
+    await symlink(outside, String(source));
+    await expect(roots.dispose(source)).rejects.toMatchObject({
+      code: "REMOTE_WORKER_INCOMPLETE_CLEANUP",
+    });
+    await expect(lstat(outside)).resolves.toMatchObject({});
+
+    const moved = `${root}-moved`;
+    await rename(root, moved);
+    await mkdir(root, { mode: 0o750 });
+    await expect(
+      roots.prepare(workspaceB, "sandbox-b", quota),
+    ).rejects.toMatchObject({ code: "REMOTE_WORKER_PATH_UNSAFE" });
+  });
+});

--- a/packages/boring-sandbox/src/providers/runsc/runtime/__tests__/sandboxRootLifecycle.test.ts
+++ b/packages/boring-sandbox/src/providers/runsc/runtime/__tests__/sandboxRootLifecycle.test.ts
@@ -3,6 +3,7 @@ import {
   lstat,
   mkdir,
   readFile,
+  readdir,
   rename,
   rm,
   rmdir,
@@ -48,6 +49,31 @@ async function lifecycle() {
 }
 
 describe("runsc per-sandbox root lifecycle", () => {
+  test.each(["prepare", "startup"] as const)(
+    "sanitizes inaccessible-root filesystem failures at the %s boundary",
+    async (operation) => {
+      const { root, roots, quota } = await lifecycle();
+      await chmod(root, 0o000);
+      let failure: unknown;
+      try {
+        if (operation === "prepare") {
+          await roots.prepare(workspaceA, "sandbox-a", quota);
+        } else {
+          await roots.startupSweep();
+        }
+      } catch (error) {
+        failure = error;
+      } finally {
+        await chmod(root, 0o750);
+      }
+      expect(failure).toMatchObject({
+        code: REMOTE_WORKER_ERROR_CODES_V1.pathUnsafe,
+      });
+      expect(String(failure)).not.toContain(root);
+      expect(JSON.stringify(failure)).not.toContain(root);
+    },
+  );
+
   test("creates exact workspace+sandbox children and removes only one", async () => {
     const { root, roots, quota } = await lifecycle();
     const sourceA = await roots.prepare(workspaceA, "sandbox-a", quota);
@@ -460,11 +486,12 @@ describe("runsc per-sandbox root lifecycle", () => {
       prepareOwnership: async () => undefined,
       trustedOwnerUid: process.getuid?.() ?? 0,
     });
+    await restarted.startupSweep();
     await restarted.prepare(workspaceA, "sandbox-c", quota);
     expect(run.mock.calls.map(([input]) => input.argv[0])).toEqual([
       "apply",
       "check",
-      "check",
+      "apply",
     ]);
   });
 
@@ -477,15 +504,37 @@ describe("runsc per-sandbox root lifecycle", () => {
       }),
       check: vi.fn(async () => undefined),
     };
-    await expect(roots.prepare(workspaceA, "sandbox-a", quota)).rejects.toThrow(
-      "quota unavailable",
-    );
+    await expect(
+      roots.prepare(workspaceA, "sandbox-a", quota),
+    ).rejects.toMatchObject({
+      code: REMOTE_WORKER_ERROR_CODES_V1.pathUnsafe,
+      message: "remote-worker sandbox root could not be prepared",
+    });
     await expect(lstat(join(root, workspaceA))).rejects.toMatchObject({
       code: "ENOENT",
     });
   });
 
-  test("bounds workspace parents as well as sandbox leaves during startup", async () => {
+  test("requires startup cleanup before restart admission", async () => {
+    const { root, roots, quota } = await lifecycle();
+    const existing = await roots.prepare(workspaceA, "sandbox-a", quota);
+    const restarted = new RunscSandboxRootLifecycleV1({
+      sandboxRoot: root,
+      prepareOwnership: async () => undefined,
+      trustedOwnerUid: process.getuid?.() ?? 0,
+    });
+
+    await expect(
+      restarted.prepare(workspaceB, "sandbox-b", quota),
+    ).rejects.toMatchObject({ code: REMOTE_WORKER_ERROR_CODES_V1.pathUnsafe });
+    await expect(lstat(String(existing))).resolves.toMatchObject({});
+    await expect(restarted.startupSweep()).resolves.toBe(1);
+    await expect(
+      restarted.prepare(workspaceB, "sandbox-b", quota),
+    ).resolves.toEqual(expect.stringContaining("sandbox-b"));
+  });
+
+  test("streams bounded startup cleanup so repeated sweeps converge", async () => {
     const { root, roots } = await lifecycle();
     for (
       let index = 1;
@@ -498,9 +547,11 @@ describe("runsc per-sandbox root lifecycle", () => {
       });
     }
     await expect(roots.startupSweep()).rejects.toMatchObject({
-      code: "REMOTE_WORKER_PATH_UNSAFE",
+      code: REMOTE_WORKER_ERROR_CODES_V1.pathUnsafe,
     });
-  });
+    await expect(roots.startupSweep()).resolves.toBe(0);
+    await expect(readdir(root)).resolves.toEqual([]);
+  }, 30_000);
 
   test("rejects a replaced trusted root and a symlink swapped before cleanup", async () => {
     const { root, roots, quota } = await lifecycle();

--- a/packages/boring-sandbox/src/providers/runsc/runtime/__tests__/sessionRetirement.test.ts
+++ b/packages/boring-sandbox/src/providers/runsc/runtime/__tests__/sessionRetirement.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { REMOTE_WORKER_ERROR_CODES_V1 } from "../../../../shared/remoteWorkerProtocolV1";
+import { trustedWorkspaceMountSource } from "../dockerArgv";
+import type {
+  DockerCommandInput,
+  DockerCommandResult,
+  DockerCommandRunner,
+} from "../dockerRunner";
+import {
+  RunscSessionRetirementManagerV1,
+  type RetirableRunscSessionRecordV1,
+} from "../sessionRetirement";
+
+const workspaceId = "00000000-0000-4000-8000-000000000001";
+
+function result(
+  overrides: Partial<DockerCommandResult> = {},
+): DockerCommandResult {
+  return {
+    exitCode: 0,
+    stdout: new Uint8Array(),
+    stderr: new Uint8Array(),
+    timedOut: false,
+    truncated: false,
+    ...overrides,
+  };
+}
+
+type CompositeRecord = RetirableRunscSessionRecordV1 & {
+  readonly workspaceId: string;
+  readonly workspaceMountSource: ReturnType<typeof trustedWorkspaceMountSource>;
+  readonly ownsWorkspaceMountSource: true;
+};
+
+function record(): CompositeRecord {
+  return {
+    workspaceId,
+    sandboxId: "sandbox-a",
+    runtimeId: "a".repeat(32),
+    workspaceMountSource: trustedWorkspaceMountSource(
+      "/srv/boring/workspaces",
+      workspaceId,
+    ),
+    ownsWorkspaceMountSource: true,
+    timer: setTimeout(() => undefined, 60_000),
+  };
+}
+
+function manager(runner: DockerCommandRunner) {
+  const detach = vi.fn();
+  const disposeMountSource = vi.fn(async () => undefined);
+  return {
+    detach,
+    disposeMountSource,
+    retirement: new RunscSessionRetirementManagerV1({
+      runner,
+      detach,
+      disposeMountSource,
+    }),
+  };
+}
+
+describe("runsc session retirement", () => {
+  test.each([
+    ["timeout-after-effect", result({ timedOut: true, exitCode: -1 })],
+    ["already-absent", result({ exitCode: 1 })],
+  ] as const)(
+    "converges when Docker removal is %s and exact absence is proven",
+    async (_label, removal) => {
+      const runner = {
+        run: vi.fn(async (input: DockerCommandInput) =>
+          input.argv[0] === "rm" ? removal : result(),
+        ),
+      };
+      const { retirement, detach, disposeMountSource } = manager(runner);
+      const session = record();
+
+      await expect(
+        retirement.retire(session, "cleanup"),
+      ).resolves.toBeUndefined();
+      expect(disposeMountSource).toHaveBeenCalledTimes(1);
+      expect(detach).toHaveBeenCalledWith(session);
+    },
+  );
+
+  test("retains retirement ownership when the exact owned container remains", async () => {
+    const runner = {
+      run: vi.fn(async (input: DockerCommandInput) =>
+        input.argv[0] === "rm"
+          ? result({ exitCode: 1 })
+          : result({ stdout: new TextEncoder().encode("container-id\n") }),
+      ),
+    };
+    const { retirement, detach, disposeMountSource } = manager(runner);
+    const session = record();
+
+    await expect(retirement.retire(session, "cleanup")).rejects.toMatchObject({
+      code: REMOTE_WORKER_ERROR_CODES_V1.incompleteCleanup,
+    });
+    expect(disposeMountSource).not.toHaveBeenCalled();
+    expect(detach).not.toHaveBeenCalled();
+    clearTimeout(session.timer);
+  });
+});

--- a/packages/boring-sandbox/src/providers/runsc/runtime/__tests__/sessionRetirement.test.ts
+++ b/packages/boring-sandbox/src/providers/runsc/runtime/__tests__/sessionRetirement.test.ts
@@ -33,6 +33,14 @@ type CompositeRecord = RetirableRunscSessionRecordV1 & {
   readonly ownsWorkspaceMountSource: true;
 };
 
+function legacyRecord(): RetirableRunscSessionRecordV1 {
+  return {
+    sandboxId: "legacy-sandbox",
+    runtimeId: "b".repeat(32),
+    timer: setTimeout(() => undefined, 60_000),
+  };
+}
+
 function record(): CompositeRecord {
   return {
     workspaceId,
@@ -83,6 +91,35 @@ describe("runsc session retirement", () => {
       expect(detach).toHaveBeenCalledWith(session);
     },
   );
+
+  test("preserves legacy detach-before-notify without retrying callback failure", async () => {
+    vi.useFakeTimers();
+    try {
+      const runner = { run: vi.fn(async () => result()) };
+      const detach = vi.fn();
+      const raw = "unlink /srv/private/workspace: TOKEN=host-secret";
+      const onRetire = vi.fn(async () => {
+        throw new Error(raw);
+      });
+      const retirement = new RunscSessionRetirementManagerV1({
+        runner,
+        detach,
+        onRetire,
+      });
+      const session = legacyRecord();
+
+      await expect(retirement.retire(session, "cleanup")).rejects.toMatchObject({
+        code: REMOTE_WORKER_ERROR_CODES_V1.incompleteCleanup,
+      });
+      expect(detach).toHaveBeenCalledOnce();
+      expect(onRetire).toHaveBeenCalledOnce();
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(runner.run).toHaveBeenCalledOnce();
+      expect(onRetire).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 
   test("retains retirement ownership when the exact owned container remains", async () => {
     const runner = {

--- a/packages/boring-sandbox/src/providers/runsc/runtime/__tests__/sessionRuntime.retirement.test.ts
+++ b/packages/boring-sandbox/src/providers/runsc/runtime/__tests__/sessionRuntime.retirement.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { REMOTE_WORKER_ERROR_CODES_V1 } from "../../../../shared/remoteWorkerProtocolV1";
+import { trustedWorkspaceMountSource } from "../dockerArgv";
+import type {
+  DockerCommandInput,
+  DockerCommandResult,
+  DockerCommandRunner,
+} from "../dockerRunner";
+import { RunscSessionRuntimeV1 } from "../sessionRuntime";
+
+const workspaceId = "00000000-0000-4000-8000-000000000001";
+const image = `registry.example/boring-workload@sha256:${"b".repeat(64)}`;
+const createInput = {
+  sandboxId: "sandbox-a",
+  clientLeaseId: "lease-a",
+  workspaceId,
+  workspaceMountSource: trustedWorkspaceMountSource(
+    "/srv/boring/workspaces",
+    workspaceId,
+  ),
+  image,
+};
+
+function success(stdout = ""): DockerCommandResult {
+  return {
+    exitCode: 0,
+    stdout: new TextEncoder().encode(stdout),
+    stderr: new Uint8Array(),
+    timedOut: false,
+    truncated: false,
+  };
+}
+
+function fakeRunner(): DockerCommandRunner & {
+  run: ReturnType<typeof vi.fn>;
+} {
+  return {
+    run: vi.fn(async (input: DockerCommandInput) => {
+      if (input.argv[0] === "ps") return success("");
+      if (input.argv[0] !== "exec") return success("container-id\n");
+      if (input.argv.at(-1) === "workspace") {
+        return success(JSON.stringify({ openat2: true }));
+      }
+      return success();
+    }),
+  };
+}
+
+function runtime(
+  runner: DockerCommandRunner,
+  now: () => number,
+  onRetire: (value: { sandboxId: string; reason: string }) => void,
+): RunscSessionRuntimeV1 {
+  let id = 0;
+  return new RunscSessionRuntimeV1({
+    runner,
+    quota: { apply: vi.fn(), check: vi.fn() },
+    runtimeIdFactory: () => (++id).toString(16).padStart(32, "0"),
+    now,
+    onRetire,
+  });
+}
+
+describe("warm runsc session retirement", () => {
+  test("retains ownership and retries expiry removal after a transient failure", async () => {
+    vi.useFakeTimers();
+    let clock = 1_000;
+    const retire = vi.fn();
+    try {
+      const runner = fakeRunner();
+      const run = runner.run.getMockImplementation() as (
+        input: DockerCommandInput,
+      ) => Promise<DockerCommandResult>;
+      let removeAttempts = 0;
+      runner.run.mockImplementation(async (input) => {
+        if (input.argv[0] === "rm" && removeAttempts++ === 0) {
+          throw Object.assign(new Error("transient docker outage"), {
+            code: "ECONNREFUSED",
+          });
+        }
+        if (input.argv[0] === "ps" && removeAttempts === 1) {
+          return success("container-id\n");
+        }
+        return await run(input);
+      });
+      const sessions = runtime(runner, () => clock, retire);
+      await sessions.create({ ...createInput, idleTtlMs: 100 });
+      clock = 1_100;
+      await vi.advanceTimersByTimeAsync(100);
+
+      await expect(sessions.renew("sandbox-a", 100)).rejects.toMatchObject({
+        code: REMOTE_WORKER_ERROR_CODES_V1.sandboxDisposed,
+      });
+      expect(() =>
+        sessions.create({ ...createInput, idleTtlMs: 100 }),
+      ).toThrowError(
+        expect.objectContaining({
+          code: REMOTE_WORKER_ERROR_CODES_V1.incompleteCleanup,
+        }),
+      );
+      expect(removeAttempts).toBe(1);
+      expect(retire).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(100);
+      expect(removeAttempts).toBe(2);
+      expect(retire).toHaveBeenCalledTimes(1);
+      expect(retire).toHaveBeenCalledWith({
+        sandboxId: "sandbox-a",
+        reason: "idle",
+      });
+      await expect(sessions.renew("sandbox-a", 100)).rejects.toMatchObject({
+        code: REMOTE_WORKER_ERROR_CODES_V1.sandboxNotFound,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/boring-sandbox/src/providers/runsc/runtime/__tests__/sessionRuntime.test.ts
+++ b/packages/boring-sandbox/src/providers/runsc/runtime/__tests__/sessionRuntime.test.ts
@@ -313,6 +313,13 @@ describe("warm runsc session runtime", () => {
             };
           }
         }
+        if (
+          input.argv[0] === "ps" &&
+          removeAttempts >= 2 &&
+          removeAttempts <= 4
+        ) {
+          return success("container-id\n");
+        }
         return await run(input);
       });
       const sessions = runtime(runner);
@@ -695,6 +702,9 @@ describe("warm runsc session runtime", () => {
             code: "ECONNREFUSED",
           });
         }
+        if (input.argv[0] === "ps" && removeAttempts === 1) {
+          return success("container-id\n");
+        }
         return await run(input);
       });
       const sessions = runtime(runner, {
@@ -767,6 +777,9 @@ describe("warm runsc session runtime", () => {
               };
             }
           }
+          if (input.argv[0] === "ps" && removeAttempts === 1) {
+            return success("container-id\n");
+          }
           return await run(input);
         });
         const sessions = runtime(runner);
@@ -798,12 +811,18 @@ describe("warm runsc session runtime", () => {
         input: DockerCommandInput,
       ) => Promise<DockerCommandResult>;
       let removeAttempts = 0;
+      let failedRemovalPending = false;
       runner.run.mockImplementation(async (input) => {
         if (input.argv[0] === "rm") {
           removeAttempts += 1;
           if (removeAttempts === 1) {
+            failedRemovalPending = true;
             throw new Error("transient docker outage");
           }
+        }
+        if (input.argv[0] === "ps" && failedRemovalPending) {
+          failedRemovalPending = false;
+          return success("container-id\n");
         }
         return await run(input);
       });

--- a/packages/boring-sandbox/src/providers/runsc/runtime/__tests__/sessionRuntime.test.ts
+++ b/packages/boring-sandbox/src/providers/runsc/runtime/__tests__/sessionRuntime.test.ts
@@ -686,63 +686,6 @@ describe("warm runsc session runtime", () => {
     }
   });
 
-  test("retains ownership and retries expiry removal after a transient failure", async () => {
-    vi.useFakeTimers();
-    let clock = 1_000;
-    const retire = vi.fn();
-    try {
-      const runner = fakeRunner();
-      const run = runner.run.getMockImplementation() as (
-        input: DockerCommandInput,
-      ) => Promise<DockerCommandResult>;
-      let removeAttempts = 0;
-      runner.run.mockImplementation(async (input) => {
-        if (input.argv[0] === "rm" && removeAttempts++ === 0) {
-          throw Object.assign(new Error("transient docker outage"), {
-            code: "ECONNREFUSED",
-          });
-        }
-        if (input.argv[0] === "ps" && removeAttempts === 1) {
-          return success("container-id\n");
-        }
-        return await run(input);
-      });
-      const sessions = runtime(runner, {
-        now: () => clock,
-        onRetire: retire,
-      });
-      await sessions.create({ ...createInput, idleTtlMs: 100 });
-      clock = 1_100;
-      await vi.advanceTimersByTimeAsync(100);
-
-      await expect(sessions.renew("sandbox-a", 100)).rejects.toMatchObject({
-        code: REMOTE_WORKER_ERROR_CODES_V1.sandboxDisposed,
-      });
-      expect(() =>
-        sessions.create({ ...createInput, idleTtlMs: 100 }),
-      ).toThrowError(
-        expect.objectContaining({
-          code: REMOTE_WORKER_ERROR_CODES_V1.incompleteCleanup,
-        }),
-      );
-      expect(removeAttempts).toBe(1);
-      expect(retire).not.toHaveBeenCalled();
-
-      await vi.advanceTimersByTimeAsync(100);
-      expect(removeAttempts).toBe(2);
-      expect(retire).toHaveBeenCalledTimes(1);
-      expect(retire).toHaveBeenCalledWith({
-        sandboxId: "sandbox-a",
-        reason: "idle",
-      });
-      await expect(sessions.renew("sandbox-a", 100)).rejects.toMatchObject({
-        code: REMOTE_WORKER_ERROR_CODES_V1.sandboxNotFound,
-      });
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
   test.each(["nonzero", "throw"] as const)(
     "retains failed-create ownership when docker rm returns %s",
     async (failureMode) => {

--- a/packages/boring-sandbox/src/providers/runsc/runtime/dockerArgv.ts
+++ b/packages/boring-sandbox/src/providers/runsc/runtime/dockerArgv.ts
@@ -1,6 +1,7 @@
 import { REMOTE_WORKER_ERROR_CODES_V1 } from "../../../shared/remoteWorkerProtocolV1";
 
 import { runscRuntimeError } from "./errors";
+import { validateCanonicalQuotaWorkspaceId } from "./quota";
 
 export const RUNSC_RUNTIME_DOCKER_LABELS_V1 = Object.freeze({
   owner: "com.hachej.boring.runsc-runtime",
@@ -18,6 +19,7 @@ export type TrustedWorkspaceMountSource = string & {
 const runtimeIdPattern = /^[a-f0-9]{32}$/;
 const workspaceIdPattern =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const sandboxIdPattern = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
 const imageDigestPattern =
   /^(?:[a-z0-9.-]+(?::[0-9]{1,5})?\/)?[a-z0-9]+(?:[._-][a-z0-9]+)*(?:\/[a-z0-9]+(?:[._-][a-z0-9]+)*)*@sha256:[a-f0-9]{64}$/;
 
@@ -40,13 +42,28 @@ export function trustedWorkspaceMountSource(
     workspaceRoot.includes("\0") ||
     workspaceRoot.includes(",") ||
     /[\r\n]/.test(workspaceRoot) ||
-    workspaceRoot.split("/").some((component) => component === ".." || component === ".")
+    workspaceRoot
+      .split("/")
+      .some((component) => component === ".." || component === ".")
   ) {
     invalidDockerInput("workspace root");
   }
   if (!workspaceIdPattern.test(workspaceId)) invalidDockerInput("workspace id");
   const source = `${workspaceRoot}/${workspaceId.toLowerCase()}`;
   if (source.length > 4096) invalidDockerInput("workspace mount source");
+  return source as TrustedWorkspaceMountSource;
+}
+
+export function trustedSandboxMountSource(
+  sandboxRoot: string,
+  workspaceId: string,
+  sandboxId: string,
+): TrustedWorkspaceMountSource {
+  validateCanonicalQuotaWorkspaceId(workspaceId);
+  const workspaceSource = trustedWorkspaceMountSource(sandboxRoot, workspaceId);
+  if (!sandboxIdPattern.test(sandboxId)) invalidDockerInput("sandbox id");
+  const source = `${workspaceSource}/${sandboxId}`;
+  if (source.length > 4096) invalidDockerInput("sandbox mount source");
   return source as TrustedWorkspaceMountSource;
 }
 
@@ -66,7 +83,8 @@ export function buildDockerRunArgv(
   profile: DockerRunProfileV1,
 ): readonly string[] {
   const containerName = dockerContainerNameV1(profile.runtimeId);
-  if (!imageDigestPattern.test(profile.image)) invalidDockerInput("image digest");
+  if (!imageDigestPattern.test(profile.image))
+    invalidDockerInput("image digest");
   return Object.freeze([
     "run",
     "-d",
@@ -159,5 +177,20 @@ export function buildDockerOwnedContainerListArgv(): readonly string[] {
     "--quiet",
     "--filter",
     `label=${RUNSC_RUNTIME_DOCKER_LABELS_V1.owner}=true`,
+  ]);
+}
+
+export function buildDockerOwnedContainerLookupArgv(
+  runtimeId: string,
+): readonly string[] {
+  const containerName = dockerContainerNameV1(runtimeId);
+  return Object.freeze([
+    "ps",
+    "--all",
+    "--quiet",
+    "--filter",
+    `label=${RUNSC_RUNTIME_DOCKER_LABELS_V1.owner}=true`,
+    "--filter",
+    `name=^/${containerName}$`,
   ]);
 }

--- a/packages/boring-sandbox/src/providers/runsc/runtime/quota.ts
+++ b/packages/boring-sandbox/src/providers/runsc/runtime/quota.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { isAbsolute, resolve } from "node:path";
 
 import { REMOTE_WORKER_ERROR_CODES_V1 } from "../../../shared/remoteWorkerProtocolV1";
 
@@ -17,7 +18,12 @@ export const RUNSC_QUOTA_HELPER_EXCEEDED_EXIT = 73;
 
 const workspaceIdPattern =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const canonicalWorkspaceIdPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
+export const RUNSC_QUOTA_LOCK_NAME = ".boring-quota.lock" as const;
+
+/** Preserves the V1 quota helper's legacy trim-and-lowercase contract. */
 export function validateQuotaWorkspaceId(workspaceId: string): string {
   const normalized = workspaceId.trim().toLowerCase();
   if (!workspaceIdPattern.test(normalized)) {
@@ -27,6 +33,17 @@ export function validateQuotaWorkspaceId(workspaceId: string): string {
     );
   }
   return normalized;
+}
+
+/** Multi-root identities must already be canonical so aliases cannot select roots. */
+export function validateCanonicalQuotaWorkspaceId(workspaceId: string): string {
+  if (!canonicalWorkspaceIdPattern.test(workspaceId)) {
+    throw runscRuntimeError(
+      REMOTE_WORKER_ERROR_CODES_V1.requestInvalid,
+      "remote-worker workspace id is invalid",
+    );
+  }
+  return workspaceId;
 }
 
 export type QuotaHelperOperationV1 = "apply" | "check";
@@ -40,21 +57,24 @@ export interface QuotaHelperCommandRunnerV1 {
   run(input: {
     readonly argv: readonly [QuotaHelperOperationV1, string, string];
     readonly timeoutMs: number;
+    readonly workspaceRoot?: string;
   }): Promise<QuotaHelperCommandResultV1>;
 }
 
-export class FixedQuotaHelperCommandRunnerV1
-  implements QuotaHelperCommandRunnerV1
-{
+export class FixedQuotaHelperCommandRunnerV1 implements QuotaHelperCommandRunnerV1 {
   async run(input: {
     readonly argv: readonly [QuotaHelperOperationV1, string, string];
     readonly timeoutMs: number;
+    readonly workspaceRoot?: string;
   }): Promise<QuotaHelperCommandResultV1> {
     return await new Promise((resolve, reject) => {
       const child = spawn(RUNSC_QUOTA_HELPER_PATH, [...input.argv], {
         shell: false,
         stdio: "ignore",
         windowsHide: true,
+        ...(input.workspaceRoot
+          ? { env: { BORING_WORKSPACE_ROOT: input.workspaceRoot } }
+          : {}),
       });
       let timedOut = false;
       const timer = setTimeout(() => {
@@ -80,7 +100,26 @@ export class FixedQuotaHelperCommandRunnerV1
 }
 
 export class FixedProjectQuotaManagerV1 {
-  constructor(private readonly runner: QuotaHelperCommandRunnerV1) {}
+  readonly workspaceRoot?: string;
+
+  constructor(
+    private readonly runner: QuotaHelperCommandRunnerV1,
+    workspaceRoot?: string,
+  ) {
+    if (workspaceRoot === undefined) return;
+    const canonical = resolve(workspaceRoot);
+    if (
+      !isAbsolute(workspaceRoot) ||
+      canonical === "/" ||
+      canonical !== workspaceRoot
+    ) {
+      throw runscRuntimeError(
+        REMOTE_WORKER_ERROR_CODES_V1.configInvalid,
+        "remote-worker quota root is invalid",
+      );
+    }
+    this.workspaceRoot = canonical;
+  }
 
   async apply(workspaceId: string): Promise<void> {
     await this.invoke("apply", workspaceId);
@@ -98,6 +137,7 @@ export class FixedProjectQuotaManagerV1 {
     const result = await this.runner.run({
       argv: [operation, normalized, RUNSC_WORKSPACE_QUOTA_PROFILE_V1.profileId],
       timeoutMs: RUNSC_RUNTIME_LIMITS_V1.createTimeoutMs,
+      ...(this.workspaceRoot ? { workspaceRoot: this.workspaceRoot } : {}),
     });
     if (result.timedOut) {
       throw runscRuntimeError(

--- a/packages/boring-sandbox/src/providers/runsc/runtime/sandboxRootLifecycle.ts
+++ b/packages/boring-sandbox/src/providers/runsc/runtime/sandboxRootLifecycle.ts
@@ -1,0 +1,489 @@
+import {
+  chown,
+  lstat,
+  mkdir,
+  readdir,
+  realpath,
+  rm,
+  rmdir,
+} from "node:fs/promises";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { REMOTE_WORKER_ERROR_CODES_V1 } from "../../../shared/remoteWorkerProtocolV1";
+import {
+  trustedSandboxMountSource,
+  type TrustedWorkspaceMountSource,
+} from "./dockerArgv";
+import { runscRuntimeError } from "./errors";
+import { RUNSC_RUNTIME_LIMITS_V1 } from "./limits";
+import {
+  RUNSC_QUOTA_LOCK_NAME,
+  validateCanonicalQuotaWorkspaceId,
+  type FixedProjectQuotaManagerV1,
+} from "./quota";
+const sandboxIdPattern = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+type QuotaManager = Pick<
+  FixedProjectQuotaManagerV1,
+  "workspaceRoot" | "apply" | "check"
+>;
+type RootIdentity = Readonly<{ dev: bigint; ino: bigint }>;
+
+interface PendingRoot {
+  readonly workspace: string;
+  readonly workspaceRoot: string;
+  readonly sandboxRoot: string;
+  workspaceCreated: boolean;
+  created: boolean;
+  retainedForCleanup: boolean;
+}
+
+export interface RunscSandboxRootLifecycleOptionsV1 {
+  readonly sandboxRoot: string;
+  readonly trustedOwnerUid?: number;
+  readonly prepareOwnership?: (path: string) => void | Promise<void>;
+  readonly removeSandboxRoot?: (path: string) => void | Promise<void>;
+  readonly removeWorkspaceRoot?: (path: string) => void | Promise<void>;
+}
+
+function invalidRoot(message: string, cause?: unknown): never {
+  throw runscRuntimeError(
+    REMOTE_WORKER_ERROR_CODES_V1.pathUnsafe,
+    message,
+    cause,
+  );
+}
+
+function normalizedSandboxId(sandboxId: string): string {
+  if (!sandboxIdPattern.test(sandboxId)) {
+    invalidRoot("remote-worker sandbox id is invalid");
+  }
+  return sandboxId;
+}
+
+function errorCode(error: unknown, code: string): boolean {
+  return Boolean(
+    error &&
+    typeof error === "object" &&
+    "code" in error &&
+    error.code === code,
+  );
+}
+
+export class RunscSandboxRootLifecycleV1 {
+  readonly sandboxRoot: string;
+  private readonly trustedOwnerUid: number;
+  private trustedRootIdentity?: RootIdentity;
+  private readonly readyWorkspaces = new Set<string>();
+  private readonly workspaceInflight = new Map<string, Promise<void>>();
+  /** Every root this process owns: preparing, active, or retained for cleanup. */
+  private readonly pendingRoots = new Map<string, PendingRoot>();
+  private ownershipOperation: Promise<unknown> = Promise.resolve();
+  constructor(private readonly options: RunscSandboxRootLifecycleOptionsV1) {
+    const normalized = resolve(options.sandboxRoot);
+    if (
+      !isAbsolute(options.sandboxRoot) ||
+      normalized === "/" ||
+      normalized !== options.sandboxRoot ||
+      normalized.length > 3800
+    ) {
+      invalidRoot("remote-worker sandbox root is invalid");
+    }
+    this.sandboxRoot = normalized;
+    this.trustedOwnerUid = options.trustedOwnerUid ?? 0;
+    if (
+      !Number.isSafeInteger(this.trustedOwnerUid) ||
+      this.trustedOwnerUid < 0
+    ) {
+      invalidRoot("remote-worker sandbox root owner is invalid");
+    }
+  }
+
+  /** Roots retained solely for retryable cleanup after create admission ended. */
+  get pendingCleanupCount(): number {
+    let count = 0;
+    for (const pending of this.pendingRoots.values()) {
+      if (pending.retainedForCleanup) count += 1;
+    }
+    return count;
+  }
+
+  /** Exact leaf + distinct workspace-parent entries a restart must enumerate. */
+  get ownedRecoveryEntryCount(): number {
+    const workspaces = new Set<string>();
+    for (const pending of this.pendingRoots.values()) {
+      workspaces.add(pending.workspace);
+    }
+    return this.pendingRoots.size + workspaces.size;
+  }
+
+  prepare(
+    workspaceId: string,
+    sandboxId: string,
+    quota: QuotaManager,
+  ): Promise<TrustedWorkspaceMountSource> {
+    return this.withOwnershipLock(
+      async () => await this.prepareOnce(workspaceId, sandboxId, quota),
+    );
+  }
+
+  private async prepareOnce(
+    workspaceId: string,
+    sandboxId: string,
+    quota: QuotaManager,
+  ): Promise<TrustedWorkspaceMountSource> {
+    const workspace = validateCanonicalQuotaWorkspaceId(workspaceId);
+    const sandbox = normalizedSandboxId(sandboxId);
+    if (quota.workspaceRoot !== this.sandboxRoot) {
+      invalidRoot("remote-worker quota and sandbox roots do not match");
+    }
+    await this.assertTrustedRoot();
+    const workspaceRoot = join(this.sandboxRoot, workspace);
+    const sandboxRoot = join(workspaceRoot, sandbox);
+    const source = trustedSandboxMountSource(
+      this.sandboxRoot,
+      workspace,
+      sandbox,
+    );
+    const workspaceAlreadyOwned = [...this.pendingRoots.values()].some(
+      (pending) => pending.workspace === workspace,
+    );
+    const additionalRecoveryEntries = workspaceAlreadyOwned ? 1 : 2;
+    if (
+      this.pendingRoots.has(sandboxRoot) ||
+      this.ownedRecoveryEntryCount + additionalRecoveryEntries >
+        RUNSC_RUNTIME_LIMITS_V1.maxStartupSweepContainers
+    ) {
+      invalidRoot("remote-worker sandbox root cleanup capacity is exhausted");
+    }
+    const pending: PendingRoot = {
+      workspace,
+      workspaceRoot,
+      sandboxRoot,
+      workspaceCreated: false,
+      created: false,
+      retainedForCleanup: false,
+    };
+    this.pendingRoots.set(sandboxRoot, pending);
+    let workspaceReady = false;
+    try {
+      await this.ensureWorkspace(workspace, workspaceRoot, quota, pending);
+      workspaceReady = true;
+      await mkdir(sandboxRoot, { mode: 0o770 });
+      pending.created = true;
+      if (this.options.prepareOwnership)
+        await this.options.prepareOwnership(sandboxRoot);
+      else await chown(sandboxRoot, 65_532, 65_532);
+      await this.assertTrustedRoot();
+      await this.assertExactDirectory(workspaceRoot, true);
+      await this.assertExactDirectory(sandboxRoot, false);
+      return source;
+    } catch (error) {
+      if (!workspaceReady) {
+        if (!pending.workspaceCreated) {
+          this.pendingRoots.delete(sandboxRoot);
+        } else {
+          await this.cleanupFailedPrepare(pending);
+        }
+        throw error;
+      }
+      if (!pending.created) {
+        await this.cleanupFailedPrepare(pending);
+        invalidRoot("remote-worker sandbox root could not be prepared", error);
+      }
+      await this.cleanupFailedPrepare(pending);
+      invalidRoot("remote-worker sandbox root could not be prepared", error);
+    }
+  }
+  retryPendingCleanup(): Promise<number> {
+    return this.withOwnershipLock(async () => await this.retryPendingCleanupOnce());
+  }
+
+  private async retryPendingCleanupOnce(): Promise<number> {
+    let cleaned = 0;
+    let firstFailure: unknown;
+    for (const pending of [...this.pendingRoots.values()]) {
+      if (!pending.retainedForCleanup) continue;
+      try {
+        await this.cleanupPendingRoot(pending);
+        cleaned += 1;
+      } catch (error) {
+        firstFailure ??= error;
+      }
+    }
+    if (firstFailure) {
+      throw runscRuntimeError(
+        REMOTE_WORKER_ERROR_CODES_V1.incompleteCleanup,
+        "remote-worker sandbox root cleanup is incomplete",
+        firstFailure,
+      );
+    }
+    return cleaned;
+  }
+  async close(): Promise<void> {
+    await this.retryPendingCleanup();
+  }
+  dispose(source: TrustedWorkspaceMountSource): Promise<void> {
+    return this.withOwnershipLock(async () => await this.disposeOnce(source));
+  }
+
+  private async disposeOnce(source: TrustedWorkspaceMountSource): Promise<void> {
+    const sandboxRoot = this.assertOwnedSource(source);
+    const workspaceRoot = dirname(sandboxRoot);
+    const workspace = workspaceRoot.slice(this.sandboxRoot.length + 1);
+    const pending = this.pendingRoots.get(sandboxRoot) ?? {
+      workspace,
+      workspaceRoot,
+      sandboxRoot,
+      workspaceCreated: true,
+      created: true,
+      retainedForCleanup: true,
+    };
+    pending.retainedForCleanup = true;
+    this.pendingRoots.set(sandboxRoot, pending);
+    try {
+      await this.cleanupPendingRoot(pending);
+    } catch (error) {
+      throw runscRuntimeError(
+        REMOTE_WORKER_ERROR_CODES_V1.incompleteCleanup,
+        "remote-worker sandbox root cleanup is incomplete",
+        error,
+      );
+    }
+  }
+  startupSweep(): Promise<number> {
+    return this.withOwnershipLock(async () => await this.startupSweepOnce());
+  }
+
+  private async startupSweepOnce(): Promise<number> {
+    const retried = await this.retryPendingCleanupOnce();
+    await this.assertTrustedRoot();
+    const entries = await readdir(this.sandboxRoot, { withFileTypes: true });
+    let discovered = 0;
+    const roots: TrustedWorkspaceMountSource[] = [];
+    for (const workspace of entries) {
+      if (workspace.name === RUNSC_QUOTA_LOCK_NAME) {
+        await this.assertQuotaMetadata(join(this.sandboxRoot, workspace.name));
+        continue;
+      }
+      if (++discovered > RUNSC_RUNTIME_LIMITS_V1.maxStartupSweepContainers) {
+        invalidRoot("remote-worker startup root cleanup exceeds its bound");
+      }
+      if (workspace.isSymbolicLink() || !workspace.isDirectory()) {
+        invalidRoot("remote-worker sandbox root contains an unowned entry");
+      }
+      validateCanonicalQuotaWorkspaceId(workspace.name);
+      const workspaceRoot = join(this.sandboxRoot, workspace.name);
+      await this.assertExactDirectory(workspaceRoot, true);
+      const sandboxes = await readdir(workspaceRoot, { withFileTypes: true });
+      for (const sandbox of sandboxes) {
+        if (
+          ++discovered > RUNSC_RUNTIME_LIMITS_V1.maxStartupSweepContainers ||
+          sandbox.isSymbolicLink() ||
+          !sandbox.isDirectory()
+        ) {
+          invalidRoot("remote-worker startup root cleanup exceeds its bound");
+        }
+        normalizedSandboxId(sandbox.name);
+        roots.push(
+          trustedSandboxMountSource(
+            this.sandboxRoot,
+            workspace.name,
+            sandbox.name,
+          ),
+        );
+      }
+      if (sandboxes.length === 0) await rmdir(workspaceRoot);
+    }
+    for (const root of roots) await this.disposeOnce(root);
+    return retried + roots.length;
+  }
+  private async cleanupFailedPrepare(pending: PendingRoot): Promise<void> {
+    try {
+      await this.cleanupPendingRoot(pending);
+    } catch (cleanupError) {
+      pending.retainedForCleanup = true;
+      throw runscRuntimeError(
+        REMOTE_WORKER_ERROR_CODES_V1.incompleteCleanup,
+        "remote-worker sandbox root cleanup is incomplete",
+        cleanupError,
+      );
+    }
+  }
+
+  private async cleanupPendingRoot(pending: PendingRoot): Promise<void> {
+    await this.assertTrustedRoot();
+    try {
+      await this.assertExactDirectory(pending.workspaceRoot, true);
+    } catch (error) {
+      if (!errorCode(error, "ENOENT")) throw error;
+      this.readyWorkspaces.delete(pending.workspace);
+      this.pendingRoots.delete(pending.sandboxRoot);
+      return;
+    }
+    if (pending.created)
+      try {
+        await this.assertExactDirectory(pending.sandboxRoot, false);
+        await this.removeSandboxRoot(pending.sandboxRoot);
+      } catch (error) {
+        if (!errorCode(error, "ENOENT")) throw error;
+      }
+    await this.removeEmptyWorkspace(pending.workspace, pending.workspaceRoot);
+    this.pendingRoots.delete(pending.sandboxRoot);
+  }
+  private async removeSandboxRoot(path: string): Promise<void> {
+    if (this.options.removeSandboxRoot)
+      await this.options.removeSandboxRoot(path);
+    else await rm(path, { recursive: true, force: true });
+  }
+  private async ensureWorkspace(
+    workspace: string,
+    workspaceRoot: string,
+    quota: QuotaManager,
+    pending: PendingRoot,
+  ): Promise<void> {
+    const existing = this.workspaceInflight.get(workspace);
+    if (existing) {
+      await existing;
+      await quota.check(workspace);
+      return;
+    }
+    let created = false;
+    const operation = (async () => {
+      if (!this.readyWorkspaces.has(workspace)) {
+        try {
+          await mkdir(workspaceRoot, { mode: 0o750 });
+          created = true;
+          pending.workspaceCreated = true;
+        } catch (error) {
+          if (!errorCode(error, "EEXIST")) throw error;
+        }
+        await this.assertExactDirectory(workspaceRoot, true);
+        if (created) await quota.apply(workspace);
+        else await quota.check(workspace);
+        this.readyWorkspaces.add(workspace);
+      } else {
+        await this.assertExactDirectory(workspaceRoot, true);
+        await quota.check(workspace);
+      }
+    })();
+    this.workspaceInflight.set(workspace, operation);
+    try {
+      await operation;
+    } finally {
+      this.workspaceInflight.delete(workspace);
+    }
+  }
+  private async removeEmptyWorkspace(
+    workspace: string,
+    workspaceRoot: string,
+  ): Promise<void> {
+    try {
+      if (this.options.removeWorkspaceRoot)
+        await this.options.removeWorkspaceRoot(workspaceRoot);
+      else await rmdir(workspaceRoot);
+      this.readyWorkspaces.delete(workspace);
+    } catch (error) {
+      if (errorCode(error, "ENOENT")) this.readyWorkspaces.delete(workspace);
+      else if (!errorCode(error, "ENOTEMPTY") && !errorCode(error, "EEXIST"))
+        throw error;
+    }
+  }
+  private withOwnershipLock<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.ownershipOperation.then(operation, operation);
+    this.ownershipOperation = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+
+  private async assertTrustedRoot(): Promise<void> {
+    try {
+      const stat = await lstat(this.sandboxRoot, { bigint: true });
+      if (!stat.isDirectory() || stat.isSymbolicLink()) throw new Error("type");
+      if (
+        Number(stat.uid) !== this.trustedOwnerUid ||
+        (Number(stat.mode) & 0o022) !== 0
+      ) {
+        throw new Error("ownership");
+      }
+      if ((await realpath(this.sandboxRoot)) !== this.sandboxRoot)
+        throw new Error("canonical path");
+      const identity = { dev: stat.dev, ino: stat.ino };
+      if (
+        this.trustedRootIdentity &&
+        (this.trustedRootIdentity.dev !== identity.dev ||
+          this.trustedRootIdentity.ino !== identity.ino)
+      ) {
+        throw new Error("root replaced");
+      }
+      this.trustedRootIdentity ??= identity;
+      await this.assertTrustedAncestors();
+    } catch (error) {
+      invalidRoot(
+        "remote-worker sandbox root is not a trusted directory",
+        error,
+      );
+    }
+  }
+  private async assertTrustedAncestors(): Promise<void> {
+    let current = dirname(this.sandboxRoot);
+    while (true) {
+      const stat = await lstat(current);
+      const mode = stat.mode & 0o7777;
+      const stickyRoot = stat.uid === 0 && (mode & 0o1000) !== 0;
+      if (
+        !stat.isDirectory() ||
+        stat.isSymbolicLink() ||
+        (stat.uid !== 0 && stat.uid !== this.trustedOwnerUid) ||
+        ((mode & 0o022) !== 0 && !stickyRoot)
+      )
+        throw new Error("untrusted ancestor");
+      const parent = dirname(current);
+      if (parent === current) return;
+      current = parent;
+    }
+  }
+  private async assertQuotaMetadata(path: string): Promise<void> {
+    const stat = await lstat(path);
+    if (
+      !stat.isFile() ||
+      stat.isSymbolicLink() ||
+      stat.uid !== this.trustedOwnerUid ||
+      (stat.mode & 0o077) !== 0 ||
+      (await realpath(path)) !== path
+    ) {
+      invalidRoot("remote-worker quota metadata is not trusted");
+    }
+  }
+  private async assertExactDirectory(
+    path: string,
+    trustedOwner: boolean,
+  ): Promise<void> {
+    const stat = await lstat(path);
+    if (
+      !stat.isDirectory() ||
+      stat.isSymbolicLink() ||
+      (trustedOwner &&
+        (stat.uid !== this.trustedOwnerUid || (stat.mode & 0o022) !== 0))
+    ) {
+      invalidRoot("remote-worker sandbox path is not a trusted directory");
+    }
+    if ((await realpath(path)) !== path)
+      invalidRoot("remote-worker sandbox path escaped its trusted root");
+  }
+  private assertOwnedSource(source: TrustedWorkspaceMountSource): string {
+    const path = resolve(String(source));
+    const child = relative(this.sandboxRoot, path);
+    const parts = child.split("/");
+    if (
+      child.startsWith("..") ||
+      isAbsolute(child) ||
+      parts.length !== 2 ||
+      validateCanonicalQuotaWorkspaceId(parts[0] ?? "") !== parts[0] ||
+      normalizedSandboxId(parts[1] ?? "") !== parts[1]
+    ) {
+      invalidRoot("remote-worker sandbox mount is outside its trusted root");
+    }
+    return path;
+  }
+}

--- a/packages/boring-sandbox/src/providers/runsc/runtime/sandboxRootLifecycle.ts
+++ b/packages/boring-sandbox/src/providers/runsc/runtime/sandboxRootLifecycle.ts
@@ -2,12 +2,13 @@ import {
   chown,
   lstat,
   mkdir,
-  readdir,
+  opendir,
   realpath,
   rm,
   rmdir,
 } from "node:fs/promises";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { SandboxProviderError } from "../../../shared/providerV1";
 import { REMOTE_WORKER_ERROR_CODES_V1 } from "../../../shared/remoteWorkerProtocolV1";
 import {
   trustedSandboxMountSource,
@@ -73,7 +74,7 @@ export class RunscSandboxRootLifecycleV1 {
   private readonly trustedOwnerUid: number;
   private trustedRootIdentity?: RootIdentity;
   private readonly readyWorkspaces = new Set<string>();
-  private readonly workspaceInflight = new Map<string, Promise<void>>();
+  private startupReady = false;
   /** Every root this process owns: preparing, active, or retained for cleanup. */
   private readonly pendingRoots = new Map<string, PendingRoot>();
   private ownershipOperation: Promise<unknown> = Promise.resolve();
@@ -121,7 +122,12 @@ export class RunscSandboxRootLifecycleV1 {
     quota: QuotaManager,
   ): Promise<TrustedWorkspaceMountSource> {
     return this.withOwnershipLock(
-      async () => await this.prepareOnce(workspaceId, sandboxId, quota),
+      async () =>
+        await this.withStableError(
+          async () => await this.prepareOnce(workspaceId, sandboxId, quota),
+          REMOTE_WORKER_ERROR_CODES_V1.pathUnsafe,
+          "remote-worker sandbox root could not be prepared",
+        ),
     );
   }
 
@@ -136,6 +142,7 @@ export class RunscSandboxRootLifecycleV1 {
       invalidRoot("remote-worker quota and sandbox roots do not match");
     }
     await this.assertTrustedRoot();
+    await this.ensureStartupAdmission();
     const workspaceRoot = join(this.sandboxRoot, workspace);
     const sandboxRoot = join(workspaceRoot, sandbox);
     const source = trustedSandboxMountSource(
@@ -194,7 +201,14 @@ export class RunscSandboxRootLifecycleV1 {
     }
   }
   retryPendingCleanup(): Promise<number> {
-    return this.withOwnershipLock(async () => await this.retryPendingCleanupOnce());
+    return this.withOwnershipLock(
+      async () =>
+        await this.withStableError(
+          async () => await this.retryPendingCleanupOnce(),
+          REMOTE_WORKER_ERROR_CODES_V1.incompleteCleanup,
+          "remote-worker sandbox root cleanup is incomplete",
+        ),
+    );
   }
 
   private async retryPendingCleanupOnce(): Promise<number> {
@@ -222,7 +236,14 @@ export class RunscSandboxRootLifecycleV1 {
     await this.retryPendingCleanup();
   }
   dispose(source: TrustedWorkspaceMountSource): Promise<void> {
-    return this.withOwnershipLock(async () => await this.disposeOnce(source));
+    return this.withOwnershipLock(
+      async () =>
+        await this.withStableError(
+          async () => await this.disposeOnce(source),
+          REMOTE_WORKER_ERROR_CODES_V1.incompleteCleanup,
+          "remote-worker sandbox root cleanup is incomplete",
+        ),
+    );
   }
 
   private async disposeOnce(source: TrustedWorkspaceMountSource): Promise<void> {
@@ -250,16 +271,24 @@ export class RunscSandboxRootLifecycleV1 {
     }
   }
   startupSweep(): Promise<number> {
-    return this.withOwnershipLock(async () => await this.startupSweepOnce());
+    return this.withOwnershipLock(
+      async () =>
+        await this.withStableError(
+          async () => await this.startupSweepOnce(),
+          REMOTE_WORKER_ERROR_CODES_V1.pathUnsafe,
+          "remote-worker startup root cleanup failed",
+        ),
+    );
   }
 
   private async startupSweepOnce(): Promise<number> {
+    this.startupReady = false;
     const retried = await this.retryPendingCleanupOnce();
     await this.assertTrustedRoot();
-    const entries = await readdir(this.sandboxRoot, { withFileTypes: true });
     let discovered = 0;
-    const roots: TrustedWorkspaceMountSource[] = [];
-    for (const workspace of entries) {
+    let cleaned = 0;
+    const entries = await opendir(this.sandboxRoot);
+    for await (const workspace of entries) {
       if (workspace.name === RUNSC_QUOTA_LOCK_NAME) {
         await this.assertQuotaMetadata(join(this.sandboxRoot, workspace.name));
         continue;
@@ -273,14 +302,16 @@ export class RunscSandboxRootLifecycleV1 {
       validateCanonicalQuotaWorkspaceId(workspace.name);
       const workspaceRoot = join(this.sandboxRoot, workspace.name);
       await this.assertExactDirectory(workspaceRoot, true);
-      const sandboxes = await readdir(workspaceRoot, { withFileTypes: true });
-      for (const sandbox of sandboxes) {
-        if (
-          ++discovered > RUNSC_RUNTIME_LIMITS_V1.maxStartupSweepContainers ||
-          sandbox.isSymbolicLink() ||
-          !sandbox.isDirectory()
-        ) {
-          invalidRoot("remote-worker startup root cleanup exceeds its bound");
+      const roots: TrustedWorkspaceMountSource[] = [];
+      let overflow = false;
+      const sandboxes = await opendir(workspaceRoot);
+      for await (const sandbox of sandboxes) {
+        if (++discovered > RUNSC_RUNTIME_LIMITS_V1.maxStartupSweepContainers) {
+          overflow = true;
+          break;
+        }
+        if (sandbox.isSymbolicLink() || !sandbox.isDirectory()) {
+          invalidRoot("remote-worker sandbox root contains an unowned entry");
         }
         normalizedSandboxId(sandbox.name);
         roots.push(
@@ -291,10 +322,17 @@ export class RunscSandboxRootLifecycleV1 {
           ),
         );
       }
-      if (sandboxes.length === 0) await rmdir(workspaceRoot);
+      for (const root of roots) {
+        await this.disposeOnce(root);
+        cleaned += 1;
+      }
+      if (roots.length === 0) await rmdir(workspaceRoot);
+      if (overflow) {
+        invalidRoot("remote-worker startup root cleanup exceeds its bound");
+      }
     }
-    for (const root of roots) await this.disposeOnce(root);
-    return retried + roots.length;
+    this.startupReady = true;
+    return retried + cleaned;
   }
   private async cleanupFailedPrepare(pending: PendingRoot): Promise<void> {
     try {
@@ -340,37 +378,23 @@ export class RunscSandboxRootLifecycleV1 {
     quota: QuotaManager,
     pending: PendingRoot,
   ): Promise<void> {
-    const existing = this.workspaceInflight.get(workspace);
-    if (existing) {
-      await existing;
-      await quota.check(workspace);
+    if (!this.readyWorkspaces.has(workspace)) {
+      let created = false;
+      try {
+        await mkdir(workspaceRoot, { mode: 0o750 });
+        created = true;
+        pending.workspaceCreated = true;
+      } catch (error) {
+        if (!errorCode(error, "EEXIST")) throw error;
+      }
+      await this.assertExactDirectory(workspaceRoot, true);
+      if (created) await quota.apply(workspace);
+      else await quota.check(workspace);
+      this.readyWorkspaces.add(workspace);
       return;
     }
-    let created = false;
-    const operation = (async () => {
-      if (!this.readyWorkspaces.has(workspace)) {
-        try {
-          await mkdir(workspaceRoot, { mode: 0o750 });
-          created = true;
-          pending.workspaceCreated = true;
-        } catch (error) {
-          if (!errorCode(error, "EEXIST")) throw error;
-        }
-        await this.assertExactDirectory(workspaceRoot, true);
-        if (created) await quota.apply(workspace);
-        else await quota.check(workspace);
-        this.readyWorkspaces.add(workspace);
-      } else {
-        await this.assertExactDirectory(workspaceRoot, true);
-        await quota.check(workspace);
-      }
-    })();
-    this.workspaceInflight.set(workspace, operation);
-    try {
-      await operation;
-    } finally {
-      this.workspaceInflight.delete(workspace);
-    }
+    await this.assertExactDirectory(workspaceRoot, true);
+    await quota.check(workspace);
   }
   private async removeEmptyWorkspace(
     workspace: string,
@@ -387,6 +411,19 @@ export class RunscSandboxRootLifecycleV1 {
         throw error;
     }
   }
+  private async ensureStartupAdmission(): Promise<void> {
+    if (this.startupReady) return;
+    const entries = await opendir(this.sandboxRoot);
+    for await (const entry of entries) {
+      if (entry.name === RUNSC_QUOTA_LOCK_NAME) {
+        await this.assertQuotaMetadata(join(this.sandboxRoot, entry.name));
+        continue;
+      }
+      invalidRoot("remote-worker startup root cleanup is required");
+    }
+    this.startupReady = true;
+  }
+
   private withOwnershipLock<T>(operation: () => Promise<T>): Promise<T> {
     const result = this.ownershipOperation.then(operation, operation);
     this.ownershipOperation = result.then(
@@ -394,6 +431,19 @@ export class RunscSandboxRootLifecycleV1 {
       () => undefined,
     );
     return result;
+  }
+
+  private async withStableError<T>(
+    operation: () => Promise<T>,
+    code: Parameters<typeof runscRuntimeError>[0],
+    message: string,
+  ): Promise<T> {
+    try {
+      return await operation();
+    } catch (error) {
+      if (error instanceof SandboxProviderError) throw error;
+      throw runscRuntimeError(code, message, error);
+    }
   }
 
   private async assertTrustedRoot(): Promise<void> {

--- a/packages/boring-sandbox/src/providers/runsc/runtime/sessionRetirement.ts
+++ b/packages/boring-sandbox/src/providers/runsc/runtime/sessionRetirement.ts
@@ -1,22 +1,26 @@
 import { REMOTE_WORKER_ERROR_CODES_V1 } from "../../../shared/remoteWorkerProtocolV1";
-
-import { buildDockerRemoveArgv } from "./dockerArgv";
+import {
+  buildDockerOwnedContainerLookupArgv,
+  buildDockerRemoveArgv,
+  type TrustedWorkspaceMountSource,
+} from "./dockerArgv";
 import type { DockerCommandRunner } from "./dockerRunner";
 import { runDockerChecked } from "./dockerRunner";
 import { runscRuntimeError } from "./errors";
 import { RUNSC_RUNTIME_LIMITS_V1 } from "./limits";
-
 const RETIREMENT_RETRY_BASE_MS = 100;
 const RETIREMENT_RETRY_MAX_MS = 5_000;
-
 export type RunscSessionRetirementReasonV1 =
   "idle" | "hard-expiry" | "missing" | "cleanup" | "history" | "shutdown";
-
+/** Legacy V1 callback payload. */
 export interface RunscSessionRetirementV1 {
   readonly sandboxId: string;
   readonly reason: RunscSessionRetirementReasonV1;
 }
-
+export interface CompositeRunscSessionRetirementV1 extends RunscSessionRetirementV1 {
+  readonly workspaceId: string;
+}
+/** Legacy V1 retirement record. */
 export interface RetirableRunscSessionRecordV1 {
   readonly sandboxId: string;
   readonly runtimeId: string;
@@ -27,27 +31,37 @@ export interface RetirableRunscSessionRecordV1 {
     attempts: number;
   };
 }
-
+interface CompositeFieldsV1 {
+  readonly workspaceId: string;
+  readonly workspaceMountSource: TrustedWorkspaceMountSource;
+  readonly ownsWorkspaceMountSource: boolean;
+}
+interface CleanupStateV1 {
+  containerRemoved: boolean;
+  rootRemoved: boolean;
+}
 export interface RunscSessionRetirementManagerOptionsV1<
   RecordV1 extends RetirableRunscSessionRecordV1,
 > {
   readonly runner: DockerCommandRunner;
   readonly detach: (record: RecordV1) => void;
-  readonly onRetire?: (
-    retirement: RunscSessionRetirementV1,
+  readonly onRetire?: (value: RunscSessionRetirementV1) => void | Promise<void>;
+  readonly onCompositeRetire?: (
+    value: CompositeRunscSessionRetirementV1,
+  ) => void | Promise<void>;
+  readonly disposeMountSource?: (
+    source: TrustedWorkspaceMountSource,
   ) => void | Promise<void>;
 }
-
 export class RunscSessionRetirementManagerV1<
   RecordV1 extends RetirableRunscSessionRecordV1,
 > {
   private readonly cleanupInflight = new Map<RecordV1, Promise<void>>();
+  private readonly cleanupState = new WeakMap<RecordV1, CleanupStateV1>();
   private readonly notificationInflight = new Map<string, Promise<void>>();
-
   constructor(
     private readonly options: RunscSessionRetirementManagerOptionsV1<RecordV1>,
   ) {}
-
   async retire(
     record: RecordV1,
     reason: RunscSessionRetirementReasonV1,
@@ -57,53 +71,128 @@ export class RunscSessionRetirementManagerV1<
     if (existing) return await existing;
     clearTimeout(record.timer);
     record.retirement ??= { reason, notify, attempts: 0 };
-    const retirement = this.removeAndDetach(record);
-    this.cleanupInflight.set(record, retirement);
+    const operation = this.removeAndDetach(record);
+    this.cleanupInflight.set(record, operation);
     try {
-      await retirement;
+      await operation;
     } finally {
       this.cleanupInflight.delete(record);
     }
   }
-
   async notifyMissing(sandboxId: string): Promise<void> {
-    const existing = this.notificationInflight.get(sandboxId);
+    await this.notifyMissingWithKey(`legacy\u0000${sandboxId}`, {
+      sandboxId,
+      reason: "missing",
+    });
+  }
+  async notifyMissingComposite(
+    workspaceId: string,
+    sandboxId: string,
+  ): Promise<void> {
+    await this.notifyMissingWithKey(`${workspaceId}\u0000${sandboxId}`, {
+      workspaceId,
+      sandboxId,
+      reason: "missing",
+    });
+  }
+  private async notifyMissingWithKey(
+    key: string,
+    value: RunscSessionRetirementV1 | CompositeRunscSessionRetirementV1,
+  ): Promise<void> {
+    const existing = this.notificationInflight.get(key);
     if (existing) return await existing;
-    const retirement = this.notify({ sandboxId, reason: "missing" });
-    this.notificationInflight.set(sandboxId, retirement);
+    const operation = this.notify(value);
+    this.notificationInflight.set(key, operation);
     try {
-      await retirement;
+      await operation;
     } finally {
-      this.notificationInflight.delete(sandboxId);
+      this.notificationInflight.delete(key);
     }
   }
-
   private async removeAndDetach(record: RecordV1): Promise<void> {
+    const composite = this.compositeFields(record);
+    const state = this.cleanupState.get(record) ?? {
+      containerRemoved: false,
+      rootRemoved: !composite?.ownsWorkspaceMountSource,
+    };
+    this.cleanupState.set(record, state);
     try {
-      await runDockerChecked(this.options.runner, {
-        argv: buildDockerRemoveArgv(record.runtimeId),
-        timeoutMs: RUNSC_RUNTIME_LIMITS_V1.disposeTimeoutMs,
-        maxOutputBytes: 64 * 1024,
-      });
+      if (!state.containerRemoved) {
+        await this.removeContainerOrProveAbsent(record.runtimeId);
+        state.containerRemoved = true;
+      }
+      if (!state.rootRemoved) {
+        if (!composite || !this.options.disposeMountSource) {
+          throw runscRuntimeError(
+            REMOTE_WORKER_ERROR_CODES_V1.configInvalid,
+            "remote-worker sandbox root disposal is unavailable",
+          );
+        }
+        await this.options.disposeMountSource(composite.workspaceMountSource);
+        state.rootRemoved = true;
+      }
+      if (record.retirement!.notify) {
+        await this.notify(
+          composite?.ownsWorkspaceMountSource
+            ? {
+                workspaceId: composite.workspaceId,
+                sandboxId: record.sandboxId,
+                reason: record.retirement!.reason,
+              }
+            : {
+                sandboxId: record.sandboxId,
+                reason: record.retirement!.reason,
+              },
+        );
+      }
     } catch (error) {
       record.retirement!.attempts += 1;
       this.scheduleRetry(record);
+      if (
+        error &&
+        typeof error === "object" &&
+        "code" in error &&
+        error.code === REMOTE_WORKER_ERROR_CODES_V1.incompleteCleanup
+      )
+        throw error;
       throw runscRuntimeError(
         REMOTE_WORKER_ERROR_CODES_V1.incompleteCleanup,
         "remote-worker sandbox cleanup is incomplete",
         error,
       );
     }
-    const retirement = record.retirement;
     this.options.detach(record);
-    if (retirement?.notify) {
-      await this.notify({
-        sandboxId: record.sandboxId,
-        reason: retirement.reason,
-      });
-    }
+    this.cleanupState.delete(record);
   }
-
+  private compositeFields(record: RecordV1): CompositeFieldsV1 | undefined {
+    const candidate = record as RecordV1 & Partial<CompositeFieldsV1>;
+    return candidate.ownsWorkspaceMountSource === undefined
+      ? undefined
+      : (candidate as RecordV1 & CompositeFieldsV1);
+  }
+  private async removeContainerOrProveAbsent(runtimeId: string): Promise<void> {
+    try {
+      const removed = await this.options.runner.run({
+        argv: buildDockerRemoveArgv(runtimeId),
+        timeoutMs: RUNSC_RUNTIME_LIMITS_V1.disposeTimeoutMs,
+        maxOutputBytes: 64 * 1024,
+      });
+      if (!removed.timedOut && !removed.aborted && removed.exitCode === 0)
+        return;
+    } catch {
+      // A process failure may occur after Docker accepted removal.
+    }
+    const lookup = await runDockerChecked(this.options.runner, {
+      argv: buildDockerOwnedContainerLookupArgv(runtimeId),
+      timeoutMs: RUNSC_RUNTIME_LIMITS_V1.disposeTimeoutMs,
+      maxOutputBytes: 64 * 1024,
+    });
+    if (new TextDecoder().decode(lookup.stdout).trim() === "") return;
+    throw runscRuntimeError(
+      REMOTE_WORKER_ERROR_CODES_V1.incompleteCleanup,
+      "remote-worker owned container removal is incomplete",
+    );
+  }
   private scheduleRetry(record: RecordV1): void {
     if (!record.retirement) return;
     const exponent = Math.max(0, record.retirement.attempts - 1);
@@ -120,10 +209,13 @@ export class RunscSessionRetirementManagerV1<
       ).catch(() => undefined);
     }, delayMs);
   }
-
-  private async notify(retirement: RunscSessionRetirementV1): Promise<void> {
+  private async notify(
+    retirement: RunscSessionRetirementV1 | CompositeRunscSessionRetirementV1,
+  ): Promise<void> {
     try {
-      await this.options.onRetire?.(retirement);
+      if ("workspaceId" in retirement)
+        await this.options.onCompositeRetire?.(retirement);
+      else await this.options.onRetire?.(retirement);
     } catch (error) {
       throw runscRuntimeError(
         REMOTE_WORKER_ERROR_CODES_V1.incompleteCleanup,

--- a/packages/boring-sandbox/src/providers/runsc/runtime/sessionRetirement.ts
+++ b/packages/boring-sandbox/src/providers/runsc/runtime/sessionRetirement.ts
@@ -111,11 +111,13 @@ export class RunscSessionRetirementManagerV1<
   }
   private async removeAndDetach(record: RecordV1): Promise<void> {
     const composite = this.compositeFields(record);
+    const ownsRoot = composite?.ownsWorkspaceMountSource === true;
     const state = this.cleanupState.get(record) ?? {
       containerRemoved: false,
-      rootRemoved: !composite?.ownsWorkspaceMountSource,
+      rootRemoved: !ownsRoot,
     };
     this.cleanupState.set(record, state);
+    let legacyDetached = false;
     try {
       if (!state.containerRemoved) {
         await this.removeContainerOrProveAbsent(record.runtimeId);
@@ -131,11 +133,16 @@ export class RunscSessionRetirementManagerV1<
         await this.options.disposeMountSource(composite.workspaceMountSource);
         state.rootRemoved = true;
       }
+      if (!ownsRoot) {
+        this.options.detach(record);
+        this.cleanupState.delete(record);
+        legacyDetached = true;
+      }
       if (record.retirement!.notify) {
         await this.notify(
-          composite?.ownsWorkspaceMountSource
+          ownsRoot
             ? {
-                workspaceId: composite.workspaceId,
+                workspaceId: composite!.workspaceId,
                 sandboxId: record.sandboxId,
                 reason: record.retirement!.reason,
               }
@@ -146,6 +153,7 @@ export class RunscSessionRetirementManagerV1<
         );
       }
     } catch (error) {
+      if (legacyDetached) throw error;
       record.retirement!.attempts += 1;
       this.scheduleRetry(record);
       if (
@@ -161,8 +169,10 @@ export class RunscSessionRetirementManagerV1<
         error,
       );
     }
-    this.options.detach(record);
-    this.cleanupState.delete(record);
+    if (ownsRoot) {
+      this.options.detach(record);
+      this.cleanupState.delete(record);
+    }
   }
   private compositeFields(record: RecordV1): CompositeFieldsV1 | undefined {
     const candidate = record as RecordV1 & Partial<CompositeFieldsV1>;


### PR DESCRIPTION
Part of #1459.

## Summary

- gives each runsc sandbox an isolated, canonical root
- owns root creation, retirement, recovery, and quota accounting
- fails closed on aliasing, incomplete cleanup, and bounded recovery exhaustion
- preserves the legacy/default runtime path

## Stack

- #1446 accepted external-effect provenance
- #1441 native sandbox leases and explicit targeting
- **this PR: A0 root/quota/retirement lifecycle**
- A1 multi-session runtime
- A2a authenticated handler
- A2b provider qualification/cleanup
- PR B all-provider disposable leases

## Validation

- affected boring-sandbox tests, typecheck, invariants, and build passed
- root lifecycle, retirement, quota, recovery, and runtime regression suites passed
- independent thermonuclear review: **SHIP**

## Limits

This does not advertise remote-worker multi-root qualification. Production admission remains fail-closed until the later authenticated capability and qualification slices land.
