### PR TITLE
feat(sandbox): add disposable leases across providers

### DIFF
--- a/packages/agent/docs/KNOWN_LIMITATIONS.md
+++ b/packages/agent/docs/KNOWN_LIMITATIONS.md
@@ -1,10 +1,12 @@
 # Known Limitations
 
-## Abandoned Vercel sandboxes (xzr)
+## Persistent Vercel runtime abandonment (xzr)
 
-`@hachej/boring-agent` v1 intentionally does **not** implement a session-close release hook.
-If a process crashes or a client disappears before cleanup, the sandbox may remain
-alive until Vercel timeout/TTL.
+This limitation applies to the legacy persistent primary-runtime path. Native
+disposable leases do implement owner/session cleanup, TTL reaping, host-shutdown
+drain, pair-owned deletion, and retryable reconciliation. A process crash before
+an unpublished cleanup task becomes durable can still leave a remote until its
+provider timeout; cross-host durable cleanup remains deferred.
 
 ### Failure modes that can orphan a sandbox
 
@@ -33,8 +35,8 @@ volume but become expensive if idle lifetimes grow.
 - Set Vercel spend/budget alerts on the team account (monthly threshold chosen
   by owner; start low and tighten with observed traffic).
 - Use `[sandbox]` logs for daily create/stop drift checks.
-  - Create log: `"[sandbox] created"` with `workspaceId`, `sandboxId`,
-    `estimatedAbandonedSessionCostUsd`.
+  - Create log: `"[sandbox] created"` with redacted/keyed correlation fields and
+    `estimatedAbandonedSessionCostUsd`; raw workspace/sandbox identifiers are forbidden.
   - Stop log (orphan guard): `"[sandbox] stopped"` with
     `reason: "orphan-guard-idle"`.
 - Compare create vs stop counts in logs:
@@ -53,7 +55,7 @@ vercel sandbox stop <sandbox-id> --team <team-id>
 
 ### Trigger to build full mitigation
 
-Implement release-on-close lifecycle when either trigger is hit:
+Implement persistent-primary release-on-close lifecycle when either trigger is hit:
 
 1. First user reports unexpected Vercel bill attributable to orphaned sandboxes.
 2. Monitoring shows `> 10` apparently abandoned sandboxes at peak.
@@ -64,7 +66,9 @@ Implement release-on-close lifecycle when either trigger is hit:
 2. Backend idle timer (`~10 min`) that calls `sandbox.stop()` when no traffic.
 3. Explicit CLI/server flag for forced idle-stop policy.
 
-v1 status: **accepted risk**, documented and monitored.
+Persistent-primary status: **accepted risk**, documented and monitored. Native
+disposable leases use the stronger lifecycle documented in
+[SANDBOX_LEASE_TOOL.md](./SANDBOX_LEASE_TOOL.md).
 
 ## GitHub Connect + `/api/v1/git/*` deferred to v1.x (nfx)
 

--- a/packages/agent/docs/SANDBOX_LEASE_TOOL.md
+++ b/packages/agent/docs/SANDBOX_LEASE_TOOL.md
@@ -21,43 +21,23 @@ use several leases concurrently.
 
 ## Host authority
 
-The embedding host constructs one shared `SandboxLeaseService` for an authorized
-profile and passes it only after Agent authorization. Multi-provider hosts use a
-versioned `SandboxLeaseProviderProfileV1`; its canonical digest binds workspace
+The embedding host supplies a trusted provider factory in a versioned
+`SandboxLeaseProviderProfileV1`; AgentHost's lifecycle registry invokes it once
+per authorized digest and owns the resulting service/provider/timer. The
+canonical digest binds workspace
 scope, placement, physical provider workspace, lease root, provider/template
 fingerprints, credential-version references, TTL, drain policy, and quotas.
 Live clients and secret bytes are excluded from that identity. Scope and digest
 validation run before environment, provider, or harness acquisition.
 
-For simple Vercel-only composition:
-
-```ts
-const provider = createVercelSandboxProvider({
-  lifecycle: 'disposable',
-  immutableCacheSource: hostResolvedCacheSource,
-})
-const leases = new SandboxLeaseService({
-  provider,
-  workspaceRoot: '/host/verification-sandboxes',
-  serviceDigest: hostPolicyDigest,
-  ttlMs: 10 * 60_000,
-  reapIntervalMs: 30_000,
-  drainTimeoutMs: 30_000,
-  maxActiveLeasesPerOwner: 3,
-  maxActiveLeasesTotal: 12,
-})
-
-return {
-  ...runtimeScope,
-  sandboxTools: { digest: hostPolicyDigest, leases },
-}
-```
-
-Multi-provider hosts should call `SandboxLeaseServiceFactoryRegistry.getOrCreate`
-with the canonical profile digest and construct through
-`createSandboxLeaseServiceFromProfileV1`. Concurrent bindings then share one
-service/provider/timer; failed construction is retryable, while a conflicting
-preconstructed service is rejected without disposing either candidate.
+Hosts return `sandboxTools: { digest, profile }`; they do not preconstruct a
+service for the profile path. `profile.providerFactory` must return a
+factory-registered disposable provider whose immutable `providerConfigDigest`
+matches the profile identity. Concurrent bindings are canonicalized by
+`SandboxLeaseServiceRegistry.getOrCreate`; the same provider object cannot be
+owned by two service digests, disposed entries are evicted, and failed
+construction remains retryable. The legacy `{ digest, leases }` form remains
+only for the already-reviewed Vercel-only #1441 composition path.
 
 The model cannot supply provider, snapshot, image, repository, environment,
 credentials, resources, network policy, TTL, quotas, host paths, or owner ID.
@@ -142,6 +122,21 @@ outcome-unknown external-effect receipt. Host shutdown clears the timer and
 awaits bounded service disposal. Creation rechecks cancellation and closure
 after provider creation and health checks; failed unpublished-pair compensation
 is retained as cleanup-pending maintenance.
+
+## Review dispositions and current proof
+
+The model schema is deliberately one strict flat object (`op`, optional
+`sandbox`, `additionalProperties:false`); runtime parsing remains the authority
+for per-operation combinations. Tests cover every valid/invalid combination and
+the OpenAI-compatible strict declaration shape. Health-check throws drain and
+reconcile; session deletion settles before owner cleanup.
+
+Bounded follow-ups are explicit rather than silently implemented: canonical
+delegate thrown-error projection, measured per-operation health cadence,
+accepted-work tool-call identity hardening, and multi-author Send-now
+provenance. Live provider status is recorded in
+`@hachej/boring-sandbox/providers/README.md`; mock proof is never called live
+qualification.
 
 ## Current boundaries
 

--- a/packages/agent/docs/SANDBOX_LEASE_TOOL.md
+++ b/packages/agent/docs/SANDBOX_LEASE_TOOL.md
@@ -22,7 +22,14 @@ use several leases concurrently.
 ## Host authority
 
 The embedding host constructs one shared `SandboxLeaseService` for an authorized
-profile and passes it only after Agent authorization:
+profile and passes it only after Agent authorization. Multi-provider hosts use a
+versioned `SandboxLeaseProviderProfileV1`; its canonical digest binds workspace
+scope, placement, physical provider workspace, lease root, provider/template
+fingerprints, credential-version references, TTL, drain policy, and quotas.
+Live clients and secret bytes are excluded from that identity. Scope and digest
+validation run before environment, provider, or harness acquisition.
+
+For simple Vercel-only composition:
 
 ```ts
 const provider = createVercelSandboxProvider({
@@ -88,6 +95,22 @@ own safely retryable error; provider cleanup ambiguity remains
 owner cleanup. Host shutdown uses one service-wide drain deadline, including
 pending creations and provider close.
 
+Lease composition rejects a normal `SandboxProviderV1`; providers must expose
+the explicit `boring-sandbox.disposable-provider.v1` refinement. Supported
+mechanical profiles are:
+
+| provider | disposable behavior |
+| --- | --- |
+| direct | fresh exact child root; pair removes only that root |
+| bwrap/local | fresh exact child root mounted at `/workspace`; pair removes only that root |
+| Blaxel | fresh strict create, no Volume or handle store, correlated delete |
+| Vercel Sandbox | fresh named fork, no resumable handle, correlated delete |
+| remote-worker | requires qualified `multi-sandbox-roots-v1`; pair alone owns published delete |
+
+Default construction remains persistent/unchanged. Direct and bwrap are not
+hostile multi-tenant boundaries; managed and remote-worker profiles still
+require separate D31 host qualification before a Worker grant.
+
 Disposable Vercel forks never enter the persistent/resumable handle store. The
 provider returns a cleanup-capable pair immediately after remote creation and
 exposes initialization through pair readiness; if setup fails, lease acquisition
@@ -103,7 +126,9 @@ key: sha256(serviceDigest + ":" + opaqueLease)
 ```
 
 The service-owned unref'ed timer reaps expired and cleanup-pending leases without
-overlapping ticks. Every attempt is routed through the closed internal
+overlapping ticks. Session deletion settles before idempotent owner cleanup;
+a cleanup failure cannot rewrite a completed deletion receipt and remains
+retryable through the lease reaper. Every attempt is routed through the closed internal
 registration and emits redacted append-only reconciliation telemetry containing
 the registration-key digest, attempt count, reason, outcome, and stable failure
 code. Retrying this qualified idempotent cleanup never rewrites an

--- a/packages/agent/docs/SANDBOX_LEASE_TOOL.md
+++ b/packages/agent/docs/SANDBOX_LEASE_TOOL.md
@@ -53,6 +53,12 @@ return {
 }
 ```
 
+Multi-provider hosts should call `SandboxLeaseServiceFactoryRegistry.getOrCreate`
+with the canonical profile digest and construct through
+`createSandboxLeaseServiceFromProfileV1`. Concurrent bindings then share one
+service/provider/timer; failed construction is retryable, while a conflicting
+preconstructed service is rejected without disposing either candidate.
+
 The model cannot supply provider, snapshot, image, repository, environment,
 credentials, resources, network policy, TTL, quotas, host paths, or owner ID.
 Ownership is derived by the host from workspace scope, Agent type, and exact

--- a/packages/agent/docs/SANDBOX_LEASE_TOOL.md
+++ b/packages/agent/docs/SANDBOX_LEASE_TOOL.md
@@ -24,10 +24,12 @@ use several leases concurrently.
 The embedding host supplies a trusted provider factory in a versioned
 `SandboxLeaseProviderProfileV1`; AgentHost's lifecycle registry invokes it once
 per authorized digest and owns the resulting service/provider/timer. The
-canonical digest binds workspace
-scope, placement, physical provider workspace, lease root, provider/template
-fingerprints, credential-version references, TTL, drain policy, and quotas.
-Live clients and secret bytes are excluded from that identity. Scope and digest
+canonical digest binds workspace scope, placement, physical provider workspace,
+lease root, provider-attested behavior configuration, credential-version
+references, TTL, drain policy, and quotas. Generic caller-supplied template
+paths or fingerprints are rejected; immutable snapshots/images/templates must
+be bound by the provider configuration digest. Live clients and secret bytes
+are excluded from that identity. Scope and digest
 validation run before environment, provider, or harness acquisition.
 
 Hosts return `sandboxTools: { digest, profile }`; they do not preconstruct a

--- a/packages/agent/src/server/agent-host/__tests__/createAgentHost.test.ts
+++ b/packages/agent/src/server/agent-host/__tests__/createAgentHost.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import Fastify from 'fastify'
-import type { SandboxProviderV1, WorkspaceSandboxPairV1 } from '@hachej/boring-sandbox/shared'
+import type { WorkspaceSandboxPairV1 } from '@hachej/boring-sandbox/shared'
 import { AgentGatewayError, AgentGatewayErrorCode, type AuthorizedAgentScope } from '../../../shared/index'
 import { ErrorCode } from '../../../shared/error-codes'
 import type { AgentHarnessFactory } from '../../../shared/harness'
@@ -12,6 +12,12 @@ import { createTestRuntimeModeAdapter } from '@agent-test-host'
 import { getEnv, restoreEnvForTest, setEnvForTest } from '../../config/env'
 import { createScriptedPiHarness } from '../../testing/scriptedPiHarness'
 import { SandboxLeaseService } from '../../sandbox/leases/sandboxLease'
+import { fakeDisposableProvider } from '../../sandbox/leases/__tests__/fakeDisposableProvider'
+import {
+  SANDBOX_LEASE_PROVIDER_PROFILE_VERSION_V1,
+  sandboxLeaseProviderProfileDigestV1,
+  type SandboxLeaseProviderProfileV1,
+} from '../../sandbox/leases/sandboxLeaseProfileIdentity'
 import { sandboxReservedToolNames } from '../../tools/sandboxTargeting'
 import { InMemorySessionChangesTracker } from '../../http/sessionChangesTracker'
 import type { RuntimeFilesystemBinding } from '../../runtime/mode'
@@ -701,6 +707,47 @@ describe('createAgentHost', () => {
     await created.host.close()
   })
 
+  it('constructs a profile-only sandbox service once through the host lifecycle registry', async () => {
+    const sessionRoot = await root()
+    const providerClose = vi.fn(async () => {})
+    const providerFactory = vi.fn(() => fakeDisposableProvider({
+      create: async () => { throw new Error('not used') },
+      close: providerClose,
+    }))
+    const identity = {
+      contractVersion: SANDBOX_LEASE_PROVIDER_PROFILE_VERSION_V1,
+      workspaceScopeId: scope.workspaceScopeId,
+      placementIdentity: 'local-qualified',
+      providerWorkspaceId: 'provider-workspace-a',
+      leaseRoot: join(sessionRoot, 'sandbox-leases'),
+      providerId: 'direct' as const,
+      providerConfigDigest: `sha256:${'a'.repeat(64)}` as const,
+      credentialVersionRefs: [],
+      ttlMs: 60_000,
+      reapIntervalMs: 60_000,
+      drainTimeoutMs: 100,
+      maxActiveLeasesPerOwner: 2,
+      maxActiveLeasesTotal: 4,
+    }
+    const profile: SandboxLeaseProviderProfileV1 = { identity, providerFactory }
+    const digest = sandboxLeaseProviderProfileDigestV1(identity)
+    const created = await createAgentHost({
+      ...options(sessionRoot),
+      resolveAuthorizedAgentRuntimeScope: vi.fn(async () => ({
+        identity: 'runtime-profile-only',
+        physicalBindingIdentity: 'runtime-profile-only',
+        resourceInputDigest: 'runtime-profile-only',
+        sessionNamespace: 'profile-only',
+        sandboxTools: { digest, profile },
+      })),
+    })
+    await created.gateway.createSession({ scope, agentTypeId: 'alpha', requestId: 'profile-only-a' })
+    await created.gateway.createSession({ scope, agentTypeId: 'alpha', requestId: 'profile-only-b' })
+    expect(providerFactory).toHaveBeenCalledOnce()
+    await created.host.close()
+    expect(providerClose).toHaveBeenCalledOnce()
+  })
+
   it('retries fail-once sandbox deletion during host shutdown until it settles', async () => {
     const sessionRoot = await root()
     const remoteDispose = vi.fn()
@@ -708,11 +755,11 @@ describe('createAgentHost', () => {
       .mockResolvedValue(undefined)
     const leases = new SandboxLeaseService({
       workspaceRoot: sessionRoot,
-      provider: {
+      provider: fakeDisposableProvider({
         async create() {
           return { dispose: remoteDispose } as unknown as WorkspaceSandboxPairV1
         },
-      } as unknown as SandboxProviderV1,
+      }),
       serviceDigest: 'host-shutdown-retry',
       ttlMs: 60_000,
       reapIntervalMs: 60_000,
@@ -752,7 +799,7 @@ describe('createAgentHost', () => {
     })
     const leases = new SandboxLeaseService({
       workspaceRoot: sessionRoot,
-      provider: { create: createSandbox } as unknown as SandboxProviderV1,
+      provider: fakeDisposableProvider({ create: createSandbox }),
       serviceDigest: 'catalog-authority',
       ttlMs: 60_000,
       reapIntervalMs: 60_000,

--- a/packages/agent/src/server/agent-host/__tests__/effectAdmission.test.ts
+++ b/packages/agent/src/server/agent-host/__tests__/effectAdmission.test.ts
@@ -98,6 +98,26 @@ describe('Embedded Agent Gateway strong effect admission', () => {
     }, ref.sessionId))
   })
 
+  it('keeps completed session deletion settled when lease cleanup fails', async () => {
+    const fixture = await createEmbeddedGatewayFixture()
+    const releaseOwner = vi.fn(async () => { throw new Error('cleanup unavailable') })
+    fixture.setSandboxTools('alpha', { releaseOwner } as unknown as SandboxLeaseService)
+    const scope = fixture.issueScope()
+    const ref = await fixture.gateway.createSession({
+      scope,
+      agentTypeId: 'alpha',
+      requestId: 'create-with-failing-cleanup',
+    })
+
+    await expect(fixture.gateway.deleteSession({
+      scope, ref, requestId: 'delete-with-failing-cleanup',
+    })).resolves.toBeUndefined()
+    await expect(fixture.gateway.readSessionState({ scope, ref })).rejects.toMatchObject({
+      code: AgentGatewayErrorCode.AGENT_SESSION_NOT_FOUND,
+    })
+    expect(releaseOwner).toHaveBeenCalledOnce()
+  })
+
   it('executes archive through inventory with replay and digest-conflict semantics', async () => {
     const { fixture, scope, ref } = await createSession()
     const input = { scope, ref, requestId: 'archive-once', archived: true }

--- a/packages/agent/src/server/agent-host/buildAgentComposition.ts
+++ b/packages/agent/src/server/agent-host/buildAgentComposition.ts
@@ -233,13 +233,16 @@ export async function buildAgentComposition(
     ...(runtimeScope.includeUploadTools ? buildUploadAgentTools(bashRuntimeBundle) : []),
   ]
   const sandboxCapability = runtimeScope.sandboxTools
+  if (sandboxCapability && !sandboxCapability.leases) {
+    throw new TypeError('sandbox provider profile was not resolved by the host registry')
+  }
   const extraTools = runtimeScope.extraTools ?? []
   // Defense in depth: Host binding resolution runs this pure preflight before
   // acquiring resources, and the assembly funnel reasserts the same policy.
   assertSandboxToolCatalogAuthority(runtimeScope)
   const standardTools = sandboxCapability
     ? addSandboxTargeting(primaryStandardTools, {
-        leases: sandboxCapability.leases,
+        leases: sandboxCapability.leases!,
         workspaceScopeId: input.workspaceScopeId,
         agentTypeId: input.agent.agentTypeId,
         includeFilesystemTools: runtimeScope.includeFilesystemTools !== false,
@@ -251,7 +254,7 @@ export async function buildAgentComposition(
     ...(sandboxCapability
       ? [createSandboxManagementTool({
           runtime: input.hostRuntime,
-          leases: sandboxCapability.leases,
+          leases: sandboxCapability.leases!,
           workspaceScopeId: input.workspaceScopeId,
           agentTypeId: input.agent.agentTypeId,
         })]

--- a/packages/agent/src/server/agent-host/createAgentHost.ts
+++ b/packages/agent/src/server/agent-host/createAgentHost.ts
@@ -490,9 +490,22 @@ function createRuntime(
           resolved.sandboxTools.profile,
           claim.workspaceScopeId,
         )
-        if (sandboxLeaseProviderProfileDigestV1(profile.identity) !== resolved.sandboxTools.digest) {
+        const digest = sandboxLeaseProviderProfileDigestV1(profile.identity)
+        if (digest !== resolved.sandboxTools.digest) {
           throw new TypeError('sandbox lease profile digest does not match capability')
         }
+        resolved.sandboxTools.leases.assertProfileBinding({
+          digest,
+          provider: profile.provider,
+          workspaceRoot: profile.identity.leaseRoot,
+          providerWorkspaceId: profile.identity.providerWorkspaceId,
+          templatePath: profile.templatePath,
+          ttlMs: profile.identity.ttlMs,
+          reapIntervalMs: profile.identity.reapIntervalMs,
+          drainTimeoutMs: profile.identity.drainTimeoutMs,
+          maxActiveLeasesPerOwner: profile.identity.maxActiveLeasesPerOwner,
+          maxActiveLeasesTotal: profile.identity.maxActiveLeasesTotal,
+        })
       }
       if (resolved.sandboxTools) sandboxLeaseServices.register(resolved.sandboxTools)
       const key = JSON.stringify([

--- a/packages/agent/src/server/agent-host/createAgentHost.ts
+++ b/packages/agent/src/server/agent-host/createAgentHost.ts
@@ -15,10 +15,7 @@ import { EnvironmentLeaseManager, type EnvironmentLease } from './environmentLea
 import { getOptionalRuntimeBundleStorageRoot } from '../runtime/mode'
 import { mergeRuntimeFilesystemBindings } from '../runtime/filesystemBindings'
 import { SandboxLeaseServiceRegistry } from '../sandbox/leases/sandboxLeaseServiceRegistry'
-import {
-  normalizeSandboxLeaseProviderProfileV1,
-  sandboxLeaseProviderProfileDigestV1,
-} from '../sandbox/leases/sandboxLeaseProfileIdentity'
+import { resolveSandboxToolCapability } from '../sandbox/leases/resolveSandboxToolCapability'
 import { assertSandboxToolCatalogAuthority } from '../tools/sandboxTargeting'
 import { createAgentHostRoutes } from './httpProjection'
 import { InMemoryAgentRequestLedger } from './requestLedger'
@@ -476,7 +473,7 @@ function createRuntime(
       await assertAgentAccess(agentTypeId, scope, claim, 'runtime.bind')
       const agent = compiledById.get(agentTypeId)
       if (!agent) throw new AgentGatewayError(AgentGatewayErrorCode.AGENT_TYPE_UNKNOWN, 'agent type is not available')
-      const resolved = resolvedRuntimeScope ?? await runtime.resolveAgentRuntimeScope(
+      let resolved = resolvedRuntimeScope ?? await runtime.resolveAgentRuntimeScope(
         agentTypeId,
         scope,
         claim,
@@ -485,29 +482,16 @@ function createRuntime(
       )
       validateResolvedRuntimeScope(resolved)
       assertSandboxToolCatalogAuthority(resolved)
-      if (resolved.sandboxTools?.profile) {
-        const profile = normalizeSandboxLeaseProviderProfileV1(
-          resolved.sandboxTools.profile,
-          claim.workspaceScopeId,
-        )
-        const digest = sandboxLeaseProviderProfileDigestV1(profile.identity)
-        if (digest !== resolved.sandboxTools.digest) {
-          throw new TypeError('sandbox lease profile digest does not match capability')
-        }
-        resolved.sandboxTools.leases.assertProfileBinding({
-          digest,
-          provider: profile.provider,
-          workspaceRoot: profile.identity.leaseRoot,
-          providerWorkspaceId: profile.identity.providerWorkspaceId,
-          templatePath: profile.templatePath,
-          ttlMs: profile.identity.ttlMs,
-          reapIntervalMs: profile.identity.reapIntervalMs,
-          drainTimeoutMs: profile.identity.drainTimeoutMs,
-          maxActiveLeasesPerOwner: profile.identity.maxActiveLeasesPerOwner,
-          maxActiveLeasesTotal: profile.identity.maxActiveLeasesTotal,
+      if (resolved.sandboxTools) {
+        resolved = Object.freeze({
+          ...resolved,
+          sandboxTools: await resolveSandboxToolCapability({
+            capability: resolved.sandboxTools,
+            workspaceScopeId: claim.workspaceScopeId,
+            registry: sandboxLeaseServices,
+          }),
         })
       }
-      if (resolved.sandboxTools) sandboxLeaseServices.register(resolved.sandboxTools)
       const key = JSON.stringify([
         agentTypeId,
         claim.workspaceScopeId,

--- a/packages/agent/src/server/agent-host/createAgentHost.ts
+++ b/packages/agent/src/server/agent-host/createAgentHost.ts
@@ -15,6 +15,10 @@ import { EnvironmentLeaseManager, type EnvironmentLease } from './environmentLea
 import { getOptionalRuntimeBundleStorageRoot } from '../runtime/mode'
 import { mergeRuntimeFilesystemBindings } from '../runtime/filesystemBindings'
 import { SandboxLeaseServiceRegistry } from '../sandbox/leases/sandboxLeaseServiceRegistry'
+import {
+  normalizeSandboxLeaseProviderProfileV1,
+  sandboxLeaseProviderProfileDigestV1,
+} from '../sandbox/leases/sandboxLeaseProfileIdentity'
 import { assertSandboxToolCatalogAuthority } from '../tools/sandboxTargeting'
 import { createAgentHostRoutes } from './httpProjection'
 import { InMemoryAgentRequestLedger } from './requestLedger'
@@ -481,6 +485,15 @@ function createRuntime(
       )
       validateResolvedRuntimeScope(resolved)
       assertSandboxToolCatalogAuthority(resolved)
+      if (resolved.sandboxTools?.profile) {
+        const profile = normalizeSandboxLeaseProviderProfileV1(
+          resolved.sandboxTools.profile,
+          claim.workspaceScopeId,
+        )
+        if (sandboxLeaseProviderProfileDigestV1(profile.identity) !== resolved.sandboxTools.digest) {
+          throw new TypeError('sandbox lease profile digest does not match capability')
+        }
+      }
       if (resolved.sandboxTools) sandboxLeaseServices.register(resolved.sandboxTools)
       const key = JSON.stringify([
         agentTypeId,

--- a/packages/agent/src/server/agent-host/embeddedGateway.ts
+++ b/packages/agent/src/server/agent-host/embeddedGateway.ts
@@ -693,7 +693,7 @@ export class EmbeddedAgentGateway implements AgentGateway {
     if (sandboxOwnerId) {
       // Session deletion is already durably settled. Lease cleanup is separate,
       // idempotent host maintenance and remains retryable through the reaper.
-      try { await binding.scope.sandboxTools!.leases.releaseOwner(sandboxOwnerId) }
+      try { await binding.scope.sandboxTools!.leases?.releaseOwner(sandboxOwnerId) }
       catch { /* cleanup-pending state remains registered */ }
     }
   }

--- a/packages/agent/src/server/agent-host/embeddedGateway.ts
+++ b/packages/agent/src/server/agent-host/embeddedGateway.ts
@@ -677,20 +677,25 @@ export class EmbeddedAgentGateway implements AgentGateway {
     const claim = await this.verify(input.scope)
     await this.assertAgentAccess(input.ref.agentTypeId, input.scope, claim, 'session.mutate')
     const binding = await this.bindingForSession(input.scope, claim, input.ref)
+    const sandboxOwnerId = binding.scope.sandboxTools
+      ? sandboxLeaseOwnerIdForSession({
+          workspaceScopeId: claim.workspaceScopeId,
+          agentTypeId: input.ref.agentTypeId,
+        }, input.ref.sessionId)
+      : undefined
     await this.sessionEffect(input.ref, input.scope, claim, 'session.delete', input.requestId, {}, async () => {
       await binding.composition.service.deleteSession!(
         context(claim, input.requestId), input.ref.sessionId,
       )
-      if (binding.scope.sandboxTools) {
-        const ownerId = sandboxLeaseOwnerIdForSession({
-          workspaceScopeId: claim.workspaceScopeId,
-          agentTypeId: input.ref.agentTypeId,
-        }, input.ref.sessionId)
-        await binding.scope.sandboxTools.leases.releaseOwner(ownerId)
-      }
       this.runtime.activity.delete(claim.workspaceScopeId, input.ref)
       return null
     }, { bindingKey: binding.key })
+    if (sandboxOwnerId) {
+      // Session deletion is already durably settled. Lease cleanup is separate,
+      // idempotent host maintenance and remains retryable through the reaper.
+      try { await binding.scope.sandboxTools!.leases.releaseOwner(sandboxOwnerId) }
+      catch { /* cleanup-pending state remains registered */ }
+    }
   }
 
   private async *authorizedEvents(

--- a/packages/agent/src/server/agent-host/types.ts
+++ b/packages/agent/src/server/agent-host/types.ts
@@ -255,8 +255,9 @@ export interface ResolvedEnvironmentScope {
 export interface ResolvedSandboxToolCapability {
   /** Host-owned profile/cache/quota identity; callers must include changes in runtime identity. */
   readonly digest: string
-  readonly leases: SandboxLeaseService
-  /** Optional structured identity for hosts composing multi-provider leases. */
+  /** Legacy preconstructed capability. New multi-provider composition uses profile-only factories. */
+  readonly leases?: SandboxLeaseService
+  /** Structured identity and trusted provider factory for registry-owned construction. */
   readonly profile?: SandboxLeaseProviderProfileV1
 }
 

--- a/packages/agent/src/server/agent-host/types.ts
+++ b/packages/agent/src/server/agent-host/types.ts
@@ -31,6 +31,7 @@ import type {
 } from '../../shared/workspaceAgentDispatcher'
 import type { AgentSkillResourceSnapshot } from '../http/routes/skills'
 import type { SandboxLeaseService } from '../sandbox/leases/sandboxLease'
+import type { SandboxLeaseProviderProfileV1 } from '../sandbox/leases/sandboxLeaseProfileIdentity'
 
 export type { LeaseBoundWorkspaceAgent } from '../../shared/workspaceAgentDispatcher'
 
@@ -255,6 +256,8 @@ export interface ResolvedSandboxToolCapability {
   /** Host-owned profile/cache/quota identity; callers must include changes in runtime identity. */
   readonly digest: string
   readonly leases: SandboxLeaseService
+  /** Optional structured identity for hosts composing multi-provider leases. */
+  readonly profile?: SandboxLeaseProviderProfileV1
 }
 
 export interface ResolvedAgentRuntimeScope {

--- a/packages/agent/src/server/harness/pi-coding-agent/__tests__/sandboxNative.realPi.test.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/__tests__/sandboxNative.realPi.test.ts
@@ -10,7 +10,7 @@ import {
 } from '@mariozechner/pi-coding-agent'
 import { describe, expect, it, vi } from 'vitest'
 
-import type { SandboxProviderV1, WorkspaceSandboxPairV1 } from '@hachej/boring-sandbox/shared'
+import type { WorkspaceSandboxPairV1 } from '@hachej/boring-sandbox/shared'
 import { buildFilesystemAgentTools, buildHarnessAgentTools } from '@hachej/boring-bash/agent'
 import type { RuntimeBundle } from '../../../runtime/mode'
 import type { RunContext } from '../../../../shared/harness'
@@ -21,6 +21,7 @@ import type { AgentRequestKey } from '../../../agent-host/types'
 import { attachAcceptedWorkProvenance } from '../../../agent-host/acceptedWork'
 import { SqliteAgentRequestLedger } from '../../../agent-host/sqliteRequestLedger'
 import { SandboxLeaseService } from '../../../sandbox/leases/sandboxLease'
+import { fakeDisposableProvider } from '../../../sandbox/leases/__tests__/fakeDisposableProvider'
 import { createScriptedPiHarness } from '../../../testing/scriptedPiHarness'
 import { buildAgentComposition } from '../../../agent-host/buildAgentComposition'
 import { adaptToolsForPi } from '../tool-adapter'
@@ -109,7 +110,7 @@ describe('native sandbox tools through real Pi', () => {
     const remote = pair()
     const providerCreate = vi.fn(async () => remote.value)
     const leases = new SandboxLeaseService({
-      workspaceRoot: '/host/leases', provider: { create: providerCreate } as unknown as SandboxProviderV1,
+      workspaceRoot: '/host/leases', provider: fakeDisposableProvider({ create: providerCreate }),
       serviceDigest: 'default-pi-composition', ttlMs: 60_000, reapIntervalMs: 60_000, drainTimeoutMs: 100,
       maxActiveLeasesPerOwner: 1, maxActiveLeasesTotal: 1,
       createHandle: () => 'lease-handle-0001',
@@ -164,7 +165,7 @@ describe('native sandbox tools through real Pi', () => {
       const remote = pair()
       const providerCreate = vi.fn(async () => remote.value)
       const leases = new SandboxLeaseService({
-        workspaceRoot: '/host/leases', provider: { create: providerCreate } as unknown as SandboxProviderV1,
+        workspaceRoot: '/host/leases', provider: fakeDisposableProvider({ create: providerCreate }),
         serviceDigest: `collision-${reserved}`, ttlMs: 60_000, reapIntervalMs: 60_000, drainTimeoutMs: 100,
         maxActiveLeasesPerOwner: 1, maxActiveLeasesTotal: 1,
         createHandle: () => 'lease-handle-0001',
@@ -223,7 +224,7 @@ describe('native sandbox tools through real Pi', () => {
     const remote = pair()
     const providerCreate = vi.fn(async () => remote.value)
     const leases = new SandboxLeaseService({
-      workspaceRoot: '/host/leases', provider: { create: providerCreate } as unknown as SandboxProviderV1,
+      workspaceRoot: '/host/leases', provider: fakeDisposableProvider({ create: providerCreate }),
       serviceDigest: 'native-test', ttlMs: 60_000, reapIntervalMs: 60_000, drainTimeoutMs: 100,
       maxActiveLeasesPerOwner: 2, maxActiveLeasesTotal: 2,
       createHandle: () => 'lease-handle-0001',

--- a/packages/agent/src/server/index.ts
+++ b/packages/agent/src/server/index.ts
@@ -25,6 +25,17 @@ export type {
   SandboxLeaseErrorCode,
   SandboxLeaseServiceOptions,
 } from './sandbox/leases/sandboxLease'
+export { SandboxLeaseServiceFactoryRegistry } from './sandbox/leases/sandboxLeaseServiceFactoryRegistry'
+export {
+  SANDBOX_LEASE_PROVIDER_PROFILE_VERSION_V1,
+  createSandboxLeaseServiceFromProfileV1,
+  normalizeSandboxLeaseProviderProfileV1,
+  sandboxLeaseProviderProfileDigestV1,
+} from './sandbox/leases/sandboxLeaseProfileIdentity'
+export type {
+  SandboxLeaseProviderProfileIdentityV1,
+  SandboxLeaseProviderProfileV1,
+} from './sandbox/leases/sandboxLeaseProfileIdentity'
 export { createRemoteWorkerModeAdapter } from './runtime/modes/remote-worker'
 export type { RemoteWorkerModeAdapterOptions } from './runtime/modes/remote-worker'
 export { createRemoteWorkerWorkspace } from './workspace/createRemoteWorkerWorkspace'

--- a/packages/agent/src/server/sandbox/leases/__tests__/fakeDisposableProvider.ts
+++ b/packages/agent/src/server/sandbox/leases/__tests__/fakeDisposableProvider.ts
@@ -1,0 +1,34 @@
+import type {
+  DisposableSandboxProviderV1,
+  SandboxProviderV1,
+  WorkspaceSandboxPairV1,
+} from '@hachej/boring-sandbox/shared'
+
+/** Test-only factory-bound provider double. Production admission remains unconditional. */
+export function fakeDisposableProvider(input: {
+  create: SandboxProviderV1['create'] | (() => Promise<WorkspaceSandboxPairV1>)
+  close?: () => Promise<void>
+  providerId?: SandboxProviderV1['providerId']
+  providerConfigDigest?: `sha256:${string}`
+}): DisposableSandboxProviderV1 {
+  let provider!: SandboxProviderV1
+  provider = {
+    contractVersion: 'boring-sandbox.provider.v1',
+    providerId: input.providerId ?? 'direct',
+    capabilities: {} as never,
+    resolveRuntimeRoot: (context) => context.workspaceRoot,
+    create: input.create,
+    close: input.close,
+    disposableProfile: {
+      contractVersion: 'boring-sandbox.disposable-provider.v1',
+      resume: false,
+      publishedCleanupOwner: 'returned-pair',
+      ambiguousCreate: 'correlated-reconciliation',
+      providerConfigDigest: input.providerConfigDigest ?? `sha256:${'a'.repeat(64)}`,
+      assertProvider(candidate: SandboxProviderV1) {
+        if (candidate !== provider) throw new TypeError('registration mismatch')
+      },
+    },
+  } as SandboxProviderV1
+  return provider as DisposableSandboxProviderV1
+}

--- a/packages/agent/src/server/sandbox/leases/__tests__/fakeDisposableProvider.ts
+++ b/packages/agent/src/server/sandbox/leases/__tests__/fakeDisposableProvider.ts
@@ -1,3 +1,5 @@
+import { registerTrustedDisposableLeaseProvider } from '../disposableProvider'
+
 import type {
   DisposableSandboxProviderV1,
   SandboxProviderV1,
@@ -30,5 +32,9 @@ export function fakeDisposableProvider(input: {
       },
     },
   } as SandboxProviderV1
+  registerTrustedDisposableLeaseProvider(
+    provider,
+    (provider as DisposableSandboxProviderV1).disposableProfile.providerConfigDigest,
+  )
   return provider as DisposableSandboxProviderV1
 }

--- a/packages/agent/src/server/sandbox/leases/__tests__/sandboxLease.test.ts
+++ b/packages/agent/src/server/sandbox/leases/__tests__/sandboxLease.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
+import { createDirectSandboxProvider } from '@hachej/boring-sandbox/providers/direct'
 import type { SandboxProviderV1, WorkspaceSandboxPairV1 } from '@hachej/boring-sandbox/shared'
 import type { Sandbox, Workspace } from '../../../../shared/index'
 import {
@@ -8,6 +9,13 @@ import {
   SandboxLeaseService,
 } from '../sandboxLease'
 import { SandboxLeaseServiceRegistry } from '../sandboxLeaseServiceRegistry'
+
+const disposableProfile = {
+  contractVersion: 'boring-sandbox.disposable-provider.v1',
+  resume: false,
+  publishedCleanupOwner: 'returned-pair',
+  ambiguousCreate: 'correlated-reconciliation',
+} as const
 
 interface FakePair {
   pair: WorkspaceSandboxPairV1
@@ -58,7 +66,7 @@ function createService(input: {
   }))
   const service = new SandboxLeaseService({
     workspaceRoot: '/host/leases',
-    provider: { create: providerCreate, close: input.close } as unknown as SandboxProviderV1,
+    provider: { disposableProfile, create: providerCreate, close: input.close } as unknown as SandboxProviderV1,
     serviceDigest: 'profile-v1',
     ttlMs: 60_000,
     reapIntervalMs: 60_000,
@@ -78,6 +86,22 @@ async function deferred<T>() {
 }
 
 describe('SandboxLeaseService lifecycle registry', () => {
+  it('rejects a resumable provider before starting its reaper', () => {
+    vi.useFakeTimers()
+    expect(() => new SandboxLeaseService({
+      workspaceRoot: '/host/leases',
+      provider: createDirectSandboxProvider(),
+      serviceDigest: 'persistent-profile',
+      ttlMs: 60_000,
+      reapIntervalMs: 60_000,
+      drainTimeoutMs: 100,
+      maxActiveLeasesPerOwner: 1,
+      maxActiveLeasesTotal: 1,
+    })).toThrow('provider must implement the disposable sandbox profile')
+    expect(vi.getTimerCount()).toBe(0)
+    vi.useRealTimers()
+  })
+
   it('creates several owner-bound leases and lists only the owner records', async () => {
     const { service, providerCreate } = createService()
     const first = await service.acquire('owner-a')
@@ -91,6 +115,7 @@ describe('SandboxLeaseService lifecycle registry', () => {
     expect(providerCreate).toHaveBeenNthCalledWith(1, {
       workspaceRoot: `/host/leases/${first.handle}`,
       sessionId: first.handle,
+      requestId: expect.stringMatching(/^[a-f0-9]{64}$/),
     })
     expect(() => service.status('owner-b', first.handle)).toThrow('sandbox lease is unavailable')
     await service.dispose()
@@ -343,6 +368,29 @@ describe('SandboxLeaseService lifecycle registry', () => {
     await service.dispose()
   })
 
+  it('drains and sanitizes a lease whose health check throws', async () => {
+    const unhealthy = fakePair('health-throw')
+    let checks = 0
+    unhealthy.pair = {
+      ...unhealthy.pair,
+      checkHealth: async () => {
+        checks += 1
+        if (checks === 1) return { state: 'ok' }
+        throw new Error('provider secret detail')
+      },
+    }
+    const { service } = createService({ create: async () => unhealthy.pair })
+    const lease = await service.acquire('owner-a')
+    await expect(service.withPair('owner-a', lease.handle, async () => undefined))
+      .rejects.toMatchObject({
+        code: SANDBOX_LEASE_ERROR_CODES.LEASE_EXPIRED,
+        message: 'sandbox lease is unavailable',
+      })
+    await vi.waitFor(() => expect(service.listOwn('owner-a')).toEqual([]))
+    expect(unhealthy.dispose).toHaveBeenCalledOnce()
+    await service.dispose()
+  })
+
   it('projects expiry without observing side effects and reaps every expired lease', async () => {
     const now = { value: 100 }
     const { service, pairs } = createService({ now })
@@ -381,7 +429,7 @@ describe('SandboxLeaseService lifecycle registry', () => {
     const telemetry = { capture: vi.fn() }
     const service = new SandboxLeaseService({
       workspaceRoot: '/host/leases',
-      provider: { create: async () => pair.pair } as unknown as SandboxProviderV1,
+      provider: { disposableProfile, create: async () => pair.pair } as unknown as SandboxProviderV1,
       serviceDigest: 'scheduled-profile',
       ttlMs: 1_000,
       reapIntervalMs: 1_000,

--- a/packages/agent/src/server/sandbox/leases/__tests__/sandboxLease.test.ts
+++ b/packages/agent/src/server/sandbox/leases/__tests__/sandboxLease.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { createDirectSandboxProvider } from '@hachej/boring-sandbox/providers/direct'
 import type { SandboxProviderV1, WorkspaceSandboxPairV1 } from '@hachej/boring-sandbox/shared'
 import type { Sandbox, Workspace } from '../../../../shared/index'
 import {
@@ -90,7 +89,10 @@ describe('SandboxLeaseService lifecycle registry', () => {
     vi.useFakeTimers()
     expect(() => new SandboxLeaseService({
       workspaceRoot: '/host/leases',
-      provider: createDirectSandboxProvider(),
+      provider: {
+        contractVersion: 'boring-sandbox.provider.v1',
+        providerId: 'direct',
+      } as unknown as SandboxProviderV1,
       serviceDigest: 'persistent-profile',
       ttlMs: 60_000,
       reapIntervalMs: 60_000,

--- a/packages/agent/src/server/sandbox/leases/__tests__/sandboxLease.test.ts
+++ b/packages/agent/src/server/sandbox/leases/__tests__/sandboxLease.test.ts
@@ -225,8 +225,18 @@ describe('SandboxLeaseService lifecycle registry', () => {
     await service.dispose()
   })
 
-  it('retains ambiguous create cleanup debt under owner and global quota until retry settles', async () => {
-    const retry = vi.fn().mockRejectedValueOnce(new Error('still ambiguous')).mockResolvedValue(undefined)
+  it('retains joined correlation cleanup debt under owner and global quota until release retry settles', async () => {
+    const cleanupOrder: string[] = []
+    let returnedObjectPending = true
+    let correlationAttempts = 0
+    const retry = vi.fn(async () => {
+      if (returnedObjectPending) {
+        cleanupOrder.push('returned-object')
+        returnedObjectPending = false
+      }
+      cleanupOrder.push('correlation')
+      if (++correlationAttempts === 1) throw new Error('correlation mismatch remains')
+    })
     const error = Object.assign(new Error('create outcome unknown'), {
       sandboxProviderCleanupDebt: { retry },
     })
@@ -235,6 +245,7 @@ describe('SandboxLeaseService lifecycle registry', () => {
     await expect(service.acquire('owner-a')).rejects.toMatchObject({
       code: SANDBOX_LEASE_ERROR_CODES.LEASE_CLEANUP_FAILED,
     })
+    expect(cleanupOrder).toEqual(['returned-object', 'correlation'])
     expect(service.listOwn('owner-a')).toEqual([
       { handle: 'lease-handle-0001', expiresAt: 60_100, state: 'cleanup-pending' },
     ])
@@ -243,6 +254,7 @@ describe('SandboxLeaseService lifecycle registry', () => {
     })
     await service.release('owner-a', 'lease-handle-0001')
     expect(retry).toHaveBeenCalledTimes(2)
+    expect(cleanupOrder).toEqual(['returned-object', 'correlation', 'correlation'])
     expect(service.listOwn('owner-a')).toEqual([])
     await service.dispose()
   })

--- a/packages/agent/src/server/sandbox/leases/__tests__/sandboxLease.test.ts
+++ b/packages/agent/src/server/sandbox/leases/__tests__/sandboxLease.test.ts
@@ -8,13 +8,7 @@ import {
   SandboxLeaseService,
 } from '../sandboxLease'
 import { SandboxLeaseServiceRegistry } from '../sandboxLeaseServiceRegistry'
-
-const disposableProfile = {
-  contractVersion: 'boring-sandbox.disposable-provider.v1',
-  resume: false,
-  publishedCleanupOwner: 'returned-pair',
-  ambiguousCreate: 'correlated-reconciliation',
-} as const
+import { fakeDisposableProvider } from './fakeDisposableProvider'
 
 interface FakePair {
   pair: WorkspaceSandboxPairV1
@@ -65,7 +59,7 @@ function createService(input: {
   }))
   const service = new SandboxLeaseService({
     workspaceRoot: '/host/leases',
-    provider: { disposableProfile, create: providerCreate, close: input.close } as unknown as SandboxProviderV1,
+    provider: fakeDisposableProvider({ create: providerCreate, close: input.close }),
     serviceDigest: 'profile-v1',
     ttlMs: 60_000,
     reapIntervalMs: 60_000,
@@ -99,6 +93,16 @@ describe('SandboxLeaseService lifecycle registry', () => {
       drainTimeoutMs: 100,
       maxActiveLeasesPerOwner: 1,
       maxActiveLeasesTotal: 1,
+    })).toThrow('provider must implement the disposable sandbox profile')
+    const registered = fakeDisposableProvider({ create: async () => fakePair('registered').pair })
+    const forged = {
+      ...registered,
+      disposableProfile: (registered as SandboxProviderV1 & { disposableProfile: unknown }).disposableProfile,
+    } as SandboxProviderV1
+    expect(() => new SandboxLeaseService({
+      workspaceRoot: '/host/leases', provider: forged, serviceDigest: 'forged-profile',
+      ttlMs: 60_000, reapIntervalMs: 60_000, drainTimeoutMs: 100,
+      maxActiveLeasesPerOwner: 1, maxActiveLeasesTotal: 1,
     })).toThrow('provider must implement the disposable sandbox profile')
     expect(vi.getTimerCount()).toBe(0)
     vi.useRealTimers()
@@ -258,7 +262,7 @@ describe('SandboxLeaseService lifecycle registry', () => {
     await expect(service.acquire('owner-b')).rejects.toMatchObject({
       code: SANDBOX_LEASE_ERROR_CODES.INVALID_LEASE_REQUEST,
     })
-    expect(providerCreate).toHaveBeenCalledOnce()
+    await vi.waitFor(() => expect(providerCreate).toHaveBeenCalledOnce())
     firstGate.resolve(firstPair.pair)
     const lease = await first
     await expect(service.acquire('owner-b')).rejects.toMatchObject({
@@ -431,7 +435,7 @@ describe('SandboxLeaseService lifecycle registry', () => {
     const telemetry = { capture: vi.fn() }
     const service = new SandboxLeaseService({
       workspaceRoot: '/host/leases',
-      provider: { disposableProfile, create: async () => pair.pair } as unknown as SandboxProviderV1,
+      provider: fakeDisposableProvider({ create: async () => pair.pair }),
       serviceDigest: 'scheduled-profile',
       ttlMs: 1_000,
       reapIntervalMs: 1_000,

--- a/packages/agent/src/server/sandbox/leases/__tests__/sandboxLease.test.ts
+++ b/packages/agent/src/server/sandbox/leases/__tests__/sandboxLease.test.ts
@@ -176,6 +176,24 @@ describe('SandboxLeaseService lifecycle registry', () => {
     await service.dispose()
   })
 
+  it('retains quota when relocated-root cleanup fails until retry settles', async () => {
+    const pair = fakePair('relocated-root')
+    pair.dispose.mockRejectedValueOnce(new Error('owned root is absent at its bound path'))
+    const { service } = createService({ maxOwner: 1, maxTotal: 1, create: async () => pair.pair })
+    const lease = await service.acquire('owner-a')
+
+    await expect(service.release('owner-a', lease.handle)).rejects.toMatchObject({
+      code: SANDBOX_LEASE_ERROR_CODES.LEASE_CLEANUP_FAILED,
+    })
+    expect(service.status('owner-a', lease.handle).state).toBe('cleanup-pending')
+    await expect(service.acquire('owner-a')).rejects.toMatchObject({
+      code: SANDBOX_LEASE_ERROR_CODES.LEASE_QUOTA_EXCEEDED,
+    })
+    await expect(service.release('owner-a', lease.handle)).resolves.toBeUndefined()
+    expect(pair.dispose).toHaveBeenCalledTimes(2)
+    await service.dispose()
+  })
+
   it('does not let provider close delete a published pair while an operation is pinned', async () => {
     const providerClose = vi.fn(async () => {})
     const { service, pairs } = createService({ drainTimeoutMs: 5, close: providerClose })

--- a/packages/agent/src/server/sandbox/leases/__tests__/sandboxLease.test.ts
+++ b/packages/agent/src/server/sandbox/leases/__tests__/sandboxLease.test.ts
@@ -225,7 +225,7 @@ describe('SandboxLeaseService lifecycle registry', () => {
     await service.dispose()
   })
 
-  it('retains joined correlation cleanup debt under owner and global quota until release retry settles', async () => {
+  it('retains provider cleanup debt and its causes under owner and global quota until release retry settles', async () => {
     const cleanupOrder: string[] = []
     let returnedObjectPending = true
     let correlationAttempts = 0
@@ -237,9 +237,12 @@ describe('SandboxLeaseService lifecycle registry', () => {
       cleanupOrder.push('correlation')
       if (++correlationAttempts === 1) throw new Error('correlation mismatch remains')
     })
-    const error = Object.assign(new Error('create outcome unknown'), {
+    const originalError = new Error('create outcome unknown')
+    const cleanupError = new Error('provider-local cleanup failed')
+    const error = Object.assign(new AggregateError([originalError, cleanupError], 'create compensation failed'), {
       sandboxProviderCleanupDebt: { retry },
     })
+    expect(error.errors).toEqual([originalError, cleanupError])
     const { service } = createService({ maxOwner: 1, maxTotal: 1, create: async () => { throw error } })
 
     await expect(service.acquire('owner-a')).rejects.toMatchObject({

--- a/packages/agent/src/server/sandbox/leases/__tests__/sandboxLease.test.ts
+++ b/packages/agent/src/server/sandbox/leases/__tests__/sandboxLease.test.ts
@@ -225,6 +225,28 @@ describe('SandboxLeaseService lifecycle registry', () => {
     await service.dispose()
   })
 
+  it('retains ambiguous create cleanup debt under owner and global quota until retry settles', async () => {
+    const retry = vi.fn().mockRejectedValueOnce(new Error('still ambiguous')).mockResolvedValue(undefined)
+    const error = Object.assign(new Error('create outcome unknown'), {
+      sandboxProviderCleanupDebt: { retry },
+    })
+    const { service } = createService({ maxOwner: 1, maxTotal: 1, create: async () => { throw error } })
+
+    await expect(service.acquire('owner-a')).rejects.toMatchObject({
+      code: SANDBOX_LEASE_ERROR_CODES.LEASE_CLEANUP_FAILED,
+    })
+    expect(service.listOwn('owner-a')).toEqual([
+      { handle: 'lease-handle-0001', expiresAt: 60_100, state: 'cleanup-pending' },
+    ])
+    await expect(service.acquire('owner-a')).rejects.toMatchObject({
+      code: SANDBOX_LEASE_ERROR_CODES.LEASE_QUOTA_EXCEEDED,
+    })
+    await service.release('owner-a', 'lease-handle-0001')
+    expect(retry).toHaveBeenCalledTimes(2)
+    expect(service.listOwn('owner-a')).toEqual([])
+    await service.dispose()
+  })
+
   it('releases quota and pending-handle ownership when the handle generator is invalid', async () => {
     let attempts = 0
     const created = fakePair('valid-after-invalid')

--- a/packages/agent/src/server/sandbox/leases/__tests__/sandboxLease.test.ts
+++ b/packages/agent/src/server/sandbox/leases/__tests__/sandboxLease.test.ts
@@ -357,6 +357,32 @@ describe('SandboxLeaseService lifecycle registry', () => {
     expect(service.listOwn('owner-a')).toEqual([])
   })
 
+  it('keeps a timed-out pending acquisition registered until its late cleanup debt converges', async () => {
+    const gate = await deferred<WorkspaceSandboxPairV1>()
+    const pair = fakePair('late-shutdown-debt')
+    pair.dispose.mockRejectedValueOnce(new Error('delete acknowledgement lost'))
+    const { service } = createService({ create: async () => await gate.promise, drainTimeoutMs: 5 })
+    const registry = new SandboxLeaseServiceRegistry()
+    registry.register({ digest: 'pending-profile', leases: service })
+    const acquiring = service.acquire('owner-a')
+    await Promise.resolve()
+
+    await expect(registry.disposeUntil(Date.now() + 15)).resolves.toEqual([
+      expect.objectContaining({ status: 'rejected' }),
+    ])
+    expect(service.isDisposed).toBe(false)
+    gate.resolve(pair.pair)
+    await expect(acquiring).rejects.toMatchObject({ code: SANDBOX_LEASE_ERROR_CODES.LEASE_CLEANUP_FAILED })
+    expect(service.listOwn('owner-a')).toEqual([
+      expect.objectContaining({ state: 'cleanup-pending' }),
+    ])
+    await expect(registry.disposeUntil(Date.now() + 100)).resolves.toEqual([
+      { status: 'fulfilled', value: undefined },
+    ])
+    expect(pair.dispose).toHaveBeenCalledTimes(2)
+    expect(service.listOwn('owner-a')).toEqual([])
+  })
+
   it('retains cleanup authority when readiness and the first compensation delete both fail', async () => {
     const pair = fakePair('setup-delete-ambiguous')
     pair.pair = { ...pair.pair, checkHealth: async () => { throw new Error('setup failed') } }

--- a/packages/agent/src/server/sandbox/leases/__tests__/sandboxLease.test.ts
+++ b/packages/agent/src/server/sandbox/leases/__tests__/sandboxLease.test.ts
@@ -47,6 +47,7 @@ function createService(input: {
   maxTotal?: number
   drainTimeoutMs?: number
   create?: () => Promise<WorkspaceSandboxPairV1>
+  provider?: SandboxProviderV1
   close?: () => Promise<void>
   createHandle?: () => string
 } = {}) {
@@ -59,7 +60,7 @@ function createService(input: {
   }))
   const service = new SandboxLeaseService({
     workspaceRoot: '/host/leases',
-    provider: fakeDisposableProvider({ create: providerCreate, close: input.close }),
+    provider: input.provider ?? fakeDisposableProvider({ create: providerCreate, close: input.close }),
     serviceDigest: 'profile-v1',
     ttlMs: 60_000,
     reapIntervalMs: 60_000,
@@ -71,6 +72,14 @@ function createService(input: {
   })
   return { service, pairs, providerCreate }
 }
+
+it('preserves the trusted legacy preconstructed service seam without Agent-private branding', async () => {
+  const branded = fakeDisposableProvider({ create: async () => fakePair('legacy').pair })
+  const legacyProvider = { ...branded } as SandboxProviderV1
+  const { service } = createService({ provider: legacyProvider })
+  await expect(service.acquire('owner-a')).resolves.toMatchObject({ handle: expect.any(String) })
+  await expect(service.dispose()).resolves.toBeUndefined()
+})
 
 async function deferred<T>() {
   let resolve!: (value: T) => void
@@ -93,16 +102,6 @@ describe('SandboxLeaseService lifecycle registry', () => {
       drainTimeoutMs: 100,
       maxActiveLeasesPerOwner: 1,
       maxActiveLeasesTotal: 1,
-    })).toThrow('provider must implement the disposable sandbox profile')
-    const registered = fakeDisposableProvider({ create: async () => fakePair('registered').pair })
-    const forged = {
-      ...registered,
-      disposableProfile: (registered as SandboxProviderV1 & { disposableProfile: unknown }).disposableProfile,
-    } as SandboxProviderV1
-    expect(() => new SandboxLeaseService({
-      workspaceRoot: '/host/leases', provider: forged, serviceDigest: 'forged-profile',
-      ttlMs: 60_000, reapIntervalMs: 60_000, drainTimeoutMs: 100,
-      maxActiveLeasesPerOwner: 1, maxActiveLeasesTotal: 1,
     })).toThrow('provider must implement the disposable sandbox profile')
     expect(vi.getTimerCount()).toBe(0)
     vi.useRealTimers()

--- a/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseProfileIdentity.test.ts
+++ b/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseProfileIdentity.test.ts
@@ -94,7 +94,6 @@ describe('sandbox lease provider profile identity', () => {
       provider,
       workspaceRoot: normalized.identity.leaseRoot,
       providerWorkspaceId: normalized.identity.providerWorkspaceId,
-      templatePath: normalized.templatePath,
       ttlMs: normalized.identity.ttlMs,
       reapIntervalMs: normalized.identity.reapIntervalMs,
       drainTimeoutMs: normalized.identity.drainTimeoutMs,
@@ -114,20 +113,15 @@ describe('sandbox lease provider profile identity', () => {
     await service.dispose()
   })
 
-  it('requires template paths and fingerprints together and binds template authority', () => {
+  it('rejects caller-asserted generic template aliases', () => {
     const value = profile()
-    expect(() => normalizeSandboxLeaseProviderProfileV1({ ...value, templatePath: '/templates/a' }, 'workspace-a'))
-      .toThrow('must be supplied together')
     expect(() => normalizeSandboxLeaseProviderProfileV1({
-      ...value, identity: { ...value.identity, templateFingerprint: sha },
-    }, 'workspace-a')).toThrow('must be supplied together')
-    const digest = (fingerprint: `sha256:${string}`) => sandboxLeaseProviderProfileDigestV1(
-      normalizeSandboxLeaseProviderProfileV1({
-        ...value, templatePath: '/templates/a',
-        identity: { ...value.identity, templateFingerprint: fingerprint },
-      }, 'workspace-a').identity,
-    )
-    expect(digest(sha)).not.toBe(digest(`sha256:${'b'.repeat(64)}`))
+      ...value, templatePath: '/templates/a',
+    } as SandboxLeaseProviderProfileV1, 'workspace-a')).toThrow('unsupported fields')
+    expect(() => normalizeSandboxLeaseProviderProfileV1({
+      ...value,
+      identity: { ...value.identity, templateFingerprint: sha },
+    } as SandboxLeaseProviderProfileV1, 'workspace-a')).toThrow('unsupported fields')
   })
 
   it('rejects cross-workspace reuse before provider use', () => {

--- a/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseProfileIdentity.test.ts
+++ b/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseProfileIdentity.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import { createDirectSandboxProvider } from '@hachej/boring-sandbox/providers/direct'
+import {
+  SANDBOX_LEASE_PROVIDER_PROFILE_VERSION_V1,
+  normalizeSandboxLeaseProviderProfileV1,
+  sandboxLeaseProviderProfileDigestV1,
+  type SandboxLeaseProviderProfileV1,
+} from '../sandboxLeaseProfileIdentity'
+
+const sha = `sha256:${'a'.repeat(64)}` as const
+
+function profile(scope = 'workspace-a'): SandboxLeaseProviderProfileV1 {
+  return {
+    provider: createDirectSandboxProvider({ leaseMode: 'disposable' }),
+    identity: {
+      contractVersion: SANDBOX_LEASE_PROVIDER_PROFILE_VERSION_V1,
+      workspaceScopeId: scope,
+      placementIdentity: 'local-trusted',
+      providerWorkspaceId: 'physical-workspace-a',
+      leaseRoot: '/host/sandbox-leases',
+      providerId: 'direct',
+      providerConfigDigest: sha,
+      credentialVersionRefs: ['credential-b@2', 'credential-a@1', 'credential-a@1'],
+      ttlMs: 60_000,
+      reapIntervalMs: 10_000,
+      drainTimeoutMs: 5_000,
+      maxActiveLeasesPerOwner: 2,
+      maxActiveLeasesTotal: 4,
+    },
+  }
+}
+
+describe('sandbox lease provider profile identity', () => {
+  it('normalizes serializable identity and produces a stable digest', () => {
+    const normalized = normalizeSandboxLeaseProviderProfileV1(profile(), 'workspace-a')
+    expect(normalized.identity.credentialVersionRefs).toEqual(['credential-a@1', 'credential-b@2'])
+    expect(sandboxLeaseProviderProfileDigestV1(normalized.identity)).toMatch(/^sha256:[a-f0-9]{64}$/)
+    expect(sandboxLeaseProviderProfileDigestV1(normalized.identity)).toBe(
+      sandboxLeaseProviderProfileDigestV1(normalized.identity),
+    )
+  })
+
+  it('rejects cross-workspace reuse before provider use', () => {
+    expect(() => normalizeSandboxLeaseProviderProfileV1(profile('workspace-a'), 'workspace-b'))
+      .toThrow('profile scope is unauthorized')
+  })
+
+  it('rejects normal providers and provider identity mismatch', () => {
+    const value = profile()
+    expect(() => normalizeSandboxLeaseProviderProfileV1({
+      ...value,
+      provider: createDirectSandboxProvider() as never,
+    }, 'workspace-a')).toThrow('provider is not disposable')
+    expect(() => normalizeSandboxLeaseProviderProfileV1({
+      ...value,
+      identity: { ...value.identity, providerId: 'bwrap' },
+    }, 'workspace-a')).toThrow('provider identity does not match')
+  })
+})

--- a/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseProfileIdentity.test.ts
+++ b/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseProfileIdentity.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { createDirectSandboxProvider } from '@hachej/boring-sandbox/providers/direct'
+import type { DisposableSandboxProviderV1, SandboxProviderV1 } from '@hachej/boring-sandbox/shared'
 import {
   SANDBOX_LEASE_PROVIDER_PROFILE_VERSION_V1,
   normalizeSandboxLeaseProviderProfileV1,
@@ -10,9 +10,25 @@ import {
 
 const sha = `sha256:${'a'.repeat(64)}` as const
 
+function disposableProvider(): DisposableSandboxProviderV1 {
+  return {
+    contractVersion: 'boring-sandbox.provider.v1',
+    providerId: 'direct',
+    capabilities: {} as never,
+    disposableProfile: {
+      contractVersion: 'boring-sandbox.disposable-provider.v1',
+      resume: false,
+      publishedCleanupOwner: 'returned-pair',
+      ambiguousCreate: 'correlated-reconciliation',
+    },
+    resolveRuntimeRoot: (context) => context.workspaceRoot,
+    async create() { throw new Error('not used') },
+  }
+}
+
 function profile(scope = 'workspace-a'): SandboxLeaseProviderProfileV1 {
   return {
-    provider: createDirectSandboxProvider({ leaseMode: 'disposable' }),
+    provider: disposableProvider(),
     identity: {
       contractVersion: SANDBOX_LEASE_PROVIDER_PROFILE_VERSION_V1,
       workspaceScopeId: scope,
@@ -50,7 +66,9 @@ describe('sandbox lease provider profile identity', () => {
     const value = profile()
     expect(() => normalizeSandboxLeaseProviderProfileV1({
       ...value,
-      provider: createDirectSandboxProvider() as never,
+      provider: {
+        contractVersion: 'boring-sandbox.provider.v1', providerId: 'direct',
+      } as unknown as SandboxProviderV1 as never,
     }, 'workspace-a')).toThrow('provider is not disposable')
     expect(() => normalizeSandboxLeaseProviderProfileV1({
       ...value,

--- a/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseProfileIdentity.test.ts
+++ b/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseProfileIdentity.test.ts
@@ -11,8 +11,9 @@ import {
 
 const sha = `sha256:${'a'.repeat(64)}` as const
 
-function disposableProvider(): DisposableSandboxProviderV1 {
-  return {
+function disposableProvider(providerConfigDigest: `sha256:${string}` = sha): DisposableSandboxProviderV1 {
+  let provider!: DisposableSandboxProviderV1
+  provider = {
     contractVersion: 'boring-sandbox.provider.v1',
     providerId: 'direct',
     capabilities: {} as never,
@@ -21,15 +22,21 @@ function disposableProvider(): DisposableSandboxProviderV1 {
       resume: false,
       publishedCleanupOwner: 'returned-pair',
       ambiguousCreate: 'correlated-reconciliation',
+      providerConfigDigest,
+      assertProvider(candidate) {
+        if (candidate !== provider) throw new TypeError('registration mismatch')
+      },
     },
     resolveRuntimeRoot: (context) => context.workspaceRoot,
     async create() { throw new Error('not used') },
   }
+  return provider
 }
 
 function profile(scope = 'workspace-a'): SandboxLeaseProviderProfileV1 {
+  const provider = disposableProvider()
   return {
-    provider: disposableProvider(),
+    providerFactory: () => provider,
     identity: {
       contractVersion: SANDBOX_LEASE_PROVIDER_PROFILE_VERSION_V1,
       workspaceScopeId: scope,
@@ -58,17 +65,38 @@ describe('sandbox lease provider profile identity', () => {
     )
   })
 
+  it('rejects unknown identity fields and provider configuration aliases', async () => {
+    const value = profile()
+    expect(() => normalizeSandboxLeaseProviderProfileV1({
+      ...value,
+      identity: { ...value.identity, hiddenAuthority: 'unexpected' } as typeof value.identity,
+    }, 'workspace-a')).toThrow('unsupported fields')
+
+    const mismatched = {
+      ...value,
+      identity: { ...value.identity, providerConfigDigest: `sha256:${'b'.repeat(64)}` as const },
+    }
+    await expect(createSandboxLeaseServiceFromProfileV1({
+      profile: mismatched,
+      verifiedWorkspaceScopeId: 'workspace-a',
+      expectedDigest: sandboxLeaseProviderProfileDigestV1(
+        normalizeSandboxLeaseProviderProfileV1(mismatched, 'workspace-a').identity,
+      ),
+    })).rejects.toThrow('configuration identity does not match')
+  })
+
   it('constructs a service bound to the complete profile identity', async () => {
     const normalized = normalizeSandboxLeaseProviderProfileV1(profile(), 'workspace-a')
     const digest = sandboxLeaseProviderProfileDigestV1(normalized.identity)
-    const service = createSandboxLeaseServiceFromProfileV1({
+    const service = await createSandboxLeaseServiceFromProfileV1({
       profile: normalized,
       verifiedWorkspaceScopeId: 'workspace-a',
       expectedDigest: digest,
     })
+    const provider = await normalized.providerFactory()
     expect(() => service.assertProfileBinding({
       digest,
-      provider: normalized.provider,
+      provider,
       workspaceRoot: normalized.identity.leaseRoot,
       providerWorkspaceId: normalized.identity.providerWorkspaceId,
       templatePath: normalized.templatePath,
@@ -79,7 +107,7 @@ describe('sandbox lease provider profile identity', () => {
       maxActiveLeasesTotal: normalized.identity.maxActiveLeasesTotal,
     })).not.toThrow()
     expect(() => service.assertProfileBinding({
-      digest, provider: normalized.provider,
+      digest, provider,
       workspaceRoot: '/other-root',
       providerWorkspaceId: normalized.identity.providerWorkspaceId,
       ttlMs: normalized.identity.ttlMs,
@@ -96,17 +124,24 @@ describe('sandbox lease provider profile identity', () => {
       .toThrow('profile scope is unauthorized')
   })
 
-  it('rejects normal providers and provider identity mismatch', () => {
-    const value = profile()
-    expect(() => normalizeSandboxLeaseProviderProfileV1({
-      ...value,
-      provider: {
-        contractVersion: 'boring-sandbox.provider.v1', providerId: 'direct',
-      } as unknown as SandboxProviderV1 as never,
-    }, 'workspace-a')).toThrow('provider is not disposable')
-    expect(() => normalizeSandboxLeaseProviderProfileV1({
-      ...value,
-      identity: { ...value.identity, providerId: 'bwrap' },
-    }, 'workspace-a')).toThrow('provider identity does not match')
+  it('rejects normal providers and provider identity mismatch during registry construction', async () => {
+    const value = normalizeSandboxLeaseProviderProfileV1(profile(), 'workspace-a')
+    const digest = sandboxLeaseProviderProfileDigestV1(value.identity)
+    await expect(createSandboxLeaseServiceFromProfileV1({
+      profile: {
+        ...value,
+        providerFactory: () => ({
+          contractVersion: 'boring-sandbox.provider.v1', providerId: 'direct',
+        } as unknown as SandboxProviderV1 as never),
+      },
+      verifiedWorkspaceScopeId: 'workspace-a',
+      expectedDigest: digest,
+    })).rejects.toThrow('factory-registered')
+    const mismatch = { ...value, identity: { ...value.identity, providerId: 'bwrap' as const } }
+    await expect(createSandboxLeaseServiceFromProfileV1({
+      profile: mismatch,
+      verifiedWorkspaceScopeId: 'workspace-a',
+      expectedDigest: sandboxLeaseProviderProfileDigestV1(mismatch.identity),
+    })).rejects.toThrow('provider identity does not match')
   })
 })

--- a/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseProfileIdentity.test.ts
+++ b/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseProfileIdentity.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import type { DisposableSandboxProviderV1, SandboxProviderV1 } from '@hachej/boring-sandbox/shared'
 import {
   SANDBOX_LEASE_PROVIDER_PROFILE_VERSION_V1,
+  createSandboxLeaseServiceFromProfileV1,
   normalizeSandboxLeaseProviderProfileV1,
   sandboxLeaseProviderProfileDigestV1,
   type SandboxLeaseProviderProfileV1,
@@ -55,6 +56,39 @@ describe('sandbox lease provider profile identity', () => {
     expect(sandboxLeaseProviderProfileDigestV1(normalized.identity)).toBe(
       sandboxLeaseProviderProfileDigestV1(normalized.identity),
     )
+  })
+
+  it('constructs a service bound to the complete profile identity', async () => {
+    const normalized = normalizeSandboxLeaseProviderProfileV1(profile(), 'workspace-a')
+    const digest = sandboxLeaseProviderProfileDigestV1(normalized.identity)
+    const service = createSandboxLeaseServiceFromProfileV1({
+      profile: normalized,
+      verifiedWorkspaceScopeId: 'workspace-a',
+      expectedDigest: digest,
+    })
+    expect(() => service.assertProfileBinding({
+      digest,
+      provider: normalized.provider,
+      workspaceRoot: normalized.identity.leaseRoot,
+      providerWorkspaceId: normalized.identity.providerWorkspaceId,
+      templatePath: normalized.templatePath,
+      ttlMs: normalized.identity.ttlMs,
+      reapIntervalMs: normalized.identity.reapIntervalMs,
+      drainTimeoutMs: normalized.identity.drainTimeoutMs,
+      maxActiveLeasesPerOwner: normalized.identity.maxActiveLeasesPerOwner,
+      maxActiveLeasesTotal: normalized.identity.maxActiveLeasesTotal,
+    })).not.toThrow()
+    expect(() => service.assertProfileBinding({
+      digest, provider: normalized.provider,
+      workspaceRoot: '/other-root',
+      providerWorkspaceId: normalized.identity.providerWorkspaceId,
+      ttlMs: normalized.identity.ttlMs,
+      reapIntervalMs: normalized.identity.reapIntervalMs,
+      drainTimeoutMs: normalized.identity.drainTimeoutMs,
+      maxActiveLeasesPerOwner: normalized.identity.maxActiveLeasesPerOwner,
+      maxActiveLeasesTotal: normalized.identity.maxActiveLeasesTotal,
+    })).toThrow('does not match')
+    await service.dispose()
   })
 
   it('rejects cross-workspace reuse before provider use', () => {

--- a/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseProfileIdentity.test.ts
+++ b/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseProfileIdentity.test.ts
@@ -12,8 +12,7 @@ import {
 const sha = `sha256:${'a'.repeat(64)}` as const
 
 function disposableProvider(providerConfigDigest: `sha256:${string}` = sha): DisposableSandboxProviderV1 {
-  let provider!: DisposableSandboxProviderV1
-  provider = {
+  return {
     contractVersion: 'boring-sandbox.provider.v1',
     providerId: 'direct',
     capabilities: {} as never,
@@ -23,14 +22,10 @@ function disposableProvider(providerConfigDigest: `sha256:${string}` = sha): Dis
       publishedCleanupOwner: 'returned-pair',
       ambiguousCreate: 'correlated-reconciliation',
       providerConfigDigest,
-      assertProvider(candidate) {
-        if (candidate !== provider) throw new TypeError('registration mismatch')
-      },
     },
     resolveRuntimeRoot: (context) => context.workspaceRoot,
     async create() { throw new Error('not used') },
   }
-  return provider
 }
 
 function profile(scope = 'workspace-a'): SandboxLeaseProviderProfileV1 {
@@ -82,7 +77,7 @@ describe('sandbox lease provider profile identity', () => {
       expectedDigest: sandboxLeaseProviderProfileDigestV1(
         normalizeSandboxLeaseProviderProfileV1(mismatched, 'workspace-a').identity,
       ),
-    })).rejects.toThrow('configuration identity does not match')
+    })).rejects.toThrow('registration does not match trusted profile')
   })
 
   it('constructs a service bound to the complete profile identity', async () => {
@@ -136,7 +131,7 @@ describe('sandbox lease provider profile identity', () => {
       },
       verifiedWorkspaceScopeId: 'workspace-a',
       expectedDigest: digest,
-    })).rejects.toThrow('factory-registered')
+    })).rejects.toThrow('registration does not match trusted profile')
     const mismatch = { ...value, identity: { ...value.identity, providerId: 'bwrap' as const } }
     await expect(createSandboxLeaseServiceFromProfileV1({
       profile: mismatch,

--- a/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseProfileIdentity.test.ts
+++ b/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseProfileIdentity.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import type { DisposableSandboxProviderV1, SandboxProviderV1 } from '@hachej/boring-sandbox/shared'
+import { SandboxLeaseService } from '../sandboxLease'
+import { SandboxLeaseServiceRegistry } from '../sandboxLeaseServiceRegistry'
 import {
   SANDBOX_LEASE_PROVIDER_PROFILE_VERSION_V1,
   createSandboxLeaseServiceFromProfileV1,
@@ -77,40 +79,22 @@ describe('sandbox lease provider profile identity', () => {
       expectedDigest: sandboxLeaseProviderProfileDigestV1(
         normalizeSandboxLeaseProviderProfileV1(mismatched, 'workspace-a').identity,
       ),
+      registry: new SandboxLeaseServiceRegistry(),
     })).rejects.toThrow('registration does not match trusted profile')
   })
 
   it('constructs a service bound to the complete profile identity', async () => {
     const normalized = normalizeSandboxLeaseProviderProfileV1(profile(), 'workspace-a')
     const digest = sandboxLeaseProviderProfileDigestV1(normalized.identity)
+    const registry = new SandboxLeaseServiceRegistry()
     const service = await createSandboxLeaseServiceFromProfileV1({
       profile: normalized,
       verifiedWorkspaceScopeId: 'workspace-a',
       expectedDigest: digest,
+      registry,
     })
-    const provider = await normalized.providerFactory()
-    expect(() => service.assertProfileBinding({
-      digest,
-      provider,
-      workspaceRoot: normalized.identity.leaseRoot,
-      providerWorkspaceId: normalized.identity.providerWorkspaceId,
-      ttlMs: normalized.identity.ttlMs,
-      reapIntervalMs: normalized.identity.reapIntervalMs,
-      drainTimeoutMs: normalized.identity.drainTimeoutMs,
-      maxActiveLeasesPerOwner: normalized.identity.maxActiveLeasesPerOwner,
-      maxActiveLeasesTotal: normalized.identity.maxActiveLeasesTotal,
-    })).not.toThrow()
-    expect(() => service.assertProfileBinding({
-      digest, provider,
-      workspaceRoot: '/other-root',
-      providerWorkspaceId: normalized.identity.providerWorkspaceId,
-      ttlMs: normalized.identity.ttlMs,
-      reapIntervalMs: normalized.identity.reapIntervalMs,
-      drainTimeoutMs: normalized.identity.drainTimeoutMs,
-      maxActiveLeasesPerOwner: normalized.identity.maxActiveLeasesPerOwner,
-      maxActiveLeasesTotal: normalized.identity.maxActiveLeasesTotal,
-    })).toThrow('does not match')
-    await service.dispose()
+    expect(service.providerIdentity).toBe(await normalized.providerFactory())
+    await registry.dispose()
   })
 
   it('validates constructor intervals before provider effects and closes on construction failure', async () => {
@@ -120,6 +104,7 @@ describe('sandbox lease provider profile identity', () => {
     await expect(createSandboxLeaseServiceFromProfileV1({
       profile: invalid, verifiedWorkspaceScopeId: 'workspace-a',
       expectedDigest: sandboxLeaseProviderProfileDigestV1(invalid.identity),
+      registry: new SandboxLeaseServiceRegistry(),
     })).rejects.toThrow('outside the supported interval')
     expect(providerFactory).not.toHaveBeenCalled()
 
@@ -132,6 +117,7 @@ describe('sandbox lease provider profile identity', () => {
         expectedDigest: sandboxLeaseProviderProfileDigestV1(
           normalizeSandboxLeaseProviderProfileV1(valid, 'workspace-a').identity,
         ),
+        registry: new SandboxLeaseServiceRegistry(),
       }).catch((error: unknown) => error)
       expect(failure).toBeInstanceOf(AggregateError)
       expect((failure as AggregateError).errors.map(String)).toEqual([
@@ -139,6 +125,78 @@ describe('sandbox lease provider profile identity', () => {
       ])
       expect(close).toHaveBeenCalledOnce()
     } finally { interval.mockRestore() }
+  })
+
+  it('claims provider ownership before validation cleanup', async () => {
+    const close = vi.fn(async () => {})
+    const provider = { ...disposableProvider(), close }
+    const owner = new SandboxLeaseService({
+      workspaceRoot: '/host/legacy-leases', provider, serviceDigest: 'legacy',
+      ttlMs: 60_000, reapIntervalMs: 10_000, drainTimeoutMs: 100,
+      maxActiveLeasesPerOwner: 1, maxActiveLeasesTotal: 1,
+    })
+    const registry = new SandboxLeaseServiceRegistry()
+    registry.register({ digest: 'legacy', leases: owner })
+    const value = profile()
+    const invalid = {
+      ...value,
+      providerFactory: () => provider,
+      identity: { ...value.identity, providerConfigDigest: `sha256:${'b'.repeat(64)}` as const },
+    }
+
+    await expect(createSandboxLeaseServiceFromProfileV1({
+      profile: invalid, verifiedWorkspaceScopeId: 'workspace-a',
+      expectedDigest: sandboxLeaseProviderProfileDigestV1(
+        normalizeSandboxLeaseProviderProfileV1(invalid, 'workspace-a').identity,
+      ),
+      registry,
+    })).rejects.toThrow('already owned or claimed')
+    expect(close).not.toHaveBeenCalled()
+    await registry.dispose()
+    expect(close).toHaveBeenCalledOnce()
+  })
+
+  it('keeps a draining provider claim atomic while closing its fresh provider once', async () => {
+    let finishClose!: () => void
+    const close = vi.fn(async () => await new Promise<void>((resolve) => { finishClose = resolve }))
+    const provider = { ...disposableProvider(), close }
+    const value = profile()
+    const digest = sandboxLeaseProviderProfileDigestV1(
+      normalizeSandboxLeaseProviderProfileV1(value, 'workspace-a').identity,
+    )
+    const registry = new SandboxLeaseServiceRegistry()
+    await registry.dispose()
+    const input = { profile: { ...value, providerFactory: () => provider }, verifiedWorkspaceScopeId: 'workspace-a', expectedDigest: digest, registry }
+
+    const first = createSandboxLeaseServiceFromProfileV1(input)
+    await vi.waitFor(() => expect(close).toHaveBeenCalledOnce())
+    await expect(createSandboxLeaseServiceFromProfileV1(input)).rejects.toThrow('already owned or claimed')
+    finishClose()
+    await expect(first).rejects.toThrow('registry is draining')
+    expect(close).toHaveBeenCalledOnce()
+  })
+
+  it('closes a fresh invalid claimed provider once and releases its claim', async () => {
+    const close = vi.fn(async () => {})
+    const provider = { ...disposableProvider(), close }
+    const value = profile()
+    const invalid = {
+      ...value,
+      providerFactory: () => provider,
+      identity: { ...value.identity, providerConfigDigest: `sha256:${'b'.repeat(64)}` as const },
+    }
+    const registry = new SandboxLeaseServiceRegistry()
+
+    await expect(createSandboxLeaseServiceFromProfileV1({
+      profile: invalid, verifiedWorkspaceScopeId: 'workspace-a',
+      expectedDigest: sandboxLeaseProviderProfileDigestV1(
+        normalizeSandboxLeaseProviderProfileV1(invalid, 'workspace-a').identity,
+      ),
+      registry,
+    })).rejects.toThrow('registration does not match trusted profile')
+    expect(close).toHaveBeenCalledOnce()
+    const release = await registry.claimProfileProvider('profile-next', provider)
+    release()
   })
 
   it('rejects caller-asserted generic template aliases', () => {
@@ -169,12 +227,14 @@ describe('sandbox lease provider profile identity', () => {
       },
       verifiedWorkspaceScopeId: 'workspace-a',
       expectedDigest: digest,
+      registry: new SandboxLeaseServiceRegistry(),
     })).rejects.toThrow('registration does not match trusted profile')
     const mismatch = { ...value, identity: { ...value.identity, providerId: 'bwrap' as const } }
     await expect(createSandboxLeaseServiceFromProfileV1({
       profile: mismatch,
       verifiedWorkspaceScopeId: 'workspace-a',
       expectedDigest: sandboxLeaseProviderProfileDigestV1(mismatch.identity),
+      registry: new SandboxLeaseServiceRegistry(),
     })).rejects.toThrow('provider identity does not match')
   })
 })

--- a/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseProfileIdentity.test.ts
+++ b/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseProfileIdentity.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { DisposableSandboxProviderV1, SandboxProviderV1 } from '@hachej/boring-sandbox/shared'
 import {
@@ -111,6 +111,34 @@ describe('sandbox lease provider profile identity', () => {
       maxActiveLeasesTotal: normalized.identity.maxActiveLeasesTotal,
     })).toThrow('does not match')
     await service.dispose()
+  })
+
+  it('validates constructor intervals before provider effects and closes on construction failure', async () => {
+    const value = profile()
+    const providerFactory = vi.fn(value.providerFactory)
+    const invalid = { ...value, providerFactory, identity: { ...value.identity, reapIntervalMs: 999 } }
+    await expect(createSandboxLeaseServiceFromProfileV1({
+      profile: invalid, verifiedWorkspaceScopeId: 'workspace-a',
+      expectedDigest: sandboxLeaseProviderProfileDigestV1(invalid.identity),
+    })).rejects.toThrow('outside the supported interval')
+    expect(providerFactory).not.toHaveBeenCalled()
+
+    const close = vi.fn(async () => { throw new Error('close failed') })
+    const valid = { ...value, providerFactory: () => ({ ...disposableProvider(), close }) }
+    const interval = vi.spyOn(globalThis, 'setInterval').mockImplementationOnce(() => { throw new Error('timer failed') })
+    try {
+      const failure = await createSandboxLeaseServiceFromProfileV1({
+        profile: valid, verifiedWorkspaceScopeId: 'workspace-a',
+        expectedDigest: sandboxLeaseProviderProfileDigestV1(
+          normalizeSandboxLeaseProviderProfileV1(valid, 'workspace-a').identity,
+        ),
+      }).catch((error: unknown) => error)
+      expect(failure).toBeInstanceOf(AggregateError)
+      expect((failure as AggregateError).errors.map(String)).toEqual([
+        'Error: timer failed', 'Error: close failed',
+      ])
+      expect(close).toHaveBeenCalledOnce()
+    } finally { interval.mockRestore() }
   })
 
   it('rejects caller-asserted generic template aliases', () => {

--- a/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseProfileIdentity.test.ts
+++ b/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseProfileIdentity.test.ts
@@ -114,6 +114,22 @@ describe('sandbox lease provider profile identity', () => {
     await service.dispose()
   })
 
+  it('requires template paths and fingerprints together and binds template authority', () => {
+    const value = profile()
+    expect(() => normalizeSandboxLeaseProviderProfileV1({ ...value, templatePath: '/templates/a' }, 'workspace-a'))
+      .toThrow('must be supplied together')
+    expect(() => normalizeSandboxLeaseProviderProfileV1({
+      ...value, identity: { ...value.identity, templateFingerprint: sha },
+    }, 'workspace-a')).toThrow('must be supplied together')
+    const digest = (fingerprint: `sha256:${string}`) => sandboxLeaseProviderProfileDigestV1(
+      normalizeSandboxLeaseProviderProfileV1({
+        ...value, templatePath: '/templates/a',
+        identity: { ...value.identity, templateFingerprint: fingerprint },
+      }, 'workspace-a').identity,
+    )
+    expect(digest(sha)).not.toBe(digest(`sha256:${'b'.repeat(64)}`))
+  })
+
   it('rejects cross-workspace reuse before provider use', () => {
     expect(() => normalizeSandboxLeaseProviderProfileV1(profile('workspace-a'), 'workspace-b'))
       .toThrow('profile scope is unauthorized')

--- a/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseServiceFactoryRegistry.test.ts
+++ b/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseServiceFactoryRegistry.test.ts
@@ -1,26 +1,54 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import type { SandboxLeaseService } from '../sandboxLease'
+import { SandboxLeaseService } from '../sandboxLease'
 import { SandboxLeaseServiceFactoryRegistry } from '../sandboxLeaseServiceFactoryRegistry'
+import { fakeDisposableProvider } from './fakeDisposableProvider'
 
-describe('SandboxLeaseServiceFactoryRegistry', () => {
-  it('invokes one factory for concurrent callers', async () => {
-    const service = {} as SandboxLeaseService
-    const factory = vi.fn(async () => service)
+function service(): SandboxLeaseService {
+  return {
+    isDisposed: false,
+    providerIdentity: {},
+    dispose: vi.fn(async () => {}),
+  } as unknown as SandboxLeaseService
+}
+
+describe('SandboxLeaseServiceFactoryRegistry compatibility alias', () => {
+  it('invokes one factory for concurrent callers and owns disposal', async () => {
+    const leases = service()
+    const factory = vi.fn(async () => leases)
     const registry = new SandboxLeaseServiceFactoryRegistry()
     const [first, second] = await Promise.all([
       registry.getOrCreate('profile-a', factory),
       registry.getOrCreate('profile-a', factory),
     ])
-    expect(first).toBe(service)
-    expect(second).toBe(service)
+    expect(first).toBe(leases)
+    expect(second).toBe(leases)
     expect(factory).toHaveBeenCalledOnce()
+    await registry.dispose()
+    expect(leases.dispose).toHaveBeenCalledOnce()
+  })
+
+  it('evicts a service disposed outside the registry and constructs a fresh service', async () => {
+    const registry = new SandboxLeaseServiceFactoryRegistry()
+    const factory = vi.fn(() => new SandboxLeaseService({
+      workspaceRoot: '/host/leases',
+      provider: fakeDisposableProvider({ create: async () => { throw new Error('not used') } }),
+      serviceDigest: 'profile-a', ttlMs: 60_000, reapIntervalMs: 60_000,
+      drainTimeoutMs: 100, maxActiveLeasesPerOwner: 1, maxActiveLeasesTotal: 1,
+    }))
+    const first = await registry.getOrCreate('profile-a', factory)
+    await first.dispose()
+    expect(first.isDisposed).toBe(true)
+    const second = await registry.getOrCreate('profile-a', factory)
+    expect(second).not.toBe(first)
+    expect(factory).toHaveBeenCalledTimes(2)
+    await registry.dispose()
   })
 
   it('allows retry after construction fails', async () => {
     const registry = new SandboxLeaseServiceFactoryRegistry()
     await expect(registry.getOrCreate('profile-a', async () => { throw new Error('failed') })).rejects.toThrow('failed')
-    const service = {} as SandboxLeaseService
-    await expect(registry.getOrCreate('profile-a', () => service)).resolves.toBe(service)
+    const leases = service()
+    await expect(registry.getOrCreate('profile-a', () => leases)).resolves.toBe(leases)
   })
 })

--- a/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseServiceFactoryRegistry.test.ts
+++ b/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseServiceFactoryRegistry.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { SandboxLeaseService } from '../sandboxLease'
+import { SandboxLeaseServiceFactoryRegistry } from '../sandboxLeaseServiceFactoryRegistry'
+
+describe('SandboxLeaseServiceFactoryRegistry', () => {
+  it('invokes one factory for concurrent callers', async () => {
+    const service = {} as SandboxLeaseService
+    const factory = vi.fn(async () => service)
+    const registry = new SandboxLeaseServiceFactoryRegistry()
+    const [first, second] = await Promise.all([
+      registry.getOrCreate('profile-a', factory),
+      registry.getOrCreate('profile-a', factory),
+    ])
+    expect(first).toBe(service)
+    expect(second).toBe(service)
+    expect(factory).toHaveBeenCalledOnce()
+  })
+
+  it('allows retry after construction fails', async () => {
+    const registry = new SandboxLeaseServiceFactoryRegistry()
+    await expect(registry.getOrCreate('profile-a', async () => { throw new Error('failed') })).rejects.toThrow('failed')
+    const service = {} as SandboxLeaseService
+    await expect(registry.getOrCreate('profile-a', () => service)).resolves.toBe(service)
+  })
+})

--- a/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseServiceRegistry.test.ts
+++ b/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseServiceRegistry.test.ts
@@ -6,6 +6,7 @@ import { SandboxLeaseServiceRegistry } from '../sandboxLeaseServiceRegistry'
 function service(dispose = vi.fn(async () => {}), providerIdentity: object = {}) {
   return {
     dispose,
+    abandonUnregistered: vi.fn(),
     isDisposed: false,
     providerIdentity,
   } as unknown as SandboxLeaseService
@@ -56,6 +57,22 @@ describe('SandboxLeaseServiceRegistry', () => {
       .toThrow('service is already bound to another capability digest')
     await registry.dispose()
     expect(leases.dispose).toHaveBeenCalledOnce()
+  })
+
+  it('drains a pending factory without publishing and rejects later acquisition', async () => {
+    let resolveFactory!: (value: SandboxLeaseService) => void
+    const pending = new Promise<SandboxLeaseService>((resolve) => { resolveFactory = resolve })
+    const leases = service()
+    const registry = new SandboxLeaseServiceRegistry()
+    const acquiring = registry.getOrCreate('profile-a', async () => await pending)
+    const draining = registry.disposeUntil(Date.now() + 500)
+    resolveFactory(leases)
+
+    await expect(acquiring).rejects.toThrow('drained during construction')
+    await expect(draining).resolves.toEqual([])
+    expect(leases.dispose).toHaveBeenCalledOnce()
+    await expect(registry.getOrCreate('profile-b', () => service())).rejects.toThrow('registry is draining')
+    expect(() => registry.register({ digest: 'profile-b', leases: service() })).toThrow('registry is draining')
   })
 
   it('retains failed services and retries them to terminal disposal within a deadline', async () => {

--- a/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseServiceRegistry.test.ts
+++ b/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseServiceRegistry.test.ts
@@ -103,6 +103,21 @@ describe('SandboxLeaseServiceRegistry', () => {
     expect(owner.dispose).toHaveBeenCalledOnce()
   })
 
+  it('claims one pending provider across digests and promotes the claim on binding', async () => {
+    const provider = {}
+    const leases = service(vi.fn(async () => {}), provider)
+    const registry = new SandboxLeaseServiceRegistry()
+    const release = await registry.claimProfileProvider('profile-a', provider)
+
+    await expect(registry.claimProfileProvider('profile-b', provider)).rejects.toThrow('already owned or claimed')
+    expect(() => registry.register({ digest: 'profile-a', leases })).toThrow('provider is already owned')
+    registry.promoteProfileProvider('profile-a', leases)
+    await expect(registry.getOrCreate('profile-a', () => service())).resolves.toBe(leases)
+    release()
+    await expect(registry.claimProfileProvider('profile-b', provider)).rejects.toThrow('already owned or claimed')
+    await registry.dispose()
+  })
+
   it('coalesces concurrent factories only within the profile namespace', async () => {
     let resolveFactory!: (value: SandboxLeaseService) => void
     const leases = service()

--- a/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseServiceRegistry.test.ts
+++ b/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseServiceRegistry.test.ts
@@ -3,8 +3,12 @@ import { describe, expect, it, vi } from 'vitest'
 import type { SandboxLeaseService } from '../sandboxLease'
 import { SandboxLeaseServiceRegistry } from '../sandboxLeaseServiceRegistry'
 
-function service() {
-  return { dispose: vi.fn(async () => {}) } as unknown as SandboxLeaseService
+function service(dispose = vi.fn(async () => {}), providerIdentity: object = {}) {
+  return {
+    dispose,
+    isDisposed: false,
+    providerIdentity,
+  } as unknown as SandboxLeaseService
 }
 
 describe('SandboxLeaseServiceRegistry', () => {
@@ -32,6 +36,17 @@ describe('SandboxLeaseServiceRegistry', () => {
     expect(conflict.dispose).not.toHaveBeenCalled()
   })
 
+  it('rejects one provider instance owned by services under different digests', async () => {
+    const provider = {}
+    const first = service(vi.fn(async () => {}), provider)
+    const alias = service(vi.fn(async () => {}), provider)
+    const registry = new SandboxLeaseServiceRegistry()
+    registry.register({ digest: 'profile-a', leases: first })
+    expect(() => registry.register({ digest: 'profile-b', leases: alias }))
+      .toThrow('provider is already owned')
+    await registry.dispose()
+  })
+
   it('rejects the same service bound to different digests', async () => {
     const leases = service()
     const registry = new SandboxLeaseServiceRegistry()
@@ -47,7 +62,7 @@ describe('SandboxLeaseServiceRegistry', () => {
     const dispose = vi.fn()
       .mockRejectedValueOnce(new Error('remote deletion acknowledgement lost'))
       .mockResolvedValue(undefined)
-    const leases = { dispose } as unknown as SandboxLeaseService
+    const leases = service(dispose)
     const registry = new SandboxLeaseServiceRegistry()
     registry.register({ digest: 'profile-a', leases })
 

--- a/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseServiceRegistry.test.ts
+++ b/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseServiceRegistry.test.ts
@@ -162,29 +162,33 @@ describe('SandboxLeaseServiceRegistry', () => {
     expect(leases.dispose).toHaveBeenCalledOnce()
   })
 
-  it('disposes registered services before a stuck factory settles and retries late cleanup debt', async () => {
+  it('retries registered cleanup while an unrelated factory remains stuck', async () => {
+    const registeredDispose = vi.fn()
+      .mockRejectedValueOnce(new Error('registered provider delete failed'))
+      .mockResolvedValue(undefined)
+    const registry = new SandboxLeaseServiceRegistry()
+    registry.register({ digest: 'registered', leases: service(registeredDispose) })
+    void registry.getOrCreate('pending', () => new Promise(() => {})).catch(() => undefined)
+
+    await expect(registry.disposeUntil(Date.now() + 40)).resolves.toEqual([
+      expect.objectContaining({ status: 'rejected' }),
+    ])
+    expect(registeredDispose).toHaveBeenCalledTimes(2)
+  })
+
+  it('runs another debt pass when a late factory fails its first cleanup', async () => {
     let resolveFactory!: (value: SandboxLeaseService) => void
-    let registeredDisposed = false
-    const registeredDispose = vi.fn(async () => { registeredDisposed = true })
     const lateDispose = vi.fn()
       .mockRejectedValueOnce(new Error('late provider delete failed'))
       .mockResolvedValue(undefined)
     const registry = new SandboxLeaseServiceRegistry()
-    registry.register({ digest: 'registered', leases: service(registeredDispose) })
     const acquiring = registry.getOrCreate('pending', () => new Promise((resolve) => { resolveFactory = resolve }))
     await vi.waitFor(() => expect(resolveFactory).toBeTypeOf('function'))
 
-    const timedOut = await registry.disposeUntil(Date.now() + 20)
-    expect(registeredDispose).toHaveBeenCalledOnce()
-    expect(registeredDisposed).toBe(true)
-    expect(timedOut).toEqual([expect.objectContaining({ status: 'rejected' })])
-
+    const draining = registry.dispose()
     resolveFactory(service(lateDispose))
     await expect(acquiring).rejects.toThrow('late provider delete failed')
-    expect(lateDispose).toHaveBeenCalledOnce()
-    await expect(registry.disposeUntil(Date.now() + 100)).resolves.toEqual([
-      { status: 'fulfilled', value: undefined },
-    ])
+    await expect(draining).resolves.toEqual([{ status: 'fulfilled', value: undefined }])
     expect(lateDispose).toHaveBeenCalledTimes(2)
     await expect(registry.dispose()).resolves.toEqual([])
   })

--- a/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseServiceRegistry.test.ts
+++ b/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseServiceRegistry.test.ts
@@ -162,6 +162,33 @@ describe('SandboxLeaseServiceRegistry', () => {
     expect(leases.dispose).toHaveBeenCalledOnce()
   })
 
+  it('disposes registered services before a stuck factory settles and retries late cleanup debt', async () => {
+    let resolveFactory!: (value: SandboxLeaseService) => void
+    let registeredDisposed = false
+    const registeredDispose = vi.fn(async () => { registeredDisposed = true })
+    const lateDispose = vi.fn()
+      .mockRejectedValueOnce(new Error('late provider delete failed'))
+      .mockResolvedValue(undefined)
+    const registry = new SandboxLeaseServiceRegistry()
+    registry.register({ digest: 'registered', leases: service(registeredDispose) })
+    const acquiring = registry.getOrCreate('pending', () => new Promise((resolve) => { resolveFactory = resolve }))
+    await vi.waitFor(() => expect(resolveFactory).toBeTypeOf('function'))
+
+    const timedOut = await registry.disposeUntil(Date.now() + 20)
+    expect(registeredDispose).toHaveBeenCalledOnce()
+    expect(registeredDisposed).toBe(true)
+    expect(timedOut).toEqual([expect.objectContaining({ status: 'rejected' })])
+
+    resolveFactory(service(lateDispose))
+    await expect(acquiring).rejects.toThrow('late provider delete failed')
+    expect(lateDispose).toHaveBeenCalledOnce()
+    await expect(registry.disposeUntil(Date.now() + 100)).resolves.toEqual([
+      { status: 'fulfilled', value: undefined },
+    ])
+    expect(lateDispose).toHaveBeenCalledTimes(2)
+    await expect(registry.dispose()).resolves.toEqual([])
+  })
+
   it('retains failed services and retries them to terminal disposal within a deadline', async () => {
     const dispose = vi.fn()
       .mockRejectedValueOnce(new Error('remote deletion acknowledgement lost'))

--- a/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseServiceRegistry.test.ts
+++ b/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseServiceRegistry.test.ts
@@ -71,6 +71,38 @@ describe('SandboxLeaseServiceRegistry', () => {
     expect(legacy.dispose).toHaveBeenCalledOnce()
   })
 
+  it('reserves a pending profile digest against legacy registration and keeps one cleanup owner', async () => {
+    let resolveFactory!: (value: SandboxLeaseService) => void
+    const profileService = service()
+    const rejectedLegacy = service()
+    const factory = vi.fn(() => new Promise<SandboxLeaseService>((resolve) => { resolveFactory = resolve }))
+    const registry = new SandboxLeaseServiceRegistry()
+    const acquiring = registry.getOrCreate('profile-a', factory)
+    await vi.waitFor(() => expect(factory).toHaveBeenCalledOnce())
+
+    expect(() => registry.register({ digest: 'profile-a', leases: rejectedLegacy }))
+      .toThrow('reserved by a pending factory')
+    resolveFactory(profileService)
+    await expect(acquiring).resolves.toBe(profileService)
+    await registry.dispose()
+    expect(profileService.dispose).toHaveBeenCalledOnce()
+    expect(rejectedLegacy.dispose).not.toHaveBeenCalled()
+  })
+
+  it('abandons only a new service wrapper when its provider is already owned', async () => {
+    const provider = {}
+    const owner = service(vi.fn(async () => {}), provider)
+    const alias = service(vi.fn(async () => {}), provider)
+    const registry = new SandboxLeaseServiceRegistry()
+    registry.register({ digest: 'legacy-a', leases: owner })
+
+    await expect(registry.getOrCreate('profile-b', () => alias)).rejects.toThrow('provider is already owned')
+    expect(alias.abandonUnregistered).toHaveBeenCalledOnce()
+    expect(alias.dispose).not.toHaveBeenCalled()
+    await registry.dispose()
+    expect(owner.dispose).toHaveBeenCalledOnce()
+  })
+
   it('coalesces concurrent factories only within the profile namespace', async () => {
     let resolveFactory!: (value: SandboxLeaseService) => void
     const leases = service()

--- a/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseServiceRegistry.test.ts
+++ b/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseServiceRegistry.test.ts
@@ -75,6 +75,19 @@ describe('SandboxLeaseServiceRegistry', () => {
     expect(() => registry.register({ digest: 'profile-b', leases: service() })).toThrow('registry is draining')
   })
 
+  it('bounds a stuck factory and owns its late service cleanup', async () => {
+    let resolveFactory!: (value: SandboxLeaseService) => void
+    const leases = service()
+    const registry = new SandboxLeaseServiceRegistry()
+    const acquiring = registry.getOrCreate('profile-a', () => new Promise((resolve) => { resolveFactory = resolve }))
+
+    const results = await registry.disposeUntil(Date.now() + 20)
+    expect(results).toEqual([expect.objectContaining({ status: 'rejected' })])
+    resolveFactory(leases)
+    await expect(acquiring).rejects.toThrow('drained during construction')
+    expect(leases.dispose).toHaveBeenCalledOnce()
+  })
+
   it('retains failed services and retries them to terminal disposal within a deadline', async () => {
     const dispose = vi.fn()
       .mockRejectedValueOnce(new Error('remote deletion acknowledgement lost'))

--- a/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseServiceRegistry.test.ts
+++ b/packages/agent/src/server/sandbox/leases/__tests__/sandboxLeaseServiceRegistry.test.ts
@@ -59,6 +59,33 @@ describe('SandboxLeaseServiceRegistry', () => {
     expect(leases.dispose).toHaveBeenCalledOnce()
   })
 
+  it('never adopts a same-digest legacy service into the profile namespace', async () => {
+    const legacy = service()
+    const factory = vi.fn(() => service())
+    const registry = new SandboxLeaseServiceRegistry()
+    registry.register({ digest: 'profile-a', leases: legacy })
+
+    await expect(registry.getOrCreate('profile-a', factory)).rejects.toThrow('owned by a legacy service')
+    expect(factory).not.toHaveBeenCalled()
+    await registry.dispose()
+    expect(legacy.dispose).toHaveBeenCalledOnce()
+  })
+
+  it('coalesces concurrent factories only within the profile namespace', async () => {
+    let resolveFactory!: (value: SandboxLeaseService) => void
+    const leases = service()
+    const factory = vi.fn(() => new Promise<SandboxLeaseService>((resolve) => { resolveFactory = resolve }))
+    const registry = new SandboxLeaseServiceRegistry()
+    const first = registry.getOrCreate('profile-a', factory)
+    const second = registry.getOrCreate('profile-a', factory)
+    await vi.waitFor(() => expect(factory).toHaveBeenCalledOnce())
+    resolveFactory(leases)
+
+    await expect(first).resolves.toBe(leases)
+    await expect(second).resolves.toBe(leases)
+    await registry.dispose()
+  })
+
   it('drains a pending factory without publishing and rejects later acquisition', async () => {
     let resolveFactory!: (value: SandboxLeaseService) => void
     const pending = new Promise<SandboxLeaseService>((resolve) => { resolveFactory = resolve })

--- a/packages/agent/src/server/sandbox/leases/disposableProvider.ts
+++ b/packages/agent/src/server/sandbox/leases/disposableProvider.ts
@@ -6,23 +6,33 @@ import type {
 const DISPOSABLE_PROFILE_VERSION = 'boring-sandbox.disposable-provider.v1'
 const SHA256 = /^sha256:[a-f0-9]{64}$/
 
-/** Agent invokes the factory-bound assertion without value-importing the sandbox package. */
+const trustedProviders = new WeakMap<SandboxProviderV1, `sha256:${string}`>()
+
+function hasDisposableShape(provider: SandboxProviderV1): provider is DisposableSandboxProviderV1 {
+  const profile = (provider as Partial<DisposableSandboxProviderV1>).disposableProfile
+  return profile?.contractVersion === DISPOSABLE_PROFILE_VERSION
+    && profile.resume === false
+    && profile.publishedCleanupOwner === 'returned-pair'
+    && profile.ambiguousCreate === 'correlated-reconciliation'
+    && SHA256.test(profile.providerConfigDigest)
+}
+
+/** Minted only by Agent's trusted host profile factory after exact digest verification. */
+export function registerTrustedDisposableLeaseProvider(
+  provider: SandboxProviderV1,
+  expectedDigest: `sha256:${string}`,
+): asserts provider is DisposableSandboxProviderV1 {
+  if (!hasDisposableShape(provider) || provider.disposableProfile.providerConfigDigest !== expectedDigest) {
+    throw new TypeError('sandbox lease provider registration does not match trusted profile')
+  }
+  trustedProviders.set(provider, expectedDigest)
+}
+
 export function isDisposableLeaseProvider(
   provider: SandboxProviderV1,
 ): provider is DisposableSandboxProviderV1 {
-  const profile = (provider as Partial<DisposableSandboxProviderV1>).disposableProfile
-  if (
-    profile?.contractVersion !== DISPOSABLE_PROFILE_VERSION
-    || profile.resume !== false
-    || profile.publishedCleanupOwner !== 'returned-pair'
-    || profile.ambiguousCreate !== 'correlated-reconciliation'
-    || !SHA256.test(profile.providerConfigDigest)
-    || typeof profile.assertProvider !== 'function'
-  ) return false
-  try {
-    profile.assertProvider(provider)
-    return true
-  } catch {
-    return false
-  }
+  const digest = trustedProviders.get(provider)
+  return digest !== undefined
+    && hasDisposableShape(provider)
+    && provider.disposableProfile.providerConfigDigest === digest
 }

--- a/packages/agent/src/server/sandbox/leases/disposableProvider.ts
+++ b/packages/agent/src/server/sandbox/leases/disposableProvider.ts
@@ -4,14 +4,25 @@ import type {
 } from '@hachej/boring-sandbox/shared'
 
 const DISPOSABLE_PROFILE_VERSION = 'boring-sandbox.disposable-provider.v1'
+const SHA256 = /^sha256:[a-f0-9]{64}$/
 
-/** Agent-side structural admission check; boring-sandbox remains a runtime leaf. */
+/** Agent invokes the factory-bound assertion without value-importing the sandbox package. */
 export function isDisposableLeaseProvider(
   provider: SandboxProviderV1,
 ): provider is DisposableSandboxProviderV1 {
   const profile = (provider as Partial<DisposableSandboxProviderV1>).disposableProfile
-  return profile?.contractVersion === DISPOSABLE_PROFILE_VERSION
-    && profile.resume === false
-    && profile.publishedCleanupOwner === 'returned-pair'
-    && profile.ambiguousCreate === 'correlated-reconciliation'
+  if (
+    profile?.contractVersion !== DISPOSABLE_PROFILE_VERSION
+    || profile.resume !== false
+    || profile.publishedCleanupOwner !== 'returned-pair'
+    || profile.ambiguousCreate !== 'correlated-reconciliation'
+    || !SHA256.test(profile.providerConfigDigest)
+    || typeof profile.assertProvider !== 'function'
+  ) return false
+  try {
+    profile.assertProvider(provider)
+    return true
+  } catch {
+    return false
+  }
 }

--- a/packages/agent/src/server/sandbox/leases/disposableProvider.ts
+++ b/packages/agent/src/server/sandbox/leases/disposableProvider.ts
@@ -1,0 +1,17 @@
+import type {
+  DisposableSandboxProviderV1,
+  SandboxProviderV1,
+} from '@hachej/boring-sandbox/shared'
+
+const DISPOSABLE_PROFILE_VERSION = 'boring-sandbox.disposable-provider.v1'
+
+/** Agent-side structural admission check; boring-sandbox remains a runtime leaf. */
+export function isDisposableLeaseProvider(
+  provider: SandboxProviderV1,
+): provider is DisposableSandboxProviderV1 {
+  const profile = (provider as Partial<DisposableSandboxProviderV1>).disposableProfile
+  return profile?.contractVersion === DISPOSABLE_PROFILE_VERSION
+    && profile.resume === false
+    && profile.publishedCleanupOwner === 'returned-pair'
+    && profile.ambiguousCreate === 'correlated-reconciliation'
+}

--- a/packages/agent/src/server/sandbox/leases/disposableProvider.ts
+++ b/packages/agent/src/server/sandbox/leases/disposableProvider.ts
@@ -8,7 +8,7 @@ const SHA256 = /^sha256:[a-f0-9]{64}$/
 
 const trustedProviders = new WeakMap<SandboxProviderV1, `sha256:${string}`>()
 
-function hasDisposableShape(provider: SandboxProviderV1): provider is DisposableSandboxProviderV1 {
+export function hasDisposableLeaseProviderShape(provider: SandboxProviderV1): provider is DisposableSandboxProviderV1 {
   const profile = (provider as Partial<DisposableSandboxProviderV1>).disposableProfile
   return profile?.contractVersion === DISPOSABLE_PROFILE_VERSION
     && profile.resume === false
@@ -22,7 +22,7 @@ export function registerTrustedDisposableLeaseProvider(
   provider: SandboxProviderV1,
   expectedDigest: `sha256:${string}`,
 ): asserts provider is DisposableSandboxProviderV1 {
-  if (!hasDisposableShape(provider) || provider.disposableProfile.providerConfigDigest !== expectedDigest) {
+  if (!hasDisposableLeaseProviderShape(provider) || provider.disposableProfile.providerConfigDigest !== expectedDigest) {
     throw new TypeError('sandbox lease provider registration does not match trusted profile')
   }
   trustedProviders.set(provider, expectedDigest)
@@ -33,6 +33,6 @@ export function isDisposableLeaseProvider(
 ): provider is DisposableSandboxProviderV1 {
   const digest = trustedProviders.get(provider)
   return digest !== undefined
-    && hasDisposableShape(provider)
+    && hasDisposableLeaseProviderShape(provider)
     && provider.disposableProfile.providerConfigDigest === digest
 }

--- a/packages/agent/src/server/sandbox/leases/resolveSandboxToolCapability.ts
+++ b/packages/agent/src/server/sandbox/leases/resolveSandboxToolCapability.ts
@@ -29,6 +29,7 @@ export async function resolveSandboxToolCapability(input: {
       profile,
       verifiedWorkspaceScopeId: workspaceScopeId,
       expectedDigest: digest,
+      registry,
     }))
   return Object.freeze({ digest, profile, leases })
 }

--- a/packages/agent/src/server/sandbox/leases/resolveSandboxToolCapability.ts
+++ b/packages/agent/src/server/sandbox/leases/resolveSandboxToolCapability.ts
@@ -1,0 +1,34 @@
+import type { ResolvedSandboxToolCapability } from '../../agent-host/types'
+import {
+  createSandboxLeaseServiceFromProfileV1,
+  normalizeSandboxLeaseProviderProfileV1,
+  sandboxLeaseProviderProfileDigestV1,
+} from './sandboxLeaseProfileIdentity'
+import type { SandboxLeaseServiceRegistry } from './sandboxLeaseServiceRegistry'
+
+/** Validates host profile authority and atomically binds it to one lifecycle-owned service. */
+export async function resolveSandboxToolCapability(input: {
+  capability: ResolvedSandboxToolCapability
+  workspaceScopeId: string
+  registry: SandboxLeaseServiceRegistry
+}): Promise<ResolvedSandboxToolCapability> {
+  const { capability, registry, workspaceScopeId } = input
+  if (!capability.profile) {
+    if (!capability.leases) throw new TypeError('sandbox capability requires a service or provider profile')
+    registry.register({ digest: capability.digest, leases: capability.leases })
+    return capability
+  }
+  if (capability.leases) {
+    throw new TypeError('profile-backed sandbox capability cannot supply a preconstructed service')
+  }
+  const profile = normalizeSandboxLeaseProviderProfileV1(capability.profile, workspaceScopeId)
+  const digest = sandboxLeaseProviderProfileDigestV1(profile.identity)
+  if (digest !== capability.digest) throw new TypeError('sandbox lease profile digest does not match capability')
+  const leases = await registry.getOrCreate(digest, async () =>
+    await createSandboxLeaseServiceFromProfileV1({
+      profile,
+      verifiedWorkspaceScopeId: workspaceScopeId,
+      expectedDigest: digest,
+    }))
+  return Object.freeze({ digest, profile, leases })
+}

--- a/packages/agent/src/server/sandbox/leases/sandboxLease.ts
+++ b/packages/agent/src/server/sandbox/leases/sandboxLease.ts
@@ -1,9 +1,11 @@
 import { createHash, randomUUID } from 'node:crypto'
+import { lstat } from 'node:fs/promises'
 import { join } from 'node:path'
 
-import type {
-  SandboxProviderV1,
-  WorkspaceSandboxPairV1,
+import {
+  isDisposableSandboxProviderV1,
+  type SandboxProviderV1,
+  type WorkspaceSandboxPairV1,
 } from '@hachej/boring-sandbox/shared'
 
 const LEASE_HANDLE_PATTERN = /^[A-Za-z0-9_-]{16,128}$/
@@ -47,6 +49,9 @@ export interface SandboxLeaseServiceOptions {
   provider: SandboxProviderV1
   /** Immutable profile/capability identity; never exposed to the model. */
   serviceDigest: string
+  /** Host-authorized physical provider scope; never derived from model input. */
+  providerWorkspaceId?: string
+  templatePath?: string
   ttlMs: number
   reapIntervalMs: number
   drainTimeoutMs: number
@@ -120,6 +125,9 @@ export class SandboxLeaseService {
   private disposal: Promise<void> | undefined
 
   constructor(private readonly options: SandboxLeaseServiceOptions) {
+    if (options.provider.contractVersion && !isDisposableSandboxProviderV1(options.provider)) {
+      this.invalid('provider must implement the disposable sandbox profile')
+    }
     if (!Number.isFinite(options.ttlMs) || options.ttlMs <= 0) this.invalid('ttlMs must be greater than zero')
     if (!Number.isFinite(options.reapIntervalMs) || options.reapIntervalMs < 1_000 || options.reapIntervalMs > Math.min(options.ttlMs, 60_000)) {
       this.invalid('reapIntervalMs must be between 1000 and min(ttlMs, 60000)')
@@ -151,9 +159,23 @@ export class SandboxLeaseService {
       this.pendingAcquisitions.add(pending)
 
       this.assertCreationPublishable(signal)
+      const workspaceRoot = join(this.options.workspaceRoot, handle)
+      if (this.options.provider.contractVersion) {
+        try {
+          await lstat(workspaceRoot)
+          throw this.creationAborted('sandbox lease root already exists')
+        } catch (error) {
+          if ((error as { code?: unknown }).code !== 'ENOENT') throw error
+        }
+      }
       pair = await this.options.provider.create({
-        workspaceRoot: join(this.options.workspaceRoot, handle),
+        workspaceRoot,
         sessionId: handle,
+        ...(this.options.providerWorkspaceId ? { workspaceId: this.options.providerWorkspaceId } : {}),
+        ...(this.options.templatePath ? { templatePath: this.options.templatePath } : {}),
+        requestId: createHash('sha256')
+          .update(`${this.options.serviceDigest}:${handle}:provider-create`)
+          .digest('hex'),
       })
       this.assertCreationPublishable(signal)
       const health = await pair.checkHealth?.()
@@ -219,7 +241,15 @@ export class SandboxLeaseService {
     lease.activeOperations += 1
     let cleanupAfterUnpin = false
     try {
-      const health = await lease.pair.checkHealth?.()
+      let health: Awaited<ReturnType<NonNullable<WorkspaceSandboxPairV1['checkHealth']>>> | undefined
+      try {
+        health = await lease.pair.checkHealth?.()
+      } catch {
+        lease.state = 'draining'
+        lease.cleanupReason = 'expiry'
+        cleanupAfterUnpin = true
+        throw new SandboxLeaseError(SANDBOX_LEASE_ERROR_CODES.LEASE_EXPIRED, 'sandbox lease is unavailable')
+      }
       if (health?.state === 'recreate') {
         lease.state = 'draining'
         lease.cleanupReason = 'expiry'

--- a/packages/agent/src/server/sandbox/leases/sandboxLease.ts
+++ b/packages/agent/src/server/sandbox/leases/sandboxLease.ts
@@ -125,7 +125,7 @@ export class SandboxLeaseService {
   private disposal: Promise<void> | undefined
 
   constructor(private readonly options: SandboxLeaseServiceOptions) {
-    if (options.provider.contractVersion && !isDisposableLeaseProvider(options.provider)) {
+    if (!isDisposableLeaseProvider(options.provider)) {
       this.invalid('provider must implement the disposable sandbox profile')
     }
     if (!Number.isFinite(options.ttlMs) || options.ttlMs <= 0) this.invalid('ttlMs must be greater than zero')
@@ -140,6 +140,17 @@ export class SandboxLeaseService {
     this.createHandle = options.createHandle ?? randomUUID
     this.timer = setInterval(() => { void this.runScheduledReap() }, options.reapIntervalMs)
     this.timer.unref?.()
+  }
+
+  get isClosed(): boolean { return this.closed }
+  get isDisposed(): boolean { return this.providerClosed && this.leases.size === 0 }
+  get providerIdentity(): SandboxProviderV1 { return this.options.provider }
+
+  /** Registry compensation before publication; no lease or provider cleanup authority was transferred. */
+  abandonUnregistered(): void {
+    if (this.leases.size || this.pendingTotal) throw new TypeError('active sandbox lease service cannot be abandoned')
+    this.closed = true
+    clearInterval(this.timer)
   }
 
   assertProfileBinding(input: {
@@ -185,7 +196,7 @@ export class SandboxLeaseService {
 
       this.assertCreationPublishable(signal)
       const workspaceRoot = join(this.options.workspaceRoot, handle)
-      if (this.options.provider.contractVersion) {
+      {
         try {
           await lstat(workspaceRoot)
           throw this.creationAborted('sandbox lease root already exists')
@@ -358,7 +369,11 @@ export class SandboxLeaseService {
   }
 
   private closeProvider(): Promise<void> {
-    if (!this.options.provider.close || this.providerClosed) return Promise.resolve()
+    if (this.providerClosed) return Promise.resolve()
+    if (!this.options.provider.close) {
+      this.providerClosed = true
+      return Promise.resolve()
+    }
     if (!this.providerCloseInFlight) {
       const effect = Promise.resolve().then(async () => { await this.options.provider.close?.() })
       const tracked = effect

--- a/packages/agent/src/server/sandbox/leases/sandboxLease.ts
+++ b/packages/agent/src/server/sandbox/leases/sandboxLease.ts
@@ -7,7 +7,7 @@ import type {
   SandboxProviderV1,
   WorkspaceSandboxPairV1,
 } from '@hachej/boring-sandbox/shared'
-import { isDisposableLeaseProvider } from './disposableProvider'
+import { hasDisposableLeaseProviderShape } from './disposableProvider'
 
 const LEASE_HANDLE_PATTERN = /^[A-Za-z0-9_-]{16,128}$/
 export const SANDBOX_REMOTE_DISPOSE_OPERATION_ID = 'sandbox.remote.dispose.v1' as const
@@ -127,9 +127,7 @@ export class SandboxLeaseService {
   private disposal: Promise<void> | undefined
 
   constructor(private readonly options: SandboxLeaseServiceOptions) {
-    if (!isDisposableLeaseProvider(options.provider)) {
-      this.invalid('provider must implement the disposable sandbox profile')
-    }
+    if (!hasDisposableLeaseProviderShape(options.provider)) this.invalid('provider must implement the disposable sandbox profile')
     if (!Number.isFinite(options.ttlMs) || options.ttlMs <= 0) this.invalid('ttlMs must be greater than zero')
     if (!Number.isFinite(options.reapIntervalMs) || options.reapIntervalMs < 1_000 || options.reapIntervalMs > Math.min(options.ttlMs, 60_000)) {
       this.invalid('reapIntervalMs must be between 1000 and min(ttlMs, 60000)')

--- a/packages/agent/src/server/sandbox/leases/sandboxLease.ts
+++ b/packages/agent/src/server/sandbox/leases/sandboxLease.ts
@@ -2,11 +2,11 @@ import { createHash, randomUUID } from 'node:crypto'
 import { lstat } from 'node:fs/promises'
 import { join } from 'node:path'
 
-import {
-  isDisposableSandboxProviderV1,
-  type SandboxProviderV1,
-  type WorkspaceSandboxPairV1,
+import type {
+  SandboxProviderV1,
+  WorkspaceSandboxPairV1,
 } from '@hachej/boring-sandbox/shared'
+import { isDisposableLeaseProvider } from './disposableProvider'
 
 const LEASE_HANDLE_PATTERN = /^[A-Za-z0-9_-]{16,128}$/
 export const SANDBOX_REMOTE_DISPOSE_OPERATION_ID = 'sandbox.remote.dispose.v1' as const
@@ -125,7 +125,7 @@ export class SandboxLeaseService {
   private disposal: Promise<void> | undefined
 
   constructor(private readonly options: SandboxLeaseServiceOptions) {
-    if (options.provider.contractVersion && !isDisposableSandboxProviderV1(options.provider)) {
+    if (options.provider.contractVersion && !isDisposableLeaseProvider(options.provider)) {
       this.invalid('provider must implement the disposable sandbox profile')
     }
     if (!Number.isFinite(options.ttlMs) || options.ttlMs <= 0) this.invalid('ttlMs must be greater than zero')

--- a/packages/agent/src/server/sandbox/leases/sandboxLease.ts
+++ b/packages/agent/src/server/sandbox/leases/sandboxLease.ts
@@ -3,6 +3,7 @@ import { lstat } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import type {
+  SandboxProviderCreateCleanupDebtV1,
   SandboxProviderV1,
   WorkspaceSandboxPairV1,
 } from '@hachej/boring-sandbox/shared'
@@ -66,7 +67,8 @@ type CleanupReason = 'release' | 'expiry' | 'owner-end' | 'host-shutdown' | 'cre
 
 interface ActiveLease extends SandboxLease {
   readonly ownerId: string
-  readonly pair: WorkspaceSandboxPairV1
+  readonly pair?: WorkspaceSandboxPairV1
+  readonly dispose: () => Promise<void>
   readonly cleanupRegistration: {
     readonly operationId: typeof SANDBOX_REMOTE_DISPOSE_OPERATION_ID
     readonly keyDigest: string
@@ -223,8 +225,10 @@ export class SandboxLeaseService {
       published = true
       return { handle, expiresAt: lease.expiresAt }
     } catch (error) {
-      if (pair && handle && !published) {
-        const compensation = this.createLease(ownerId, handle, pair, 'cleanup-pending')
+      const debt = (error as Partial<SandboxProviderCreateCleanupDebtV1>)?.sandboxProviderCleanupDebt
+      const retry = pair ? () => pair!.dispose() : typeof debt?.retry === 'function' ? () => debt.retry() : undefined
+      if (retry && handle && !published) {
+        const compensation = this.createLease(ownerId, handle, pair, 'cleanup-pending', retry)
         compensation.cleanupReason = 'create-compensation'
         try {
           await this.runRegisteredCleanup(compensation, this.deadlineAfterDrain())
@@ -268,6 +272,8 @@ export class SandboxLeaseService {
     this.assertOpen()
     const lease = this.requireOwned(ownerId, handle)
     if (lease.state !== 'active') throw this.unavailableForState(lease.state)
+    const pair = lease.pair
+    if (!pair) throw this.unavailableForState('cleanup-pending')
     if (lease.expiresAt <= this.now()) {
       lease.state = 'draining'
       lease.cleanupReason = 'expiry'
@@ -279,7 +285,7 @@ export class SandboxLeaseService {
     try {
       let health: Awaited<ReturnType<NonNullable<WorkspaceSandboxPairV1['checkHealth']>>> | undefined
       try {
-        health = await lease.pair.checkHealth?.()
+        health = await pair.checkHealth?.()
       } catch {
         lease.state = 'draining'
         lease.cleanupReason = 'expiry'
@@ -292,7 +298,7 @@ export class SandboxLeaseService {
         cleanupAfterUnpin = true
         throw new SandboxLeaseError(SANDBOX_LEASE_ERROR_CODES.LEASE_EXPIRED, 'sandbox lease is unavailable')
       }
-      return await action(lease.pair)
+      return await action(pair)
     } finally {
       lease.activeOperations -= 1
       if (lease.activeOperations === 0) {
@@ -468,13 +474,15 @@ export class SandboxLeaseService {
   private createLease(
     ownerId: string,
     handle: string,
-    pair: WorkspaceSandboxPairV1,
+    pair: WorkspaceSandboxPairV1 | undefined,
     state: ActiveLease['state'],
+    dispose = (): Promise<void> => pair!.dispose(),
   ): ActiveLease {
     return {
       handle,
       ownerId,
       pair,
+      dispose,
       expiresAt: this.now() + this.options.ttlMs,
       cleanupRegistration: {
         operationId: SANDBOX_REMOTE_DISPOSE_OPERATION_ID,
@@ -491,7 +499,7 @@ export class SandboxLeaseService {
     const registration = lease.cleanupRegistration
     registration.attempts += 1
     if (!registration.inFlight) {
-      const effect = Promise.resolve().then(async () => await lease.pair.dispose())
+      const effect = Promise.resolve().then(lease.dispose)
       const tracked = effect.finally(() => {
         if (registration.inFlight === tracked) registration.inFlight = undefined
       })

--- a/packages/agent/src/server/sandbox/leases/sandboxLease.ts
+++ b/packages/agent/src/server/sandbox/leases/sandboxLease.ts
@@ -143,7 +143,7 @@ export class SandboxLeaseService {
   }
 
   get isClosed(): boolean { return this.closed }
-  get isDisposed(): boolean { return this.providerClosed && this.leases.size === 0 }
+  get isDisposed(): boolean { return this.providerClosed && this.leases.size === 0 && this.pendingTotal === 0 }
   get providerIdentity(): SandboxProviderV1 { return this.options.provider }
 
   /** Registry compensation before publication; no lease or provider cleanup authority was transferred. */
@@ -151,31 +151,6 @@ export class SandboxLeaseService {
     if (this.leases.size || this.pendingTotal) throw new TypeError('active sandbox lease service cannot be abandoned')
     this.closed = true
     clearInterval(this.timer)
-  }
-
-  assertProfileBinding(input: {
-    readonly digest: string
-    readonly provider: SandboxProviderV1
-    readonly workspaceRoot: string
-    readonly providerWorkspaceId: string
-    readonly templatePath?: string
-    readonly ttlMs: number
-    readonly reapIntervalMs: number
-    readonly drainTimeoutMs: number
-    readonly maxActiveLeasesPerOwner: number
-    readonly maxActiveLeasesTotal: number
-  }): void {
-    const matches = this.options.serviceDigest === input.digest
-      && this.options.provider === input.provider
-      && this.options.workspaceRoot === input.workspaceRoot
-      && this.options.providerWorkspaceId === input.providerWorkspaceId
-      && this.options.templatePath === input.templatePath
-      && this.options.ttlMs === input.ttlMs
-      && this.options.reapIntervalMs === input.reapIntervalMs
-      && this.options.drainTimeoutMs === input.drainTimeoutMs
-      && this.options.maxActiveLeasesPerOwner === input.maxActiveLeasesPerOwner
-      && this.options.maxActiveLeasesTotal === input.maxActiveLeasesTotal
-    if (!matches) throw new TypeError('sandbox lease service does not match its profile identity')
   }
 
   async acquire(ownerId: string, signal?: AbortSignal): Promise<SandboxLease> {

--- a/packages/agent/src/server/sandbox/leases/sandboxLease.ts
+++ b/packages/agent/src/server/sandbox/leases/sandboxLease.ts
@@ -142,6 +142,31 @@ export class SandboxLeaseService {
     this.timer.unref?.()
   }
 
+  assertProfileBinding(input: {
+    readonly digest: string
+    readonly provider: SandboxProviderV1
+    readonly workspaceRoot: string
+    readonly providerWorkspaceId: string
+    readonly templatePath?: string
+    readonly ttlMs: number
+    readonly reapIntervalMs: number
+    readonly drainTimeoutMs: number
+    readonly maxActiveLeasesPerOwner: number
+    readonly maxActiveLeasesTotal: number
+  }): void {
+    const matches = this.options.serviceDigest === input.digest
+      && this.options.provider === input.provider
+      && this.options.workspaceRoot === input.workspaceRoot
+      && this.options.providerWorkspaceId === input.providerWorkspaceId
+      && this.options.templatePath === input.templatePath
+      && this.options.ttlMs === input.ttlMs
+      && this.options.reapIntervalMs === input.reapIntervalMs
+      && this.options.drainTimeoutMs === input.drainTimeoutMs
+      && this.options.maxActiveLeasesPerOwner === input.maxActiveLeasesPerOwner
+      && this.options.maxActiveLeasesTotal === input.maxActiveLeasesTotal
+    if (!matches) throw new TypeError('sandbox lease service does not match its profile identity')
+  }
+
   async acquire(ownerId: string, signal?: AbortSignal): Promise<SandboxLease> {
     this.assertOpen()
     this.assertOwner(ownerId)

--- a/packages/agent/src/server/sandbox/leases/sandboxLeaseProfileIdentity.ts
+++ b/packages/agent/src/server/sandbox/leases/sandboxLeaseProfileIdentity.ts
@@ -5,8 +5,8 @@ import type {
   DisposableSandboxProviderV1,
   ExtractedSandboxProviderIdV1,
 } from '@hachej/boring-sandbox/shared'
-import { isDisposableSandboxProviderV1 } from '@hachej/boring-sandbox/shared'
 import { SandboxLeaseService } from './sandboxLease'
+import { isDisposableLeaseProvider } from './disposableProvider'
 
 export const SANDBOX_LEASE_PROVIDER_PROFILE_VERSION_V1 =
   'boring-agent.sandbox-lease-profile.v1' as const
@@ -52,7 +52,7 @@ export function normalizeSandboxLeaseProviderProfileV1(
   }
   const workspaceScopeId = nonEmpty(identity.workspaceScopeId, 'workspaceScopeId')
   if (workspaceScopeId !== verifiedWorkspaceScopeId) throw new TypeError('sandbox lease profile scope is unauthorized')
-  if (!isDisposableSandboxProviderV1(profile.provider)) throw new TypeError('sandbox lease provider is not disposable')
+  if (!isDisposableLeaseProvider(profile.provider)) throw new TypeError('sandbox lease provider is not disposable')
   if (profile.provider.providerId !== identity.providerId) throw new TypeError('sandbox lease provider identity does not match')
   const leaseRoot = resolve(identity.leaseRoot)
   if (!isAbsolute(identity.leaseRoot) || parse(leaseRoot).root === leaseRoot) {

--- a/packages/agent/src/server/sandbox/leases/sandboxLeaseProfileIdentity.ts
+++ b/packages/agent/src/server/sandbox/leases/sandboxLeaseProfileIdentity.ts
@@ -6,7 +6,10 @@ import type {
   ExtractedSandboxProviderIdV1,
 } from '@hachej/boring-sandbox/shared'
 import { SandboxLeaseService } from './sandboxLease'
-import { isDisposableLeaseProvider } from './disposableProvider'
+import {
+  isDisposableLeaseProvider,
+  registerTrustedDisposableLeaseProvider,
+} from './disposableProvider'
 
 export const SANDBOX_LEASE_PROVIDER_PROFILE_VERSION_V1 =
   'boring-agent.sandbox-lease-profile.v1' as const
@@ -118,11 +121,9 @@ export async function createSandboxLeaseServiceFromProfileV1(input: {
   const identity = profile.identity
   const provider = await profile.providerFactory()
   try {
+    registerTrustedDisposableLeaseProvider(provider, identity.providerConfigDigest)
     if (!isDisposableLeaseProvider(provider)) throw new TypeError('sandbox lease provider is not factory-registered')
     if (provider.providerId !== identity.providerId) throw new TypeError('sandbox lease provider identity does not match')
-    if (provider.disposableProfile.providerConfigDigest !== identity.providerConfigDigest) {
-      throw new TypeError('sandbox lease provider configuration identity does not match')
-    }
   } catch (error) {
     try { await provider.close?.() }
     catch (cleanupError) {

--- a/packages/agent/src/server/sandbox/leases/sandboxLeaseProfileIdentity.ts
+++ b/packages/agent/src/server/sandbox/leases/sandboxLeaseProfileIdentity.ts
@@ -37,6 +37,7 @@ export interface SandboxLeaseProviderProfileV1 {
 }
 
 const SHA256 = /^sha256:[a-f0-9]{64}$/
+const PROVIDER_IDS = new Set(['direct', 'bwrap', 'blaxel', 'vercel-sandbox', 'remote-worker'])
 const PROFILE_KEYS = new Set(['identity', 'providerFactory'])
 const IDENTITY_KEYS = new Set([
   'contractVersion', 'workspaceScopeId', 'placementIdentity', 'providerWorkspaceId',
@@ -80,7 +81,11 @@ export function normalizeSandboxLeaseProviderProfileV1(
     throw new TypeError('sandbox lease root must be an absolute non-root path')
   }
   if (!SHA256.test(identity.providerConfigDigest)) throw new TypeError('providerConfigDigest must be sha256')
+  if (!PROVIDER_IDS.has(identity.providerId)) throw new TypeError('providerId is unsupported')
   const credentialVersionRefs = [...new Set(identity.credentialVersionRefs.map((value) => nonEmpty(value, 'credentialVersionRef')))].sort()
+  const ttlMs = positiveInteger(identity.ttlMs, 'ttlMs')
+  const reapIntervalMs = positiveInteger(identity.reapIntervalMs, 'reapIntervalMs')
+  if (reapIntervalMs < 1_000 || reapIntervalMs > Math.min(ttlMs, 60_000)) throw new TypeError('reapIntervalMs is outside the supported interval')
   const normalizedIdentity: SandboxLeaseProviderProfileIdentityV1 = Object.freeze({
     contractVersion: SANDBOX_LEASE_PROVIDER_PROFILE_VERSION_V1,
     workspaceScopeId,
@@ -90,8 +95,8 @@ export function normalizeSandboxLeaseProviderProfileV1(
     providerId: identity.providerId,
     providerConfigDigest: identity.providerConfigDigest,
     credentialVersionRefs: Object.freeze(credentialVersionRefs),
-    ttlMs: positiveInteger(identity.ttlMs, 'ttlMs'),
-    reapIntervalMs: positiveInteger(identity.reapIntervalMs, 'reapIntervalMs'),
+    ttlMs,
+    reapIntervalMs,
     drainTimeoutMs: positiveInteger(identity.drainTimeoutMs, 'drainTimeoutMs'),
     maxActiveLeasesPerOwner: positiveInteger(identity.maxActiveLeasesPerOwner, 'maxActiveLeasesPerOwner'),
     maxActiveLeasesTotal: positiveInteger(identity.maxActiveLeasesTotal, 'maxActiveLeasesTotal'),
@@ -119,24 +124,21 @@ export async function createSandboxLeaseServiceFromProfileV1(input: {
     registerTrustedDisposableLeaseProvider(provider, identity.providerConfigDigest)
     if (!isDisposableLeaseProvider(provider)) throw new TypeError('sandbox lease provider is not factory-registered')
     if (provider.providerId !== identity.providerId) throw new TypeError('sandbox lease provider identity does not match')
+    return new SandboxLeaseService({
+      workspaceRoot: identity.leaseRoot, provider, serviceDigest: digest,
+      providerWorkspaceId: identity.providerWorkspaceId,
+      ttlMs: identity.ttlMs, reapIntervalMs: identity.reapIntervalMs,
+      drainTimeoutMs: identity.drainTimeoutMs,
+      maxActiveLeasesPerOwner: identity.maxActiveLeasesPerOwner,
+      maxActiveLeasesTotal: identity.maxActiveLeasesTotal,
+    })
   } catch (error) {
     try { await provider.close?.() }
     catch (cleanupError) {
-      throw new AggregateError([error, cleanupError], 'sandbox lease provider attestation cleanup failed')
+      throw new AggregateError([error, cleanupError], 'sandbox lease provider composition cleanup failed')
     }
     throw error
   }
-  return new SandboxLeaseService({
-    workspaceRoot: identity.leaseRoot,
-    provider,
-    serviceDigest: digest,
-    providerWorkspaceId: identity.providerWorkspaceId,
-    ttlMs: identity.ttlMs,
-    reapIntervalMs: identity.reapIntervalMs,
-    drainTimeoutMs: identity.drainTimeoutMs,
-    maxActiveLeasesPerOwner: identity.maxActiveLeasesPerOwner,
-    maxActiveLeasesTotal: identity.maxActiveLeasesTotal,
-  })
 }
 
 export function sandboxLeaseProviderProfileDigestV1(

--- a/packages/agent/src/server/sandbox/leases/sandboxLeaseProfileIdentity.ts
+++ b/packages/agent/src/server/sandbox/leases/sandboxLeaseProfileIdentity.ts
@@ -6,6 +6,7 @@ import type {
   ExtractedSandboxProviderIdV1,
 } from '@hachej/boring-sandbox/shared'
 import { SandboxLeaseService } from './sandboxLease'
+import type { SandboxLeaseServiceRegistry } from './sandboxLeaseServiceRegistry'
 import {
   isDisposableLeaseProvider,
   registerTrustedDisposableLeaseProvider,
@@ -101,16 +102,14 @@ export function normalizeSandboxLeaseProviderProfileV1(
     maxActiveLeasesPerOwner: positiveInteger(identity.maxActiveLeasesPerOwner, 'maxActiveLeasesPerOwner'),
     maxActiveLeasesTotal: positiveInteger(identity.maxActiveLeasesTotal, 'maxActiveLeasesTotal'),
   })
-  return Object.freeze({
-    identity: normalizedIdentity,
-    providerFactory: profile.providerFactory,
-  })
+  return Object.freeze({ identity: normalizedIdentity, providerFactory: profile.providerFactory })
 }
 
 export async function createSandboxLeaseServiceFromProfileV1(input: {
   readonly profile: SandboxLeaseProviderProfileV1
   readonly verifiedWorkspaceScopeId: string
   readonly expectedDigest: string
+  readonly registry: SandboxLeaseServiceRegistry
 }): Promise<SandboxLeaseService> {
   const profile = normalizeSandboxLeaseProviderProfileV1(
     input.profile,
@@ -120,11 +119,13 @@ export async function createSandboxLeaseServiceFromProfileV1(input: {
   if (digest !== input.expectedDigest) throw new TypeError('sandbox lease profile digest does not match capability')
   const identity = profile.identity
   const provider = await profile.providerFactory()
+  const releaseClaim = await input.registry.claimProfileProvider(digest, provider)
+  let service: SandboxLeaseService | undefined
   try {
     registerTrustedDisposableLeaseProvider(provider, identity.providerConfigDigest)
     if (!isDisposableLeaseProvider(provider)) throw new TypeError('sandbox lease provider is not factory-registered')
     if (provider.providerId !== identity.providerId) throw new TypeError('sandbox lease provider identity does not match')
-    return new SandboxLeaseService({
+    service = new SandboxLeaseService({
       workspaceRoot: identity.leaseRoot, provider, serviceDigest: digest,
       providerWorkspaceId: identity.providerWorkspaceId,
       ttlMs: identity.ttlMs, reapIntervalMs: identity.reapIntervalMs,
@@ -132,11 +133,14 @@ export async function createSandboxLeaseServiceFromProfileV1(input: {
       maxActiveLeasesPerOwner: identity.maxActiveLeasesPerOwner,
       maxActiveLeasesTotal: identity.maxActiveLeasesTotal,
     })
+    input.registry.promoteProfileProvider(digest, service)
+    return service
   } catch (error) {
+    service?.abandonUnregistered()
     try { await provider.close?.() }
     catch (cleanupError) {
       throw new AggregateError([error, cleanupError], 'sandbox lease provider composition cleanup failed')
-    }
+    } finally { releaseClaim() }
     throw error
   }
 }

--- a/packages/agent/src/server/sandbox/leases/sandboxLeaseProfileIdentity.ts
+++ b/packages/agent/src/server/sandbox/leases/sandboxLeaseProfileIdentity.ts
@@ -30,11 +30,30 @@ export interface SandboxLeaseProviderProfileIdentityV1 {
 
 export interface SandboxLeaseProviderProfileV1 {
   readonly identity: SandboxLeaseProviderProfileIdentityV1
-  readonly provider: DisposableSandboxProviderV1
+  /** Trusted host factory. The lifecycle registry invokes it at most once per digest. */
+  readonly providerFactory: () => DisposableSandboxProviderV1 | Promise<DisposableSandboxProviderV1>
   readonly templatePath?: string
 }
 
 const SHA256 = /^sha256:[a-f0-9]{64}$/
+const PROFILE_KEYS = new Set(['identity', 'providerFactory', 'templatePath'])
+const IDENTITY_KEYS = new Set([
+  'contractVersion', 'workspaceScopeId', 'placementIdentity', 'providerWorkspaceId',
+  'leaseRoot', 'providerId', 'providerConfigDigest', 'templateFingerprint',
+  'credentialVersionRefs', 'ttlMs', 'reapIntervalMs', 'drainTimeoutMs',
+  'maxActiveLeasesPerOwner', 'maxActiveLeasesTotal',
+])
+
+function assertExactKeys(value: object, allowed: ReadonlySet<string>, name: string): void {
+  if (Object.keys(value).some((key) => !allowed.has(key))) {
+    throw new TypeError(`${name} contains unsupported fields`)
+  }
+}
+
+function positiveInteger(value: number, name: string): number {
+  if (!Number.isSafeInteger(value) || value <= 0) throw new TypeError(`${name} must be a positive integer`)
+  return value
+}
 
 function nonEmpty(value: string, name: string): string {
   const normalized = value.trim()
@@ -46,37 +65,50 @@ export function normalizeSandboxLeaseProviderProfileV1(
   profile: SandboxLeaseProviderProfileV1,
   verifiedWorkspaceScopeId: string,
 ): SandboxLeaseProviderProfileV1 {
+  assertExactKeys(profile, PROFILE_KEYS, 'sandbox lease profile')
   const identity = profile.identity
+  assertExactKeys(identity, IDENTITY_KEYS, 'sandbox lease profile identity')
   if (identity.contractVersion !== SANDBOX_LEASE_PROVIDER_PROFILE_VERSION_V1) {
     throw new TypeError('sandbox lease profile version is unsupported')
   }
   const workspaceScopeId = nonEmpty(identity.workspaceScopeId, 'workspaceScopeId')
   if (workspaceScopeId !== verifiedWorkspaceScopeId) throw new TypeError('sandbox lease profile scope is unauthorized')
-  if (!isDisposableLeaseProvider(profile.provider)) throw new TypeError('sandbox lease provider is not disposable')
-  if (profile.provider.providerId !== identity.providerId) throw new TypeError('sandbox lease provider identity does not match')
+  if (typeof profile.providerFactory !== 'function') throw new TypeError('sandbox lease provider factory is required')
   const leaseRoot = resolve(identity.leaseRoot)
-  if (!isAbsolute(identity.leaseRoot) || parse(leaseRoot).root === leaseRoot) {
+  if (!isAbsolute(identity.leaseRoot) || identity.leaseRoot !== leaseRoot || parse(leaseRoot).root === leaseRoot) {
     throw new TypeError('sandbox lease root must be an absolute non-root path')
   }
   if (!SHA256.test(identity.providerConfigDigest)) throw new TypeError('providerConfigDigest must be sha256')
   if (identity.templateFingerprint && !SHA256.test(identity.templateFingerprint)) throw new TypeError('templateFingerprint must be sha256')
   const credentialVersionRefs = [...new Set(identity.credentialVersionRefs.map((value) => nonEmpty(value, 'credentialVersionRef')))].sort()
-  const normalizedIdentity = Object.freeze({
-    ...identity,
+  const normalizedIdentity: SandboxLeaseProviderProfileIdentityV1 = Object.freeze({
+    contractVersion: SANDBOX_LEASE_PROVIDER_PROFILE_VERSION_V1,
     workspaceScopeId,
     placementIdentity: nonEmpty(identity.placementIdentity, 'placementIdentity'),
     providerWorkspaceId: nonEmpty(identity.providerWorkspaceId, 'providerWorkspaceId'),
     leaseRoot,
+    providerId: identity.providerId,
+    providerConfigDigest: identity.providerConfigDigest,
+    ...(identity.templateFingerprint ? { templateFingerprint: identity.templateFingerprint } : {}),
     credentialVersionRefs: Object.freeze(credentialVersionRefs),
+    ttlMs: positiveInteger(identity.ttlMs, 'ttlMs'),
+    reapIntervalMs: positiveInteger(identity.reapIntervalMs, 'reapIntervalMs'),
+    drainTimeoutMs: positiveInteger(identity.drainTimeoutMs, 'drainTimeoutMs'),
+    maxActiveLeasesPerOwner: positiveInteger(identity.maxActiveLeasesPerOwner, 'maxActiveLeasesPerOwner'),
+    maxActiveLeasesTotal: positiveInteger(identity.maxActiveLeasesTotal, 'maxActiveLeasesTotal'),
   })
-  return Object.freeze({ ...profile, identity: normalizedIdentity })
+  return Object.freeze({
+    identity: normalizedIdentity,
+    providerFactory: profile.providerFactory,
+    ...(profile.templatePath ? { templatePath: profile.templatePath } : {}),
+  })
 }
 
-export function createSandboxLeaseServiceFromProfileV1(input: {
+export async function createSandboxLeaseServiceFromProfileV1(input: {
   readonly profile: SandboxLeaseProviderProfileV1
   readonly verifiedWorkspaceScopeId: string
   readonly expectedDigest: string
-}): SandboxLeaseService {
+}): Promise<SandboxLeaseService> {
   const profile = normalizeSandboxLeaseProviderProfileV1(
     input.profile,
     input.verifiedWorkspaceScopeId,
@@ -84,9 +116,23 @@ export function createSandboxLeaseServiceFromProfileV1(input: {
   const digest = sandboxLeaseProviderProfileDigestV1(profile.identity)
   if (digest !== input.expectedDigest) throw new TypeError('sandbox lease profile digest does not match capability')
   const identity = profile.identity
+  const provider = await profile.providerFactory()
+  try {
+    if (!isDisposableLeaseProvider(provider)) throw new TypeError('sandbox lease provider is not factory-registered')
+    if (provider.providerId !== identity.providerId) throw new TypeError('sandbox lease provider identity does not match')
+    if (provider.disposableProfile.providerConfigDigest !== identity.providerConfigDigest) {
+      throw new TypeError('sandbox lease provider configuration identity does not match')
+    }
+  } catch (error) {
+    try { await provider.close?.() }
+    catch (cleanupError) {
+      throw new AggregateError([error, cleanupError], 'sandbox lease provider attestation cleanup failed')
+    }
+    throw error
+  }
   return new SandboxLeaseService({
     workspaceRoot: identity.leaseRoot,
-    provider: profile.provider,
+    provider,
     serviceDigest: digest,
     providerWorkspaceId: identity.providerWorkspaceId,
     templatePath: profile.templatePath,

--- a/packages/agent/src/server/sandbox/leases/sandboxLeaseProfileIdentity.ts
+++ b/packages/agent/src/server/sandbox/leases/sandboxLeaseProfileIdentity.ts
@@ -22,7 +22,6 @@ export interface SandboxLeaseProviderProfileIdentityV1 {
   readonly leaseRoot: string
   readonly providerId: ExtractedSandboxProviderIdV1
   readonly providerConfigDigest: `sha256:${string}`
-  readonly templateFingerprint?: `sha256:${string}`
   readonly credentialVersionRefs: readonly string[]
   readonly ttlMs: number
   readonly reapIntervalMs: number
@@ -35,14 +34,13 @@ export interface SandboxLeaseProviderProfileV1 {
   readonly identity: SandboxLeaseProviderProfileIdentityV1
   /** Trusted host factory. The lifecycle registry invokes it at most once per digest. */
   readonly providerFactory: () => DisposableSandboxProviderV1 | Promise<DisposableSandboxProviderV1>
-  readonly templatePath?: string
 }
 
 const SHA256 = /^sha256:[a-f0-9]{64}$/
-const PROFILE_KEYS = new Set(['identity', 'providerFactory', 'templatePath'])
+const PROFILE_KEYS = new Set(['identity', 'providerFactory'])
 const IDENTITY_KEYS = new Set([
   'contractVersion', 'workspaceScopeId', 'placementIdentity', 'providerWorkspaceId',
-  'leaseRoot', 'providerId', 'providerConfigDigest', 'templateFingerprint',
+  'leaseRoot', 'providerId', 'providerConfigDigest',
   'credentialVersionRefs', 'ttlMs', 'reapIntervalMs', 'drainTimeoutMs',
   'maxActiveLeasesPerOwner', 'maxActiveLeasesTotal',
 ])
@@ -82,13 +80,6 @@ export function normalizeSandboxLeaseProviderProfileV1(
     throw new TypeError('sandbox lease root must be an absolute non-root path')
   }
   if (!SHA256.test(identity.providerConfigDigest)) throw new TypeError('providerConfigDigest must be sha256')
-  if (identity.templateFingerprint && !SHA256.test(identity.templateFingerprint)) throw new TypeError('templateFingerprint must be sha256')
-  const templatePath = profile.templatePath === undefined
-    ? undefined
-    : nonEmpty(profile.templatePath, 'templatePath')
-  if (Boolean(templatePath) !== Boolean(identity.templateFingerprint)) {
-    throw new TypeError('templatePath and templateFingerprint must be supplied together')
-  }
   const credentialVersionRefs = [...new Set(identity.credentialVersionRefs.map((value) => nonEmpty(value, 'credentialVersionRef')))].sort()
   const normalizedIdentity: SandboxLeaseProviderProfileIdentityV1 = Object.freeze({
     contractVersion: SANDBOX_LEASE_PROVIDER_PROFILE_VERSION_V1,
@@ -98,7 +89,6 @@ export function normalizeSandboxLeaseProviderProfileV1(
     leaseRoot,
     providerId: identity.providerId,
     providerConfigDigest: identity.providerConfigDigest,
-    ...(identity.templateFingerprint ? { templateFingerprint: identity.templateFingerprint } : {}),
     credentialVersionRefs: Object.freeze(credentialVersionRefs),
     ttlMs: positiveInteger(identity.ttlMs, 'ttlMs'),
     reapIntervalMs: positiveInteger(identity.reapIntervalMs, 'reapIntervalMs'),
@@ -109,7 +99,6 @@ export function normalizeSandboxLeaseProviderProfileV1(
   return Object.freeze({
     identity: normalizedIdentity,
     providerFactory: profile.providerFactory,
-    ...(templatePath ? { templatePath } : {}),
   })
 }
 
@@ -142,7 +131,6 @@ export async function createSandboxLeaseServiceFromProfileV1(input: {
     provider,
     serviceDigest: digest,
     providerWorkspaceId: identity.providerWorkspaceId,
-    templatePath: profile.templatePath,
     ttlMs: identity.ttlMs,
     reapIntervalMs: identity.reapIntervalMs,
     drainTimeoutMs: identity.drainTimeoutMs,
@@ -162,7 +150,6 @@ export function sandboxLeaseProviderProfileDigestV1(
     leaseRoot: identity.leaseRoot,
     providerId: identity.providerId,
     providerConfigDigest: identity.providerConfigDigest,
-    templateFingerprint: identity.templateFingerprint ?? null,
     credentialVersionRefs: [...identity.credentialVersionRefs],
     ttlMs: identity.ttlMs,
     reapIntervalMs: identity.reapIntervalMs,

--- a/packages/agent/src/server/sandbox/leases/sandboxLeaseProfileIdentity.ts
+++ b/packages/agent/src/server/sandbox/leases/sandboxLeaseProfileIdentity.ts
@@ -1,0 +1,121 @@
+import { createHash } from 'node:crypto'
+import { isAbsolute, parse, resolve } from 'node:path'
+
+import type {
+  DisposableSandboxProviderV1,
+  ExtractedSandboxProviderIdV1,
+} from '@hachej/boring-sandbox/shared'
+import { isDisposableSandboxProviderV1 } from '@hachej/boring-sandbox/shared'
+import { SandboxLeaseService } from './sandboxLease'
+
+export const SANDBOX_LEASE_PROVIDER_PROFILE_VERSION_V1 =
+  'boring-agent.sandbox-lease-profile.v1' as const
+
+export interface SandboxLeaseProviderProfileIdentityV1 {
+  readonly contractVersion: typeof SANDBOX_LEASE_PROVIDER_PROFILE_VERSION_V1
+  readonly workspaceScopeId: string
+  readonly placementIdentity: string
+  readonly providerWorkspaceId: string
+  readonly leaseRoot: string
+  readonly providerId: ExtractedSandboxProviderIdV1
+  readonly providerConfigDigest: `sha256:${string}`
+  readonly templateFingerprint?: `sha256:${string}`
+  readonly credentialVersionRefs: readonly string[]
+  readonly ttlMs: number
+  readonly reapIntervalMs: number
+  readonly drainTimeoutMs: number
+  readonly maxActiveLeasesPerOwner: number
+  readonly maxActiveLeasesTotal: number
+}
+
+export interface SandboxLeaseProviderProfileV1 {
+  readonly identity: SandboxLeaseProviderProfileIdentityV1
+  readonly provider: DisposableSandboxProviderV1
+  readonly templatePath?: string
+}
+
+const SHA256 = /^sha256:[a-f0-9]{64}$/
+
+function nonEmpty(value: string, name: string): string {
+  const normalized = value.trim()
+  if (!normalized) throw new TypeError(`${name} is required`)
+  return normalized
+}
+
+export function normalizeSandboxLeaseProviderProfileV1(
+  profile: SandboxLeaseProviderProfileV1,
+  verifiedWorkspaceScopeId: string,
+): SandboxLeaseProviderProfileV1 {
+  const identity = profile.identity
+  if (identity.contractVersion !== SANDBOX_LEASE_PROVIDER_PROFILE_VERSION_V1) {
+    throw new TypeError('sandbox lease profile version is unsupported')
+  }
+  const workspaceScopeId = nonEmpty(identity.workspaceScopeId, 'workspaceScopeId')
+  if (workspaceScopeId !== verifiedWorkspaceScopeId) throw new TypeError('sandbox lease profile scope is unauthorized')
+  if (!isDisposableSandboxProviderV1(profile.provider)) throw new TypeError('sandbox lease provider is not disposable')
+  if (profile.provider.providerId !== identity.providerId) throw new TypeError('sandbox lease provider identity does not match')
+  const leaseRoot = resolve(identity.leaseRoot)
+  if (!isAbsolute(identity.leaseRoot) || parse(leaseRoot).root === leaseRoot) {
+    throw new TypeError('sandbox lease root must be an absolute non-root path')
+  }
+  if (!SHA256.test(identity.providerConfigDigest)) throw new TypeError('providerConfigDigest must be sha256')
+  if (identity.templateFingerprint && !SHA256.test(identity.templateFingerprint)) throw new TypeError('templateFingerprint must be sha256')
+  const credentialVersionRefs = [...new Set(identity.credentialVersionRefs.map((value) => nonEmpty(value, 'credentialVersionRef')))].sort()
+  const normalizedIdentity = Object.freeze({
+    ...identity,
+    workspaceScopeId,
+    placementIdentity: nonEmpty(identity.placementIdentity, 'placementIdentity'),
+    providerWorkspaceId: nonEmpty(identity.providerWorkspaceId, 'providerWorkspaceId'),
+    leaseRoot,
+    credentialVersionRefs: Object.freeze(credentialVersionRefs),
+  })
+  return Object.freeze({ ...profile, identity: normalizedIdentity })
+}
+
+export function createSandboxLeaseServiceFromProfileV1(input: {
+  readonly profile: SandboxLeaseProviderProfileV1
+  readonly verifiedWorkspaceScopeId: string
+  readonly expectedDigest: string
+}): SandboxLeaseService {
+  const profile = normalizeSandboxLeaseProviderProfileV1(
+    input.profile,
+    input.verifiedWorkspaceScopeId,
+  )
+  const digest = sandboxLeaseProviderProfileDigestV1(profile.identity)
+  if (digest !== input.expectedDigest) throw new TypeError('sandbox lease profile digest does not match capability')
+  const identity = profile.identity
+  return new SandboxLeaseService({
+    workspaceRoot: identity.leaseRoot,
+    provider: profile.provider,
+    serviceDigest: digest,
+    providerWorkspaceId: identity.providerWorkspaceId,
+    templatePath: profile.templatePath,
+    ttlMs: identity.ttlMs,
+    reapIntervalMs: identity.reapIntervalMs,
+    drainTimeoutMs: identity.drainTimeoutMs,
+    maxActiveLeasesPerOwner: identity.maxActiveLeasesPerOwner,
+    maxActiveLeasesTotal: identity.maxActiveLeasesTotal,
+  })
+}
+
+export function sandboxLeaseProviderProfileDigestV1(
+  identity: SandboxLeaseProviderProfileIdentityV1,
+): `sha256:${string}` {
+  const bytes = JSON.stringify({
+    contractVersion: identity.contractVersion,
+    workspaceScopeId: identity.workspaceScopeId,
+    placementIdentity: identity.placementIdentity,
+    providerWorkspaceId: identity.providerWorkspaceId,
+    leaseRoot: identity.leaseRoot,
+    providerId: identity.providerId,
+    providerConfigDigest: identity.providerConfigDigest,
+    templateFingerprint: identity.templateFingerprint ?? null,
+    credentialVersionRefs: [...identity.credentialVersionRefs],
+    ttlMs: identity.ttlMs,
+    reapIntervalMs: identity.reapIntervalMs,
+    drainTimeoutMs: identity.drainTimeoutMs,
+    maxActiveLeasesPerOwner: identity.maxActiveLeasesPerOwner,
+    maxActiveLeasesTotal: identity.maxActiveLeasesTotal,
+  })
+  return `sha256:${createHash('sha256').update(bytes).digest('hex')}`
+}

--- a/packages/agent/src/server/sandbox/leases/sandboxLeaseProfileIdentity.ts
+++ b/packages/agent/src/server/sandbox/leases/sandboxLeaseProfileIdentity.ts
@@ -83,6 +83,12 @@ export function normalizeSandboxLeaseProviderProfileV1(
   }
   if (!SHA256.test(identity.providerConfigDigest)) throw new TypeError('providerConfigDigest must be sha256')
   if (identity.templateFingerprint && !SHA256.test(identity.templateFingerprint)) throw new TypeError('templateFingerprint must be sha256')
+  const templatePath = profile.templatePath === undefined
+    ? undefined
+    : nonEmpty(profile.templatePath, 'templatePath')
+  if (Boolean(templatePath) !== Boolean(identity.templateFingerprint)) {
+    throw new TypeError('templatePath and templateFingerprint must be supplied together')
+  }
   const credentialVersionRefs = [...new Set(identity.credentialVersionRefs.map((value) => nonEmpty(value, 'credentialVersionRef')))].sort()
   const normalizedIdentity: SandboxLeaseProviderProfileIdentityV1 = Object.freeze({
     contractVersion: SANDBOX_LEASE_PROVIDER_PROFILE_VERSION_V1,
@@ -103,7 +109,7 @@ export function normalizeSandboxLeaseProviderProfileV1(
   return Object.freeze({
     identity: normalizedIdentity,
     providerFactory: profile.providerFactory,
-    ...(profile.templatePath ? { templatePath: profile.templatePath } : {}),
+    ...(templatePath ? { templatePath } : {}),
   })
 }
 

--- a/packages/agent/src/server/sandbox/leases/sandboxLeaseServiceFactoryRegistry.ts
+++ b/packages/agent/src/server/sandbox/leases/sandboxLeaseServiceFactoryRegistry.ts
@@ -1,0 +1,21 @@
+import type { SandboxLeaseService } from './sandboxLease'
+
+/** Atomically constructs one host-owned service per immutable profile digest. */
+export class SandboxLeaseServiceFactoryRegistry {
+  private readonly services = new Map<string, Promise<SandboxLeaseService>>()
+
+  getOrCreate(
+    digest: string,
+    factory: () => SandboxLeaseService | Promise<SandboxLeaseService>,
+  ): Promise<SandboxLeaseService> {
+    if (!digest.trim()) throw new TypeError('sandbox capability digest is required')
+    const existing = this.services.get(digest)
+    if (existing) return existing
+    const creation = Promise.resolve().then(factory)
+    this.services.set(digest, creation)
+    void creation.catch(() => {
+      if (this.services.get(digest) === creation) this.services.delete(digest)
+    })
+    return creation
+  }
+}

--- a/packages/agent/src/server/sandbox/leases/sandboxLeaseServiceFactoryRegistry.ts
+++ b/packages/agent/src/server/sandbox/leases/sandboxLeaseServiceFactoryRegistry.ts
@@ -1,21 +1,4 @@
-import type { SandboxLeaseService } from './sandboxLease'
+import { SandboxLeaseServiceRegistry } from './sandboxLeaseServiceRegistry'
 
-/** Atomically constructs one host-owned service per immutable profile digest. */
-export class SandboxLeaseServiceFactoryRegistry {
-  private readonly services = new Map<string, Promise<SandboxLeaseService>>()
-
-  getOrCreate(
-    digest: string,
-    factory: () => SandboxLeaseService | Promise<SandboxLeaseService>,
-  ): Promise<SandboxLeaseService> {
-    if (!digest.trim()) throw new TypeError('sandbox capability digest is required')
-    const existing = this.services.get(digest)
-    if (existing) return existing
-    const creation = Promise.resolve().then(factory)
-    this.services.set(digest, creation)
-    void creation.catch(() => {
-      if (this.services.get(digest) === creation) this.services.delete(digest)
-    })
-    return creation
-  }
-}
+/** @deprecated Compatibility name; construction and disposal share one lifecycle registry. */
+export class SandboxLeaseServiceFactoryRegistry extends SandboxLeaseServiceRegistry {}

--- a/packages/agent/src/server/sandbox/leases/sandboxLeaseServiceRegistry.ts
+++ b/packages/agent/src/server/sandbox/leases/sandboxLeaseServiceRegistry.ts
@@ -6,6 +6,7 @@ export class SandboxLeaseServiceRegistry {
   private readonly pendingByDigest = new Map<string, Promise<SandboxLeaseService>>()
   private readonly digestByService = new WeakMap<SandboxLeaseService, string>()
   private readonly digestByProvider = new WeakMap<object, string>()
+  private readonly profileFactoryServices = new WeakSet<SandboxLeaseService>()
   private readonly drainingServices = new Set<SandboxLeaseService>()
   private draining = false
 
@@ -15,7 +16,10 @@ export class SandboxLeaseServiceRegistry {
   ): Promise<SandboxLeaseService> {
     if (this.draining) throw new TypeError('sandbox lease service registry is draining')
     const current = this.serviceByDigest.get(digest)
-    if (current && !current.isDisposed) return current
+    if (current && !current.isDisposed) {
+      if (!this.profileFactoryServices.has(current)) throw new TypeError('sandbox profile digest is owned by a legacy service')
+      return current
+    }
     if (current?.isDisposed) this.evict(digest, current)
     const pending = this.pendingByDigest.get(digest)
     if (pending) return await pending
@@ -29,9 +33,11 @@ export class SandboxLeaseServiceRegistry {
         throw new TypeError('sandbox lease service registry drained during construction')
       }
       try {
+        this.profileFactoryServices.add(service)
         this.register({ digest, leases: service })
         return service
       } catch (error) {
+        this.profileFactoryServices.delete(service)
         service.abandonUnregistered()
         throw error
       }

--- a/packages/agent/src/server/sandbox/leases/sandboxLeaseServiceRegistry.ts
+++ b/packages/agent/src/server/sandbox/leases/sandboxLeaseServiceRegistry.ts
@@ -3,9 +3,35 @@ import type { SandboxLeaseService } from './sandboxLease'
 /** Host-owned one-to-one identity registry for capability digest/service pairs. */
 export class SandboxLeaseServiceRegistry {
   private readonly serviceByDigest = new Map<string, SandboxLeaseService>()
+  private readonly pendingByDigest = new Map<string, Promise<SandboxLeaseService>>()
   private readonly digestByService = new WeakMap<SandboxLeaseService, string>()
+  private readonly digestByProvider = new WeakMap<object, string>()
+
+  async getOrCreate(
+    digest: string,
+    factory: () => SandboxLeaseService | Promise<SandboxLeaseService>,
+  ): Promise<SandboxLeaseService> {
+    const current = this.serviceByDigest.get(digest)
+    if (current && !current.isDisposed) return current
+    if (current?.isDisposed) this.evict(digest, current)
+    const pending = this.pendingByDigest.get(digest)
+    if (pending) return await pending
+    const creation = Promise.resolve().then(factory).then((service) => {
+      try {
+        this.register({ digest, leases: service })
+        return service
+      } catch (error) {
+        service.abandonUnregistered()
+        throw error
+      }
+    })
+    this.pendingByDigest.set(digest, creation)
+    try { return await creation }
+    finally { if (this.pendingByDigest.get(digest) === creation) this.pendingByDigest.delete(digest) }
+  }
 
   register(capability: { readonly digest: string; readonly leases: SandboxLeaseService }): void {
+    if (capability.leases.isDisposed) throw new TypeError('disposed sandbox lease service cannot be registered')
     const existingService = this.serviceByDigest.get(capability.digest)
     if (existingService && existingService !== capability.leases) {
       throw new TypeError('sandbox capability digest is already bound to another lease service')
@@ -14,18 +40,29 @@ export class SandboxLeaseServiceRegistry {
     if (existingDigest && existingDigest !== capability.digest) {
       throw new TypeError('sandbox lease service is already bound to another capability digest')
     }
+    const provider = capability.leases.providerIdentity
+    const providerDigest = this.digestByProvider.get(provider)
+    if (providerDigest && providerDigest !== capability.digest) {
+      throw new TypeError('sandbox provider is already owned by another lease service')
+    }
     this.serviceByDigest.set(capability.digest, capability.leases)
     this.digestByService.set(capability.leases, capability.digest)
+    this.digestByProvider.set(provider, capability.digest)
+  }
+
+  private evict(digest: string, service: SandboxLeaseService): void {
+    if (this.serviceByDigest.get(digest) === service) this.serviceByDigest.delete(digest)
+    this.digestByService.delete(service)
+    if (this.digestByProvider.get(service.providerIdentity) === digest) {
+      this.digestByProvider.delete(service.providerIdentity)
+    }
   }
 
   async dispose(): Promise<readonly PromiseSettledResult<void>[]> {
     const entries = [...this.serviceByDigest.entries()]
     return await Promise.allSettled(entries.map(async ([digest, service]) => {
       await service.dispose()
-      if (this.serviceByDigest.get(digest) === service) {
-        this.serviceByDigest.delete(digest)
-        this.digestByService.delete(service)
-      }
+      this.evict(digest, service)
     }))
   }
 

--- a/packages/agent/src/server/sandbox/leases/sandboxLeaseServiceRegistry.ts
+++ b/packages/agent/src/server/sandbox/leases/sandboxLeaseServiceRegistry.ts
@@ -6,17 +6,28 @@ export class SandboxLeaseServiceRegistry {
   private readonly pendingByDigest = new Map<string, Promise<SandboxLeaseService>>()
   private readonly digestByService = new WeakMap<SandboxLeaseService, string>()
   private readonly digestByProvider = new WeakMap<object, string>()
+  private readonly drainingServices = new Set<SandboxLeaseService>()
+  private draining = false
 
   async getOrCreate(
     digest: string,
     factory: () => SandboxLeaseService | Promise<SandboxLeaseService>,
   ): Promise<SandboxLeaseService> {
+    if (this.draining) throw new TypeError('sandbox lease service registry is draining')
     const current = this.serviceByDigest.get(digest)
     if (current && !current.isDisposed) return current
     if (current?.isDisposed) this.evict(digest, current)
     const pending = this.pendingByDigest.get(digest)
     if (pending) return await pending
-    const creation = Promise.resolve().then(factory).then((service) => {
+    const creation = Promise.resolve().then(factory).then(async (service) => {
+      if (this.draining) {
+        this.drainingServices.add(service)
+        try { await service.dispose(); this.drainingServices.delete(service) }
+        catch (error) {
+          throw new AggregateError([error], 'sandbox lease service registry drain cleanup failed')
+        }
+        throw new TypeError('sandbox lease service registry drained during construction')
+      }
       try {
         this.register({ digest, leases: service })
         return service
@@ -31,6 +42,7 @@ export class SandboxLeaseServiceRegistry {
   }
 
   register(capability: { readonly digest: string; readonly leases: SandboxLeaseService }): void {
+    if (this.draining) throw new TypeError('sandbox lease service registry is draining')
     if (capability.leases.isDisposed) throw new TypeError('disposed sandbox lease service cannot be registered')
     const existingService = this.serviceByDigest.get(capability.digest)
     if (existingService && existingService !== capability.leases) {
@@ -59,11 +71,24 @@ export class SandboxLeaseServiceRegistry {
   }
 
   async dispose(): Promise<readonly PromiseSettledResult<void>[]> {
+    this.draining = true
+    const pending = [...this.pendingByDigest.values()]
+    const pendingResults = await Promise.allSettled(pending)
     const entries = [...this.serviceByDigest.entries()]
-    return await Promise.allSettled(entries.map(async ([digest, service]) => {
+    const serviceResults = await Promise.allSettled(entries.map(async ([digest, service]) => {
       await service.dispose()
       this.evict(digest, service)
     }))
+    const debtResults = await Promise.allSettled([...this.drainingServices].map(async (service) => {
+      await service.dispose()
+      this.drainingServices.delete(service)
+    }))
+    for (const [digest, service] of this.serviceByDigest) {
+      if (service.isDisposed) this.evict(digest, service)
+    }
+    return [...pendingResults.map((result): PromiseSettledResult<void> => result.status === 'fulfilled'
+      ? { status: 'fulfilled', value: undefined }
+      : result), ...serviceResults, ...debtResults]
   }
 
   async disposeUntil(deadline: number): Promise<readonly PromiseSettledResult<void>[]> {

--- a/packages/agent/src/server/sandbox/leases/sandboxLeaseServiceRegistry.ts
+++ b/packages/agent/src/server/sandbox/leases/sandboxLeaseServiceRegistry.ts
@@ -33,12 +33,14 @@ export class SandboxLeaseServiceRegistry {
         throw new TypeError('sandbox lease service registry drained during construction')
       }
       try {
+        this.bind({ digest, leases: service })
         this.profileFactoryServices.add(service)
-        this.register({ digest, leases: service })
         return service
       } catch (error) {
-        this.profileFactoryServices.delete(service)
-        service.abandonUnregistered()
+        if (!this.digestByService.has(service)) {
+          if (this.digestByProvider.has(service.providerIdentity)) service.abandonUnregistered()
+          else await service.dispose()
+        }
         throw error
       }
     })
@@ -48,6 +50,11 @@ export class SandboxLeaseServiceRegistry {
   }
 
   register(capability: { readonly digest: string; readonly leases: SandboxLeaseService }): void {
+    if (this.pendingByDigest.has(capability.digest)) throw new TypeError('sandbox profile digest is reserved by a pending factory')
+    this.bind(capability)
+  }
+
+  private bind(capability: { readonly digest: string; readonly leases: SandboxLeaseService }): void {
     if (this.draining) throw new TypeError('sandbox lease service registry is draining')
     if (capability.leases.isDisposed) throw new TypeError('disposed sandbox lease service cannot be registered')
     const existingService = this.serviceByDigest.get(capability.digest)

--- a/packages/agent/src/server/sandbox/leases/sandboxLeaseServiceRegistry.ts
+++ b/packages/agent/src/server/sandbox/leases/sandboxLeaseServiceRegistry.ts
@@ -92,12 +92,22 @@ export class SandboxLeaseServiceRegistry {
   }
 
   async disposeUntil(deadline: number): Promise<readonly PromiseSettledResult<void>[]> {
-    let results = await this.dispose()
-    while (results.some((result) => result.status === 'rejected') && Date.now() < deadline) {
+    for (;;) {
       const remaining = deadline - Date.now()
-      await new Promise<void>((resolve) => setTimeout(resolve, Math.min(10, remaining)))
-      results = await this.dispose()
+      if (remaining <= 0) return [{ status: 'rejected', reason: new Error('sandbox lease registry drain deadline exceeded') }]
+      const attempt = this.dispose()
+      let timer: number | undefined
+      const results = await Promise.race([
+        attempt,
+        new Promise<undefined>((resolve) => { timer = setTimeout(resolve, remaining) }),
+      ])
+      if (timer) clearTimeout(timer)
+      if (!results) {
+        void attempt.catch(() => { /* late factory cleanup remains registry-owned */ })
+        return [{ status: 'rejected', reason: new Error('sandbox lease registry drain deadline exceeded') }]
+      }
+      if (results.every((result) => result.status === 'fulfilled')) return results
+      await new Promise<void>((resolve) => setTimeout(resolve, Math.min(10, deadline - Date.now())))
     }
-    return results
   }
 }

--- a/packages/agent/src/server/sandbox/leases/sandboxLeaseServiceRegistry.ts
+++ b/packages/agent/src/server/sandbox/leases/sandboxLeaseServiceRegistry.ts
@@ -101,7 +101,7 @@ export class SandboxLeaseServiceRegistry {
 
   async dispose(): Promise<readonly PromiseSettledResult<void>[]> {
     this.draining = true
-    const pendingResults = await Promise.allSettled([...this.pendingByDigest.values()])
+    const pendingResults = Promise.allSettled([...this.pendingByDigest.values()])
     const serviceResults = await Promise.allSettled([...this.serviceByDigest].map(async ([digest, service]) => {
       await service.dispose()
       this.evict(digest, service)
@@ -110,7 +110,7 @@ export class SandboxLeaseServiceRegistry {
       async (service) => await this.disposeUnpublished(service),
     ))
     for (const [digest, service] of this.serviceByDigest) if (service.isDisposed) this.evict(digest, service)
-    return [...pendingResults.map((result): PromiseSettledResult<void> => result.status === 'fulfilled'
+    return [...(await pendingResults).map((result): PromiseSettledResult<void> => result.status === 'fulfilled'
       ? { status: 'fulfilled', value: undefined }
       : result), ...serviceResults, ...debtResults]
   }

--- a/packages/agent/src/server/sandbox/leases/sandboxLeaseServiceRegistry.ts
+++ b/packages/agent/src/server/sandbox/leases/sandboxLeaseServiceRegistry.ts
@@ -6,6 +6,7 @@ export class SandboxLeaseServiceRegistry {
   private readonly pendingByDigest = new Map<string, Promise<SandboxLeaseService>>()
   private readonly digestByService = new WeakMap<SandboxLeaseService, string>()
   private readonly digestByProvider = new WeakMap<object, string>()
+  private readonly providerClaims = new WeakMap<object, string>()
   private readonly profileFactoryServices = new WeakSet<SandboxLeaseService>()
   private readonly drainingServices = new Set<SandboxLeaseService>()
   private draining = false
@@ -25,22 +26,15 @@ export class SandboxLeaseServiceRegistry {
     if (pending) return await pending
     const creation = Promise.resolve().then(factory).then(async (service) => {
       if (this.draining) {
-        this.drainingServices.add(service)
-        try { await service.dispose(); this.drainingServices.delete(service) }
-        catch (error) {
-          throw new AggregateError([error], 'sandbox lease service registry drain cleanup failed')
-        }
+        await this.disposeUnpublished(service)
         throw new TypeError('sandbox lease service registry drained during construction')
       }
       try {
-        this.bind({ digest, leases: service })
+        this.bind(digest, service)
         this.profileFactoryServices.add(service)
         return service
       } catch (error) {
-        if (!this.digestByService.has(service)) {
-          if (this.digestByProvider.has(service.providerIdentity)) service.abandonUnregistered()
-          else await service.dispose()
-        }
+        if (!this.digestByService.has(service)) service.abandonUnregistered()
         throw error
       }
     })
@@ -51,54 +45,71 @@ export class SandboxLeaseServiceRegistry {
 
   register(capability: { readonly digest: string; readonly leases: SandboxLeaseService }): void {
     if (this.pendingByDigest.has(capability.digest)) throw new TypeError('sandbox profile digest is reserved by a pending factory')
-    this.bind(capability)
+    this.bind(capability.digest, capability.leases)
   }
 
-  private bind(capability: { readonly digest: string; readonly leases: SandboxLeaseService }): void {
+  async claimProfileProvider(digest: string, provider: { close?(): Promise<void> }): Promise<() => void> {
+    if (this.digestByProvider.has(provider) || this.providerClaims.has(provider)) {
+      throw new TypeError('sandbox provider is already owned or claimed')
+    }
+    if (this.draining) {
+      this.providerClaims.set(provider, digest)
+      const error = new TypeError('sandbox lease service registry is draining')
+      try { await provider.close?.() }
+      catch (cleanupError) { throw new AggregateError([error, cleanupError], 'sandbox profile claim cleanup failed') }
+      finally { this.providerClaims.delete(provider) }
+      throw error
+    }
+    this.providerClaims.set(provider, digest)
+    return () => { if (this.providerClaims.get(provider) === digest) this.providerClaims.delete(provider) }
+  }
+
+  promoteProfileProvider(digest: string, leases: SandboxLeaseService): void {
+    if (this.providerClaims.get(leases.providerIdentity) !== digest) throw new TypeError('sandbox profile provider claim is not owned by this digest')
+    this.bind(digest, leases, true)
+    this.profileFactoryServices.add(leases)
+  }
+
+  private bind(digest: string, leases: SandboxLeaseService, acceptClaim = false): void {
     if (this.draining) throw new TypeError('sandbox lease service registry is draining')
-    if (capability.leases.isDisposed) throw new TypeError('disposed sandbox lease service cannot be registered')
-    const existingService = this.serviceByDigest.get(capability.digest)
-    if (existingService && existingService !== capability.leases) {
-      throw new TypeError('sandbox capability digest is already bound to another lease service')
-    }
-    const existingDigest = this.digestByService.get(capability.leases)
-    if (existingDigest && existingDigest !== capability.digest) {
-      throw new TypeError('sandbox lease service is already bound to another capability digest')
-    }
-    const provider = capability.leases.providerIdentity
+    if (leases.isDisposed) throw new TypeError('disposed sandbox lease service cannot be registered')
+    const existingService = this.serviceByDigest.get(digest)
+    if (existingService && existingService !== leases) throw new TypeError('sandbox capability digest is already bound to another lease service')
+    const existingDigest = this.digestByService.get(leases)
+    if (existingDigest && existingDigest !== digest) throw new TypeError('sandbox lease service is already bound to another capability digest')
+    const provider = leases.providerIdentity
     const providerDigest = this.digestByProvider.get(provider)
-    if (providerDigest && providerDigest !== capability.digest) {
-      throw new TypeError('sandbox provider is already owned by another lease service')
-    }
-    this.serviceByDigest.set(capability.digest, capability.leases)
-    this.digestByService.set(capability.leases, capability.digest)
-    this.digestByProvider.set(provider, capability.digest)
+    const providerClaim = this.providerClaims.get(provider)
+    if ((providerDigest && providerDigest !== digest) || (providerClaim && (!acceptClaim || providerClaim !== digest))) throw new TypeError('sandbox provider is already owned by another lease service')
+    this.serviceByDigest.set(digest, leases)
+    this.digestByService.set(leases, digest)
+    this.digestByProvider.set(provider, digest)
+    this.providerClaims.delete(provider)
+  }
+
+  private async disposeUnpublished(service: SandboxLeaseService): Promise<void> {
+    this.drainingServices.add(service)
+    await service.dispose()
+    this.drainingServices.delete(service)
   }
 
   private evict(digest: string, service: SandboxLeaseService): void {
     if (this.serviceByDigest.get(digest) === service) this.serviceByDigest.delete(digest)
     this.digestByService.delete(service)
-    if (this.digestByProvider.get(service.providerIdentity) === digest) {
-      this.digestByProvider.delete(service.providerIdentity)
-    }
+    if (this.digestByProvider.get(service.providerIdentity) === digest) this.digestByProvider.delete(service.providerIdentity)
   }
 
   async dispose(): Promise<readonly PromiseSettledResult<void>[]> {
     this.draining = true
-    const pending = [...this.pendingByDigest.values()]
-    const pendingResults = await Promise.allSettled(pending)
-    const entries = [...this.serviceByDigest.entries()]
-    const serviceResults = await Promise.allSettled(entries.map(async ([digest, service]) => {
+    const pendingResults = await Promise.allSettled([...this.pendingByDigest.values()])
+    const serviceResults = await Promise.allSettled([...this.serviceByDigest].map(async ([digest, service]) => {
       await service.dispose()
       this.evict(digest, service)
     }))
-    const debtResults = await Promise.allSettled([...this.drainingServices].map(async (service) => {
-      await service.dispose()
-      this.drainingServices.delete(service)
-    }))
-    for (const [digest, service] of this.serviceByDigest) {
-      if (service.isDisposed) this.evict(digest, service)
-    }
+    const debtResults = await Promise.allSettled([...this.drainingServices].map(
+      async (service) => await this.disposeUnpublished(service),
+    ))
+    for (const [digest, service] of this.serviceByDigest) if (service.isDisposed) this.evict(digest, service)
     return [...pendingResults.map((result): PromiseSettledResult<void> => result.status === 'fulfilled'
       ? { status: 'fulfilled', value: undefined }
       : result), ...serviceResults, ...debtResults]

--- a/packages/agent/src/server/sandbox/leases/sandboxLeaseServiceRegistry.ts
+++ b/packages/agent/src/server/sandbox/leases/sandboxLeaseServiceRegistry.ts
@@ -52,15 +52,14 @@ export class SandboxLeaseServiceRegistry {
     if (this.digestByProvider.has(provider) || this.providerClaims.has(provider)) {
       throw new TypeError('sandbox provider is already owned or claimed')
     }
+    this.providerClaims.set(provider, digest)
     if (this.draining) {
-      this.providerClaims.set(provider, digest)
       const error = new TypeError('sandbox lease service registry is draining')
       try { await provider.close?.() }
       catch (cleanupError) { throw new AggregateError([error, cleanupError], 'sandbox profile claim cleanup failed') }
       finally { this.providerClaims.delete(provider) }
       throw error
     }
-    this.providerClaims.set(provider, digest)
     return () => { if (this.providerClaims.get(provider) === digest) this.providerClaims.delete(provider) }
   }
 
@@ -89,8 +88,7 @@ export class SandboxLeaseServiceRegistry {
 
   private async disposeUnpublished(service: SandboxLeaseService): Promise<void> {
     this.drainingServices.add(service)
-    await service.dispose()
-    this.drainingServices.delete(service)
+    await service.dispose().then(() => this.drainingServices.delete(service))
   }
 
   private evict(digest: string, service: SandboxLeaseService): void {
@@ -99,38 +97,38 @@ export class SandboxLeaseServiceRegistry {
     if (this.digestByProvider.get(service.providerIdentity) === digest) this.digestByProvider.delete(service.providerIdentity)
   }
 
+  private async disposeCurrent(): Promise<readonly PromiseSettledResult<void>[]> {
+    return await Promise.allSettled([
+      ...[...this.serviceByDigest].map(async ([digest, service]) => {
+        await service.dispose(); this.evict(digest, service)
+      }),
+      ...[...this.drainingServices].map((service) => this.disposeUnpublished(service)),
+    ])
+  }
+
   async dispose(): Promise<readonly PromiseSettledResult<void>[]> {
     this.draining = true
-    const pendingResults = Promise.allSettled([...this.pendingByDigest.values()])
-    const serviceResults = await Promise.allSettled([...this.serviceByDigest].map(async ([digest, service]) => {
-      await service.dispose()
-      this.evict(digest, service)
-    }))
-    const debtResults = await Promise.allSettled([...this.drainingServices].map(
-      async (service) => await this.disposeUnpublished(service),
-    ))
-    for (const [digest, service] of this.serviceByDigest) if (service.isDisposed) this.evict(digest, service)
-    return [...(await pendingResults).map((result): PromiseSettledResult<void> => result.status === 'fulfilled'
-      ? { status: 'fulfilled', value: undefined }
-      : result), ...serviceResults, ...debtResults]
+    const current = this.disposeCurrent()
+    const pending = Promise.allSettled([...this.pendingByDigest.values()])
+    return [...(await current).filter((result) => result.status === 'fulfilled'), ...await pending.then(() => this.disposeCurrent())]
   }
 
   async disposeUntil(deadline: number): Promise<readonly PromiseSettledResult<void>[]> {
+    this.draining = true
     for (;;) {
       const remaining = deadline - Date.now()
-      if (remaining <= 0) return [{ status: 'rejected', reason: new Error('sandbox lease registry drain deadline exceeded') }]
-      const attempt = this.dispose()
+      const failure = { status: 'rejected' as const, reason: new Error('sandbox lease registry drain deadline exceeded') }
+      if (remaining <= 0) return [failure]
+      const pass = this.disposeCurrent()
       let timer: number | undefined
       const results = await Promise.race([
-        attempt,
+        pass,
         new Promise<undefined>((resolve) => { timer = setTimeout(resolve, remaining) }),
       ])
       if (timer) clearTimeout(timer)
-      if (!results) {
-        void attempt.catch(() => { /* late factory cleanup remains registry-owned */ })
-        return [{ status: 'rejected', reason: new Error('sandbox lease registry drain deadline exceeded') }]
-      }
-      if (results.every((result) => result.status === 'fulfilled')) return results
+      if (!results) { void pass.catch(() => undefined); return [failure] }
+      const workRemains = this.pendingByDigest.size || this.serviceByDigest.size || this.drainingServices.size
+      if (!workRemains && results.every((result) => result.status === 'fulfilled')) return results
       await new Promise<void>((resolve) => setTimeout(resolve, Math.min(10, deadline - Date.now())))
     }
   }

--- a/packages/agent/src/server/tools/__tests__/sandboxManagement.test.ts
+++ b/packages/agent/src/server/tools/__tests__/sandboxManagement.test.ts
@@ -80,6 +80,16 @@ describe('sandbox management tool', () => {
     }
     expect(text).toContain('create')
     expect(text).toContain('release')
+    expect(tool.parameters).toMatchObject({
+      type: 'object',
+      required: ['op'],
+      additionalProperties: false,
+      properties: {
+        op: { type: 'string', enum: ['create', 'list', 'status', 'release'] },
+        sandbox: { type: 'string' },
+      },
+    })
+    expect(tool.parameters).not.toHaveProperty('oneOf')
   })
 
   it('fails closed through ordinary public execution', async () => {

--- a/packages/agent/src/server/tools/__tests__/sandboxManagement.test.ts
+++ b/packages/agent/src/server/tools/__tests__/sandboxManagement.test.ts
@@ -93,6 +93,27 @@ describe('sandbox management tool', () => {
     expect(tool.parameters).not.toHaveProperty('oneOf')
   })
 
+  it('passes the actual OpenAI Responses strict tool adapter', async () => {
+    const { tool } = fixture()
+    const codingAgentUrl = import.meta.resolve('@mariozechner/pi-coding-agent')
+    const adapterUrl = import.meta.resolve(
+      '@earendil-works/pi-ai/api/openai-responses-shared',
+      codingAgentUrl,
+    )
+    const adapter = await import(adapterUrl) as {
+      convertResponsesTools(tools: unknown[], options: unknown): Array<Record<string, unknown>>
+    }
+    const [converted] = adapter.convertResponsesTools([{
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.parameters,
+    }], { strict: true, supportsStrictMode: true })
+    expect(converted).toMatchObject({
+      type: 'function', name: 'sandbox', strict: true,
+      parameters: tool.parameters,
+    })
+  })
+
   it.each([
     {},
     { op: 'unknown' },

--- a/packages/agent/src/server/tools/__tests__/sandboxManagement.test.ts
+++ b/packages/agent/src/server/tools/__tests__/sandboxManagement.test.ts
@@ -7,13 +7,14 @@ import type { AgentHostRuntime } from '../../agent-host/createAgentHost'
 import { InMemoryAgentRequestLedger } from '../../agent-host/requestLedger'
 import { acceptedExternalEffectExecutor } from '../../agent-host/acceptedWork'
 import type { AgentRequestKey } from '../../agent-host/types'
-import type { SandboxProviderV1, WorkspaceSandboxPairV1 } from '@hachej/boring-sandbox/shared'
+import type { WorkspaceSandboxPairV1 } from '@hachej/boring-sandbox/shared'
 import {
   SANDBOX_LEASE_ERROR_CODES,
   SandboxLeaseError,
   SandboxLeaseService,
 } from '../../sandbox/leases/sandboxLease'
 import { sandboxLeaseOwnerId } from '../../sandbox/leases/sandboxLeaseOwner'
+import { fakeDisposableProvider } from '../../sandbox/leases/__tests__/fakeDisposableProvider'
 import { createSandboxManagementTool } from '../sandboxManagement'
 
 const parentKey: AgentRequestKey = {
@@ -90,6 +91,46 @@ describe('sandbox management tool', () => {
       },
     })
     expect(tool.parameters).not.toHaveProperty('oneOf')
+  })
+
+  it.each([
+    {},
+    { op: 'unknown' },
+    { op: 1 },
+    { op: 'create', sandbox: 'lease-handle-0001' },
+    { op: 'list', sandbox: 'lease-handle-0001' },
+    { op: 'status' },
+    { op: 'status', sandbox: '' },
+    { op: 'status', sandbox: 'short' },
+    { op: 'status', sandbox: 'lease-handle-0001', extra: true },
+    { op: 'release' },
+    { op: 'release', sandbox: 'lease-handle-0001', provider: 'direct' },
+  ])('runtime parser rejects invalid operation/handle combination %#', async (input) => {
+    const { tool } = fixture()
+    const execute = acceptedExternalEffectExecutor(tool, input)
+    const response = execute
+      ? await execute(input, ctx, { ...invocation, toolCallId: `invalid-${JSON.stringify(input)}` })
+      : await tool.execute(input, ctx)
+    expect(response).toMatchObject({
+      isError: true,
+      details: { code: SANDBOX_LEASE_ERROR_CODES.INVALID_LEASE_REQUEST },
+    })
+  })
+
+  it('accepts exactly the four valid operation shapes through their proper execution paths', async () => {
+    for (const input of [
+      { op: 'create' },
+      { op: 'list' },
+      { op: 'status', sandbox: 'lease-handle-0001' },
+      { op: 'release', sandbox: 'lease-handle-0001' },
+    ]) {
+      const { tool } = fixture()
+      const execute = acceptedExternalEffectExecutor(tool, input)
+      const response = execute
+        ? await execute(input, ctx, { ...invocation, toolCallId: `valid-${input.op}` })
+        : await tool.execute(input, ctx)
+      expect(response.isError).toBe(false)
+    }
   })
 
   it('fails closed through ordinary public execution', async () => {
@@ -171,9 +212,7 @@ describe('sandbox management tool', () => {
       sandbox: {},
       dispose,
     } as unknown as WorkspaceSandboxPairV1
-    const provider = {
-      create: vi.fn(async () => pair),
-    } as unknown as SandboxProviderV1
+    const provider = fakeDisposableProvider({ create: vi.fn(async () => pair) })
     const leases = new SandboxLeaseService({
       workspaceRoot: '/host/sandboxes',
       provider,

--- a/packages/agent/src/server/tools/sandboxManagement.ts
+++ b/packages/agent/src/server/tools/sandboxManagement.ts
@@ -217,20 +217,12 @@ export function createSandboxManagementTool(options: SandboxManagementToolOption
     description: 'Create, inspect, list, or release disposable remote coding sandboxes. Use the returned sandbox handle with ordinary bash and file tools.',
     parameters: {
       type: 'object',
-      oneOf: [
-        { properties: { op: { const: 'create' } }, required: ['op'], additionalProperties: false },
-        { properties: { op: { const: 'list' } }, required: ['op'], additionalProperties: false },
-        {
-          properties: { op: { const: 'status' }, sandbox: { type: 'string', pattern: HANDLE_PATTERN } },
-          required: ['op', 'sandbox'],
-          additionalProperties: false,
-        },
-        {
-          properties: { op: { const: 'release' }, sandbox: { type: 'string', pattern: HANDLE_PATTERN } },
-          required: ['op', 'sandbox'],
-          additionalProperties: false,
-        },
-      ],
+      properties: {
+        op: { type: 'string', enum: ['create', 'list', 'status', 'release'] },
+        sandbox: { type: 'string', pattern: HANDLE_PATTERN },
+      },
+      required: ['op'],
+      additionalProperties: false,
     },
     async execute(params, ctx) {
       return await executeObservation(options, params, ctx)

--- a/packages/boring-sandbox/src/providers/README.md
+++ b/packages/boring-sandbox/src/providers/README.md
@@ -40,8 +40,8 @@ must not grant a profile whose live row is not qualified for its tenant policy.
 | Proof | Exact command | Result at delivery head |
 | --- | --- | --- |
 | Disposable 13-law pair surface | `pnpm -C packages/boring-sandbox exec vitest run src/providers/__tests__/dualTargetParity.test.ts src/providers/remote-worker/__tests__/createRemoteWorkerProvider.test.ts` | PASS: the shared seven Workspace plus six Sandbox law helper runs against direct, bwrap, Blaxel, Vercel, and remote-worker disposable pairs |
-| Provider lifecycle/ambiguity | `pnpm -C packages/boring-sandbox exec vitest run --passWithNoTests --maxWorkers=4` | PASS: 69 files / 809 tests |
-| Agent authority/registry/strict adapter | `pnpm --filter @hachej/boring-agent test` | PASS: 2,350 passed / 18 skipped |
+| Provider lifecycle/ambiguity | `pnpm -C packages/boring-sandbox exec vitest run --passWithNoTests --maxWorkers=4` | PASS: 69 files / 810 tests |
+| Agent authority/registry/strict adapter | `pnpm -C packages/agent exec vitest run --maxWorkers=4` | PASS: 2,352 passed / 18 skipped |
 | Canonical wrappers | `pnpm --filter @hachej/boring-bash test` | PASS: 90 tests |
 | Direct/bwrap exact roots | `pnpm -C packages/boring-sandbox exec vitest run src/providers/__tests__/disposableLocalProviders.test.ts` | PASS: provider removes the exact owned child, sibling/parent survive, ancestor aliases and root swaps fail closed, default roots remain |
 | Remote worker | `RUN_RUNSC_INTEGRATION=1 pnpm --filter @hachej/boring-sandbox test:remote-worker:multi-lease` | PASS evidence, `qualified:false`, capability unadvertised (`openat2` ENOSYS) |

--- a/packages/boring-sandbox/src/providers/README.md
+++ b/packages/boring-sandbox/src/providers/README.md
@@ -35,6 +35,22 @@ advertise remote-worker multi-root support because `openat2` is unavailable.
 Mock proof is mandatory but is not represented as live qualification. A host
 must not grant a profile whose live row is not qualified for its tenant policy.
 
+### Reproducible proof matrix
+
+| Proof | Exact command | Result at delivery head |
+| --- | --- | --- |
+| Disposable 13-law pair surface | `pnpm -C packages/boring-sandbox exec vitest run src/providers/__tests__/dualTargetParity.test.ts src/providers/remote-worker/__tests__/createRemoteWorkerProvider.test.ts` | PASS: the shared seven Workspace plus six Sandbox law helper runs against direct, bwrap, Blaxel, Vercel, and remote-worker disposable pairs |
+| Provider lifecycle/ambiguity | `pnpm --filter @hachej/boring-sandbox test` | PASS: 69 files / 791 tests |
+| Agent authority/registry/strict adapter | `pnpm --filter @hachej/boring-agent test -- --maxWorkers=4` | PASS: 2,348 passed / 18 skipped (one initial unrelated timeout passed in isolation and full rerun) |
+| Canonical wrappers | `pnpm --filter @hachej/boring-bash test` | PASS: 90 tests |
+| Direct/bwrap exact roots | `pnpm -C packages/boring-sandbox exec vitest run src/providers/__tests__/disposableLocalProviders.test.ts` | PASS: provider removes the exact owned child, sibling/parent survive, ancestor aliases and root swaps fail closed, default roots remain |
+| Remote worker | `RUN_RUNSC_INTEGRATION=1 pnpm --filter @hachej/boring-sandbox test:remote-worker:multi-lease` | PASS evidence, `qualified:false`, capability unadvertised (`openat2` ENOSYS) |
+| Vercel disposable live | Vault-backed `/tmp/prb-vercel-smoke.ts` using this factory | Run after the delivery commit; sanitized result is recorded in the review receipt, never with IDs or credentials |
+
+Sequential `typecheck`, invariant, and build gates pass for sandbox, Agent, and
+boring-bash. Blaxel remains `LIVE NOT RUN`; no credential or remote identifier
+is stored in this repository.
+
 `resolveMode()` itself is owned by `@hachej/boring-bash/modes`. It resolves a
 mode id to one of these provider values; providers do not resolve modes.
 

--- a/packages/boring-sandbox/src/providers/README.md
+++ b/packages/boring-sandbox/src/providers/README.md
@@ -40,8 +40,8 @@ must not grant a profile whose live row is not qualified for its tenant policy.
 | Proof | Exact command | Result at delivery head |
 | --- | --- | --- |
 | Disposable 13-law pair surface | `pnpm -C packages/boring-sandbox exec vitest run src/providers/__tests__/dualTargetParity.test.ts src/providers/remote-worker/__tests__/createRemoteWorkerProvider.test.ts` | PASS: the shared seven Workspace plus six Sandbox law helper runs against direct, bwrap, Blaxel, Vercel, and remote-worker disposable pairs |
-| Provider lifecycle/ambiguity | `pnpm --filter @hachej/boring-sandbox test` | PASS: 69 files / 791 tests |
-| Agent authority/registry/strict adapter | `pnpm --filter @hachej/boring-agent test -- --maxWorkers=4` | PASS: 2,348 passed / 18 skipped (one initial unrelated timeout passed in isolation and full rerun) |
+| Provider lifecycle/ambiguity | `pnpm -C packages/boring-sandbox exec vitest run --passWithNoTests --maxWorkers=4` | PASS: 69 files / 809 tests |
+| Agent authority/registry/strict adapter | `pnpm --filter @hachej/boring-agent test` | PASS: 2,350 passed / 18 skipped |
 | Canonical wrappers | `pnpm --filter @hachej/boring-bash test` | PASS: 90 tests |
 | Direct/bwrap exact roots | `pnpm -C packages/boring-sandbox exec vitest run src/providers/__tests__/disposableLocalProviders.test.ts` | PASS: provider removes the exact owned child, sibling/parent survive, ancestor aliases and root swaps fail closed, default roots remain |
 | Remote worker | `RUN_RUNSC_INTEGRATION=1 pnpm --filter @hachej/boring-sandbox test:remote-worker:multi-lease` | PASS evidence, `qualified:false`, capability unadvertised (`openat2` ENOSYS) |

--- a/packages/boring-sandbox/src/providers/README.md
+++ b/packages/boring-sandbox/src/providers/README.md
@@ -6,13 +6,21 @@ Concrete sandbox providers live behind this subpath as they move out of
 
 | Runtime mode | Sandbox provider | Notes |
 | --- | --- | --- |
-| `direct` | `direct` | Trusted host mode; no isolation. |
-| `local` | `bwrap` | Linux bubblewrap. The mode id intentionally differs from the provider id. |
-| `vercel-sandbox` | `vercel-sandbox` | Optional remote PROXY provider. |
-| `blaxel` | `blaxel` | EU-region remote provider with a persistent Volume at `/workspace`; SDK 0.3.11 output caps are local and cancellation is best effort. |
-| `remote-worker` | `remote-worker` | Client/provider split from the app-owned worker server. Worker-dependent facts stay `unknown` until the P5 handshake reports them. |
+| `direct` | `direct` | Trusted host mode; no isolation. Explicit disposable mode removes its exact lease root; default retains it. |
+| `local` | `bwrap` | Linux bubblewrap. Explicit disposable mode removes its exact lease root; default retains it. The mode id intentionally differs from the provider id. |
+| `vercel-sandbox` | `vercel-sandbox` | Disposable named forks delete without resumable handles; persistent default is unchanged. |
+| `blaxel` | `blaxel` | Disposable mode is fresh/no-Volume/no-resume; default remains an EU-region persistent Volume at `/workspace`. |
+| `remote-worker` | `remote-worker` | Disposable mode requires negotiated `multi-sandbox-roots-v1` and transfers published cleanup to the pair; unqualified workers fail closed. |
 | pure/headless | `none` | No boring-bash environment. |
 | readonly files | `readonly` facade | File UI/search/watch without exec. |
+
+The disposable refinement is a host-only construction option, never a model
+input. It promises fresh creation, pre-effect correlated reconciliation,
+returned-pair ownership after publication, retryable idempotent disposal, and
+not-found convergence. Mechanical support does not grant D31 production
+qualification: direct/bwrap remain unsuitable for hostile tenants, Blaxel live
+qualification is profile-specific, and the current local gVisor profile cannot
+advertise remote-worker multi-root support because `openat2` is unavailable.
 
 `resolveMode()` itself is owned by `@hachej/boring-bash/modes`. It resolves a
 mode id to one of these provider values; providers do not resolve modes.

--- a/packages/boring-sandbox/src/providers/README.md
+++ b/packages/boring-sandbox/src/providers/README.md
@@ -22,6 +22,19 @@ qualification: direct/bwrap remain unsuitable for hostile tenants, Blaxel live
 qualification is profile-specific, and the current local gVisor profile cannot
 advertise remote-worker multi-root support because `openat2` is unavailable.
 
+## #1459 qualification status
+
+| Provider | Lifecycle proof at this head | Live status |
+| --- | --- | --- |
+| direct | real create/execute/two-root isolation/exact cleanup/default retention | PASS locally |
+| bwrap | real Linux bubblewrap create/execute/isolation/exact cleanup/default retention | PASS locally |
+| Blaxel | mock fresh create, conflict ownership, create/close race, retry/not-found, no Volume/store | LIVE NOT RUN — no D31-qualified profile credentials |
+| Vercel | named create, conflict ownership, ambiguity reconciliation, retry/not-found, keyed redaction | LIVE PASS on the exact reviewed working tree via Vault-backed credentials: create/readiness/read-write/exec/provider-close ownership/remote deletion |
+| remote-worker | authenticated mock protocol, ownership races, retry/not-found, capability fail-closed | LIVE NOT QUALIFIED — installed gVisor returns `ENOSYS` for `openat2`; capability remains unadvertised |
+
+Mock proof is mandatory but is not represented as live qualification. A host
+must not grant a profile whose live row is not qualified for its tenant policy.
+
 `resolveMode()` itself is owned by `@hachej/boring-bash/modes`. It resolves a
 mode id to one of these provider values; providers do not resolve modes.
 

--- a/packages/boring-sandbox/src/providers/__tests__/conformance/disposableProvider.ts
+++ b/packages/boring-sandbox/src/providers/__tests__/conformance/disposableProvider.ts
@@ -1,4 +1,5 @@
 import { expect } from 'vitest'
+import { join } from 'node:path'
 
 import {
   DISPOSABLE_SANDBOX_PROVIDER_PROFILE_V1,
@@ -22,12 +23,7 @@ export function expectDisposableProviderProfile(
     publishedCleanupOwner: 'returned-pair',
     ambiguousCreate: 'correlated-reconciliation',
     providerConfigDigest: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
-    assertProvider: expect.any(Function),
   })
-  expect(() => provider.disposableProfile.assertProvider(provider)).not.toThrow()
-  const copied = { ...provider, disposableProfile: provider.disposableProfile } as SandboxProviderV1
-  expect(isDisposableSandboxProviderV1(copied)).toBe(false)
-  expect(() => provider.disposableProfile.assertProvider(copied)).toThrow()
 }
 
 /** Shared publication, provider-close, joined-disposal, and terminal-cleanup laws. */
@@ -41,6 +37,40 @@ export async function expectPublishedPairLifecycle(input: {
   await input.assertUsableAfterProviderClose()
   await Promise.all([input.pair.dispose(), input.pair.dispose()])
   await input.assertTerminalCleanup()
+}
+
+/** The shared seven Workspace plus six Sandbox laws for disposable pairs. */
+export async function expectDisposablePairSurfaceLaws(pair: WorkspaceSandboxPairV1): Promise<void> {
+  const { workspace, sandbox } = pair
+  await workspace.mkdir('src', { recursive: true })
+  await workspace.writeFile('src/hello.txt', 'hello world')
+  expect(await workspace.readFile('src/hello.txt')).toBe('hello world')
+  expect(await workspace.stat('src/hello.txt')).toMatchObject({ kind: 'file', size: 11 })
+  await workspace.rename('src/hello.txt', 'src/renamed.txt')
+  expect(await workspace.readFile('src/renamed.txt')).toBe('hello world')
+  await workspace.mkdir('a/b/c', { recursive: true })
+  expect(await workspace.stat('a/b/c')).toMatchObject({ kind: 'dir' })
+  await workspace.unlink('src/renamed.txt')
+  await expect(workspace.readFile('src/renamed.txt')).rejects.toThrow()
+  for (const bad of ['../etc/passwd', '/etc/passwd', `bad\0name`]) {
+    await expect(workspace.readFile(bad)).rejects.toThrow()
+  }
+
+  expect(new TextDecoder().decode((await sandbox.exec('echo hello')).stdout)).toContain('hello')
+  expect((await sandbox.exec('exit 7')).exitCode).toBe(7)
+  await workspace.mkdir('nested', { recursive: true })
+  await workspace.writeFile('nested/note.txt', 'cwd-ok')
+  const cwd = await sandbox.exec('pwd && cat note.txt', { cwd: join(workspace.root, 'nested') })
+  expect(new TextDecoder().decode(cwd.stdout)).toContain('cwd-ok')
+  expect((await sandbox.exec('node -e "setInterval(() => {}, 1000)"', { timeoutMs: 500 })).exitCode).toBe(124)
+  const bounded = await sandbox.exec(`node -e "process.stdout.write('x'.repeat(2_000_000))"`, { maxOutputBytes: 1024 })
+  expect(bounded.truncated).toBe(true)
+  let heartbeats = 0
+  await sandbox.exec('node -e "setTimeout(() => {}, 2100)"', {
+    timeoutMs: 5_000,
+    onHeartbeat: () => { heartbeats += 1 },
+  })
+  expect(heartbeats).toBeGreaterThanOrEqual(1)
 }
 
 export function expectPersistentProviderDefault(provider: SandboxProviderV1): void {

--- a/packages/boring-sandbox/src/providers/__tests__/conformance/disposableProvider.ts
+++ b/packages/boring-sandbox/src/providers/__tests__/conformance/disposableProvider.ts
@@ -1,0 +1,28 @@
+import { expect } from 'vitest'
+
+import {
+  DISPOSABLE_SANDBOX_PROVIDER_PROFILE_V1,
+  isDisposableSandboxProviderV1,
+  type ExtractedSandboxProviderIdV1,
+  type SandboxProviderV1,
+} from '../../../shared/providerV1'
+
+/** Shared marker/ownership law used by every disposable provider qualification. */
+export function expectDisposableProviderProfile(
+  provider: SandboxProviderV1,
+  providerId: ExtractedSandboxProviderIdV1,
+): void {
+  expect(provider.providerId).toBe(providerId)
+  expect(isDisposableSandboxProviderV1(provider)).toBe(true)
+  if (!isDisposableSandboxProviderV1(provider)) return
+  expect(provider.disposableProfile).toEqual({
+    contractVersion: DISPOSABLE_SANDBOX_PROVIDER_PROFILE_V1,
+    resume: false,
+    publishedCleanupOwner: 'returned-pair',
+    ambiguousCreate: 'correlated-reconciliation',
+  })
+}
+
+export function expectPersistentProviderDefault(provider: SandboxProviderV1): void {
+  expect(isDisposableSandboxProviderV1(provider)).toBe(false)
+}

--- a/packages/boring-sandbox/src/providers/__tests__/conformance/disposableProvider.ts
+++ b/packages/boring-sandbox/src/providers/__tests__/conformance/disposableProvider.ts
@@ -5,6 +5,7 @@ import {
   isDisposableSandboxProviderV1,
   type ExtractedSandboxProviderIdV1,
   type SandboxProviderV1,
+  type WorkspaceSandboxPairV1,
 } from '../../../shared/providerV1'
 
 /** Shared marker/ownership law used by every disposable provider qualification. */
@@ -15,12 +16,31 @@ export function expectDisposableProviderProfile(
   expect(provider.providerId).toBe(providerId)
   expect(isDisposableSandboxProviderV1(provider)).toBe(true)
   if (!isDisposableSandboxProviderV1(provider)) return
-  expect(provider.disposableProfile).toEqual({
+  expect(provider.disposableProfile).toMatchObject({
     contractVersion: DISPOSABLE_SANDBOX_PROVIDER_PROFILE_V1,
     resume: false,
     publishedCleanupOwner: 'returned-pair',
     ambiguousCreate: 'correlated-reconciliation',
+    providerConfigDigest: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+    assertProvider: expect.any(Function),
   })
+  expect(() => provider.disposableProfile.assertProvider(provider)).not.toThrow()
+  const copied = { ...provider, disposableProfile: provider.disposableProfile } as SandboxProviderV1
+  expect(isDisposableSandboxProviderV1(copied)).toBe(false)
+  expect(() => provider.disposableProfile.assertProvider(copied)).toThrow()
+}
+
+/** Shared publication, provider-close, joined-disposal, and terminal-cleanup laws. */
+export async function expectPublishedPairLifecycle(input: {
+  provider: SandboxProviderV1
+  pair: WorkspaceSandboxPairV1
+  assertUsableAfterProviderClose(): Promise<void>
+  assertTerminalCleanup(): Promise<void>
+}): Promise<void> {
+  await input.provider.close?.()
+  await input.assertUsableAfterProviderClose()
+  await Promise.all([input.pair.dispose(), input.pair.dispose()])
+  await input.assertTerminalCleanup()
 }
 
 export function expectPersistentProviderDefault(provider: SandboxProviderV1): void {

--- a/packages/boring-sandbox/src/providers/__tests__/disposableLocalProviders.test.ts
+++ b/packages/boring-sandbox/src/providers/__tests__/disposableLocalProviders.test.ts
@@ -70,6 +70,18 @@ describe.each([
     await pairB.dispose()
   })
 
+  test('close fences a concurrent create and removes its unpublished root', async () => {
+    const parent = await mkdtemp(join(tmpdir(), 'boring-disposable-close-'))
+    cleanupRoots.push(parent)
+    const root = join(parent, 'lease-aaaaaaaaaaaaaaaa')
+    const provider = factory({ leaseMode: 'disposable' })
+    const creation = provider.create({ workspaceRoot: root, sessionId: 'closing' })
+    const closing = provider.close!()
+    await expect(creation).rejects.toMatchObject({ code: 'CONFIG_INVALID' })
+    await expect(closing).resolves.toBeUndefined()
+    expect(await exists(root)).toBe(false)
+  })
+
   test('rejects root aliases and pre-existing directory or symlink roots before effects', async () => {
     const provider = factory({ leaseMode: 'disposable' })
     for (const workspaceRoot of ['//', '/./', '/tmp/..', '/tmp/../']) {

--- a/packages/boring-sandbox/src/providers/__tests__/disposableLocalProviders.test.ts
+++ b/packages/boring-sandbox/src/providers/__tests__/disposableLocalProviders.test.ts
@@ -118,7 +118,7 @@ describe.each([
     })).rejects.toMatchObject({ code: 'CONFIG_INVALID' })
   })
 
-  test('fails closed if the owned root is swapped before recursive deletion', async () => {
+  test('retains cleanup debt if the owned root is relocated or swapped before deletion', async () => {
     const parent = await mkdtemp(join(tmpdir(), 'boring-disposable-swap-'))
     cleanupRoots.push(parent)
     const root = join(parent, 'lease-aaaaaaaaaaaaaaaa')
@@ -128,14 +128,18 @@ describe.each([
     await writeFile(join(outside, 'preserved'), 'yes')
     const provider = factory({ leaseMode: 'disposable' })
     const pair = await provider.create({ workspaceRoot: root, sessionId: 'swap' })
+    await writeFile(join(root, 'owned'), 'still-owned')
     await rename(root, moved)
-    await symlink(outside, root)
 
+    await expect(pair.dispose()).rejects.toThrow('disposable local sandbox cleanup failed')
+    expect(await exists(join(moved, 'owned'))).toBe(true)
+    await symlink(outside, root)
     await expect(pair.dispose()).rejects.toThrow('disposable local sandbox cleanup failed')
     expect(await exists(join(outside, 'preserved'))).toBe(true)
     await unlink(root)
     await rename(moved, root)
     await expect(pair.dispose()).resolves.toBeUndefined()
+    expect(await exists(root)).toBe(false)
   })
 
   test('keeps the primary root when disposable mode is omitted', async () => {

--- a/packages/boring-sandbox/src/providers/__tests__/disposableLocalProviders.test.ts
+++ b/packages/boring-sandbox/src/providers/__tests__/disposableLocalProviders.test.ts
@@ -1,4 +1,4 @@
-import { access, mkdtemp, mkdir, rm } from 'node:fs/promises'
+import { access, mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, test } from 'vitest'
 import {
   expectDisposableProviderProfile,
   expectPersistentProviderDefault,
+  expectPublishedPairLifecycle,
 } from './conformance/disposableProvider'
 import { createBwrapSandboxProvider } from '../bwrap/createBwrapProvider'
 import { createDirectSandboxProvider } from '../direct/createDirectProvider'
@@ -38,12 +39,47 @@ describe.each([
     expect(Buffer.from((await pairA.sandbox.exec('cat marker.txt')).stdout).toString()).toBe('a')
     expect(Buffer.from((await pairB.sandbox.exec('cat marker.txt')).stdout).toString()).toBe('b')
 
-    await Promise.all([pairA.dispose(), pairA.dispose()])
-    expect(await exists(rootA)).toBe(false)
+    await expectPublishedPairLifecycle({
+      provider,
+      pair: pairA,
+      assertUsableAfterProviderClose: async () => {
+        expect(await pairA.workspace.readFile('marker.txt')).toBe('a')
+        await rm(rootA, { recursive: true })
+      },
+      assertTerminalCleanup: async () => {
+        expect(await exists(rootA)).toBe(false)
+      },
+    })
     expect(await exists(rootB)).toBe(true)
     expect(await pairB.workspace.readFile('marker.txt')).toBe('b')
     await pairB.dispose()
-    await provider.close?.()
+  })
+
+  test('rejects root aliases and pre-existing directory or symlink roots before effects', async () => {
+    const provider = factory({ leaseMode: 'disposable' })
+    for (const workspaceRoot of ['//', '/./', '/tmp/..', '/tmp/../']) {
+      await expect(provider.create({ workspaceRoot, sessionId: 'unsafe' })).rejects.toMatchObject({
+        code: 'CONFIG_INVALID',
+      })
+    }
+
+    const parent = await mkdtemp(join(tmpdir(), 'boring-disposable-guard-'))
+    cleanupRoots.push(parent)
+    const existing = join(parent, 'existing')
+    await mkdir(existing)
+    await expect(provider.create({ workspaceRoot: existing, sessionId: 'existing' })).rejects.toMatchObject({
+      code: 'EEXIST',
+    })
+
+    const target = join(parent, 'target')
+    const linked = join(parent, 'linked')
+    await mkdir(target)
+    await writeFile(join(target, 'marker'), 'preserved')
+    await symlink(target, linked)
+    await expect(provider.create({ workspaceRoot: linked, sessionId: 'linked' })).rejects.toMatchObject({
+      code: 'EEXIST',
+    })
+    expect(await exists(join(target, 'marker'))).toBe(true)
   })
 
   test('keeps the primary root when disposable mode is omitted', async () => {

--- a/packages/boring-sandbox/src/providers/__tests__/disposableLocalProviders.test.ts
+++ b/packages/boring-sandbox/src/providers/__tests__/disposableLocalProviders.test.ts
@@ -1,10 +1,11 @@
-import { access, mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises'
+import { access, mkdtemp, mkdir, rename, rm, symlink, unlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { afterEach, describe, expect, test } from 'vitest'
 
 import {
+  expectDisposablePairSurfaceLaws,
   expectDisposableProviderProfile,
   expectPersistentProviderDefault,
   expectPublishedPairLifecycle,
@@ -20,6 +21,17 @@ afterEach(async () => {
 async function exists(path: string): Promise<boolean> {
   try { await access(path); return true } catch { return false }
 }
+
+test('bwrap config digest changes with trusted network policy', () => {
+  const shared = createBwrapSandboxProvider({
+    leaseMode: 'disposable', sandbox: { network: 'shared' },
+  })
+  const isolated = createBwrapSandboxProvider({
+    leaseMode: 'disposable', sandbox: { network: 'isolated' },
+  })
+  expect(shared.disposableProfile.providerConfigDigest)
+    .not.toBe(isolated.disposableProfile.providerConfigDigest)
+})
 
 describe.each([
   ['direct', createDirectSandboxProvider] as const,
@@ -38,13 +50,13 @@ describe.each([
     await pairB.workspace.writeFile('marker.txt', 'b')
     expect(Buffer.from((await pairA.sandbox.exec('cat marker.txt')).stdout).toString()).toBe('a')
     expect(Buffer.from((await pairB.sandbox.exec('cat marker.txt')).stdout).toString()).toBe('b')
+    await expectDisposablePairSurfaceLaws(pairA)
 
     await expectPublishedPairLifecycle({
       provider,
       pair: pairA,
       assertUsableAfterProviderClose: async () => {
         expect(await pairA.workspace.readFile('marker.txt')).toBe('a')
-        await rm(rootA, { recursive: true })
       },
       assertTerminalCleanup: async () => {
         expect(await exists(rootA)).toBe(false)
@@ -77,9 +89,38 @@ describe.each([
     await writeFile(join(target, 'marker'), 'preserved')
     await symlink(target, linked)
     await expect(provider.create({ workspaceRoot: linked, sessionId: 'linked' })).rejects.toMatchObject({
-      code: 'EEXIST',
+      code: 'CONFIG_INVALID',
     })
     expect(await exists(join(target, 'marker'))).toBe(true)
+
+    const realParent = join(parent, 'real-parent')
+    const parentAlias = join(parent, 'parent-alias')
+    await mkdir(realParent)
+    await symlink(realParent, parentAlias)
+    await expect(provider.create({
+      workspaceRoot: join(parentAlias, 'lease-aliased'),
+      sessionId: 'ancestor-linked',
+    })).rejects.toMatchObject({ code: 'CONFIG_INVALID' })
+  })
+
+  test('fails closed if the owned root is swapped before recursive deletion', async () => {
+    const parent = await mkdtemp(join(tmpdir(), 'boring-disposable-swap-'))
+    cleanupRoots.push(parent)
+    const root = join(parent, 'lease-aaaaaaaaaaaaaaaa')
+    const moved = join(parent, 'moved-owned-root')
+    const outside = join(parent, 'outside')
+    await mkdir(outside)
+    await writeFile(join(outside, 'preserved'), 'yes')
+    const provider = factory({ leaseMode: 'disposable' })
+    const pair = await provider.create({ workspaceRoot: root, sessionId: 'swap' })
+    await rename(root, moved)
+    await symlink(outside, root)
+
+    await expect(pair.dispose()).rejects.toThrow('disposable local sandbox cleanup failed')
+    expect(await exists(join(outside, 'preserved'))).toBe(true)
+    await unlink(root)
+    await rename(moved, root)
+    await expect(pair.dispose()).resolves.toBeUndefined()
   })
 
   test('keeps the primary root when disposable mode is omitted', async () => {

--- a/packages/boring-sandbox/src/providers/__tests__/disposableLocalProviders.test.ts
+++ b/packages/boring-sandbox/src/providers/__tests__/disposableLocalProviders.test.ts
@@ -1,0 +1,59 @@
+import { access, mkdtemp, mkdir, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, test } from 'vitest'
+
+import {
+  expectDisposableProviderProfile,
+  expectPersistentProviderDefault,
+} from './conformance/disposableProvider'
+import { createBwrapSandboxProvider } from '../bwrap/createBwrapProvider'
+import { createDirectSandboxProvider } from '../direct/createDirectProvider'
+
+const cleanupRoots: string[] = []
+afterEach(async () => {
+  await Promise.all(cleanupRoots.splice(0).map(async (root) => { await rm(root, { recursive: true, force: true }) }))
+})
+
+async function exists(path: string): Promise<boolean> {
+  try { await access(path); return true } catch { return false }
+}
+
+describe.each([
+  ['direct', createDirectSandboxProvider] as const,
+  ['bwrap', createBwrapSandboxProvider] as const,
+])('disposable %s provider', (_providerId, factory) => {
+  test('creates two isolated roots and removes only the disposed lease', async () => {
+    const parent = await mkdtemp(join(tmpdir(), 'boring-disposable-local-'))
+    cleanupRoots.push(parent)
+    const rootA = join(parent, 'lease-aaaaaaaaaaaaaaaa')
+    const rootB = join(parent, 'lease-bbbbbbbbbbbbbbbb')
+    const provider = factory({ leaseMode: 'disposable' })
+    expectDisposableProviderProfile(provider, _providerId)
+    const pairA = await provider.create({ workspaceRoot: rootA, sessionId: 'lease-a' })
+    const pairB = await provider.create({ workspaceRoot: rootB, sessionId: 'lease-b' })
+    await pairA.workspace.writeFile('marker.txt', 'a')
+    await pairB.workspace.writeFile('marker.txt', 'b')
+    expect(Buffer.from((await pairA.sandbox.exec('cat marker.txt')).stdout).toString()).toBe('a')
+    expect(Buffer.from((await pairB.sandbox.exec('cat marker.txt')).stdout).toString()).toBe('b')
+
+    await Promise.all([pairA.dispose(), pairA.dispose()])
+    expect(await exists(rootA)).toBe(false)
+    expect(await exists(rootB)).toBe(true)
+    expect(await pairB.workspace.readFile('marker.txt')).toBe('b')
+    await pairB.dispose()
+    await provider.close?.()
+  })
+
+  test('keeps the primary root when disposable mode is omitted', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'boring-primary-local-'))
+    cleanupRoots.push(root)
+    await mkdir(root, { recursive: true })
+    const provider = factory()
+    expectPersistentProviderDefault(provider)
+    const pair = await provider.create({ workspaceRoot: root, sessionId: 'primary' })
+    await pair.dispose()
+    expect(await exists(root)).toBe(true)
+  })
+})

--- a/packages/boring-sandbox/src/providers/__tests__/disposableLocalProviders.test.ts
+++ b/packages/boring-sandbox/src/providers/__tests__/disposableLocalProviders.test.ts
@@ -22,15 +22,18 @@ async function exists(path: string): Promise<boolean> {
   try { await access(path); return true } catch { return false }
 }
 
-test('bwrap config digest changes with trusted network policy', () => {
-  const shared = createBwrapSandboxProvider({
-    leaseMode: 'disposable', sandbox: { network: 'shared' },
-  })
-  const isolated = createBwrapSandboxProvider({
-    leaseMode: 'disposable', sandbox: { network: 'isolated' },
-  })
-  expect(shared.disposableProfile.providerConfigDigest)
-    .not.toBe(isolated.disposableProfile.providerConfigDigest)
+test('bwrap config digest hashes effective network and capability policy', () => {
+  const digest = (sandbox?: NonNullable<Parameters<typeof createBwrapSandboxProvider>[0]>['sandbox']) =>
+    createBwrapSandboxProvider({ leaseMode: 'disposable', sandbox })
+      .disposableProfile.providerConfigDigest
+  expect(digest({ network: 'shared' })).not.toBe(digest({ network: 'isolated' }))
+  expect(digest()).toBe(digest({ dropAllCapabilities: false }))
+  expect(digest()).toBe(digest({ namespaceProfile: 'full', dropAllCapabilities: false }))
+  expect(digest()).not.toBe(digest({ dropAllCapabilities: true }))
+  expect(digest({ namespaceProfile: 'docker' }))
+    .toBe(digest({ namespaceProfile: 'docker', dropAllCapabilities: false }))
+  expect(digest({ namespaceProfile: 'docker' }))
+    .toBe(digest({ namespaceProfile: 'docker', dropAllCapabilities: true }))
 })
 
 describe.each([

--- a/packages/boring-sandbox/src/providers/__tests__/dualTargetParity.test.ts
+++ b/packages/boring-sandbox/src/providers/__tests__/dualTargetParity.test.ts
@@ -110,6 +110,49 @@ async function makeBlaxelHarness(): Promise<TargetHarness> {
   }
 }
 
+async function makeDisposableHarness(providerCase: ProviderCase): Promise<TargetHarness> {
+  if (providerCase === 'vercel-sandbox') {
+    const mock = await createMockVercelSandboxHarness()
+    const handle = Object.assign(mock.sandbox, {
+      sandboxId: `sandbox-disposable-${TARGET}`,
+      persistent: true,
+      delete: async () => {},
+    })
+    const client: VercelSandboxClient = {
+      async create(params) { return Object.assign(handle, { name: params?.name }) },
+      async get(params) { return Object.assign(handle, { name: params.name }) },
+    }
+    return {
+      provider: createVercelSandboxProvider({
+        vercelClient: client,
+        lifecycle: 'disposable',
+        getEnvVar: (name) => ({
+          VERCEL_OIDC_TOKEN: 'test-token',
+          VERCEL_TEAM_ID: 'test-team',
+          BORING_SANDBOX_TELEMETRY_SALT: 'conformance-telemetry-salt',
+        })[name],
+      }),
+      cleanup: mock.cleanup,
+    }
+  }
+  if (providerCase === 'blaxel') {
+    const client = await createMockBlaxelClient()
+    return {
+      provider: createBlaxelSandboxProvider({
+        leaseMode: 'disposable', client, region: 'eu-fra-1',
+        volume: { enabled: false, sizeMb: 2048 },
+      }),
+      async cleanup() {},
+    }
+  }
+  return {
+    provider: providerCase === 'direct'
+      ? createDirectSandboxProvider({ leaseMode: 'disposable' })
+      : createBwrapSandboxProvider({ leaseMode: 'disposable' }),
+    async cleanup() {},
+  }
+}
+
 async function makeHarness(providerCase: ProviderCase): Promise<TargetHarness> {
   if (providerCase === 'vercel-sandbox') return await makeVercelHarness()
   if (providerCase === 'blaxel') return await makeBlaxelHarness()
@@ -204,6 +247,42 @@ for (const providerCase of ['direct', 'bwrap', 'blaxel', 'vercel-sandbox'] as co
       }
     }, { skip, skipReason })
   }
+}
+
+for (const providerCase of ['direct', 'bwrap', 'blaxel', 'vercel-sandbox'] as const) {
+  const id = `${TARGET}:${providerCase}:disposable-13-law`
+  const skip = providerCase === 'bwrap' && !bwrapAvailable
+  const make = async () => {
+    const targetHarness = await makeDisposableHarness(providerCase)
+    const parent = await mkdtemp(join(tmpdir(), `boring-disposable-13-${providerCase}-`))
+    const workspaceRoot = join(parent, 'lease-aaaaaaaaaaaaaaaa')
+    const pair = await targetHarness.provider.create({
+      workspaceRoot,
+      workspaceId: `${providerCase}-${TARGET}-disposable`,
+      sessionId: 'session-disposable-conformance',
+      requestId: 'request-disposable-conformance',
+    })
+    return {
+      pair,
+      async cleanup() {
+        await pair.dispose()
+        await targetHarness.cleanup()
+        await rm(parent, { recursive: true, force: true })
+      },
+    }
+  }
+  workspaceConformance(`${id}:workspace`, async () => {
+    const harness = await make()
+    return { workspace: harness.pair.workspace, cleanup: harness.cleanup }
+  })
+  sandboxConformance(`${id}:sandbox`, async () => {
+    const harness = await make()
+    return {
+      workspace: harness.pair.workspace,
+      sandbox: harness.pair.sandbox,
+      cleanup: harness.cleanup,
+    }
+  }, { skip, skipReason: skip ? 'bubblewrap is unavailable on this runner' : undefined })
 }
 
 const tempDirs: string[] = []

--- a/packages/boring-sandbox/src/providers/__tests__/localProviderCleanupDebt.test.ts
+++ b/packages/boring-sandbox/src/providers/__tests__/localProviderCleanupDebt.test.ts
@@ -1,0 +1,61 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
+
+const controls = vi.hoisted(() => ({ disposeFailures: 0 }))
+
+function mockedSandbox(provider: 'direct' | 'bwrap') {
+  return {
+    id: provider,
+    placement: 'server' as const,
+    provider,
+    capabilities: ['exec'] as const,
+    async init() { throw new Error(`${provider} init failed`) },
+    async exec() { throw new Error('unreachable') },
+    async dispose() {
+      if (controls.disposeFailures-- > 0) throw new Error(`${provider} dispose failed`)
+    },
+  }
+}
+
+vi.mock('../direct/createDirectSandbox', () => ({
+  createDirectSandbox: () => mockedSandbox('direct'),
+}))
+vi.mock('../bwrap/createBwrapSandbox', () => ({
+  createBwrapSandbox: () => mockedSandbox('bwrap'),
+}))
+
+import { createBwrapSandboxProvider } from '../bwrap/createBwrapProvider'
+import { createDirectSandboxProvider } from '../direct/createDirectProvider'
+
+const cleanupRoots: string[] = []
+beforeEach(() => { controls.disposeFailures = 1 })
+afterEach(async () => {
+  await Promise.all(cleanupRoots.splice(0).map(async (root) => { await rm(root, { recursive: true, force: true }) }))
+})
+
+test.each(['direct', 'bwrap'] as const)(
+  '%s exposes failed unpublished cleanup as retryable provider debt',
+  async (providerId) => {
+    const parent = await mkdtemp(join(tmpdir(), 'boring-local-debt-'))
+    cleanupRoots.push(parent)
+    const provider = providerId === 'direct'
+      ? createDirectSandboxProvider({ leaseMode: 'disposable' })
+      : createBwrapSandboxProvider({ leaseMode: 'disposable' })
+    const failure = await provider.create({
+      workspaceRoot: join(parent, 'lease-aaaaaaaaaaaaaaaa'),
+      sessionId: 'cleanup-debt',
+    }).catch((caught: unknown) => caught) as AggregateError & {
+      sandboxProviderCleanupDebt: { retry(): Promise<void> }
+    }
+
+    expect(failure).toBeInstanceOf(AggregateError)
+    expect(failure.errors[0]).toMatchObject({ message: `${providerId} init failed` })
+    expect(failure.errors[1]).toBeInstanceOf(AggregateError)
+    expect(failure.sandboxProviderCleanupDebt.retry).toBeTypeOf('function')
+    await expect(failure.sandboxProviderCleanupDebt.retry()).resolves.toBeUndefined()
+    await expect(provider.close!()).resolves.toBeUndefined()
+  },
+)

--- a/packages/boring-sandbox/src/providers/blaxel/__tests__/blaxelDisposableProvider.test.ts
+++ b/packages/boring-sandbox/src/providers/blaxel/__tests__/blaxelDisposableProvider.test.ts
@@ -175,6 +175,28 @@ describe('disposable Blaxel provider', () => {
     expect(client.sandboxes.size).toBe(0)
   })
 
+  test('retains ambiguous create debt through 404 and deletes a late appearance on close retry', async () => {
+    const client = await createMockBlaxelClient()
+    const createFresh = client.createFreshSandbox.bind(client)
+    let pending: Parameters<typeof createFresh>[0] | undefined
+    client.createFreshSandbox = async (config) => {
+      pending = config
+      throw Object.assign(new Error('create acknowledgement lost'), { status: 503 })
+    }
+    const provider = createBlaxelSandboxProvider({
+      leaseMode: 'disposable', client, region: 'eu-fra-1',
+      volume: { enabled: false, sizeMb: 2048 },
+    })
+    await expect(provider.create({
+      workspaceRoot: '/host/lease-late', workspaceId: 'workspace-a',
+      sessionId: 'session-late', requestId: 'request-late',
+    })).rejects.toBeTruthy()
+    await expect(provider.close!()).rejects.toBeTruthy()
+    await createFresh(pending!)
+    await expect(provider.close!()).resolves.toBeUndefined()
+    expect(client.sandboxes.size).toBe(0)
+  })
+
   test('provider close drains a concurrent create without publishing or leaking', async () => {
     const client = await createMockBlaxelClient()
     const createFresh = client.createFreshSandbox.bind(client)

--- a/packages/boring-sandbox/src/providers/blaxel/__tests__/blaxelDisposableProvider.test.ts
+++ b/packages/boring-sandbox/src/providers/blaxel/__tests__/blaxelDisposableProvider.test.ts
@@ -5,6 +5,7 @@ import {
   expectDisposableProviderProfile,
   expectPublishedPairLifecycle,
 } from '../../__tests__/conformance/disposableProvider'
+import type { BlaxelRemoteSandbox } from '../client'
 import { createBlaxelSandboxProvider } from '../createBlaxelSandboxProvider'
 import { createMockBlaxelClient } from './mockBlaxelClient'
 
@@ -210,6 +211,58 @@ describe('disposable Blaxel provider', () => {
     })).rejects.toMatchObject({ code: 'BLAXEL_CONFIG_DRIFT' })
     await expect(provider.close!()).rejects.toBeTruthy()
     expect(client.deleteSandbox).not.toHaveBeenCalled()
+  })
+
+  const configurationDrifts: Array<[string, (remote: BlaxelRemoteSandbox) => void]> = [
+    ['region', (remote) => { Object.assign(remote.spec, { region: 'us-drift-1' }) }],
+    ['image', (remote) => { Object.assign(remote.spec.runtime!, { image: 'image:drift' }) }],
+    ['memory', (remote) => { Object.assign(remote.spec.runtime!, { memory: 123 }) }],
+    ['volumes', (remote) => { Object.assign(remote.spec, { volumes: [{ name: 'unexpected', mountPath: '/workspace' }] }) }],
+  ]
+  test.each(configurationDrifts)('rejects and cleans disposable %s drift before publication', async (_field, mutate) => {
+    const client = await createMockBlaxelClient()
+    const createFresh = client.createFreshSandbox.bind(client)
+    client.createFreshSandbox = async (config) => {
+      const remote = await createFresh(config)
+      mutate(remote)
+      return remote
+    }
+    client.deleteSandbox = vi.fn(client.deleteSandbox.bind(client))
+    const provider = createBlaxelSandboxProvider({
+      leaseMode: 'disposable', client, region: 'eu-fra-1', image: 'image:v1', memoryMb: 4096,
+      volume: { enabled: false, sizeMb: 2048 },
+    })
+    await expect(provider.create({
+      workspaceRoot: '/host/lease-drift', workspaceId: 'workspace-a',
+      sessionId: 'session-drift', requestId: 'request-drift',
+    })).rejects.toMatchObject({ code: 'BLAXEL_CONFIG_DRIFT' })
+    expect(client.deleteSandbox).toHaveBeenCalledOnce()
+    expect(client.sandboxes.size).toBe(0)
+  })
+
+  test('retains config-drift cleanup debt when correlated deletion fails', async () => {
+    const client = await createMockBlaxelClient()
+    const createFresh = client.createFreshSandbox.bind(client)
+    const deleteSandbox = client.deleteSandbox.bind(client)
+    client.createFreshSandbox = async (config) => {
+      const remote = await createFresh(config)
+      Object.assign(remote.spec.runtime!, { image: 'image:drift' })
+      return remote
+    }
+    client.deleteSandbox = vi.fn(async () => { throw new Error('delete unavailable') })
+    const provider = createBlaxelSandboxProvider({
+      leaseMode: 'disposable', client, region: 'eu-fra-1', image: 'image:v1',
+      volume: { enabled: false, sizeMb: 2048 },
+    })
+    const failure = await provider.create({
+      workspaceRoot: '/host/lease-drift-debt', workspaceId: 'workspace-a',
+      sessionId: 'session-drift-debt', requestId: 'request-drift-debt',
+    }).catch((error: unknown) => error) as { code?: string; sandboxProviderCleanupDebt?: { retry(): Promise<void> } }
+    expect(failure.code).toBe('BLAXEL_CONFIG_DRIFT')
+    expect(failure.sandboxProviderCleanupDebt?.retry).toBeTypeOf('function')
+    client.deleteSandbox = deleteSandbox
+    await expect(failure.sandboxProviderCleanupDebt!.retry()).resolves.toBeUndefined()
+    expect(client.sandboxes.size).toBe(0)
   })
 
   test('reconciles an acknowledged create whose response is lost', async () => {

--- a/packages/boring-sandbox/src/providers/blaxel/__tests__/blaxelDisposableProvider.test.ts
+++ b/packages/boring-sandbox/src/providers/blaxel/__tests__/blaxelDisposableProvider.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from 'vitest'
 
-import { expectDisposableProviderProfile } from '../../__tests__/conformance/disposableProvider'
+import {
+  expectDisposableProviderProfile,
+  expectPublishedPairLifecycle,
+} from '../../__tests__/conformance/disposableProvider'
 import { createBlaxelSandboxProvider } from '../createBlaxelSandboxProvider'
 import { createMockBlaxelClient } from './mockBlaxelClient'
 
@@ -39,6 +42,104 @@ describe('disposable Blaxel provider', () => {
     expect(client.sandboxes.size).toBe(0)
   })
 
+  test('a duplicate request cannot delete an already-published pair', async () => {
+    const client = await createMockBlaxelClient()
+    const provider = createBlaxelSandboxProvider({
+      leaseMode: 'disposable', client, region: 'eu-fra-1',
+      volume: { enabled: false, sizeMb: 2048 },
+    })
+    const context = {
+      workspaceRoot: '/host/lease-a', workspaceId: 'workspace-a',
+      sessionId: 'session-a', requestId: 'request-a',
+    }
+    const pair = await provider.create(context)
+    await expect(provider.create(context)).rejects.toMatchObject({ code: 'BLAXEL_CONFIG_DRIFT' })
+    expect(client.sandboxes.size).toBe(1)
+    await expectPublishedPairLifecycle({
+      provider,
+      pair,
+      assertUsableAfterProviderClose: async () => {
+        await pair.workspace.writeFile('still-owned.txt', 'yes')
+        expect(await pair.workspace.readFile('still-owned.txt')).toBe('yes')
+      },
+      assertTerminalCleanup: async () => {
+        expect(client.sandboxes.size).toBe(0)
+      },
+    })
+  })
+
+  test('publishes cleanup ownership before setup failure is reported through readiness', async () => {
+    const client = await createMockBlaxelClient()
+    const createFresh = client.createFreshSandbox.bind(client)
+    client.createFreshSandbox = async (config) => {
+      const remote = await createFresh(config)
+      remote.process.exec = async () => ({
+        command: 'preflight', exitCode: 1, name: 'failed', pid: 'failed',
+        status: 'failed', stderr: 'preflight failed', stdout: '', workingDir: '/workspace',
+      })
+      return remote
+    }
+    const provider = createBlaxelSandboxProvider({
+      leaseMode: 'disposable', client, region: 'eu-fra-1',
+      volume: { enabled: false, sizeMb: 2048 },
+    })
+    const pair = await provider.create({
+      workspaceRoot: '/host/lease-readiness', workspaceId: 'workspace-a',
+      sessionId: 'session-readiness', requestId: 'request-readiness',
+    })
+    expect(client.sandboxes.size).toBe(1)
+    await expect(pair.checkHealth?.()).rejects.toMatchObject({ code: 'BLAXEL_RUNTIME_UNQUALIFIED' })
+    await pair.dispose()
+    expect(client.sandboxes.size).toBe(0)
+  })
+
+  test('attempts remote deletion even when local pair disposal fails', async () => {
+    const client = await createMockBlaxelClient()
+    const provider = createBlaxelSandboxProvider({
+      leaseMode: 'disposable', client, region: 'eu-fra-1',
+      volume: { enabled: false, sizeMb: 2048 },
+    })
+    const pair = await provider.create({
+      workspaceRoot: '/host/lease-independent', workspaceId: 'workspace-a',
+      sessionId: 'session-independent', requestId: 'request-independent',
+    })
+    await pair.checkHealth?.()
+    const sandbox = pair.sandbox as unknown as { dispose(): Promise<void> }
+    const originalDispose = sandbox.dispose.bind(sandbox)
+    sandbox.dispose = async () => { throw new Error('local dispose failed') }
+    await expect(pair.dispose()).rejects.toThrow('Blaxel sandbox cleanup failed')
+    expect(client.sandboxes.size).toBe(0)
+    sandbox.dispose = originalDispose
+    await expect(pair.dispose()).resolves.toBeUndefined()
+  })
+
+  test('retries ambiguous deletion and converges when the remote is already absent', async () => {
+    const client = await createMockBlaxelClient()
+    const deleteSandbox = client.deleteSandbox.bind(client)
+    let failDelete = true
+    client.deleteSandbox = async (name) => {
+      if (failDelete) {
+        failDelete = false
+        throw Object.assign(new Error('delete acknowledgement lost'), { status: 503 })
+      }
+      await deleteSandbox(name)
+    }
+    const provider = createBlaxelSandboxProvider({
+      leaseMode: 'disposable', client, region: 'eu-fra-1',
+      volume: { enabled: false, sizeMb: 2048 },
+    })
+    const pair = await provider.create({
+      workspaceRoot: '/host/lease-delete-retry', workspaceId: 'workspace-a',
+      sessionId: 'session-delete-retry', requestId: 'request-delete-retry',
+    })
+    await pair.checkHealth?.()
+    await expect(pair.dispose()).rejects.toThrow('Blaxel sandbox cleanup failed')
+    const [name] = client.sandboxes.keys()
+    await deleteSandbox(name!)
+    await expect(pair.dispose()).resolves.toBeUndefined()
+    expect(client.sandboxes.size).toBe(0)
+  })
+
   test('reconciles an acknowledged create whose response is lost', async () => {
     const client = await createMockBlaxelClient()
     const createFresh = client.createFreshSandbox.bind(client)
@@ -56,6 +157,30 @@ describe('disposable Blaxel provider', () => {
     })).rejects.toBeTruthy()
     expect(client.sandboxes.size).toBe(1)
     await provider.close?.()
+    expect(client.sandboxes.size).toBe(0)
+  })
+
+  test('provider close drains a concurrent create without publishing or leaking', async () => {
+    const client = await createMockBlaxelClient()
+    const createFresh = client.createFreshSandbox.bind(client)
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => { release = resolve })
+    client.createFreshSandbox = async (config) => {
+      await gate
+      return await createFresh(config)
+    }
+    const provider = createBlaxelSandboxProvider({
+      leaseMode: 'disposable', client, region: 'eu-fra-1',
+      volume: { enabled: false, sizeMb: 2048 },
+    })
+    const creation = provider.create({
+      workspaceRoot: '/host/lease-race', workspaceId: 'workspace-a',
+      sessionId: 'session-race', requestId: 'request-race',
+    })
+    const closing = provider.close!()
+    release()
+    await expect(creation).rejects.toMatchObject({ code: 'BLAXEL_API_ERROR' })
+    await expect(closing).resolves.toBeUndefined()
     expect(client.sandboxes.size).toBe(0)
   })
 

--- a/packages/boring-sandbox/src/providers/blaxel/__tests__/blaxelDisposableProvider.test.ts
+++ b/packages/boring-sandbox/src/providers/blaxel/__tests__/blaxelDisposableProvider.test.ts
@@ -217,6 +217,12 @@ describe('disposable Blaxel provider', () => {
     ['region', (remote) => { Object.assign(remote.spec, { region: 'us-drift-1' }) }],
     ['image', (remote) => { Object.assign(remote.spec.runtime!, { image: 'image:drift' }) }],
     ['memory', (remote) => { Object.assign(remote.spec.runtime!, { memory: 123 }) }],
+    ['ttl', (remote) => { Object.assign(remote.spec.runtime!, { ttl: '3h' }) }],
+    ['missing lifecycle', (remote) => { Object.assign(remote.spec, { lifecycle: undefined }) }],
+    ['additional lifecycle policy', (remote) => {
+      remote.spec.lifecycle!.expirationPolicies!.push({ action: 'delete', type: 'ttl-max-age', value: '4h' })
+    }],
+    ['lifecycle drift', (remote) => { Object.assign(remote.spec.lifecycle!, { terminatedRetention: '2h' }) }],
     ['volumes', (remote) => { Object.assign(remote.spec, { volumes: [{ name: 'unexpected', mountPath: '/workspace' }] }) }],
   ]
   test.each(configurationDrifts)('rejects and cleans disposable %s drift before publication', async (_field, mutate) => {
@@ -229,7 +235,11 @@ describe('disposable Blaxel provider', () => {
     }
     client.deleteSandbox = vi.fn(client.deleteSandbox.bind(client))
     const provider = createBlaxelSandboxProvider({
-      leaseMode: 'disposable', client, region: 'eu-fra-1', image: 'image:v1', memoryMb: 4096,
+      leaseMode: 'disposable', client, region: 'eu-fra-1', image: 'image:v1', memoryMb: 4096, ttl: '2h',
+      lifecycle: {
+        expirationPolicies: [{ action: 'delete', type: 'ttl-idle', value: '30m' }],
+        terminatedRetention: '1h',
+      },
       volume: { enabled: false, sizeMb: 2048 },
     })
     await expect(provider.create({

--- a/packages/boring-sandbox/src/providers/blaxel/__tests__/blaxelDisposableProvider.test.ts
+++ b/packages/boring-sandbox/src/providers/blaxel/__tests__/blaxelDisposableProvider.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'vitest'
+
+import { expectDisposableProviderProfile } from '../../__tests__/conformance/disposableProvider'
+import { createBlaxelSandboxProvider } from '../createBlaxelSandboxProvider'
+import { createMockBlaxelClient } from './mockBlaxelClient'
+
+describe('disposable Blaxel provider', () => {
+  test('creates fresh no-volume pairs and deletes the remote on dispose', async () => {
+    const client = await createMockBlaxelClient()
+    const provider = createBlaxelSandboxProvider({
+      leaseMode: 'disposable',
+      client,
+      region: 'eu-fra-1',
+      volume: { enabled: false, sizeMb: 2048 },
+    })
+    expectDisposableProviderProfile(provider, 'blaxel')
+    const pair = await provider.create({
+      workspaceRoot: '/host/lease-a',
+      workspaceId: 'workspace-a',
+      sessionId: 'session-a',
+      requestId: 'request-a',
+    })
+    const sibling = await provider.create({
+      workspaceRoot: '/host/lease-b',
+      workspaceId: 'workspace-a',
+      sessionId: 'session-b',
+      requestId: 'request-b',
+    })
+    await pair.workspace.writeFile('marker.txt', 'a')
+    await sibling.workspace.writeFile('marker.txt', 'b')
+    expect(await pair.workspace.readFile('marker.txt')).toBe('a')
+    expect(await sibling.workspace.readFile('marker.txt')).toBe('b')
+    expect(client.sandboxes.size).toBe(2)
+    expect(client.volumes.size).toBe(0)
+    await Promise.all([pair.dispose(), pair.dispose()])
+    expect(client.sandboxes.size).toBe(1)
+    expect(await sibling.workspace.readFile('marker.txt')).toBe('b')
+    await sibling.dispose()
+    expect(client.sandboxes.size).toBe(0)
+  })
+
+  test('reconciles an acknowledged create whose response is lost', async () => {
+    const client = await createMockBlaxelClient()
+    const createFresh = client.createFreshSandbox.bind(client)
+    client.createFreshSandbox = async (config) => {
+      await createFresh(config)
+      throw Object.assign(new Error('response lost'), { status: 503 })
+    }
+    const provider = createBlaxelSandboxProvider({
+      leaseMode: 'disposable', client, region: 'eu-fra-1',
+      volume: { enabled: false, sizeMb: 2048 },
+    })
+    await expect(provider.create({
+      workspaceRoot: '/host/lease-a', workspaceId: 'workspace-a',
+      sessionId: 'session-a', requestId: 'request-a',
+    })).rejects.toBeTruthy()
+    expect(client.sandboxes.size).toBe(1)
+    await provider.close?.()
+    expect(client.sandboxes.size).toBe(0)
+  })
+
+  test('rejects persistence configuration before API effects', async () => {
+    const client = await createMockBlaxelClient()
+    const provider = createBlaxelSandboxProvider({
+      leaseMode: 'disposable', client, region: 'eu-fra-1',
+    })
+    await expect(provider.create({
+      workspaceRoot: '/host/lease-a', workspaceId: 'workspace-a',
+      sessionId: 'session-a', requestId: 'request-a',
+    })).rejects.toMatchObject({ code: 'CONFIG_INVALID' })
+    expect(client.sandboxes.size).toBe(0)
+    expect(client.volumes.size).toBe(0)
+  })
+})

--- a/packages/boring-sandbox/src/providers/blaxel/__tests__/blaxelDisposableProvider.test.ts
+++ b/packages/boring-sandbox/src/providers/blaxel/__tests__/blaxelDisposableProvider.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 
 import {
   expectDisposablePairSurfaceLaws,
@@ -153,6 +153,62 @@ describe('disposable Blaxel provider', () => {
     await deleteSandbox(name!)
     await expect(pair.dispose()).resolves.toBeUndefined()
     expect(client.sandboxes.size).toBe(0)
+  })
+
+  test('a definitive create rejection has no reconciliation debt', async () => {
+    const client = await createMockBlaxelClient()
+    client.createFreshSandbox = async () => { throw Object.assign(new Error('invalid request'), { status: 422 }) }
+    client.getSandbox = vi.fn(client.getSandbox.bind(client))
+    const provider = createBlaxelSandboxProvider({
+      leaseMode: 'disposable', client, region: 'eu-fra-1',
+      volume: { enabled: false, sizeMb: 2048 },
+    })
+    await expect(provider.create({
+      workspaceRoot: '/host/lease-rejected', workspaceId: 'workspace-a',
+      sessionId: 'session-rejected', requestId: 'request-rejected',
+    })).rejects.toBeTruthy()
+    await expect(provider.close!()).resolves.toBeUndefined()
+    expect(client.getSandbox).not.toHaveBeenCalled()
+  })
+
+  test.each([408, 409, 429, 503, undefined])(
+    'retains ambiguous create debt for status %s',
+    async (status) => {
+      const client = await createMockBlaxelClient()
+      client.createFreshSandbox = async () => {
+        throw Object.assign(new Error('create outcome unknown'), status === undefined ? {} : { status })
+      }
+      const provider = createBlaxelSandboxProvider({
+        leaseMode: 'disposable', client, region: 'eu-fra-1',
+        volume: { enabled: false, sizeMb: 2048 },
+      })
+      await expect(provider.create({
+        workspaceRoot: '/host/lease-ambiguous', workspaceId: 'workspace-a',
+        sessionId: `session-${status}`, requestId: `request-${status}`,
+      })).rejects.toBeTruthy()
+      await expect(provider.close!()).rejects.toBeTruthy()
+    },
+  )
+
+  test('a correlation mismatch remains debt and never deletes the wrong remote', async () => {
+    const client = await createMockBlaxelClient()
+    const createFresh = client.createFreshSandbox.bind(client)
+    client.createFreshSandbox = async (config) => {
+      const remote = await createFresh(config)
+      ;(remote as { externalId?: string }).externalId = 'unrelated'
+      return remote
+    }
+    client.deleteSandbox = vi.fn(client.deleteSandbox.bind(client))
+    const provider = createBlaxelSandboxProvider({
+      leaseMode: 'disposable', client, region: 'eu-fra-1',
+      volume: { enabled: false, sizeMb: 2048 },
+    })
+    await expect(provider.create({
+      workspaceRoot: '/host/lease-mismatch', workspaceId: 'workspace-a',
+      sessionId: 'session-mismatch', requestId: 'request-mismatch',
+    })).rejects.toMatchObject({ code: 'BLAXEL_CONFIG_DRIFT' })
+    await expect(provider.close!()).rejects.toBeTruthy()
+    expect(client.deleteSandbox).not.toHaveBeenCalled()
   })
 
   test('reconciles an acknowledged create whose response is lost', async () => {

--- a/packages/boring-sandbox/src/providers/blaxel/__tests__/blaxelDisposableProvider.test.ts
+++ b/packages/boring-sandbox/src/providers/blaxel/__tests__/blaxelDisposableProvider.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest'
 
 import {
+  expectDisposablePairSurfaceLaws,
   expectDisposableProviderProfile,
   expectPublishedPairLifecycle,
 } from '../../__tests__/conformance/disposableProvider'
@@ -8,6 +9,19 @@ import { createBlaxelSandboxProvider } from '../createBlaxelSandboxProvider'
 import { createMockBlaxelClient } from './mockBlaxelClient'
 
 describe('disposable Blaxel provider', () => {
+  test('derives configuration identity from the resolved image and policy', async () => {
+    const client = await createMockBlaxelClient()
+    const first = createBlaxelSandboxProvider({
+      leaseMode: 'disposable', client, region: 'eu-fra-1', image: 'image:v1',
+      volume: { enabled: false, sizeMb: 2048 },
+    })
+    const second = createBlaxelSandboxProvider({
+      leaseMode: 'disposable', client, region: 'eu-fra-1', image: 'image:v2',
+      volume: { enabled: false, sizeMb: 2048 },
+    })
+    expect(first.disposableProfile.providerConfigDigest)
+      .not.toBe(second.disposableProfile.providerConfigDigest)
+  })
   test('creates fresh no-volume pairs and deletes the remote on dispose', async () => {
     const client = await createMockBlaxelClient()
     const provider = createBlaxelSandboxProvider({
@@ -33,6 +47,7 @@ describe('disposable Blaxel provider', () => {
     await sibling.workspace.writeFile('marker.txt', 'b')
     expect(await pair.workspace.readFile('marker.txt')).toBe('a')
     expect(await sibling.workspace.readFile('marker.txt')).toBe('b')
+    await expectDisposablePairSurfaceLaws(pair)
     expect(client.sandboxes.size).toBe(2)
     expect(client.volumes.size).toBe(0)
     await Promise.all([pair.dispose(), pair.dispose()])
@@ -155,7 +170,7 @@ describe('disposable Blaxel provider', () => {
       workspaceRoot: '/host/lease-a', workspaceId: 'workspace-a',
       sessionId: 'session-a', requestId: 'request-a',
     })).rejects.toBeTruthy()
-    expect(client.sandboxes.size).toBe(1)
+    expect(client.sandboxes.size).toBe(0)
     await provider.close?.()
     expect(client.sandboxes.size).toBe(0)
   })

--- a/packages/boring-sandbox/src/providers/blaxel/__tests__/blaxelDisposableProvider.test.ts
+++ b/packages/boring-sandbox/src/providers/blaxel/__tests__/blaxelDisposableProvider.test.ts
@@ -182,10 +182,11 @@ describe('disposable Blaxel provider', () => {
         leaseMode: 'disposable', client, region: 'eu-fra-1',
         volume: { enabled: false, sizeMb: 2048 },
       })
-      await expect(provider.create({
+      const failure = await provider.create({
         workspaceRoot: '/host/lease-ambiguous', workspaceId: 'workspace-a',
         sessionId: `session-${status}`, requestId: `request-${status}`,
-      })).rejects.toBeTruthy()
+      }).catch((caught: unknown) => caught) as { sandboxProviderCleanupDebt?: { retry(): Promise<void> } }
+      expect(failure.sandboxProviderCleanupDebt?.retry).toBeTypeOf('function')
       await expect(provider.close!()).rejects.toBeTruthy()
     },
   )

--- a/packages/boring-sandbox/src/providers/blaxel/__tests__/mockBlaxelClient.ts
+++ b/packages/boring-sandbox/src/providers/blaxel/__tests__/mockBlaxelClient.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process'
-import { mkdir, readFile, readdir, stat, unlink, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, readdir, rm, stat, unlink, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
@@ -47,12 +47,16 @@ export async function createMockBlaxelClient(): Promise<BlaxelClient & {
     readonly watchState: typeof watchState
     failGuestStagingMoveOn: number | undefined
   }
-  const mapPath = (path: string) => path === '/workspace'
-    ? root
-    : join(root, path.replace(/^\/workspace\/?/, ''))
-  const mapCommand = (command: string) => command.replaceAll('/workspace', root)
-
-  function remote(name: string, config: Parameters<BlaxelClient['createSandbox']>[0]): BlaxelRemoteSandbox {
+  function remote(
+    name: string,
+    config: Parameters<BlaxelClient['createSandbox']>[0],
+    isolated = false,
+  ): BlaxelRemoteSandbox {
+    const workspaceRoot = isolated ? join(root, name) : root
+    const mapPath = (path: string) => path === '/workspace'
+      ? workspaceRoot
+      : join(workspaceRoot, path.replace(/^\/workspace\/?/, ''))
+    const mapCommand = (command: string) => command.replaceAll('/workspace', workspaceRoot)
     const spec = {
       region: config.region,
       runtime: { image: config.image, memory: config.memory, ttl: config.ttl },
@@ -67,10 +71,8 @@ export async function createMockBlaxelClient(): Promise<BlaxelClient & {
       async readBinary(path: string) { return new Blob([await readFile(mapPath(path))]) },
       async rm(path: string, recursive?: boolean) {
         const target = mapPath(path)
-        if (recursive) {
-          const { rm } = await import('node:fs/promises')
-          await rm(target, { recursive: true })
-        } else await unlink(target)
+        if (recursive) await rm(target, { recursive: true })
+        else await unlink(target)
       },
       async ls(path: string) {
         const entries = await readdir(mapPath(path), { withFileTypes: true })
@@ -169,6 +171,17 @@ export async function createMockBlaxelClient(): Promise<BlaxelClient & {
       const value = remote(name, config)
       sandboxes.set(name, value)
       return value
+    },
+    async createFreshSandbox(config) {
+      const name = config.name!
+      if (sandboxes.has(name)) throw Object.assign(new Error('sandbox exists'), { status: 409 })
+      const value = remote(name, config, true)
+      sandboxes.set(name, value)
+      return value
+    },
+    async deleteSandbox(name) {
+      if (!sandboxes.delete(name)) throw notFound('sandbox not found')
+      await rm(join(root, name), { recursive: true, force: true })
     },
     async getVolume(name) {
       const value = volumes.get(name)

--- a/packages/boring-sandbox/src/providers/blaxel/__tests__/mockBlaxelClient.ts
+++ b/packages/boring-sandbox/src/providers/blaxel/__tests__/mockBlaxelClient.ts
@@ -61,7 +61,7 @@ export async function createMockBlaxelClient(): Promise<BlaxelClient & {
       region: config.region,
       runtime: { image: config.image, memory: config.memory, ttl: config.ttl },
       volumes: config.volumes,
-      lifecycle: config.lifecycle,
+      lifecycle: config.lifecycle ? structuredClone(config.lifecycle) : undefined,
     }
     const fs = {
       async mkdir(path: string) { await mkdir(mapPath(path)) },

--- a/packages/boring-sandbox/src/providers/blaxel/__tests__/resolveSandboxHandle.test.ts
+++ b/packages/boring-sandbox/src/providers/blaxel/__tests__/resolveSandboxHandle.test.ts
@@ -1,6 +1,7 @@
 import type { SandboxHandleRecord, SandboxHandleStore } from '@hachej/boring-agent/shared'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 
+import type { BlaxelRemoteSandbox } from '../client'
 import { resolveBlaxelConfig } from '../config'
 import { createBlaxelSandboxProvider } from '../createBlaxelSandboxProvider'
 import {
@@ -57,6 +58,33 @@ describe('Blaxel durable handle resolution', () => {
       config: resolveBlaxelConfig({ region: 'eu-fra-1', volume: { enabled: false, sizeMb: 2048 } }, {}),
     })).rejects.toMatchObject({ code: 'BLAXEL_CONFIG_DRIFT' })
     expect(blaxelExternalId('workspace')).not.toBe('another-workspace')
+  })
+
+  test.each([
+    ['ttl', (remote: BlaxelRemoteSandbox) => { Object.assign(remote.spec.runtime!, { ttl: '3h' }) }],
+    ['missing lifecycle', (remote: BlaxelRemoteSandbox) => { Object.assign(remote.spec, { lifecycle: undefined }) }],
+    ['additional lifecycle', (remote: BlaxelRemoteSandbox) => {
+      remote.spec.lifecycle!.expirationPolicies!.push({ action: 'delete', type: 'ttl-max-age', value: '4h' })
+    }],
+  ])('rejects persistent %s policy drift', async (_field, mutate) => {
+    const client = await createMockBlaxelClient()
+    const name = blaxelSandboxName('policy-workspace')
+    const lifecycle = {
+      expirationPolicies: [{ action: 'delete' as const, type: 'ttl-idle' as const, value: '30m' }],
+      terminatedRetention: '1h',
+    }
+    const remote = await client.createSandbox({
+      name, externalId: blaxelExternalId('policy-workspace'), image: 'image:v1', memory: 4096,
+      region: 'eu-fra-1', ttl: '2h', lifecycle,
+    })
+    mutate(remote)
+    await expect(createBlaxelSandboxHandleResolver().resolve({
+      workspaceId: 'policy-workspace', client, store: new MemoryStore(),
+      config: resolveBlaxelConfig({
+        region: 'eu-fra-1', image: 'image:v1', memoryMb: 4096, ttl: '2h', lifecycle,
+        volume: { enabled: false, sizeMb: 2048 },
+      }, {}),
+    })).rejects.toMatchObject({ code: 'BLAXEL_CONFIG_DRIFT' })
   })
 
   test('keeps caches provider-scoped and refreshes lastUsedAt on a cache hit', async () => {

--- a/packages/boring-sandbox/src/providers/blaxel/client.ts
+++ b/packages/boring-sandbox/src/providers/blaxel/client.ts
@@ -88,6 +88,8 @@ export interface BlaxelRemoteVolume {
 export interface BlaxelClient {
   getSandbox(name: string): Promise<BlaxelRemoteSandbox>
   createSandbox(config: SandboxCreateConfiguration): Promise<BlaxelRemoteSandbox>
+  createFreshSandbox(config: SandboxCreateConfiguration): Promise<BlaxelRemoteSandbox>
+  deleteSandbox(name: string): Promise<void>
   getVolume(name: string): Promise<BlaxelRemoteVolume>
   createVolume(config: VolumeCreateConfiguration): Promise<BlaxelRemoteVolume>
   getVolumeAttachment(name: string): Promise<string | undefined>
@@ -118,6 +120,12 @@ export function createBlaxelClient(): BlaxelClient {
     },
     async createSandbox(config) {
       return toSandbox(await SandboxInstance.createIfNotExists(config))
+    },
+    async createFreshSandbox(config) {
+      return toSandbox(await SandboxInstance.create(config, { safe: true, createIfNotExist: false }))
+    },
+    async deleteSandbox(name) {
+      await SandboxInstance.delete(name)
     },
     async getVolume(name) {
       return toVolume(await VolumeInstance.get(name))

--- a/packages/boring-sandbox/src/providers/blaxel/config.ts
+++ b/packages/boring-sandbox/src/providers/blaxel/config.ts
@@ -10,6 +10,7 @@ export const BLAXEL_DEFAULT_MEMORY_MB = 4096
 export const BLAXEL_DEFAULT_VOLUME_SIZE_MB = 2048
 
 export interface BlaxelSandboxProviderOptions {
+  leaseMode?: 'disposable'
   image?: string
   memoryMb?: number
   region?: string

--- a/packages/boring-sandbox/src/providers/blaxel/config.ts
+++ b/packages/boring-sandbox/src/providers/blaxel/config.ts
@@ -11,6 +11,7 @@ export const BLAXEL_DEFAULT_VOLUME_SIZE_MB = 2048
 
 export interface BlaxelSandboxProviderOptions {
   leaseMode?: 'disposable'
+  providerConfigDigest?: `sha256:${string}`
   image?: string
   memoryMb?: number
   region?: string

--- a/packages/boring-sandbox/src/providers/blaxel/config.ts
+++ b/packages/boring-sandbox/src/providers/blaxel/config.ts
@@ -11,7 +11,6 @@ export const BLAXEL_DEFAULT_VOLUME_SIZE_MB = 2048
 
 export interface BlaxelSandboxProviderOptions {
   leaseMode?: 'disposable'
-  providerConfigDigest?: `sha256:${string}`
   image?: string
   memoryMb?: number
   region?: string

--- a/packages/boring-sandbox/src/providers/blaxel/createBlaxelSandboxProvider.ts
+++ b/packages/boring-sandbox/src/providers/blaxel/createBlaxelSandboxProvider.ts
@@ -1,10 +1,13 @@
-import { randomUUID } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 
 import type { SandboxHandleStore } from '@hachej/boring-agent/shared'
 
 import { PROVIDER_CAPABILITIES, PROVIDER_CONTRACT_VERSION } from '../../shared/providerMatrix'
-import type { SandboxProviderV1 } from '../../shared/providerV1'
-import { SandboxProviderError } from '../../shared/providerV1'
+import type { DisposableSandboxProviderV1, SandboxProviderV1 } from '../../shared/providerV1'
+import {
+  DISPOSABLE_SANDBOX_PROVIDER_PROFILE_V1,
+  SandboxProviderError,
+} from '../../shared/providerV1'
 import { createBlaxelClient } from './client'
 import {
   assertBlaxelCredentials,
@@ -265,31 +268,106 @@ rm -rf -- "$lock"`
   }
 }
 
+function disposableBlaxelIdentity(context: { workspaceId?: string; sessionId: string; requestId?: string }) {
+  if (!context.workspaceId?.trim() || !context.requestId?.trim()) {
+    throw new SandboxProviderError('CONFIG_INVALID', 'disposable Blaxel requires host workspace and request identity')
+  }
+  const digest = createHash('sha256')
+    .update(`${context.workspaceId}:${context.sessionId}:${context.requestId}`)
+    .digest('hex')
+  return { name: `boring-lease-${digest.slice(0, 40)}`, externalId: `boring-lease-${digest}` }
+}
+
+export function createBlaxelSandboxProvider(
+  options: BlaxelSandboxProviderOptions & { leaseMode: 'disposable' },
+): DisposableSandboxProviderV1
+export function createBlaxelSandboxProvider(
+  options?: BlaxelSandboxProviderOptions,
+): SandboxProviderV1
 export function createBlaxelSandboxProvider(
   options: BlaxelSandboxProviderOptions = {},
 ): SandboxProviderV1 {
-  const store: SandboxHandleStore = options.handleStore ?? new BlaxelFileHandleStore()
+  const store: SandboxHandleStore | undefined = options.leaseMode === 'disposable'
+    ? undefined
+    : options.handleStore ?? new BlaxelFileHandleStore()
   const client = options.client ?? createBlaxelClient()
   const handles = createBlaxelSandboxHandleResolver()
   const seeds = new Map<string, { fingerprint: string; promise: Promise<void> }>()
+  const unpublished = new Set<() => Promise<void>>()
 
   return {
     contractVersion: PROVIDER_CONTRACT_VERSION,
     providerId: 'blaxel',
     capabilities: PROVIDER_CAPABILITIES.blaxel,
+    ...(options.leaseMode === 'disposable' ? {
+      disposableProfile: {
+        contractVersion: DISPOSABLE_SANDBOX_PROVIDER_PROFILE_V1,
+        resume: false as const,
+        publishedCleanupOwner: 'returned-pair' as const,
+        ambiguousCreate: 'correlated-reconciliation' as const,
+      },
+    } : {}),
     resolveRuntimeRoot: () => BLAXEL_WORKSPACE_ROOT,
     async create(context) {
       if (!options.client) assertBlaxelCredentials()
       const config = resolveBlaxelConfig(options)
       const workspaceId = context.workspaceId?.trim() || context.workspaceRoot.trim()
       if (!workspaceId) throw new SandboxProviderError('CONFIG_INVALID', 'workspaceId is required for blaxel mode')
-      const remote = await handles.resolve({
-        workspaceId,
-        store,
-        client,
-        config,
-        now: options.now,
-      })
+      if (options.leaseMode === 'disposable' && (config.volume.enabled || options.handleStore)) {
+        throw new SandboxProviderError('CONFIG_INVALID', 'disposable Blaxel forbids volumes and handle persistence')
+      }
+      let cleanupRemote: (() => Promise<void>) | undefined
+      let remote
+      if (options.leaseMode === 'disposable') {
+        const identity = disposableBlaxelIdentity(context)
+        let deleted = false
+        let deletion: Promise<void> | undefined
+        cleanupRemote = async () => {
+          if (deleted) return
+          if (deletion) return await deletion
+          const operation = (async () => {
+            try {
+              const current = await client.getSandbox(identity.name)
+              if (current.externalId !== identity.externalId) {
+                throw new SandboxProviderError('BLAXEL_CONFIG_DRIFT', 'Blaxel cleanup identity does not match')
+              }
+              await client.deleteSandbox(identity.name)
+            } catch (error) {
+              if (!isBlaxelNotFound(error)) throw normalizeBlaxelError(error)
+            }
+            deleted = true
+            unpublished.delete(cleanupRemote!)
+          })()
+          deletion = operation
+          try { await operation } finally { if (deletion === operation) deletion = undefined }
+        }
+        unpublished.add(cleanupRemote)
+        try {
+          remote = await client.createFreshSandbox({
+            name: identity.name,
+            externalId: identity.externalId,
+            image: config.image,
+            memory: config.memoryMb,
+            region: config.region,
+            ttl: config.ttl,
+            lifecycle: config.lifecycle,
+            labels: { owner: 'boring-ui', lease: identity.externalId.slice(-32) },
+          })
+        } catch (error) {
+          throw normalizeBlaxelError(error)
+        }
+        if (remote.name !== identity.name || remote.externalId !== identity.externalId) {
+          throw new SandboxProviderError('BLAXEL_CONFIG_DRIFT', 'Blaxel create identity does not match')
+        }
+      } else {
+        remote = await handles.resolve({
+          workspaceId,
+          store: store!,
+          client,
+          config,
+          now: options.now,
+        })
+      }
       if (!config.volume.enabled) {
         try { await remote.fs.mkdir(BLAXEL_WORKSPACE_ROOT) }
         catch (error) {
@@ -298,6 +376,9 @@ export function createBlaxelSandboxProvider(
       }
 
       let disposed = false
+      let workspaceDisposed = false
+      let sandboxDisposed = false
+      let disposeInFlight: Promise<void> | undefined
       const workspace = createBlaxelSandboxWorkspace(remote)
       const sandbox = createBlaxelSandboxExec(remote, {
         onMutation: workspace.invalidateMetadataCache,
@@ -313,7 +394,8 @@ export function createBlaxelSandboxProvider(
         const provisioning = createBlaxelProvisioningAdapter({ workspace, sandbox })
         if (context.templatePath) {
           const fingerprint = await fingerprintBlaxelHostTree(context.templatePath)
-          const existingSeed = seeds.get(workspaceId)
+          const seedKey = options.leaseMode === 'disposable' ? remote.name : workspaceId
+          const existingSeed = seeds.get(seedKey)
           if (existingSeed && existingSeed.fingerprint !== fingerprint) {
             throw new SandboxProviderError('BLAXEL_CONFIG_DRIFT', 'Concurrent Blaxel seed requests use different template content')
           }
@@ -323,11 +405,12 @@ export function createBlaxelSandboxProvider(
             templatePath: context.templatePath,
             fingerprint,
           })
-          if (!existingSeed) seeds.set(workspaceId, { fingerprint, promise: seed })
+          if (!existingSeed) seeds.set(seedKey, { fingerprint, promise: seed })
           try { await seed } finally {
-            if (seeds.get(workspaceId)?.promise === seed) seeds.delete(workspaceId)
+            if (seeds.get(seedKey)?.promise === seed) seeds.delete(seedKey)
           }
         }
+        if (cleanupRemote) unpublished.delete(cleanupRemote)
         return {
           workspace,
           sandbox,
@@ -345,22 +428,38 @@ export function createBlaxelSandboxProvider(
           },
           async dispose() {
             if (disposed) return
-            disposed = true
-            workspace.dispose()
-            await sandbox.dispose()
+            if (disposeInFlight) return await disposeInFlight
+            const operation = (async () => {
+              if (!workspaceDisposed) { workspace.dispose(); workspaceDisposed = true }
+              if (!sandboxDisposed) { await sandbox.dispose(); sandboxDisposed = true }
+              await cleanupRemote?.()
+              disposed = true
+            })()
+            disposeInFlight = operation
+            try { await operation } finally { if (disposeInFlight === operation) disposeInFlight = undefined }
           },
         }
       } catch (error) {
         workspace.dispose()
-        await sandbox.dispose().catch(() => {})
+        const cleanupFailures: unknown[] = []
+        try { await sandbox.dispose() } catch (cleanupError) { cleanupFailures.push(cleanupError) }
+        if (cleanupRemote) {
+          try { await cleanupRemote() } catch (cleanupError) { cleanupFailures.push(cleanupError) }
+        }
+        if (cleanupFailures.length) throw new AggregateError([error, ...cleanupFailures], 'Blaxel sandbox creation cleanup failed')
         if (error instanceof SandboxProviderError) throw error
         throw normalizeBlaxelError(error)
       }
     },
-    invalidate({ workspaceId }) { handles.invalidate(workspaceId) },
+    invalidate({ workspaceId }) {
+      if (options.leaseMode !== 'disposable') handles.invalidate(workspaceId)
+    },
     async close() {
-      handles.clear()
+      if (options.leaseMode !== 'disposable') handles.clear()
       seeds.clear()
+      const results = await Promise.allSettled([...unpublished].map(async (cleanup) => await cleanup()))
+      const failures = results.filter((result) => result.status === 'rejected')
+      if (failures.length) throw new AggregateError(failures.map((failure) => failure.reason))
     },
   }
 }

--- a/packages/boring-sandbox/src/providers/blaxel/createBlaxelSandboxProvider.ts
+++ b/packages/boring-sandbox/src/providers/blaxel/createBlaxelSandboxProvider.ts
@@ -25,9 +25,7 @@ import {
   fingerprintBlaxelHostTree,
   type BlaxelProvisioningAdapter,
 } from './provisioningAdapter'
-import {
-  createBlaxelSandboxHandleResolver,
-} from './resolveSandboxHandle'
+import { assertCompatible, createBlaxelSandboxHandleResolver } from './resolveSandboxHandle'
 import { shellQuote } from './runtimeHelpers'
 
 const PROVISIONING_ROOT = '.boring/provisioning'
@@ -385,9 +383,7 @@ export function createBlaxelSandboxProvider(
           throw normalizeBlaxelError(error)
         }
         remoteCleanupPhase = 'created'
-        if (remote.name !== identity.name || remote.externalId !== identity.externalId) {
-          throw new SandboxProviderError('BLAXEL_CONFIG_DRIFT', 'Blaxel create identity does not match')
-        }
+        assertCompatible(remote, config, identity.name, identity.externalId, '')
       } else {
         remote = await handles.resolve({
           workspaceId,
@@ -513,6 +509,7 @@ export function createBlaxelSandboxProvider(
       }
       return pair
       } catch (error) {
+        if (cleanupRemote && unpublished.has(cleanupRemote)) try { await cleanupRemote() } catch { /* retained as debt */ }
         const normalized = error instanceof SandboxProviderError ? error : normalizeBlaxelError(error)
         throw cleanupRemote && unpublished.has(cleanupRemote)
           ? attachSandboxProviderCleanupDebt(normalized, cleanupRemote)

--- a/packages/boring-sandbox/src/providers/blaxel/createBlaxelSandboxProvider.ts
+++ b/packages/boring-sandbox/src/providers/blaxel/createBlaxelSandboxProvider.ts
@@ -4,10 +4,8 @@ import type { SandboxHandleStore } from '@hachej/boring-agent/shared'
 
 import { PROVIDER_CAPABILITIES, PROVIDER_CONTRACT_VERSION } from '../../shared/providerMatrix'
 import type { DisposableSandboxProviderV1, SandboxProviderV1 } from '../../shared/providerV1'
-import {
-  DISPOSABLE_SANDBOX_PROVIDER_PROFILE_V1,
-  SandboxProviderError,
-} from '../../shared/providerV1'
+import { SandboxProviderError } from '../../shared/providerV1'
+import { registerDisposableSandboxProviderV1 } from '../disposableProviderRegistration'
 import { createBlaxelClient } from './client'
 import {
   assertBlaxelCredentials,
@@ -268,6 +266,14 @@ rm -rf -- "$lock"`
   }
 }
 
+function isBlaxelCreateConflict(error: unknown): boolean {
+  const status = (error as { status?: unknown; statusCode?: unknown } | null)?.status
+    ?? (error as { statusCode?: unknown } | null)?.statusCode
+  const code = (error as { code?: unknown } | null)?.code
+  const message = error instanceof Error ? error.message : String(error)
+  return status === 409 || code === 409 || code === 'conflict' || /already exists|conflict/i.test(message)
+}
+
 function disposableBlaxelIdentity(context: { workspaceId?: string; sessionId: string; requestId?: string }) {
   if (!context.workspaceId?.trim() || !context.requestId?.trim()) {
     throw new SandboxProviderError('CONFIG_INVALID', 'disposable Blaxel requires host workspace and request identity')
@@ -294,21 +300,22 @@ export function createBlaxelSandboxProvider(
   const handles = createBlaxelSandboxHandleResolver()
   const seeds = new Map<string, { fingerprint: string; promise: Promise<void> }>()
   const unpublished = new Set<() => Promise<void>>()
+  const reservedDisposableNames = new Set<string>()
+  const publishedDisposableNames = new Set<string>()
+  const pendingCreates = new Set<Promise<void>>()
+  let closed = false
 
-  return {
+  const provider: SandboxProviderV1 = {
     contractVersion: PROVIDER_CONTRACT_VERSION,
     providerId: 'blaxel',
     capabilities: PROVIDER_CAPABILITIES.blaxel,
-    ...(options.leaseMode === 'disposable' ? {
-      disposableProfile: {
-        contractVersion: DISPOSABLE_SANDBOX_PROVIDER_PROFILE_V1,
-        resume: false as const,
-        publishedCleanupOwner: 'returned-pair' as const,
-        ambiguousCreate: 'correlated-reconciliation' as const,
-      },
-    } : {}),
     resolveRuntimeRoot: () => BLAXEL_WORKSPACE_ROOT,
     async create(context) {
+      if (closed) throw new SandboxProviderError('BLAXEL_API_ERROR', 'Blaxel provider is closed')
+      let finishCreate!: () => void
+      const pendingCreate = new Promise<void>((resolve) => { finishCreate = resolve })
+      pendingCreates.add(pendingCreate)
+      try {
       if (!options.client) assertBlaxelCredentials()
       const config = resolveBlaxelConfig(options)
       const workspaceId = context.workspaceId?.trim() || context.workspaceRoot.trim()
@@ -320,6 +327,10 @@ export function createBlaxelSandboxProvider(
       let remote
       if (options.leaseMode === 'disposable') {
         const identity = disposableBlaxelIdentity(context)
+        if (reservedDisposableNames.has(identity.name) || publishedDisposableNames.has(identity.name)) {
+          throw new SandboxProviderError('BLAXEL_CONFIG_DRIFT', 'disposable Blaxel request identity is already owned')
+        }
+        reservedDisposableNames.add(identity.name)
         let deleted = false
         let deletion: Promise<void> | undefined
         cleanupRemote = async () => {
@@ -336,6 +347,8 @@ export function createBlaxelSandboxProvider(
               if (!isBlaxelNotFound(error)) throw normalizeBlaxelError(error)
             }
             deleted = true
+            reservedDisposableNames.delete(identity.name)
+            publishedDisposableNames.delete(identity.name)
             unpublished.delete(cleanupRemote!)
           })()
           deletion = operation
@@ -354,6 +367,11 @@ export function createBlaxelSandboxProvider(
             labels: { owner: 'boring-ui', lease: identity.externalId.slice(-32) },
           })
         } catch (error) {
+          if (isBlaxelCreateConflict(error)) {
+            unpublished.delete(cleanupRemote)
+            reservedDisposableNames.delete(identity.name)
+            cleanupRemote = undefined
+          }
           throw normalizeBlaxelError(error)
         }
         if (remote.name !== identity.name || remote.externalId !== identity.externalId) {
@@ -368,13 +386,6 @@ export function createBlaxelSandboxProvider(
           now: options.now,
         })
       }
-      if (!config.volume.enabled) {
-        try { await remote.fs.mkdir(BLAXEL_WORKSPACE_ROOT) }
-        catch (error) {
-          if (!isBlaxelAlreadyExists(error)) throw normalizeBlaxelError(error)
-        }
-      }
-
       let disposed = false
       let workspaceDisposed = false
       let sandboxDisposed = false
@@ -383,7 +394,15 @@ export function createBlaxelSandboxProvider(
       const sandbox = createBlaxelSandboxExec(remote, {
         onMutation: workspace.invalidateMetadataCache,
       })
-      try {
+      const provisioning = createBlaxelProvisioningAdapter({ workspace, sandbox })
+      let setupError: unknown
+      const readiness = (async () => {
+        if (!config.volume.enabled) {
+          try { await remote.fs.mkdir(BLAXEL_WORKSPACE_ROOT) }
+          catch (error) {
+            if (!isBlaxelAlreadyExists(error)) throw normalizeBlaxelError(error)
+          }
+        }
         const preflight = await sandbox.exec(
           `set -eu; export LC_ALL=C; command -v sh >/dev/null; command -v stat >/dev/null; command -v mv >/dev/null; command -v mkdir >/dev/null; command -v realpath >/dev/null; command -v mktemp >/dev/null; command -v rm >/dev/null; command -v sed >/dev/null; command -v flock >/dev/null; test -d ${shellQuote(BLAXEL_WORKSPACE_ROOT)}; d=$(mktemp -d /tmp/boring-blaxel-preflight.XXXXXX); volume_lock=$(mktemp ${shellQuote(`${BLAXEL_WORKSPACE_ROOT}/.boring-blaxel-flock-preflight.XXXXXX`)}); trap 'rm -rf -- "$d"; rm -f -- "$volume_lock"' EXIT; mkdir -p -- "$d/a"; printf x >"$d/a/f"; stat -Lc '%s|%Y|%F' -- "$d/a/f" >/dev/null; realpath "$d/a/f" >/dev/null; realpath "$d/a/missing" >/dev/null; mv -T -- "$d/a/f" "$d/a/g"; flock -x -n "$volume_lock" true`,
           { timeoutMs: 10_000, maxOutputBytes: 8 * 1024 },
@@ -391,7 +410,6 @@ export function createBlaxelSandboxProvider(
         if (preflight.exitCode !== 0) {
           throw new SandboxProviderError('BLAXEL_RUNTIME_UNQUALIFIED', 'Blaxel runtime image failed workspace/tool preflight')
         }
-        const provisioning = createBlaxelProvisioningAdapter({ workspace, sandbox })
         if (context.templatePath) {
           const fingerprint = await fingerprintBlaxelHostTree(context.templatePath)
           const seedKey = options.leaseMode === 'disposable' ? remote.name : workspaceId
@@ -410,51 +428,90 @@ export function createBlaxelSandboxProvider(
             if (seeds.get(seedKey)?.promise === seed) seeds.delete(seedKey)
           }
         }
-        if (cleanupRemote) unpublished.delete(cleanupRemote)
-        return {
-          workspace,
-          sandbox,
-          provisioning,
-          async checkHealth() {
-            try {
-              const current = await client.getSandbox(remote.name)
-              return /failed|terminated|deleted/i.test(current.status ?? '')
-                ? { state: 'recreate' as const, error: normalizeBlaxelError(new Error(`sandbox status ${current.status}`)) }
-                : { state: 'ok' as const }
-            } catch (error) {
-              if (isBlaxelNotFound(error)) return { state: 'recreate' as const, error: normalizeBlaxelError(error) }
-              throw normalizeBlaxelError(error)
-            }
-          },
-          async dispose() {
-            if (disposed) return
-            if (disposeInFlight) return await disposeInFlight
-            const operation = (async () => {
-              if (!workspaceDisposed) { workspace.dispose(); workspaceDisposed = true }
-              if (!sandboxDisposed) { await sandbox.dispose(); sandboxDisposed = true }
-              await cleanupRemote?.()
-              disposed = true
-            })()
-            disposeInFlight = operation
-            try { await operation } finally { if (disposeInFlight === operation) disposeInFlight = undefined }
-          },
+      })().catch((error: unknown) => { setupError = error })
+      const disposePair = async (): Promise<void> => {
+        if (disposed) return
+        if (disposeInFlight) return await disposeInFlight
+        const operation = (async () => {
+          await readiness
+          const attempts: Promise<void>[] = []
+          if (!workspaceDisposed) attempts.push(Promise.resolve().then(() => {
+            workspace.dispose()
+            workspaceDisposed = true
+          }))
+          if (!sandboxDisposed) attempts.push(Promise.resolve().then(async () => {
+            await sandbox.dispose()
+            sandboxDisposed = true
+          }))
+          if (cleanupRemote) attempts.push(cleanupRemote())
+          const results = await Promise.allSettled(attempts)
+          const failures = results.flatMap((result) => result.status === 'rejected' ? [result.reason] : [])
+          if (failures.length) throw new AggregateError(failures, 'Blaxel sandbox cleanup failed')
+          disposed = true
+        })()
+        disposeInFlight = operation
+        try { await operation } finally { if (disposeInFlight === operation) disposeInFlight = undefined }
+      }
+      const pair = {
+        workspace,
+        sandbox,
+        provisioning,
+        async checkHealth() {
+          await readiness
+          if (setupError) {
+            if (setupError instanceof SandboxProviderError) throw setupError
+            throw normalizeBlaxelError(setupError)
+          }
+          try {
+            const current = await client.getSandbox(remote.name)
+            return /failed|terminated|deleted/i.test(current.status ?? '')
+              ? { state: 'recreate' as const, error: normalizeBlaxelError(new Error(`sandbox status ${current.status}`)) }
+              : { state: 'ok' as const }
+          } catch (error) {
+            if (isBlaxelNotFound(error)) return { state: 'recreate' as const, error: normalizeBlaxelError(error) }
+            throw normalizeBlaxelError(error)
+          }
+        },
+        dispose: disposePair,
+      }
+      if (options.leaseMode !== 'disposable') {
+        await readiness
+        if (setupError) {
+          try { await disposePair() }
+          catch (cleanupError) {
+            throw new AggregateError([setupError, cleanupError], 'Blaxel sandbox creation cleanup failed')
+          }
+          if (setupError instanceof SandboxProviderError) throw setupError
+          throw normalizeBlaxelError(setupError)
         }
-      } catch (error) {
-        workspace.dispose()
-        const cleanupFailures: unknown[] = []
-        try { await sandbox.dispose() } catch (cleanupError) { cleanupFailures.push(cleanupError) }
-        if (cleanupRemote) {
-          try { await cleanupRemote() } catch (cleanupError) { cleanupFailures.push(cleanupError) }
+      }
+      if (closed) {
+        try { await disposePair() }
+        catch (cleanupError) {
+          throw new AggregateError([
+            new SandboxProviderError('BLAXEL_API_ERROR', 'Blaxel provider closed during create'),
+            cleanupError,
+          ], 'Blaxel sandbox creation cleanup failed')
         }
-        if (cleanupFailures.length) throw new AggregateError([error, ...cleanupFailures], 'Blaxel sandbox creation cleanup failed')
-        if (error instanceof SandboxProviderError) throw error
-        throw normalizeBlaxelError(error)
+        throw new SandboxProviderError('BLAXEL_API_ERROR', 'Blaxel provider closed during create')
+      }
+      if (cleanupRemote) {
+        unpublished.delete(cleanupRemote)
+        reservedDisposableNames.delete(remote.name)
+        publishedDisposableNames.add(remote.name)
+      }
+      return pair
+      } finally {
+        finishCreate()
+        pendingCreates.delete(pendingCreate)
       }
     },
     invalidate({ workspaceId }) {
       if (options.leaseMode !== 'disposable') handles.invalidate(workspaceId)
     },
     async close() {
+      closed = true
+      await Promise.allSettled([...pendingCreates])
       if (options.leaseMode !== 'disposable') handles.clear()
       seeds.clear()
       const results = await Promise.allSettled([...unpublished].map(async (cleanup) => await cleanup()))
@@ -462,6 +519,13 @@ export function createBlaxelSandboxProvider(
       if (failures.length) throw new AggregateError(failures.map((failure) => failure.reason))
     },
   }
+  return options.leaseMode === 'disposable'
+    ? registerDisposableSandboxProviderV1(
+        provider,
+        options.providerConfigDigest
+          ?? 'sha256:8a29722f47b8b03b484890933995c5f12a462a5e0fb3292e3d193fe77771c783',
+      )
+    : provider
 }
 
 export type { BlaxelSandboxProviderOptions }

--- a/packages/boring-sandbox/src/providers/blaxel/createBlaxelSandboxProvider.ts
+++ b/packages/boring-sandbox/src/providers/blaxel/createBlaxelSandboxProvider.ts
@@ -5,7 +5,10 @@ import type { SandboxHandleStore } from '@hachej/boring-agent/shared'
 import { PROVIDER_CAPABILITIES, PROVIDER_CONTRACT_VERSION } from '../../shared/providerMatrix'
 import type { DisposableSandboxProviderV1, SandboxProviderV1 } from '../../shared/providerV1'
 import { SandboxProviderError } from '../../shared/providerV1'
-import { registerDisposableSandboxProviderV1 } from '../disposableProviderRegistration'
+import {
+  disposableProviderConfigDigestV1,
+  registerDisposableSandboxProviderV1,
+} from '../disposableProviderRegistration'
 import { createBlaxelClient } from './client'
 import {
   assertBlaxelCredentials,
@@ -303,6 +306,9 @@ export function createBlaxelSandboxProvider(
   const reservedDisposableNames = new Set<string>()
   const publishedDisposableNames = new Set<string>()
   const pendingCreates = new Set<Promise<void>>()
+  const disposableConfig = options.leaseMode === 'disposable'
+    ? resolveBlaxelConfig(options)
+    : undefined
   let closed = false
 
   const provider: SandboxProviderV1 = {
@@ -317,13 +323,14 @@ export function createBlaxelSandboxProvider(
       pendingCreates.add(pendingCreate)
       try {
       if (!options.client) assertBlaxelCredentials()
-      const config = resolveBlaxelConfig(options)
+      const config = disposableConfig ?? resolveBlaxelConfig(options)
       const workspaceId = context.workspaceId?.trim() || context.workspaceRoot.trim()
       if (!workspaceId) throw new SandboxProviderError('CONFIG_INVALID', 'workspaceId is required for blaxel mode')
       if (options.leaseMode === 'disposable' && (config.volume.enabled || options.handleStore)) {
         throw new SandboxProviderError('CONFIG_INVALID', 'disposable Blaxel forbids volumes and handle persistence')
       }
       let cleanupRemote: (() => Promise<void>) | undefined
+      let remoteCleanupPhase: 'creating' | 'created' | 'returned' | undefined
       let remote
       if (options.leaseMode === 'disposable') {
         const identity = disposableBlaxelIdentity(context)
@@ -331,6 +338,7 @@ export function createBlaxelSandboxProvider(
           throw new SandboxProviderError('BLAXEL_CONFIG_DRIFT', 'disposable Blaxel request identity is already owned')
         }
         reservedDisposableNames.add(identity.name)
+        remoteCleanupPhase = 'creating'
         let deleted = false
         let deletion: Promise<void> | undefined
         cleanupRemote = async () => {
@@ -345,6 +353,7 @@ export function createBlaxelSandboxProvider(
               await client.deleteSandbox(identity.name)
             } catch (error) {
               if (!isBlaxelNotFound(error)) throw normalizeBlaxelError(error)
+              if (remoteCleanupPhase === 'creating') return
             }
             deleted = true
             reservedDisposableNames.delete(identity.name)
@@ -367,13 +376,10 @@ export function createBlaxelSandboxProvider(
             labels: { owner: 'boring-ui', lease: identity.externalId.slice(-32) },
           })
         } catch (error) {
-          if (isBlaxelCreateConflict(error)) {
-            unpublished.delete(cleanupRemote)
-            reservedDisposableNames.delete(identity.name)
-            cleanupRemote = undefined
-          }
+          try { await cleanupRemote() } catch { /* retained for provider close reconciliation */ }
           throw normalizeBlaxelError(error)
         }
+        remoteCleanupPhase = 'created'
         if (remote.name !== identity.name || remote.externalId !== identity.externalId) {
           throw new SandboxProviderError('BLAXEL_CONFIG_DRIFT', 'Blaxel create identity does not match')
         }
@@ -433,7 +439,6 @@ export function createBlaxelSandboxProvider(
         if (disposed) return
         if (disposeInFlight) return await disposeInFlight
         const operation = (async () => {
-          await readiness
           const attempts: Promise<void>[] = []
           if (!workspaceDisposed) attempts.push(Promise.resolve().then(() => {
             workspace.dispose()
@@ -499,6 +504,7 @@ export function createBlaxelSandboxProvider(
         unpublished.delete(cleanupRemote)
         reservedDisposableNames.delete(remote.name)
         publishedDisposableNames.add(remote.name)
+        remoteCleanupPhase = 'returned'
       }
       return pair
       } finally {
@@ -522,8 +528,17 @@ export function createBlaxelSandboxProvider(
   return options.leaseMode === 'disposable'
     ? registerDisposableSandboxProviderV1(
         provider,
-        options.providerConfigDigest
-          ?? 'sha256:8a29722f47b8b03b484890933995c5f12a462a5e0fb3292e3d193fe77771c783',
+        disposableProviderConfigDigestV1('blaxel', {
+          leaseMode: 'disposable',
+          image: disposableConfig!.image,
+          memoryMb: disposableConfig!.memoryMb,
+          region: disposableConfig!.region,
+          ttl: disposableConfig!.ttl ?? null,
+          lifecycle: disposableConfig!.lifecycle ?? null,
+          volume: disposableConfig!.volume,
+          workspaceRoot: disposableConfig!.workspaceRoot,
+          client: options.client ? 'host-injected-v1' : 'sdk-default-v1',
+        }),
       )
     : provider
 }

--- a/packages/boring-sandbox/src/providers/blaxel/createBlaxelSandboxProvider.ts
+++ b/packages/boring-sandbox/src/providers/blaxel/createBlaxelSandboxProvider.ts
@@ -4,7 +4,7 @@ import type { SandboxHandleStore } from '@hachej/boring-agent/shared'
 
 import { PROVIDER_CAPABILITIES, PROVIDER_CONTRACT_VERSION } from '../../shared/providerMatrix'
 import type { DisposableSandboxProviderV1, SandboxProviderV1 } from '../../shared/providerV1'
-import { SandboxProviderError } from '../../shared/providerV1'
+import { attachSandboxProviderCleanupDebt, SandboxProviderError } from '../../shared/providerV1'
 import {
   disposableProviderConfigDigestV1,
   registerDisposableSandboxProviderV1,
@@ -320,6 +320,7 @@ export function createBlaxelSandboxProvider(
       let finishCreate!: () => void
       const pendingCreate = new Promise<void>((resolve) => { finishCreate = resolve })
       pendingCreates.add(pendingCreate)
+      let cleanupRemote: (() => Promise<void>) | undefined
       try {
       if (!options.client) assertBlaxelCredentials()
       const config = disposableConfig ?? resolveBlaxelConfig(options)
@@ -328,7 +329,6 @@ export function createBlaxelSandboxProvider(
       if (options.leaseMode === 'disposable' && (config.volume.enabled || options.handleStore)) {
         throw new SandboxProviderError('CONFIG_INVALID', 'disposable Blaxel forbids volumes and handle persistence')
       }
-      let cleanupRemote: (() => Promise<void>) | undefined
       let remoteCleanupPhase: 'creating' | 'created' | 'returned' | undefined
       let remote
       if (options.leaseMode === 'disposable') {
@@ -512,6 +512,11 @@ export function createBlaxelSandboxProvider(
         remoteCleanupPhase = 'returned'
       }
       return pair
+      } catch (error) {
+        const normalized = error instanceof SandboxProviderError ? error : normalizeBlaxelError(error)
+        throw cleanupRemote && unpublished.has(cleanupRemote)
+          ? attachSandboxProviderCleanupDebt(normalized, cleanupRemote)
+          : normalized
       } finally {
         finishCreate()
         pendingCreates.delete(pendingCreate)

--- a/packages/boring-sandbox/src/providers/blaxel/createBlaxelSandboxProvider.ts
+++ b/packages/boring-sandbox/src/providers/blaxel/createBlaxelSandboxProvider.ts
@@ -352,8 +352,9 @@ export function createBlaxelSandboxProvider(
               }
               await client.deleteSandbox(identity.name)
             } catch (error) {
-              if (!isBlaxelNotFound(error)) throw normalizeBlaxelError(error)
-              if (remoteCleanupPhase === 'creating') return
+              if (!isBlaxelNotFound(error) || remoteCleanupPhase === 'creating') {
+                throw normalizeBlaxelError(error)
+              }
             }
             deleted = true
             reservedDisposableNames.delete(identity.name)

--- a/packages/boring-sandbox/src/providers/blaxel/createBlaxelSandboxProvider.ts
+++ b/packages/boring-sandbox/src/providers/blaxel/createBlaxelSandboxProvider.ts
@@ -269,12 +269,11 @@ rm -rf -- "$lock"`
   }
 }
 
-function isBlaxelCreateConflict(error: unknown): boolean {
+function isDefinitiveBlaxelCreateRejection(error: unknown): boolean {
   const status = (error as { status?: unknown; statusCode?: unknown } | null)?.status
     ?? (error as { statusCode?: unknown } | null)?.statusCode
-  const code = (error as { code?: unknown } | null)?.code
-  const message = error instanceof Error ? error.message : String(error)
-  return status === 409 || code === 409 || code === 'conflict' || /already exists|conflict/i.test(message)
+  return typeof status === 'number' && status >= 400 && status < 500
+    && status !== 408 && status !== 409 && status !== 429
 }
 
 function disposableBlaxelIdentity(context: { workspaceId?: string; sessionId: string; requestId?: string }) {
@@ -377,7 +376,12 @@ export function createBlaxelSandboxProvider(
             labels: { owner: 'boring-ui', lease: identity.externalId.slice(-32) },
           })
         } catch (error) {
-          try { await cleanupRemote() } catch { /* retained for provider close reconciliation */ }
+          if (isDefinitiveBlaxelCreateRejection(error)) {
+            unpublished.delete(cleanupRemote)
+            reservedDisposableNames.delete(identity.name)
+            cleanupRemote = undefined
+            remoteCleanupPhase = undefined
+          } else try { await cleanupRemote() } catch { /* retained for provider close reconciliation */ }
           throw normalizeBlaxelError(error)
         }
         remoteCleanupPhase = 'created'

--- a/packages/boring-sandbox/src/providers/blaxel/resolveSandboxHandle.ts
+++ b/packages/boring-sandbox/src/providers/blaxel/resolveSandboxHandle.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto'
+import { isDeepStrictEqual } from 'node:util'
 
 import type { SandboxHandleRecord, SandboxHandleStore } from '@hachej/boring-agent/shared'
 
@@ -40,6 +41,7 @@ export function assertCompatible(
   expectedExternalId: string,
   volumeName: string,
 ): void {
+  const normalizedLifecycle = (value: unknown): unknown => JSON.parse(JSON.stringify(value ?? {}))
   const runtime = remote.spec.runtime
   const attachment = remote.spec.volumes?.find((volume) => volume.mountPath === config.workspaceRoot)
   const mismatch = remote.name !== expectedName
@@ -47,10 +49,12 @@ export function assertCompatible(
     || remote.spec.region !== config.region
     || runtime?.image !== config.image
     || runtime?.memory !== config.memoryMb
+    || runtime?.ttl !== config.ttl
+    || !isDeepStrictEqual(normalizedLifecycle(remote.spec.lifecycle), normalizedLifecycle(config.lifecycle))
     || (config.volume.enabled && (attachment?.name !== volumeName || attachment.readOnly === true))
     || (!config.volume.enabled && (remote.spec.volumes?.length ?? 0) > 0)
   if (mismatch) {
-    throw normalizeBlaxelError(new Error('existing sandbox configuration does not match requested region, image, memory, or Volume'), 'BLAXEL_CONFIG_DRIFT')
+    throw normalizeBlaxelError(new Error('existing sandbox configuration does not match requested runtime or lifecycle policy'), 'BLAXEL_CONFIG_DRIFT')
   }
 }
 

--- a/packages/boring-sandbox/src/providers/blaxel/resolveSandboxHandle.ts
+++ b/packages/boring-sandbox/src/providers/blaxel/resolveSandboxHandle.ts
@@ -33,7 +33,7 @@ async function waitForVolumeAvailable(client: BlaxelClient, name: string): Promi
   throw normalizeBlaxelError(new Error('persistent Volume is still attached'), 'BLAXEL_VOLUME_BUSY')
 }
 
-function assertCompatible(
+export function assertCompatible(
   remote: BlaxelRemoteSandbox,
   config: ResolvedBlaxelConfig,
   expectedName: string,

--- a/packages/boring-sandbox/src/providers/bwrap/createBwrapProvider.ts
+++ b/packages/boring-sandbox/src/providers/bwrap/createBwrapProvider.ts
@@ -14,6 +14,7 @@ import {
 import {
   assertDisposableLocalRoot,
   createDisposableLocalDisposer,
+  createDisposableLocalProviderLifecycle,
 } from '../local/disposableLocalLifecycle'
 import { createNodeWorkspace, disposeNodeWorkspace } from '../node-workspace/createNodeWorkspace'
 import {
@@ -35,9 +36,7 @@ export function createBwrapSandboxProvider(
 export function createBwrapSandboxProvider(
   options: BwrapSandboxProviderOptions = {},
 ): SandboxProviderV1 {
-  const pendingCleanup = new Set<() => Promise<void>>()
-  const pendingCreates = new Set<Promise<void>>()
-  let closed = false
+  const lifecycle = createDisposableLocalProviderLifecycle('bwrap')
   const provider: SandboxProviderV1 = {
     contractVersion: PROVIDER_CONTRACT_VERSION,
     providerId: 'bwrap',
@@ -46,10 +45,8 @@ export function createBwrapSandboxProvider(
       return '/workspace'
     },
     async create(context): Promise<WorkspaceSandboxPairV1> {
-      if (closed) throw new SandboxProviderError('CONFIG_INVALID', 'bwrap provider is closed')
-      let finishCreate!: () => void
-      const pendingCreate = new Promise<void>((resolve) => { finishCreate = resolve })
-      pendingCreates.add(pendingCreate)
+      if (lifecycle.closed) throw new SandboxProviderError('CONFIG_INVALID', 'bwrap provider is closed')
+      const finishCreate = lifecycle.beginCreate()
       try {
       const workspaceRoot = options.leaseMode === 'disposable'
         ? assertDisposableLocalRoot(context.workspaceRoot)
@@ -76,15 +73,13 @@ export function createBwrapSandboxProvider(
             disposeSandbox: async () => { await sandbox.dispose?.() },
           })
         : undefined
-      if (cleanup) pendingCleanup.add(cleanup)
+      if (cleanup) lifecycle.own(cleanup)
 
       try {
         await sandbox.init?.({ workspace, sessionId: context.sessionId })
       } catch (error) {
-        if (cleanup) {
-          try { await cleanup(); pendingCleanup.delete(cleanup) }
-          catch (cleanupError) { throw new AggregateError([error, cleanupError], 'bwrap sandbox creation cleanup failed') }
-        } else {
+        if (cleanup) await lifecycle.compensate(error, cleanup)
+        else {
           disposeNodeWorkspace(workspace)
           await sandbox.dispose?.()
         }
@@ -96,11 +91,9 @@ export function createBwrapSandboxProvider(
       }
 
       if (cleanup) {
-        if (closed) {
-          await cleanup(); pendingCleanup.delete(cleanup)
-          throw new SandboxProviderError('CONFIG_INVALID', 'bwrap provider closed during create')
-        }
-        pendingCleanup.delete(cleanup)
+        if (lifecycle.closed) throw await lifecycle.compensate(
+          new SandboxProviderError('CONFIG_INVALID', 'bwrap provider closed during create'), cleanup)
+        lifecycle.publish(cleanup)
         return { workspace, sandbox, dispose: cleanup }
       }
       let disposed = false
@@ -114,22 +107,10 @@ export function createBwrapSandboxProvider(
           await sandbox.dispose?.()
         },
       }
-      } finally {
-        finishCreate()
-        pendingCreates.delete(pendingCreate)
-      }
+      } finally { finishCreate() }
     },
     ...(options.leaseMode === 'disposable' ? {
-      async close() {
-        closed = true
-        await Promise.allSettled([...pendingCreates])
-        const results = await Promise.allSettled([...pendingCleanup].map(async (cleanup) => {
-          await cleanup()
-          pendingCleanup.delete(cleanup)
-        }))
-        const failures = results.filter((result) => result.status === 'rejected')
-        if (failures.length) throw new AggregateError(failures.map((failure) => failure.reason))
-      },
+      async close() { await lifecycle.close() },
     } : {}),
   }
   return options.leaseMode === 'disposable'

--- a/packages/boring-sandbox/src/providers/bwrap/createBwrapProvider.ts
+++ b/packages/boring-sandbox/src/providers/bwrap/createBwrapProvider.ts
@@ -7,7 +7,10 @@ import {
   type SandboxProviderV1,
   type WorkspaceSandboxPairV1,
 } from '../../shared/providerV1'
-import { registerDisposableSandboxProviderV1 } from '../disposableProviderRegistration'
+import {
+  disposableProviderConfigDigestV1,
+  registerDisposableSandboxProviderV1,
+} from '../disposableProviderRegistration'
 import {
   assertDisposableLocalRoot,
   createDisposableLocalDisposer,
@@ -21,7 +24,6 @@ import {
 export interface BwrapSandboxProviderOptions {
   sandbox?: Omit<CreateBwrapSandboxOptions, 'hostWorkspaceRoot' | 'runtimeContext'>
   leaseMode?: 'disposable'
-  providerConfigDigest?: `sha256:${string}`
 }
 
 export function createBwrapSandboxProvider(
@@ -116,8 +118,13 @@ export function createBwrapSandboxProvider(
   return options.leaseMode === 'disposable'
     ? registerDisposableSandboxProviderV1(
         provider,
-        options.providerConfigDigest
-          ?? 'sha256:1abc44c5c6195bac525222dd44c3620de2725f62e56df35220f977cebfd56fef',
+        disposableProviderConfigDigestV1('bwrap', {
+          leaseMode: 'disposable',
+          network: options.sandbox?.network ?? 'shared',
+          dropAllCapabilities: options.sandbox?.dropAllCapabilities ?? true,
+          namespaceProfile: options.sandbox?.namespaceProfile ?? null,
+          resourceLimits: options.sandbox?.resourceLimits ?? null,
+        }),
       )
     : provider
 }

--- a/packages/boring-sandbox/src/providers/bwrap/createBwrapProvider.ts
+++ b/packages/boring-sandbox/src/providers/bwrap/createBwrapProvider.ts
@@ -2,10 +2,16 @@ import { mkdir } from 'node:fs/promises'
 
 import { PROVIDER_CAPABILITIES, PROVIDER_CONTRACT_VERSION } from '../../shared/providerMatrix'
 import {
+  DISPOSABLE_SANDBOX_PROVIDER_PROFILE_V1,
   SandboxProviderError,
+  type DisposableSandboxProviderV1,
   type SandboxProviderV1,
   type WorkspaceSandboxPairV1,
 } from '../../shared/providerV1'
+import {
+  assertDisposableLocalRoot,
+  createDisposableLocalDisposer,
+} from '../local/disposableLocalLifecycle'
 import { createNodeWorkspace, disposeNodeWorkspace } from '../node-workspace/createNodeWorkspace'
 import {
   createBwrapSandbox,
@@ -14,19 +20,36 @@ import {
 
 export interface BwrapSandboxProviderOptions {
   sandbox?: Omit<CreateBwrapSandboxOptions, 'hostWorkspaceRoot' | 'runtimeContext'>
+  leaseMode?: 'disposable'
 }
 
 export function createBwrapSandboxProvider(
+  options: BwrapSandboxProviderOptions & { leaseMode: 'disposable' },
+): DisposableSandboxProviderV1
+export function createBwrapSandboxProvider(
+  options?: BwrapSandboxProviderOptions,
+): SandboxProviderV1
+export function createBwrapSandboxProvider(
   options: BwrapSandboxProviderOptions = {},
 ): SandboxProviderV1 {
+  const pendingCleanup = new Set<() => Promise<void>>()
   return {
     contractVersion: PROVIDER_CONTRACT_VERSION,
     providerId: 'bwrap',
     capabilities: PROVIDER_CAPABILITIES.bwrap,
+    ...(options.leaseMode === 'disposable' ? {
+      disposableProfile: {
+        contractVersion: DISPOSABLE_SANDBOX_PROVIDER_PROFILE_V1,
+        resume: false as const,
+        publishedCleanupOwner: 'returned-pair' as const,
+        ambiguousCreate: 'correlated-reconciliation' as const,
+      },
+    } : {}),
     resolveRuntimeRoot() {
       return '/workspace'
     },
     async create(context): Promise<WorkspaceSandboxPairV1> {
+      if (options.leaseMode === 'disposable') assertDisposableLocalRoot(context.workspaceRoot)
       if (process.platform !== 'linux') {
         throw new SandboxProviderError(
           'BWRAP_UNAVAILABLE',
@@ -42,21 +65,36 @@ export function createBwrapSandboxProvider(
         hostWorkspaceRoot: context.workspaceRoot,
         runtimeContext,
       })
+      const cleanup = options.leaseMode === 'disposable'
+        ? createDisposableLocalDisposer({
+            workspaceRoot: context.workspaceRoot,
+            disposeWorkspace: () => disposeNodeWorkspace(workspace),
+            disposeSandbox: async () => { await sandbox.dispose?.() },
+          })
+        : undefined
+      if (cleanup) pendingCleanup.add(cleanup)
 
       try {
         await sandbox.init?.({ workspace, sessionId: context.sessionId })
       } catch (error) {
-        disposeNodeWorkspace(workspace)
-        await sandbox.dispose?.()
+        if (cleanup) {
+          try { await cleanup(); pendingCleanup.delete(cleanup) }
+          catch (cleanupError) { throw new AggregateError([error, cleanupError], 'bwrap sandbox creation cleanup failed') }
+        } else {
+          disposeNodeWorkspace(workspace)
+          await sandbox.dispose?.()
+        }
         const message = error instanceof Error ? error.message : String(error)
         if (/bubblewrap|\bbwrap\b/i.test(message)) {
-          throw new SandboxProviderError('BWRAP_UNAVAILABLE', message, {
-            cause: error,
-          })
+          throw new SandboxProviderError('BWRAP_UNAVAILABLE', message, { cause: error })
         }
         throw error
       }
 
+      if (cleanup) {
+        pendingCleanup.delete(cleanup)
+        return { workspace, sandbox, dispose: cleanup }
+      }
       let disposed = false
       return {
         workspace,
@@ -69,5 +107,15 @@ export function createBwrapSandboxProvider(
         },
       }
     },
+    ...(options.leaseMode === 'disposable' ? {
+      async close() {
+        const results = await Promise.allSettled([...pendingCleanup].map(async (cleanup) => {
+          await cleanup()
+          pendingCleanup.delete(cleanup)
+        }))
+        const failures = results.filter((result) => result.status === 'rejected')
+        if (failures.length) throw new AggregateError(failures.map((failure) => failure.reason))
+      },
+    } : {}),
   }
 }

--- a/packages/boring-sandbox/src/providers/bwrap/createBwrapProvider.ts
+++ b/packages/boring-sandbox/src/providers/bwrap/createBwrapProvider.ts
@@ -2,12 +2,12 @@ import { mkdir } from 'node:fs/promises'
 
 import { PROVIDER_CAPABILITIES, PROVIDER_CONTRACT_VERSION } from '../../shared/providerMatrix'
 import {
-  DISPOSABLE_SANDBOX_PROVIDER_PROFILE_V1,
   SandboxProviderError,
   type DisposableSandboxProviderV1,
   type SandboxProviderV1,
   type WorkspaceSandboxPairV1,
 } from '../../shared/providerV1'
+import { registerDisposableSandboxProviderV1 } from '../disposableProviderRegistration'
 import {
   assertDisposableLocalRoot,
   createDisposableLocalDisposer,
@@ -21,6 +21,7 @@ import {
 export interface BwrapSandboxProviderOptions {
   sandbox?: Omit<CreateBwrapSandboxOptions, 'hostWorkspaceRoot' | 'runtimeContext'>
   leaseMode?: 'disposable'
+  providerConfigDigest?: `sha256:${string}`
 }
 
 export function createBwrapSandboxProvider(
@@ -33,23 +34,17 @@ export function createBwrapSandboxProvider(
   options: BwrapSandboxProviderOptions = {},
 ): SandboxProviderV1 {
   const pendingCleanup = new Set<() => Promise<void>>()
-  return {
+  const provider: SandboxProviderV1 = {
     contractVersion: PROVIDER_CONTRACT_VERSION,
     providerId: 'bwrap',
     capabilities: PROVIDER_CAPABILITIES.bwrap,
-    ...(options.leaseMode === 'disposable' ? {
-      disposableProfile: {
-        contractVersion: DISPOSABLE_SANDBOX_PROVIDER_PROFILE_V1,
-        resume: false as const,
-        publishedCleanupOwner: 'returned-pair' as const,
-        ambiguousCreate: 'correlated-reconciliation' as const,
-      },
-    } : {}),
     resolveRuntimeRoot() {
       return '/workspace'
     },
     async create(context): Promise<WorkspaceSandboxPairV1> {
-      if (options.leaseMode === 'disposable') assertDisposableLocalRoot(context.workspaceRoot)
+      const workspaceRoot = options.leaseMode === 'disposable'
+        ? assertDisposableLocalRoot(context.workspaceRoot)
+        : context.workspaceRoot
       if (process.platform !== 'linux') {
         throw new SandboxProviderError(
           'BWRAP_UNAVAILABLE',
@@ -57,17 +52,17 @@ export function createBwrapSandboxProvider(
         )
       }
 
-      await mkdir(context.workspaceRoot, { recursive: true })
+      await mkdir(workspaceRoot, { recursive: options.leaseMode !== 'disposable' })
       const runtimeContext = { runtimeCwd: '/workspace' }
-      const workspace = createNodeWorkspace(context.workspaceRoot, { runtimeContext })
+      const workspace = createNodeWorkspace(workspaceRoot, { runtimeContext })
       const sandbox = createBwrapSandbox({
         ...options.sandbox,
-        hostWorkspaceRoot: context.workspaceRoot,
+        hostWorkspaceRoot: workspaceRoot,
         runtimeContext,
       })
       const cleanup = options.leaseMode === 'disposable'
         ? createDisposableLocalDisposer({
-            workspaceRoot: context.workspaceRoot,
+            workspaceRoot,
             disposeWorkspace: () => disposeNodeWorkspace(workspace),
             disposeSandbox: async () => { await sandbox.dispose?.() },
           })
@@ -118,4 +113,11 @@ export function createBwrapSandboxProvider(
       },
     } : {}),
   }
+  return options.leaseMode === 'disposable'
+    ? registerDisposableSandboxProviderV1(
+        provider,
+        options.providerConfigDigest
+          ?? 'sha256:1abc44c5c6195bac525222dd44c3620de2725f62e56df35220f977cebfd56fef',
+      )
+    : provider
 }

--- a/packages/boring-sandbox/src/providers/bwrap/createBwrapProvider.ts
+++ b/packages/boring-sandbox/src/providers/bwrap/createBwrapProvider.ts
@@ -121,8 +121,9 @@ export function createBwrapSandboxProvider(
         disposableProviderConfigDigestV1('bwrap', {
           leaseMode: 'disposable',
           network: options.sandbox?.network ?? 'shared',
-          dropAllCapabilities: options.sandbox?.dropAllCapabilities ?? true,
-          namespaceProfile: options.sandbox?.namespaceProfile ?? null,
+          dropAllCapabilities: options.sandbox?.namespaceProfile === 'docker'
+            || options.sandbox?.dropAllCapabilities === true,
+          namespaceProfile: options.sandbox?.namespaceProfile ?? 'full',
           resourceLimits: options.sandbox?.resourceLimits ?? null,
         }),
       )

--- a/packages/boring-sandbox/src/providers/bwrap/createBwrapProvider.ts
+++ b/packages/boring-sandbox/src/providers/bwrap/createBwrapProvider.ts
@@ -36,6 +36,8 @@ export function createBwrapSandboxProvider(
   options: BwrapSandboxProviderOptions = {},
 ): SandboxProviderV1 {
   const pendingCleanup = new Set<() => Promise<void>>()
+  const pendingCreates = new Set<Promise<void>>()
+  let closed = false
   const provider: SandboxProviderV1 = {
     contractVersion: PROVIDER_CONTRACT_VERSION,
     providerId: 'bwrap',
@@ -44,6 +46,11 @@ export function createBwrapSandboxProvider(
       return '/workspace'
     },
     async create(context): Promise<WorkspaceSandboxPairV1> {
+      if (closed) throw new SandboxProviderError('CONFIG_INVALID', 'bwrap provider is closed')
+      let finishCreate!: () => void
+      const pendingCreate = new Promise<void>((resolve) => { finishCreate = resolve })
+      pendingCreates.add(pendingCreate)
+      try {
       const workspaceRoot = options.leaseMode === 'disposable'
         ? assertDisposableLocalRoot(context.workspaceRoot)
         : context.workspaceRoot
@@ -89,6 +96,10 @@ export function createBwrapSandboxProvider(
       }
 
       if (cleanup) {
+        if (closed) {
+          await cleanup(); pendingCleanup.delete(cleanup)
+          throw new SandboxProviderError('CONFIG_INVALID', 'bwrap provider closed during create')
+        }
         pendingCleanup.delete(cleanup)
         return { workspace, sandbox, dispose: cleanup }
       }
@@ -103,9 +114,15 @@ export function createBwrapSandboxProvider(
           await sandbox.dispose?.()
         },
       }
+      } finally {
+        finishCreate()
+        pendingCreates.delete(pendingCreate)
+      }
     },
     ...(options.leaseMode === 'disposable' ? {
       async close() {
+        closed = true
+        await Promise.allSettled([...pendingCreates])
         const results = await Promise.allSettled([...pendingCleanup].map(async (cleanup) => {
           await cleanup()
           pendingCleanup.delete(cleanup)

--- a/packages/boring-sandbox/src/providers/direct/createDirectProvider.ts
+++ b/packages/boring-sandbox/src/providers/direct/createDirectProvider.ts
@@ -14,6 +14,7 @@ import {
 import {
   assertDisposableLocalRoot,
   createDisposableLocalDisposer,
+  createDisposableLocalProviderLifecycle,
 } from '../local/disposableLocalLifecycle'
 import { createNodeWorkspace, disposeNodeWorkspace } from '../node-workspace/createNodeWorkspace'
 import { createDirectSandbox, type CreateDirectSandboxOptions } from './createDirectSandbox'
@@ -32,9 +33,7 @@ export function createDirectSandboxProvider(
 export function createDirectSandboxProvider(
   options: DirectSandboxProviderOptions = {},
 ): SandboxProviderV1 {
-  const pendingCleanup = new Set<() => Promise<void>>()
-  const pendingCreates = new Set<Promise<void>>()
-  let closed = false
+  const lifecycle = createDisposableLocalProviderLifecycle('direct')
   const provider: SandboxProviderV1 = {
     contractVersion: PROVIDER_CONTRACT_VERSION,
     providerId: 'direct',
@@ -43,10 +42,8 @@ export function createDirectSandboxProvider(
       return context.workspaceRoot
     },
     async create(context): Promise<WorkspaceSandboxPairV1> {
-      if (closed) throw new SandboxProviderError('CONFIG_INVALID', 'direct provider is closed')
-      let finishCreate!: () => void
-      const pendingCreate = new Promise<void>((resolve) => { finishCreate = resolve })
-      pendingCreates.add(pendingCreate)
+      if (lifecycle.closed) throw new SandboxProviderError('CONFIG_INVALID', 'direct provider is closed')
+      const finishCreate = lifecycle.beginCreate()
       try {
       const workspaceRoot = options.leaseMode === 'disposable'
         ? assertDisposableLocalRoot(context.workspaceRoot)
@@ -62,15 +59,13 @@ export function createDirectSandboxProvider(
             disposeSandbox: async () => { await sandbox.dispose?.() },
           })
         : undefined
-      if (cleanup) pendingCleanup.add(cleanup)
+      if (cleanup) lifecycle.own(cleanup)
 
       try {
         await sandbox.init?.({ workspace, sessionId: context.sessionId })
       } catch (error) {
-        if (cleanup) {
-          try { await cleanup(); pendingCleanup.delete(cleanup) }
-          catch (cleanupError) { throw new AggregateError([error, cleanupError], 'direct sandbox creation cleanup failed') }
-        } else {
+        if (cleanup) await lifecycle.compensate(error, cleanup)
+        else {
           disposeNodeWorkspace(workspace)
           await sandbox.dispose?.()
         }
@@ -78,11 +73,9 @@ export function createDirectSandboxProvider(
       }
 
       if (cleanup) {
-        if (closed) {
-          await cleanup(); pendingCleanup.delete(cleanup)
-          throw new SandboxProviderError('CONFIG_INVALID', 'direct provider closed during create')
-        }
-        pendingCleanup.delete(cleanup)
+        if (lifecycle.closed) throw await lifecycle.compensate(
+          new SandboxProviderError('CONFIG_INVALID', 'direct provider closed during create'), cleanup)
+        lifecycle.publish(cleanup)
         return { workspace, sandbox, dispose: cleanup }
       }
       let disposed = false
@@ -96,22 +89,10 @@ export function createDirectSandboxProvider(
           await sandbox.dispose?.()
         },
       }
-      } finally {
-        finishCreate()
-        pendingCreates.delete(pendingCreate)
-      }
+      } finally { finishCreate() }
     },
     ...(options.leaseMode === 'disposable' ? {
-      async close() {
-        closed = true
-        await Promise.allSettled([...pendingCreates])
-        const results = await Promise.allSettled([...pendingCleanup].map(async (cleanup) => {
-          await cleanup()
-          pendingCleanup.delete(cleanup)
-        }))
-        const failures = results.filter((result) => result.status === 'rejected')
-        if (failures.length) throw new AggregateError(failures.map((failure) => failure.reason))
-      },
+      async close() { await lifecycle.close() },
     } : {}),
   }
   return options.leaseMode === 'disposable'

--- a/packages/boring-sandbox/src/providers/direct/createDirectProvider.ts
+++ b/packages/boring-sandbox/src/providers/direct/createDirectProvider.ts
@@ -2,11 +2,11 @@ import { mkdir } from 'node:fs/promises'
 
 import { PROVIDER_CAPABILITIES, PROVIDER_CONTRACT_VERSION } from '../../shared/providerMatrix'
 import {
-  DISPOSABLE_SANDBOX_PROVIDER_PROFILE_V1,
   type DisposableSandboxProviderV1,
   type SandboxProviderV1,
   type WorkspaceSandboxPairV1,
 } from '../../shared/providerV1'
+import { registerDisposableSandboxProviderV1 } from '../disposableProviderRegistration'
 import {
   assertDisposableLocalRoot,
   createDisposableLocalDisposer,
@@ -17,6 +17,7 @@ import { createDirectSandbox, type CreateDirectSandboxOptions } from './createDi
 export interface DirectSandboxProviderOptions {
   sandbox?: Omit<CreateDirectSandboxOptions, 'runtimeContext'>
   leaseMode?: 'disposable'
+  providerConfigDigest?: `sha256:${string}`
 }
 
 export function createDirectSandboxProvider(
@@ -29,30 +30,24 @@ export function createDirectSandboxProvider(
   options: DirectSandboxProviderOptions = {},
 ): SandboxProviderV1 {
   const pendingCleanup = new Set<() => Promise<void>>()
-  return {
+  const provider: SandboxProviderV1 = {
     contractVersion: PROVIDER_CONTRACT_VERSION,
     providerId: 'direct',
     capabilities: PROVIDER_CAPABILITIES.direct,
-    ...(options.leaseMode === 'disposable' ? {
-      disposableProfile: {
-        contractVersion: DISPOSABLE_SANDBOX_PROVIDER_PROFILE_V1,
-        resume: false as const,
-        publishedCleanupOwner: 'returned-pair' as const,
-        ambiguousCreate: 'correlated-reconciliation' as const,
-      },
-    } : {}),
     resolveRuntimeRoot(context) {
       return context.workspaceRoot
     },
     async create(context): Promise<WorkspaceSandboxPairV1> {
-      if (options.leaseMode === 'disposable') assertDisposableLocalRoot(context.workspaceRoot)
-      await mkdir(context.workspaceRoot, { recursive: true })
-      const runtimeContext = { runtimeCwd: context.workspaceRoot }
-      const workspace = createNodeWorkspace(context.workspaceRoot, { runtimeContext })
+      const workspaceRoot = options.leaseMode === 'disposable'
+        ? assertDisposableLocalRoot(context.workspaceRoot)
+        : context.workspaceRoot
+      await mkdir(workspaceRoot, { recursive: options.leaseMode !== 'disposable' })
+      const runtimeContext = { runtimeCwd: workspaceRoot }
+      const workspace = createNodeWorkspace(workspaceRoot, { runtimeContext })
       const sandbox = createDirectSandbox({ ...options.sandbox, runtimeContext })
       const cleanup = options.leaseMode === 'disposable'
         ? createDisposableLocalDisposer({
-            workspaceRoot: context.workspaceRoot,
+            workspaceRoot,
             disposeWorkspace: () => disposeNodeWorkspace(workspace),
             disposeSandbox: async () => { await sandbox.dispose?.() },
           })
@@ -99,4 +94,11 @@ export function createDirectSandboxProvider(
       },
     } : {}),
   }
+  return options.leaseMode === 'disposable'
+    ? registerDisposableSandboxProviderV1(
+        provider,
+        options.providerConfigDigest
+          ?? 'sha256:76208b7f908e519027ef456c2ae52c8d951b2a246a1c33d9e2ce7ecb63450198',
+      )
+    : provider
 }

--- a/packages/boring-sandbox/src/providers/direct/createDirectProvider.ts
+++ b/packages/boring-sandbox/src/providers/direct/createDirectProvider.ts
@@ -2,6 +2,7 @@ import { mkdir } from 'node:fs/promises'
 
 import { PROVIDER_CAPABILITIES, PROVIDER_CONTRACT_VERSION } from '../../shared/providerMatrix'
 import {
+  SandboxProviderError,
   type DisposableSandboxProviderV1,
   type SandboxProviderV1,
   type WorkspaceSandboxPairV1,
@@ -32,6 +33,8 @@ export function createDirectSandboxProvider(
   options: DirectSandboxProviderOptions = {},
 ): SandboxProviderV1 {
   const pendingCleanup = new Set<() => Promise<void>>()
+  const pendingCreates = new Set<Promise<void>>()
+  let closed = false
   const provider: SandboxProviderV1 = {
     contractVersion: PROVIDER_CONTRACT_VERSION,
     providerId: 'direct',
@@ -40,6 +43,11 @@ export function createDirectSandboxProvider(
       return context.workspaceRoot
     },
     async create(context): Promise<WorkspaceSandboxPairV1> {
+      if (closed) throw new SandboxProviderError('CONFIG_INVALID', 'direct provider is closed')
+      let finishCreate!: () => void
+      const pendingCreate = new Promise<void>((resolve) => { finishCreate = resolve })
+      pendingCreates.add(pendingCreate)
+      try {
       const workspaceRoot = options.leaseMode === 'disposable'
         ? assertDisposableLocalRoot(context.workspaceRoot)
         : context.workspaceRoot
@@ -70,6 +78,10 @@ export function createDirectSandboxProvider(
       }
 
       if (cleanup) {
+        if (closed) {
+          await cleanup(); pendingCleanup.delete(cleanup)
+          throw new SandboxProviderError('CONFIG_INVALID', 'direct provider closed during create')
+        }
         pendingCleanup.delete(cleanup)
         return { workspace, sandbox, dispose: cleanup }
       }
@@ -84,9 +96,15 @@ export function createDirectSandboxProvider(
           await sandbox.dispose?.()
         },
       }
+      } finally {
+        finishCreate()
+        pendingCreates.delete(pendingCreate)
+      }
     },
     ...(options.leaseMode === 'disposable' ? {
       async close() {
+        closed = true
+        await Promise.allSettled([...pendingCreates])
         const results = await Promise.allSettled([...pendingCleanup].map(async (cleanup) => {
           await cleanup()
           pendingCleanup.delete(cleanup)

--- a/packages/boring-sandbox/src/providers/direct/createDirectProvider.ts
+++ b/packages/boring-sandbox/src/providers/direct/createDirectProvider.ts
@@ -1,38 +1,81 @@
 import { mkdir } from 'node:fs/promises'
 
 import { PROVIDER_CAPABILITIES, PROVIDER_CONTRACT_VERSION } from '../../shared/providerMatrix'
-import type { SandboxProviderV1, WorkspaceSandboxPairV1 } from '../../shared/providerV1'
+import {
+  DISPOSABLE_SANDBOX_PROVIDER_PROFILE_V1,
+  type DisposableSandboxProviderV1,
+  type SandboxProviderV1,
+  type WorkspaceSandboxPairV1,
+} from '../../shared/providerV1'
+import {
+  assertDisposableLocalRoot,
+  createDisposableLocalDisposer,
+} from '../local/disposableLocalLifecycle'
 import { createNodeWorkspace, disposeNodeWorkspace } from '../node-workspace/createNodeWorkspace'
 import { createDirectSandbox, type CreateDirectSandboxOptions } from './createDirectSandbox'
 
 export interface DirectSandboxProviderOptions {
   sandbox?: Omit<CreateDirectSandboxOptions, 'runtimeContext'>
+  leaseMode?: 'disposable'
 }
 
 export function createDirectSandboxProvider(
+  options: DirectSandboxProviderOptions & { leaseMode: 'disposable' },
+): DisposableSandboxProviderV1
+export function createDirectSandboxProvider(
+  options?: DirectSandboxProviderOptions,
+): SandboxProviderV1
+export function createDirectSandboxProvider(
   options: DirectSandboxProviderOptions = {},
 ): SandboxProviderV1 {
+  const pendingCleanup = new Set<() => Promise<void>>()
   return {
     contractVersion: PROVIDER_CONTRACT_VERSION,
     providerId: 'direct',
     capabilities: PROVIDER_CAPABILITIES.direct,
+    ...(options.leaseMode === 'disposable' ? {
+      disposableProfile: {
+        contractVersion: DISPOSABLE_SANDBOX_PROVIDER_PROFILE_V1,
+        resume: false as const,
+        publishedCleanupOwner: 'returned-pair' as const,
+        ambiguousCreate: 'correlated-reconciliation' as const,
+      },
+    } : {}),
     resolveRuntimeRoot(context) {
       return context.workspaceRoot
     },
     async create(context): Promise<WorkspaceSandboxPairV1> {
+      if (options.leaseMode === 'disposable') assertDisposableLocalRoot(context.workspaceRoot)
       await mkdir(context.workspaceRoot, { recursive: true })
       const runtimeContext = { runtimeCwd: context.workspaceRoot }
       const workspace = createNodeWorkspace(context.workspaceRoot, { runtimeContext })
       const sandbox = createDirectSandbox({ ...options.sandbox, runtimeContext })
+      const cleanup = options.leaseMode === 'disposable'
+        ? createDisposableLocalDisposer({
+            workspaceRoot: context.workspaceRoot,
+            disposeWorkspace: () => disposeNodeWorkspace(workspace),
+            disposeSandbox: async () => { await sandbox.dispose?.() },
+          })
+        : undefined
+      if (cleanup) pendingCleanup.add(cleanup)
 
       try {
         await sandbox.init?.({ workspace, sessionId: context.sessionId })
       } catch (error) {
-        disposeNodeWorkspace(workspace)
-        await sandbox.dispose?.()
+        if (cleanup) {
+          try { await cleanup(); pendingCleanup.delete(cleanup) }
+          catch (cleanupError) { throw new AggregateError([error, cleanupError], 'direct sandbox creation cleanup failed') }
+        } else {
+          disposeNodeWorkspace(workspace)
+          await sandbox.dispose?.()
+        }
         throw error
       }
 
+      if (cleanup) {
+        pendingCleanup.delete(cleanup)
+        return { workspace, sandbox, dispose: cleanup }
+      }
       let disposed = false
       return {
         workspace,
@@ -45,5 +88,15 @@ export function createDirectSandboxProvider(
         },
       }
     },
+    ...(options.leaseMode === 'disposable' ? {
+      async close() {
+        const results = await Promise.allSettled([...pendingCleanup].map(async (cleanup) => {
+          await cleanup()
+          pendingCleanup.delete(cleanup)
+        }))
+        const failures = results.filter((result) => result.status === 'rejected')
+        if (failures.length) throw new AggregateError(failures.map((failure) => failure.reason))
+      },
+    } : {}),
   }
 }

--- a/packages/boring-sandbox/src/providers/direct/createDirectProvider.ts
+++ b/packages/boring-sandbox/src/providers/direct/createDirectProvider.ts
@@ -6,7 +6,10 @@ import {
   type SandboxProviderV1,
   type WorkspaceSandboxPairV1,
 } from '../../shared/providerV1'
-import { registerDisposableSandboxProviderV1 } from '../disposableProviderRegistration'
+import {
+  disposableProviderConfigDigestV1,
+  registerDisposableSandboxProviderV1,
+} from '../disposableProviderRegistration'
 import {
   assertDisposableLocalRoot,
   createDisposableLocalDisposer,
@@ -17,7 +20,6 @@ import { createDirectSandbox, type CreateDirectSandboxOptions } from './createDi
 export interface DirectSandboxProviderOptions {
   sandbox?: Omit<CreateDirectSandboxOptions, 'runtimeContext'>
   leaseMode?: 'disposable'
-  providerConfigDigest?: `sha256:${string}`
 }
 
 export function createDirectSandboxProvider(
@@ -97,8 +99,10 @@ export function createDirectSandboxProvider(
   return options.leaseMode === 'disposable'
     ? registerDisposableSandboxProviderV1(
         provider,
-        options.providerConfigDigest
-          ?? 'sha256:76208b7f908e519027ef456c2ae52c8d951b2a246a1c33d9e2ce7ecb63450198',
+        disposableProviderConfigDigestV1('direct', {
+          leaseMode: 'disposable',
+          runtime: 'host-process',
+        }),
       )
     : provider
 }

--- a/packages/boring-sandbox/src/providers/disposableProviderRegistration.ts
+++ b/packages/boring-sandbox/src/providers/disposableProviderRegistration.ts
@@ -1,0 +1,39 @@
+import type {
+  DisposableSandboxProviderProfileV1,
+  DisposableSandboxProviderV1,
+  SandboxProviderV1,
+} from '../shared/providerV1'
+
+const PROFILE_VERSION = 'boring-sandbox.disposable-provider.v1' as const
+const SHA256_DIGEST = /^sha256:[a-f0-9]{64}$/
+const disposableProviders = new WeakMap<SandboxProviderV1, DisposableSandboxProviderProfileV1>()
+
+/** Internal factory registration; intentionally absent from public package exports. */
+export function registerDisposableSandboxProviderV1<T extends SandboxProviderV1>(
+  provider: T,
+  providerConfigDigest: `sha256:${string}`,
+): T & DisposableSandboxProviderV1 {
+  if (!SHA256_DIGEST.test(providerConfigDigest)) {
+    throw new TypeError('disposable provider config identity must be sha256')
+  }
+  const profile: DisposableSandboxProviderProfileV1 = Object.freeze({
+    contractVersion: PROFILE_VERSION,
+    resume: false,
+    publishedCleanupOwner: 'returned-pair',
+    ambiguousCreate: 'correlated-reconciliation',
+    providerConfigDigest,
+    assertProvider(candidate: SandboxProviderV1) {
+      if (candidate !== provider || disposableProviders.get(candidate) !== profile) {
+        throw new TypeError('disposable provider registration does not match')
+      }
+    },
+  })
+  Object.defineProperty(provider, 'disposableProfile', {
+    configurable: false,
+    enumerable: true,
+    value: profile,
+    writable: false,
+  })
+  disposableProviders.set(provider, profile)
+  return provider as T & DisposableSandboxProviderV1
+}

--- a/packages/boring-sandbox/src/providers/disposableProviderRegistration.ts
+++ b/packages/boring-sandbox/src/providers/disposableProviderRegistration.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto'
+
 import type {
   DisposableSandboxProviderProfileV1,
   DisposableSandboxProviderV1,
@@ -6,8 +8,26 @@ import type {
 
 const PROFILE_VERSION = 'boring-sandbox.disposable-provider.v1' as const
 const SHA256_DIGEST = /^sha256:[a-f0-9]{64}$/
-const disposableProviders = new WeakMap<SandboxProviderV1, DisposableSandboxProviderProfileV1>()
 
+function canonical(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonical)
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value as Record<string, unknown>)
+      .filter(([, entry]) => entry !== undefined && typeof entry !== 'function')
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => [key, canonical(entry)]))
+  }
+  if (typeof value === 'bigint') return value.toString()
+  return value
+}
+
+export function disposableProviderConfigDigestV1(
+  providerId: string,
+  behavior: Record<string, unknown>,
+): `sha256:${string}` {
+  const bytes = JSON.stringify(canonical({ providerId, behavior }))
+  return `sha256:${createHash('sha256').update(bytes).digest('hex')}`
+}
 /** Internal factory registration; intentionally absent from public package exports. */
 export function registerDisposableSandboxProviderV1<T extends SandboxProviderV1>(
   provider: T,
@@ -22,11 +42,6 @@ export function registerDisposableSandboxProviderV1<T extends SandboxProviderV1>
     publishedCleanupOwner: 'returned-pair',
     ambiguousCreate: 'correlated-reconciliation',
     providerConfigDigest,
-    assertProvider(candidate: SandboxProviderV1) {
-      if (candidate !== provider || disposableProviders.get(candidate) !== profile) {
-        throw new TypeError('disposable provider registration does not match')
-      }
-    },
   })
   Object.defineProperty(provider, 'disposableProfile', {
     configurable: false,
@@ -34,6 +49,5 @@ export function registerDisposableSandboxProviderV1<T extends SandboxProviderV1>
     value: profile,
     writable: false,
   })
-  disposableProviders.set(provider, profile)
   return provider as T & DisposableSandboxProviderV1
 }

--- a/packages/boring-sandbox/src/providers/local/disposableLocalLifecycle.ts
+++ b/packages/boring-sandbox/src/providers/local/disposableLocalLifecycle.ts
@@ -1,15 +1,22 @@
 import { rm } from 'node:fs/promises'
-import { isAbsolute, parse } from 'node:path'
+import { isAbsolute, parse, resolve } from 'node:path'
 
 import { SandboxProviderError, type WorkspaceSandboxPairV1 } from '../../shared/providerV1'
 
-export function assertDisposableLocalRoot(workspaceRoot: string): void {
-  if (!workspaceRoot || !isAbsolute(workspaceRoot) || parse(workspaceRoot).root === workspaceRoot) {
+export function assertDisposableLocalRoot(workspaceRoot: string): string {
+  const canonical = resolve(workspaceRoot)
+  if (
+    !workspaceRoot
+    || !isAbsolute(workspaceRoot)
+    || workspaceRoot !== canonical
+    || parse(canonical).root === canonical
+  ) {
     throw new SandboxProviderError(
       'CONFIG_INVALID',
-      'disposable workspace root must be an absolute non-root path',
+      'disposable workspace root must be one canonical absolute non-root path',
     )
   }
+  return canonical
 }
 
 export function createDisposableLocalDisposer(input: {
@@ -17,7 +24,7 @@ export function createDisposableLocalDisposer(input: {
   disposeWorkspace(): void
   disposeSandbox(): Promise<void>
 }): () => Promise<void> {
-  assertDisposableLocalRoot(input.workspaceRoot)
+  const workspaceRoot = assertDisposableLocalRoot(input.workspaceRoot)
   let workspaceDisposed = false
   let sandboxDisposed = false
   let rootRemoved = false
@@ -35,7 +42,7 @@ export function createDisposableLocalDisposer(input: {
         try { await input.disposeSandbox(); sandboxDisposed = true } catch (error) { failures.push(error) }
       }
       if (!rootRemoved) {
-        try { await rm(input.workspaceRoot, { recursive: true, force: true }); rootRemoved = true }
+        try { await rm(workspaceRoot, { recursive: true, force: true }); rootRemoved = true }
         catch (error) { failures.push(error) }
       }
       if (failures.length) throw new AggregateError(failures, 'disposable local sandbox cleanup failed')

--- a/packages/boring-sandbox/src/providers/local/disposableLocalLifecycle.ts
+++ b/packages/boring-sandbox/src/providers/local/disposableLocalLifecycle.ts
@@ -1,8 +1,45 @@
+import {
+  lstatSync,
+  realpathSync,
+  statSync,
+} from 'node:fs'
 import { rm } from 'node:fs/promises'
-import { isAbsolute, parse, resolve } from 'node:path'
+import { dirname, isAbsolute, join, parse, relative, resolve, sep } from 'node:path'
 
 import { SandboxProviderError, type WorkspaceSandboxPairV1 } from '../../shared/providerV1'
 
+interface RootIdentity {
+  readonly workspaceRoot: string
+  readonly parentRealPath: string
+  readonly parentDev: number
+  readonly parentIno: number
+  readonly rootDev: number
+  readonly rootIno: number
+}
+
+function invalidRoot(): never {
+  throw new SandboxProviderError(
+    'CONFIG_INVALID',
+    'disposable workspace root must be one canonical non-symlinked child of a trusted local root',
+  )
+}
+
+function assertNoSymlinkAncestors(path: string): void {
+  const root = parse(path).root
+  const components = relative(root, path).split(sep).filter(Boolean)
+  let cursor = root
+  for (const component of components) {
+    cursor = join(cursor, component)
+    const stat = lstatSync(cursor)
+    if (stat.isSymbolicLink() || !stat.isDirectory()) invalidRoot()
+  }
+}
+
+/**
+ * Local disposable mode is for trusted host work, not hostile multi-tenant
+ * containment. It fails closed on every detectable ancestor/target alias and
+ * revalidates inode identity immediately before recursive deletion.
+ */
 export function assertDisposableLocalRoot(workspaceRoot: string): string {
   const canonical = resolve(workspaceRoot)
   if (
@@ -10,13 +47,48 @@ export function assertDisposableLocalRoot(workspaceRoot: string): string {
     || !isAbsolute(workspaceRoot)
     || workspaceRoot !== canonical
     || parse(canonical).root === canonical
-  ) {
-    throw new SandboxProviderError(
-      'CONFIG_INVALID',
-      'disposable workspace root must be one canonical absolute non-root path',
-    )
+  ) invalidRoot()
+  const parent = dirname(canonical)
+  assertNoSymlinkAncestors(parent)
+  if (realpathSync(parent) !== parent) invalidRoot()
+  try {
+    const target = lstatSync(canonical)
+    if (target.isSymbolicLink() || !target.isDirectory() || realpathSync(canonical) !== canonical) invalidRoot()
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
   }
   return canonical
+}
+
+function captureRootIdentity(workspaceRoot: string): RootIdentity {
+  assertDisposableLocalRoot(workspaceRoot)
+  const parent = statSync(dirname(workspaceRoot))
+  const root = lstatSync(workspaceRoot)
+  if (root.isSymbolicLink() || !root.isDirectory()) invalidRoot()
+  return {
+    workspaceRoot,
+    parentRealPath: realpathSync(dirname(workspaceRoot)),
+    parentDev: parent.dev,
+    parentIno: parent.ino,
+    rootDev: root.dev,
+    rootIno: root.ino,
+  }
+}
+
+function revalidateRootIdentity(identity: RootIdentity): void {
+  assertNoSymlinkAncestors(dirname(identity.workspaceRoot))
+  const parent = statSync(dirname(identity.workspaceRoot))
+  const root = lstatSync(identity.workspaceRoot)
+  if (
+    realpathSync(dirname(identity.workspaceRoot)) !== identity.parentRealPath
+    || parent.dev !== identity.parentDev
+    || parent.ino !== identity.parentIno
+    || root.isSymbolicLink()
+    || !root.isDirectory()
+    || root.dev !== identity.rootDev
+    || root.ino !== identity.rootIno
+    || realpathSync(identity.workspaceRoot) !== identity.workspaceRoot
+  ) invalidRoot()
 }
 
 export function createDisposableLocalDisposer(input: {
@@ -24,7 +96,7 @@ export function createDisposableLocalDisposer(input: {
   disposeWorkspace(): void
   disposeSandbox(): Promise<void>
 }): () => Promise<void> {
-  const workspaceRoot = assertDisposableLocalRoot(input.workspaceRoot)
+  const identity = captureRootIdentity(input.workspaceRoot)
   let workspaceDisposed = false
   let sandboxDisposed = false
   let rootRemoved = false
@@ -42,8 +114,14 @@ export function createDisposableLocalDisposer(input: {
         try { await input.disposeSandbox(); sandboxDisposed = true } catch (error) { failures.push(error) }
       }
       if (!rootRemoved) {
-        try { await rm(workspaceRoot, { recursive: true, force: true }); rootRemoved = true }
-        catch (error) { failures.push(error) }
+        try {
+          revalidateRootIdentity(identity)
+          await rm(identity.workspaceRoot, { recursive: true, force: false })
+          rootRemoved = true
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === 'ENOENT') rootRemoved = true
+          else failures.push(error)
+        }
       }
       if (failures.length) throw new AggregateError(failures, 'disposable local sandbox cleanup failed')
     })()

--- a/packages/boring-sandbox/src/providers/local/disposableLocalLifecycle.ts
+++ b/packages/boring-sandbox/src/providers/local/disposableLocalLifecycle.ts
@@ -6,7 +6,10 @@ import {
 import { rm } from 'node:fs/promises'
 import { dirname, isAbsolute, join, parse, relative, resolve, sep } from 'node:path'
 
-import { SandboxProviderError, type WorkspaceSandboxPairV1 } from '../../shared/providerV1'
+import {
+  attachSandboxProviderCleanupDebt,
+  SandboxProviderError,
+} from '../../shared/providerV1'
 
 interface RootIdentity {
   readonly workspaceRoot: string
@@ -18,10 +21,8 @@ interface RootIdentity {
 }
 
 function invalidRoot(): never {
-  throw new SandboxProviderError(
-    'CONFIG_INVALID',
-    'disposable workspace root must be one canonical non-symlinked child of a trusted local root',
-  )
+  throw new SandboxProviderError('CONFIG_INVALID',
+    'disposable workspace root must be one canonical non-symlinked child of a trusted local root')
 }
 
 function assertNoSymlinkAncestors(path: string): void {
@@ -131,20 +132,37 @@ export function createDisposableLocalDisposer(input: {
   }
 }
 
-/** Owns only the exact provider context root; failed steps remain retryable. */
-export function createDisposableLocalPair(input: {
-  workspaceRoot: string
-  pair: Omit<WorkspaceSandboxPairV1, 'dispose'>
-  disposeWorkspace(): void
-  disposeSandbox(): Promise<void>
-}): WorkspaceSandboxPairV1 {
-  return { ...input.pair, dispose: createDisposableLocalDisposer(input) }
-}
-
-export async function cleanupDisposableLocalCreateFailure(input: {
-  workspaceRoot: string
-  disposeWorkspace(): void
-  disposeSandbox(): Promise<void>
-}): Promise<void> {
-  await createDisposableLocalDisposer(input)()
+export function createDisposableLocalProviderLifecycle(providerId: 'direct' | 'bwrap') {
+  const cleanups = new Set<() => Promise<void>>()
+  const creates = new Set<Promise<void>>()
+  let closed = false
+  const settle = async (cleanup: () => Promise<void>): Promise<void> => {
+    await cleanup(); cleanups.delete(cleanup)
+  }
+  return {
+    get closed() { return closed },
+    beginCreate(): () => void {
+      let finish!: () => void
+      const pending = new Promise<void>((resolve) => { finish = resolve })
+      creates.add(pending)
+      return () => { finish(); creates.delete(pending) }
+    },
+    own(cleanup: () => Promise<void>): void { cleanups.add(cleanup) },
+    publish(cleanup: () => Promise<void>): void { cleanups.delete(cleanup) },
+    async compensate(error: unknown, cleanup: () => Promise<void>): Promise<unknown> {
+      try { await settle(cleanup) }
+      catch (cleanupError) {
+        throw attachSandboxProviderCleanupDebt(
+          new AggregateError([error, cleanupError], `${providerId} sandbox creation cleanup failed`), () => settle(cleanup))
+      }
+      return error
+    },
+    async close(): Promise<void> {
+      closed = true
+      await Promise.allSettled([...creates])
+      const failures = (await Promise.allSettled([...cleanups].map(settle))).filter(
+        (result): result is PromiseRejectedResult => result.status === 'rejected')
+      if (failures.length) throw new AggregateError(failures.map((failure) => failure.reason))
+    },
+  }
 }

--- a/packages/boring-sandbox/src/providers/local/disposableLocalLifecycle.ts
+++ b/packages/boring-sandbox/src/providers/local/disposableLocalLifecycle.ts
@@ -36,11 +36,7 @@ function assertNoSymlinkAncestors(path: string): void {
   }
 }
 
-/**
- * Local disposable mode is for trusted host work, not hostile multi-tenant
- * containment. It fails closed on every detectable ancestor/target alias and
- * revalidates inode identity immediately before recursive deletion.
- */
+/** Trusted-host local mode fails closed on aliases and revalidates inode identity before recursive deletion. */
 export function assertDisposableLocalRoot(workspaceRoot: string): string {
   const canonical = resolve(workspaceRoot)
   if (
@@ -120,8 +116,7 @@ export function createDisposableLocalDisposer(input: {
           await rm(identity.workspaceRoot, { recursive: true, force: false })
           rootRemoved = true
         } catch (error) {
-          if ((error as NodeJS.ErrnoException).code === 'ENOENT') rootRemoved = true
-          else failures.push(error)
+          failures.push(error)
         }
       }
       if (failures.length) throw new AggregateError(failures, 'disposable local sandbox cleanup failed')

--- a/packages/boring-sandbox/src/providers/local/disposableLocalLifecycle.ts
+++ b/packages/boring-sandbox/src/providers/local/disposableLocalLifecycle.ts
@@ -1,0 +1,65 @@
+import { rm } from 'node:fs/promises'
+import { isAbsolute, parse } from 'node:path'
+
+import { SandboxProviderError, type WorkspaceSandboxPairV1 } from '../../shared/providerV1'
+
+export function assertDisposableLocalRoot(workspaceRoot: string): void {
+  if (!workspaceRoot || !isAbsolute(workspaceRoot) || parse(workspaceRoot).root === workspaceRoot) {
+    throw new SandboxProviderError(
+      'CONFIG_INVALID',
+      'disposable workspace root must be an absolute non-root path',
+    )
+  }
+}
+
+export function createDisposableLocalDisposer(input: {
+  workspaceRoot: string
+  disposeWorkspace(): void
+  disposeSandbox(): Promise<void>
+}): () => Promise<void> {
+  assertDisposableLocalRoot(input.workspaceRoot)
+  let workspaceDisposed = false
+  let sandboxDisposed = false
+  let rootRemoved = false
+  let inFlight: Promise<void> | undefined
+
+  return (): Promise<void> => {
+    if (workspaceDisposed && sandboxDisposed && rootRemoved) return Promise.resolve()
+    if (inFlight) return inFlight
+    const operation = (async () => {
+      const failures: unknown[] = []
+      if (!workspaceDisposed) {
+        try { input.disposeWorkspace(); workspaceDisposed = true } catch (error) { failures.push(error) }
+      }
+      if (!sandboxDisposed) {
+        try { await input.disposeSandbox(); sandboxDisposed = true } catch (error) { failures.push(error) }
+      }
+      if (!rootRemoved) {
+        try { await rm(input.workspaceRoot, { recursive: true, force: true }); rootRemoved = true }
+        catch (error) { failures.push(error) }
+      }
+      if (failures.length) throw new AggregateError(failures, 'disposable local sandbox cleanup failed')
+    })()
+    inFlight = operation
+    void operation.finally(() => { if (inFlight === operation) inFlight = undefined }).catch(() => undefined)
+    return operation
+  }
+}
+
+/** Owns only the exact provider context root; failed steps remain retryable. */
+export function createDisposableLocalPair(input: {
+  workspaceRoot: string
+  pair: Omit<WorkspaceSandboxPairV1, 'dispose'>
+  disposeWorkspace(): void
+  disposeSandbox(): Promise<void>
+}): WorkspaceSandboxPairV1 {
+  return { ...input.pair, dispose: createDisposableLocalDisposer(input) }
+}
+
+export async function cleanupDisposableLocalCreateFailure(input: {
+  workspaceRoot: string
+  disposeWorkspace(): void
+  disposeSandbox(): Promise<void>
+}): Promise<void> {
+  await createDisposableLocalDisposer(input)()
+}

--- a/packages/boring-sandbox/src/providers/remote-worker/__tests__/createRemoteWorkerProvider.test.ts
+++ b/packages/boring-sandbox/src/providers/remote-worker/__tests__/createRemoteWorkerProvider.test.ts
@@ -92,6 +92,7 @@ class FakeTransport implements RemoteWorkerTransportV1 {
   streamCloseFailures = 0;
   streamCloseNeverSettles = false;
   createFailures = 0;
+  createProtocolMismatches = 0;
   createGate?: Promise<void>;
   advertiseExclusiveBinaryCreate = false;
   advertiseMultiSandboxRoots = false;
@@ -152,8 +153,11 @@ class FakeTransport implements RemoteWorkerTransportV1 {
         requestDigest: remoteWorkerRequestDigestV1(request),
         expiresAtMs: this.leaseExpiresAtMs,
       };
+      const createProtocolVersion = this.createProtocolMismatches > 0
+        ? (this.createProtocolMismatches -= 1, 'boring.remote-worker.v0')
+        : REMOTE_WORKER_PROTOCOL_VERSION;
       return {
-        protocolVersion: REMOTE_WORKER_PROTOCOL_VERSION,
+        protocolVersion: createProtocolVersion,
         providerContractVersion: PROVIDER_CONTRACT_VERSION,
         workerId: this.createResponseWorkerId,
         sandboxId: "sandbox-1",
@@ -761,6 +765,26 @@ describe("remote-worker SandboxProviderV1 placement binding", () => {
     ).rejects.toMatchObject({
       code: REMOTE_WORKER_ERROR_CODES_V1.protocolMismatch,
     });
+  });
+
+  test('retains deterministic cleanup debt for malformed accepted create responses', async () => {
+    const transport = new FakeTransport();
+    transport.createProtocolMismatches = 2;
+    const provider = createRemoteWorkerSandboxProviderV1(providerOptions(transport));
+
+    const failure = await provider.create({
+      workspaceRoot: '/unused', workspaceId: 'workspace-a', sessionId: 'session-a', requestId: 'request-a',
+    }).catch((error: unknown) => error) as Error & {
+      sandboxProviderCleanupDebt: { retry(): Promise<void> };
+    };
+    expect(failure).toMatchObject({ code: REMOTE_WORKER_ERROR_CODES_V1.protocolMismatch });
+    expect(failure.sandboxProviderCleanupDebt.retry).toBeTypeOf('function');
+    await failure.sandboxProviderCleanupDebt.retry();
+    const creates = transport.requests.filter((request) => request.path === '/internal/v1/sandboxes');
+    expect(new Set(creates.map((request) => (request.body as RemoteWorkerCreateRequestV1).clientLeaseId)).size).toBe(1);
+    expect(creates).toHaveLength(3);
+    expect(transport.requests.filter((request) => request.method === 'DELETE')).toHaveLength(1);
+    await provider.close?.();
   });
 
   test("sanitizes an unknown transport failure", async () => {

--- a/packages/boring-sandbox/src/providers/remote-worker/__tests__/createRemoteWorkerProvider.test.ts
+++ b/packages/boring-sandbox/src/providers/remote-worker/__tests__/createRemoteWorkerProvider.test.ts
@@ -327,6 +327,38 @@ describe("remote-worker SandboxProviderV1 placement binding", () => {
     await Promise.all([firstPair.dispose(), secondPair.dispose()])
   })
 
+  test('reserves one deterministic create identity through concurrency and pair ownership', async () => {
+    const transport = new FakeTransport(); transport.advertiseMultiSandboxRoots = true
+    let releaseCreate!: () => void
+    transport.createGate = new Promise<void>((resolve) => { releaseCreate = resolve })
+    const provider = createRemoteWorkerSandboxProviderV1({
+      ...providerOptions(transport, [], true), leaseMode: 'disposable',
+    })
+    const context = {
+      workspaceRoot: '/unused', workspaceId: 'workspace-a',
+      sessionId: 'session-duplicate', requestId: 'request-duplicate',
+    }
+    const first = provider.create(context)
+    await vi.waitFor(() => expect(
+      transport.requests.filter((request) => request.path === '/internal/v1/sandboxes'),
+    ).toHaveLength(1))
+    await expect(provider.create(context)).rejects.toMatchObject({
+      code: REMOTE_WORKER_ERROR_CODES_V1.configInvalid,
+    })
+    releaseCreate()
+    const pair = await first
+    await expect(provider.create(context)).rejects.toMatchObject({
+      code: REMOTE_WORKER_ERROR_CODES_V1.configInvalid,
+    })
+    expect(transport.requests.filter((request) => request.path === '/internal/v1/sandboxes')).toHaveLength(1)
+
+    await pair.dispose()
+    transport.createGate = undefined
+    const retryPair = await provider.create(context)
+    expect(transport.requests.filter((request) => request.path === '/internal/v1/sandboxes')).toHaveLength(2)
+    await retryPair.dispose()
+  })
+
   test("requires qualified multi-root placement for disposable mode", async () => {
     const unavailable = new FakeTransport();
     expect(() => createRemoteWorkerSandboxProviderV1({
@@ -779,11 +811,19 @@ describe("remote-worker SandboxProviderV1 placement binding", () => {
     };
     expect(failure).toMatchObject({ code: REMOTE_WORKER_ERROR_CODES_V1.protocolMismatch });
     expect(failure.sandboxProviderCleanupDebt.retry).toBeTypeOf('function');
+    const context = {
+      workspaceRoot: '/unused', workspaceId: 'workspace-a', sessionId: 'session-a', requestId: 'request-a',
+    };
+    await expect(provider.create(context)).rejects.toMatchObject({
+      code: REMOTE_WORKER_ERROR_CODES_V1.configInvalid,
+    });
     await failure.sandboxProviderCleanupDebt.retry();
+    const replacement = await provider.create(context);
+    await replacement.dispose();
     const creates = transport.requests.filter((request) => request.path === '/internal/v1/sandboxes');
     expect(new Set(creates.map((request) => (request.body as RemoteWorkerCreateRequestV1).clientLeaseId)).size).toBe(1);
-    expect(creates).toHaveLength(3);
-    expect(transport.requests.filter((request) => request.method === 'DELETE')).toHaveLength(1);
+    expect(creates).toHaveLength(4);
+    expect(transport.requests.filter((request) => request.method === 'DELETE')).toHaveLength(2);
     await provider.close?.();
   });
 

--- a/packages/boring-sandbox/src/providers/remote-worker/__tests__/createRemoteWorkerProvider.test.ts
+++ b/packages/boring-sandbox/src/providers/remote-worker/__tests__/createRemoteWorkerProvider.test.ts
@@ -78,6 +78,8 @@ class FakeTransport implements RemoteWorkerTransportV1 {
     RemoteWorkerEventStreamV1 & { close: ReturnType<typeof vi.fn> }
   > = [];
   swappedWorkspaceId?: string;
+  swappedWorkspaceResponses = Number.POSITIVE_INFINITY;
+  readonly createResponseSandboxIds: string[] = [];
   createResponseWorkerId = "worker-1";
   protocolVersion: string = REMOTE_WORKER_PROTOCOL_VERSION;
   deleteFailures = 0;
@@ -144,9 +146,11 @@ class FakeTransport implements RemoteWorkerTransportV1 {
         throw new Error("ambiguous create response loss");
       }
       const request = input.body as RemoteWorkerCreateRequestV1;
+      const responseSandboxId = this.createResponseSandboxIds.shift() ?? "sandbox-1";
       const payload: RemoteWorkerBindingReceiptPayloadV1 = {
         protocolVersion: REMOTE_WORKER_PROTOCOL_VERSION,
-        workspaceId: this.swappedWorkspaceId ?? request.workspaceId,
+        workspaceId: this.swappedWorkspaceId && this.swappedWorkspaceResponses-- > 0
+          ? this.swappedWorkspaceId : request.workspaceId,
         clientLeaseId: request.clientLeaseId,
         workerId: "worker-1",
         sandboxId: "sandbox-1",
@@ -160,7 +164,7 @@ class FakeTransport implements RemoteWorkerTransportV1 {
         protocolVersion: createProtocolVersion,
         providerContractVersion: PROVIDER_CONTRACT_VERSION,
         workerId: this.createResponseWorkerId,
-        sandboxId: "sandbox-1",
+        sandboxId: responseSandboxId,
         runtimeCwd: "/workspace",
         leaseExpiresAtMs: this.leaseExpiresAtMs,
         bindingReceipt: {
@@ -694,30 +698,26 @@ describe("remote-worker SandboxProviderV1 placement binding", () => {
     expect(transport.requests).toHaveLength(0);
   });
 
-  test("refuses a validly authenticated but swapped create receipt", async () => {
+  test("never deletes a sibling ID from an unattested response and cleans a verified replay", async () => {
     const transport = new FakeTransport();
-    transport.swappedWorkspaceId = "workspace-b";
-    const provider = createRemoteWorkerSandboxProviderV1(
-      providerOptions(transport),
-    );
+    transport.createResponseSandboxIds.push("sibling-sandbox", "sandbox-1");
+    const provider = createRemoteWorkerSandboxProviderV1(providerOptions(transport));
 
-    await expect(
-      provider.create({
-        workspaceRoot: "/unused",
-        workspaceId: "workspace-a",
-        sessionId: "session-a",
-      }),
-    ).rejects.toMatchObject({
+    await expect(provider.create({
+      workspaceRoot: "/unused", workspaceId: "workspace-a", sessionId: "session-a",
+    })).rejects.toMatchObject({
       code: REMOTE_WORKER_ERROR_CODES_V1.bindingReceiptInvalid,
     } satisfies Partial<SandboxProviderError>);
-    expect(
-      transport.requests.filter((request) => request.method === "DELETE"),
-    ).toHaveLength(1);
+    const deletes = transport.requests.filter((request) => request.method === "DELETE");
+    expect(deletes).toHaveLength(1);
+    expect(deletes[0]!.path).toContain("/sandbox-1");
+    expect(deletes[0]!.path).not.toContain("sibling-sandbox");
   });
 
   test("retains invalid-attestation cleanup for provider reconciliation", async () => {
     const transport = new FakeTransport();
     transport.swappedWorkspaceId = "workspace-b";
+    transport.swappedWorkspaceResponses = 1;
     transport.deleteFailures = 3;
     const provider = createRemoteWorkerSandboxProviderV1(providerOptions(transport));
 
@@ -742,6 +742,7 @@ describe("remote-worker SandboxProviderV1 placement binding", () => {
   test("retries retained invalid-attestation cleanup across provider close", async () => {
     const transport = new FakeTransport();
     transport.swappedWorkspaceId = "workspace-b";
+    transport.swappedWorkspaceResponses = 1;
     transport.deleteFailures = 6;
     const provider = createRemoteWorkerSandboxProviderV1(providerOptions(transport));
 
@@ -770,14 +771,16 @@ describe("remote-worker SandboxProviderV1 placement binding", () => {
       providerOptions(transport),
     );
 
-    await expect(
-      provider.create({
-        workspaceRoot: "/unused",
-        workspaceId: "workspace-a",
-        sessionId: "session-a",
-      }),
-    ).rejects.toMatchObject({
-      code: REMOTE_WORKER_ERROR_CODES_V1.bindingReceiptInvalid,
+    const failure = await provider.create({
+      workspaceRoot: "/unused", workspaceId: "workspace-a", sessionId: "session-a",
+    }).catch((error: unknown) => error) as SandboxProviderError & {
+      sandboxProviderCleanupDebt?: { retry(): Promise<void> }
+    };
+    expect(failure).toMatchObject({ code: REMOTE_WORKER_ERROR_CODES_V1.bindingReceiptInvalid });
+    expect(failure.sandboxProviderCleanupDebt?.retry).toBeTypeOf("function");
+    expect(transport.requests.filter((request) => request.method === "DELETE")).toHaveLength(0);
+    await expect(provider.close!()).rejects.toMatchObject({
+      code: REMOTE_WORKER_ERROR_CODES_V1.incompleteCleanup,
     });
   });
 

--- a/packages/boring-sandbox/src/providers/remote-worker/__tests__/createRemoteWorkerProvider.test.ts
+++ b/packages/boring-sandbox/src/providers/remote-worker/__tests__/createRemoteWorkerProvider.test.ts
@@ -15,6 +15,7 @@ import {
 import { PROVIDER_CONTRACT_VERSION } from "../../../shared/providerMatrix";
 import { SandboxProviderError } from "../../../shared/providerV1";
 import {
+  expectDisposablePairSurfaceLaws,
   expectDisposableProviderProfile,
   expectPublishedPairLifecycle,
 } from "../../__tests__/conformance/disposableProvider";
@@ -95,6 +96,9 @@ class FakeTransport implements RemoteWorkerTransportV1 {
   advertiseExclusiveBinaryCreate = false;
   advertiseMultiSandboxRoots = false;
   negotiatedCapabilitiesOverride?: unknown;
+  readonly files = new Map<string, string>();
+  readonly deletedPaths = new Set<string>();
+  readonly directories = new Set<string>(['']);
 
   async request(input: RemoteWorkerTransportRequestV1): Promise<unknown> {
     this.requests.push(input);
@@ -163,20 +167,63 @@ class FakeTransport implements RemoteWorkerTransportV1 {
     }
     if (input.path.endsWith("/fs")) {
       const operation = input.body as RemoteWorkerWorkspaceOperationV1;
-      if (operation.op === "readFile") return { content: "tenant-file" };
+      const op = operation as RemoteWorkerWorkspaceOperationV1 & Record<string, unknown>;
+      for (const value of [op.path, op.from, op.to]) {
+        if (typeof value === 'string' && (value.startsWith('/') || value.includes('\0') || value.split('/').includes('..'))) {
+          throw new Error('invalid path');
+        }
+      }
+      if (op.op === 'writeFile') { this.files.set(String(op.path), String(op.data)); this.deletedPaths.delete(String(op.path)); return { ok: true }; }
+      if (op.op === 'writeBinaryFile') { this.files.set(String(op.path), Buffer.from(String(op.dataBase64), 'base64').toString()); this.deletedPaths.delete(String(op.path)); return { ok: true }; }
+      if (op.op === 'readFile') {
+        if (this.deletedPaths.has(String(op.path))) throw new Error('not found');
+        return { content: this.files.get(String(op.path)) ?? 'tenant-file' };
+      }
+      if (op.op === 'readBinaryFile') {
+        if (!this.files.has(String(op.path))) throw new Error('not found');
+        return { dataBase64: Buffer.from(this.files.get(String(op.path))!).toString('base64') };
+      }
+      if (op.op === 'mkdir') { this.directories.add(String(op.path)); return { ok: true }; }
+      if (op.op === 'unlink') { this.files.delete(String(op.path)); this.deletedPaths.add(String(op.path)); return { ok: true }; }
+      if (op.op === 'rename') {
+        const value = this.files.get(String(op.from));
+        if (value === undefined) throw new Error('not found');
+        this.files.delete(String(op.from)); this.files.set(String(op.to), value); return { ok: true };
+      }
+      if (op.op === 'stat') {
+        const path = String(op.path);
+        if (this.files.has(path)) return { stat: { kind: 'file', size: Buffer.byteLength(this.files.get(path)!), mtimeMs: 1 } };
+        if (this.directories.has(path)) return { stat: { kind: 'dir', size: 0, mtimeMs: 1 } };
+        throw new Error('not found');
+      }
+      if (op.op === 'readdir') {
+        const prefix = String(op.path) ? `${String(op.path)}/` : '';
+        const names = new Map<string, 'file' | 'dir'>();
+        for (const path of this.files.keys()) if (path.startsWith(prefix)) names.set(path.slice(prefix.length).split('/')[0]!, 'file');
+        for (const path of this.directories) if (path.startsWith(prefix) && path !== String(op.path)) names.set(path.slice(prefix.length).split('/')[0]!, 'dir');
+        return { entries: [...names].map(([name, kind]) => ({ name, kind })) };
+      }
       return { ok: true };
     }
     if (input.path.endsWith("/exec")) {
       if (this.rawExecError) throw this.rawExecError;
       const request = input.body as RemoteWorkerExecRequestV1;
+      let stdout = this.execStdout || `ran:${request.command}`;
+      let exitCode = 0;
+      let durationMs = 2;
+      let truncated = false;
+      if (request.command === 'echo hello') stdout = 'hello\n';
+      else if (request.command === 'exit 7') { stdout = ''; exitCode = 7; }
+      else if (request.command === 'pwd && cat note.txt') stdout = `${request.cwd}\ncwd-ok`;
+      else if (request.command.includes('setInterval')) { stdout = ''; exitCode = 124; durationMs = 500; }
+      else if (request.command.includes("repeat(2_000_000)")) { stdout = 'x'.repeat(request.maxOutputBytes); truncated = true; }
+      else if (request.command.includes('setTimeout')) { await new Promise((resolve) => setTimeout(resolve, 2_100)); stdout = ''; durationMs = 2_100; }
       return {
-        stdoutBase64: Buffer.from(
-          this.execStdout || `ran:${request.command}`,
-        ).toString("base64"),
+        stdoutBase64: Buffer.from(stdout).toString("base64"),
         stderrBase64: "",
-        exitCode: 0,
-        durationMs: 2,
-        truncated: false,
+        exitCode,
+        durationMs,
+        truncated,
         stdoutEncoding: "utf-8",
         stderrEncoding: "utf-8",
       };
@@ -253,6 +300,29 @@ function providerOptions(
 }
 
 describe("remote-worker SandboxProviderV1 placement binding", () => {
+  test('derives a deterministic client lease identity from trusted request correlation', async () => {
+    const firstTransport = new FakeTransport(); firstTransport.advertiseMultiSandboxRoots = true
+    const secondTransport = new FakeTransport(); secondTransport.advertiseMultiSandboxRoots = true
+    const context = {
+      workspaceRoot: '/unused', workspaceId: 'workspace-a',
+      sessionId: 'session-a', requestId: 'request-a',
+    }
+    const first = createRemoteWorkerSandboxProviderV1({
+      ...providerOptions(firstTransport, [], true), leaseMode: 'disposable',
+    })
+    const second = createRemoteWorkerSandboxProviderV1({
+      ...providerOptions(secondTransport, [], true), leaseMode: 'disposable',
+    })
+    const firstPair = await first.create(context)
+    const secondPair = await second.create(context)
+    await expectDisposablePairSurfaceLaws(firstPair)
+    const firstRequest = firstTransport.requests.find((request) => request.path === '/internal/v1/sandboxes')?.body as RemoteWorkerCreateRequestV1
+    const secondRequest = secondTransport.requests.find((request) => request.path === '/internal/v1/sandboxes')?.body as RemoteWorkerCreateRequestV1
+    expect(firstRequest.clientLeaseId).toBe(secondRequest.clientLeaseId)
+    expect(firstRequest.clientLeaseId).toMatch(/^lease-[a-f0-9]{48}$/)
+    await Promise.all([firstPair.dispose(), secondPair.dispose()])
+  })
+
   test("requires qualified multi-root placement for disposable mode", async () => {
     const unavailable = new FakeTransport();
     expect(() => createRemoteWorkerSandboxProviderV1({

--- a/packages/boring-sandbox/src/providers/remote-worker/__tests__/createRemoteWorkerProvider.test.ts
+++ b/packages/boring-sandbox/src/providers/remote-worker/__tests__/createRemoteWorkerProvider.test.ts
@@ -14,7 +14,10 @@ import {
 } from "../../../shared/remoteWorkerProtocolV1";
 import { PROVIDER_CONTRACT_VERSION } from "../../../shared/providerMatrix";
 import { SandboxProviderError } from "../../../shared/providerV1";
-import { expectDisposableProviderProfile } from "../../__tests__/conformance/disposableProvider";
+import {
+  expectDisposableProviderProfile,
+  expectPublishedPairLifecycle,
+} from "../../__tests__/conformance/disposableProvider";
 import { createStaticSandboxProvidersV1 } from "../../static";
 import {
   createRemoteWorkerSandboxProviderV1,
@@ -77,6 +80,7 @@ class FakeTransport implements RemoteWorkerTransportV1 {
   createResponseWorkerId = "worker-1";
   protocolVersion: string = REMOTE_WORKER_PROTOCOL_VERSION;
   deleteFailures = 0;
+  deleteNotFound = false;
   execStdout = "";
   qualifiedAtMs = nowMs - 1;
   leaseExpiresAtMs = nowMs + 60_000;
@@ -87,6 +91,7 @@ class FakeTransport implements RemoteWorkerTransportV1 {
   streamCloseFailures = 0;
   streamCloseNeverSettles = false;
   createFailures = 0;
+  createGate?: Promise<void>;
   advertiseExclusiveBinaryCreate = false;
   advertiseMultiSandboxRoots = false;
   negotiatedCapabilitiesOverride?: unknown;
@@ -127,6 +132,7 @@ class FakeTransport implements RemoteWorkerTransportV1 {
       };
     }
     if (input.path === "/internal/v1/sandboxes") {
+      await this.createGate;
       if (this.rawCreateError) throw this.rawCreateError;
       if (this.createFailures > 0) {
         this.createFailures -= 1;
@@ -179,6 +185,12 @@ class FakeTransport implements RemoteWorkerTransportV1 {
       return { leaseExpiresAtMs: this.renewLeaseExpiresAtMs };
     }
     if (input.method === "DELETE") {
+      if (this.deleteNotFound) {
+        throw new SandboxProviderError(
+          REMOTE_WORKER_ERROR_CODES_V1.sandboxNotFound,
+          'fake already absent',
+        );
+      }
       if (this.deleteFailures > 0) {
         this.deleteFailures -= 1;
         throw new SandboxProviderError(
@@ -258,8 +270,51 @@ describe("remote-worker SandboxProviderV1 placement binding", () => {
       workspaceRoot: '/unused', workspaceId: 'workspace-a',
       sessionId: 'session-a', requestId: 'request-a',
     });
-    await pair.dispose();
-    await provider.close?.();
+    await expectPublishedPairLifecycle({
+      provider,
+      pair,
+      assertUsableAfterProviderClose: async () => {
+        await expect(pair.workspace.readFile('hello.txt')).resolves.toBe('tenant-file');
+      },
+      assertTerminalCleanup: async () => {
+        expect(transport.requests.filter((request) => request.method === 'DELETE')).toHaveLength(1);
+      },
+    });
+  });
+
+  test('disposable deletion treats an already-absent remote as terminal success', async () => {
+    const transport = new FakeTransport();
+    transport.advertiseMultiSandboxRoots = true;
+    const provider = createRemoteWorkerSandboxProviderV1({
+      ...providerOptions(transport, [], true), leaseMode: 'disposable',
+    });
+    const pair = await provider.create({
+      workspaceRoot: '/unused', workspaceId: 'workspace-a',
+      sessionId: 'session-absent', requestId: 'request-absent',
+    });
+    transport.deleteNotFound = true;
+    await expect(pair.dispose()).resolves.toBeUndefined();
+  });
+
+  test('provider close drains an in-flight disposable create without publishing or leaking', async () => {
+    const transport = new FakeTransport();
+    transport.advertiseMultiSandboxRoots = true;
+    let release!: () => void;
+    transport.createGate = new Promise<void>((resolve) => { release = resolve; });
+    const provider = createRemoteWorkerSandboxProviderV1({
+      ...providerOptions(transport, [], true), leaseMode: 'disposable',
+    });
+    const creation = provider.create({
+      workspaceRoot: '/unused', workspaceId: 'workspace-a',
+      sessionId: 'session-race', requestId: 'request-race',
+    });
+    await vi.waitFor(() => {
+      expect(transport.requests.some((request) => request.path === '/internal/v1/sandboxes')).toBe(true);
+    });
+    const closing = provider.close!();
+    release();
+    await expect(creation).rejects.toMatchObject({ code: REMOTE_WORKER_ERROR_CODES_V1.unavailable });
+    await expect(closing).resolves.toBeUndefined();
     expect(transport.requests.filter((request) => request.method === 'DELETE')).toHaveLength(1);
   });
 

--- a/packages/boring-sandbox/src/providers/remote-worker/__tests__/createRemoteWorkerProvider.test.ts
+++ b/packages/boring-sandbox/src/providers/remote-worker/__tests__/createRemoteWorkerProvider.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../../../shared/remoteWorkerProtocolV1";
 import { PROVIDER_CONTRACT_VERSION } from "../../../shared/providerMatrix";
 import { SandboxProviderError } from "../../../shared/providerV1";
+import { expectDisposableProviderProfile } from "../../__tests__/conformance/disposableProvider";
 import { createStaticSandboxProvidersV1 } from "../../static";
 import {
   createRemoteWorkerSandboxProviderV1,
@@ -240,6 +241,28 @@ function providerOptions(
 }
 
 describe("remote-worker SandboxProviderV1 placement binding", () => {
+  test("requires qualified multi-root placement for disposable mode", async () => {
+    const unavailable = new FakeTransport();
+    expect(() => createRemoteWorkerSandboxProviderV1({
+      ...providerOptions(unavailable), leaseMode: 'disposable',
+    })).toThrow('requires the qualified multi-sandbox root capability');
+    expect(unavailable.requests).toHaveLength(0);
+
+    const transport = new FakeTransport();
+    transport.advertiseMultiSandboxRoots = true;
+    const provider = createRemoteWorkerSandboxProviderV1({
+      ...providerOptions(transport, [], true), leaseMode: 'disposable',
+    });
+    expectDisposableProviderProfile(provider, 'remote-worker');
+    const pair = await provider.create({
+      workspaceRoot: '/unused', workspaceId: 'workspace-a',
+      sessionId: 'session-a', requestId: 'request-a',
+    });
+    await pair.dispose();
+    await provider.close?.();
+    expect(transport.requests.filter((request) => request.method === 'DELETE')).toHaveLength(1);
+  });
+
   test("acquires one receipt-bound pair and performs lifecycle operations", async () => {
     const transport = new FakeTransport();
     const claims: RemoteWorkerCapabilityClaimsV1[] = [];

--- a/packages/boring-sandbox/src/providers/remote-worker/createRemoteWorkerProvider.ts
+++ b/packages/boring-sandbox/src/providers/remote-worker/createRemoteWorkerProvider.ts
@@ -18,12 +18,12 @@ import {
   type RemoteWorkerCreateResponseV1,
 } from "../../shared/remoteWorkerProtocolV1";
 import {
-  DISPOSABLE_SANDBOX_PROVIDER_PROFILE_V1,
   SandboxProviderError,
   type DisposableSandboxProviderV1,
   type SandboxProviderV1,
   type WorkspaceSandboxPairV1,
 } from "../../shared/providerV1";
+import { registerDisposableSandboxProviderV1 } from '../disposableProviderRegistration';
 import {
   parseRemoteWorkerFleetConfigV1,
   remoteWorkerFleetConfigDigestV1,
@@ -244,19 +244,11 @@ export function createRemoteWorkerSandboxProviderV1(
   };
   let closed = false;
 
-  return {
+  const provider: RemoteWorkerSandboxProviderV1 = {
     contractVersion: PROVIDER_CONTRACT_VERSION,
     providerId: "remote-worker",
     providerConfigDigest,
     capabilities: PROVIDER_CAPABILITIES["remote-worker"],
-    ...(options.leaseMode === 'disposable' ? {
-      disposableProfile: {
-        contractVersion: DISPOSABLE_SANDBOX_PROVIDER_PROFILE_V1,
-        resume: false as const,
-        publishedCleanupOwner: 'returned-pair' as const,
-        ambiguousCreate: 'correlated-reconciliation' as const,
-      },
-    } : {}),
     resolveRuntimeRoot() {
       return REMOTE_WORKER_RUNTIME_CWD;
     },
@@ -430,6 +422,12 @@ export function createRemoteWorkerSandboxProviderV1(
             "remote-worker create binding receipt is invalid",
           );
         }
+        if (closed) {
+          throw new SandboxProviderError(
+            REMOTE_WORKER_ERROR_CODES_V1.unavailable,
+            "remote-worker provider closed during create",
+          );
+        }
 
         let leaseExpiresAtMs = createResponse.leaseExpiresAtMs;
         const leaseClient = client.bind(createResponse.sandboxId);
@@ -562,4 +560,7 @@ export function createRemoteWorkerSandboxProviderV1(
       }
     },
   };
+  return options.leaseMode === 'disposable'
+    ? registerDisposableSandboxProviderV1(provider, providerConfigDigest)
+    : provider;
 }

--- a/packages/boring-sandbox/src/providers/remote-worker/createRemoteWorkerProvider.ts
+++ b/packages/boring-sandbox/src/providers/remote-worker/createRemoteWorkerProvider.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 
 import {
   PROVIDER_CAPABILITIES,
@@ -23,10 +23,12 @@ import {
   type SandboxProviderV1,
   type WorkspaceSandboxPairV1,
 } from "../../shared/providerV1";
-import { registerDisposableSandboxProviderV1 } from '../disposableProviderRegistration';
+import {
+  disposableProviderConfigDigestV1,
+  registerDisposableSandboxProviderV1,
+} from '../disposableProviderRegistration';
 import {
   parseRemoteWorkerFleetConfigV1,
-  remoteWorkerFleetConfigDigestV1,
   resolveRemoteWorkerPlacementV1,
   type RemoteWorkerFleetConfigV1,
   type RemoteWorkerFleetWorkerConfigV1,
@@ -167,7 +169,6 @@ export function createRemoteWorkerSandboxProviderV1(
   const fleet = parseRemoteWorkerFleetConfigV1(options.fleet, {
     allowInsecureLoopback: options.allowInsecureLoopback,
   });
-  const providerConfigDigest = remoteWorkerFleetConfigDigestV1(fleet);
   if (options.leaseMode === 'disposable' && fleet.workers.some((worker) =>
     !(worker.requiredCapabilities ?? []).includes(REMOTE_WORKER_MULTI_SANDBOX_ROOTS_CAPABILITY_V1))) {
     throw new SandboxProviderError(
@@ -218,6 +219,22 @@ export function createRemoteWorkerSandboxProviderV1(
     DEFAULT_DISPOSE_ATTEMPTS,
     "disposeAttempts",
   );
+  const providerConfigDigest = disposableProviderConfigDigestV1('remote-worker', {
+    fleet,
+    leaseMode: options.leaseMode ?? null,
+    requestTimeoutMs,
+    execTimeoutMs,
+    idleTimeoutMs,
+    maxOutputBytes,
+    capabilityLifetimeMs,
+    eventStreamLifetimeMs,
+    qualificationMaxAgeMs,
+    disposeAttempts,
+    allowInsecureLoopback: options.allowInsecureLoopback === true,
+    transport: 'host-transport-v1',
+    capabilityIssuer: 'host-issuer-v1',
+    bindingReceiptVerifier: 'host-verifier-v1',
+  });
   if (
     capabilityLifetimeMs > REMOTE_WORKER_MAX_CAPABILITY_LIFETIME_MS ||
     eventStreamLifetimeMs > REMOTE_WORKER_MAX_CAPABILITY_LIFETIME_MS
@@ -299,6 +316,11 @@ export function createRemoteWorkerSandboxProviderV1(
           requiredCapabilities: worker.requiredCapabilities,
         });
 
+        const correlation = context.requestId ?? `${workspaceId}:${sessionId}`;
+        const clientLeaseId = `lease-${createHash('sha256')
+          .update(`${providerConfigDigest}:${correlation}`)
+          .digest('hex')
+          .slice(0, 48)}`;
         const request = parseRemoteWorkerRequestV1(
           RemoteWorkerCreateRequestSchemaV1,
           {
@@ -306,7 +328,7 @@ export function createRemoteWorkerSandboxProviderV1(
             providerContractVersion: PROVIDER_CONTRACT_VERSION,
             workspaceId,
             sessionId,
-            clientLeaseId: idFactory(),
+            clientLeaseId,
             idleTimeoutMs,
             maxOutputBytes,
             expectedEvidenceDigest: worker.expectedEvidenceDigest,

--- a/packages/boring-sandbox/src/providers/remote-worker/createRemoteWorkerProvider.ts
+++ b/packages/boring-sandbox/src/providers/remote-worker/createRemoteWorkerProvider.ts
@@ -247,6 +247,7 @@ export function createRemoteWorkerSandboxProviderV1(
   }
 
   const ownedCleanups = new Map<string, Set<() => Promise<void>>>();
+  const ownedClientLeaseIds = new Set<string>();
   const pendingCreates = new Set<Promise<void>>();
   const registerCleanup = (
     workspaceId: string,
@@ -278,6 +279,7 @@ export function createRemoteWorkerSandboxProviderV1(
       pendingCreates.add(pendingCreate);
       let unpublishedCleanup: (() => Promise<void>) | undefined;
       let unregisterUnpublished: (() => void) | undefined;
+      let releaseClientLeaseId = (): void => {};
       try {
         if (closed) {
           throw new SandboxProviderError(
@@ -322,6 +324,12 @@ export function createRemoteWorkerSandboxProviderV1(
           .update(`${providerConfigDigest}:${correlation}`)
           .digest('hex')
           .slice(0, 48)}`;
+        if (ownedClientLeaseIds.has(clientLeaseId)) {
+          void client.close().catch(() => undefined);
+          throw new SandboxProviderError(REMOTE_WORKER_ERROR_CODES_V1.configInvalid, "remote-worker create identity is already owned");
+        }
+        ownedClientLeaseIds.add(clientLeaseId);
+        releaseClientLeaseId = () => { ownedClientLeaseIds.delete(clientLeaseId); };
         const request = parseRemoteWorkerRequestV1(
           RemoteWorkerCreateRequestSchemaV1,
           {
@@ -388,6 +396,7 @@ export function createRemoteWorkerSandboxProviderV1(
             }
             provisionalDeleteConfirmed = true;
             unregisterUnpublished?.();
+            releaseClientLeaseId();
             void client.close().catch(() => undefined);
           })();
           provisionalDeleteInFlight = operation;
@@ -498,6 +507,7 @@ export function createRemoteWorkerSandboxProviderV1(
             void leaseClient.close().catch(() => undefined);
             disposed = true;
             unregisterPair();
+            releaseClientLeaseId();
           })();
           disposeInFlight = operation;
           try {
@@ -556,7 +566,7 @@ export function createRemoteWorkerSandboxProviderV1(
             );
             throw attachSandboxProviderCleanupDebt(normalized, unpublishedCleanup);
           }
-        }
+        } else releaseClientLeaseId();
         throw error;
       } finally {
         finishCreate();

--- a/packages/boring-sandbox/src/providers/remote-worker/createRemoteWorkerProvider.ts
+++ b/packages/boring-sandbox/src/providers/remote-worker/createRemoteWorkerProvider.ts
@@ -7,6 +7,7 @@ import {
 import {
   REMOTE_WORKER_ERROR_CODES_V1,
   REMOTE_WORKER_EXCLUSIVE_BINARY_CREATE_CAPABILITY_V1,
+  REMOTE_WORKER_MULTI_SANDBOX_ROOTS_CAPABILITY_V1,
   REMOTE_WORKER_MAX_CAPABILITY_LIFETIME_MS,
   REMOTE_WORKER_PROTOCOL_VERSION,
   REMOTE_WORKER_RUNTIME_CWD,
@@ -14,9 +15,12 @@ import {
   RemoteWorkerOpaqueIdSchemaV1,
   type RemoteWorkerBindingReceiptV1,
   type RemoteWorkerCreateRequestV1,
+  type RemoteWorkerCreateResponseV1,
 } from "../../shared/remoteWorkerProtocolV1";
 import {
+  DISPOSABLE_SANDBOX_PROVIDER_PROFILE_V1,
   SandboxProviderError,
+  type DisposableSandboxProviderV1,
   type SandboxProviderV1,
   type WorkspaceSandboxPairV1,
 } from "../../shared/providerV1";
@@ -75,6 +79,7 @@ export interface RemoteWorkerSandboxProviderV1 extends SandboxProviderV1 {
 }
 
 export interface RemoteWorkerSandboxProviderOptionsV1 {
+  leaseMode?: 'disposable';
   fleet: RemoteWorkerFleetConfigV1;
   capabilityIssuer: RemoteWorkerCapabilityIssuerV1;
   bindingReceiptVerifier: RemoteWorkerBindingReceiptVerifierV1;
@@ -151,12 +156,25 @@ async function deleteRemoteSandboxV1(
 }
 
 export function createRemoteWorkerSandboxProviderV1(
+  options: RemoteWorkerSandboxProviderOptionsV1 & { leaseMode: 'disposable' },
+): RemoteWorkerSandboxProviderV1 & DisposableSandboxProviderV1
+export function createRemoteWorkerSandboxProviderV1(
+  options: RemoteWorkerSandboxProviderOptionsV1,
+): RemoteWorkerSandboxProviderV1
+export function createRemoteWorkerSandboxProviderV1(
   options: RemoteWorkerSandboxProviderOptionsV1,
 ): RemoteWorkerSandboxProviderV1 {
   const fleet = parseRemoteWorkerFleetConfigV1(options.fleet, {
     allowInsecureLoopback: options.allowInsecureLoopback,
   });
   const providerConfigDigest = remoteWorkerFleetConfigDigestV1(fleet);
+  if (options.leaseMode === 'disposable' && fleet.workers.some((worker) =>
+    !(worker.requiredCapabilities ?? []).includes(REMOTE_WORKER_MULTI_SANDBOX_ROOTS_CAPABILITY_V1))) {
+    throw new SandboxProviderError(
+      REMOTE_WORKER_ERROR_CODES_V1.configInvalid,
+      'disposable remote-worker requires the qualified multi-sandbox root capability',
+    );
+  }
   const transport = options.transport;
   const now = options.now ?? Date.now;
   const idFactory = options.idFactory ?? randomUUID;
@@ -231,6 +249,14 @@ export function createRemoteWorkerSandboxProviderV1(
     providerId: "remote-worker",
     providerConfigDigest,
     capabilities: PROVIDER_CAPABILITIES["remote-worker"],
+    ...(options.leaseMode === 'disposable' ? {
+      disposableProfile: {
+        contractVersion: DISPOSABLE_SANDBOX_PROVIDER_PROFILE_V1,
+        resume: false as const,
+        publishedCleanupOwner: 'returned-pair' as const,
+        ambiguousCreate: 'correlated-reconciliation' as const,
+      },
+    } : {}),
     resolveRuntimeRoot() {
       return REMOTE_WORKER_RUNTIME_CWD;
     },
@@ -327,15 +353,16 @@ export function createRemoteWorkerSandboxProviderV1(
         }
 
         const requestDigest = remoteWorkerRequestDigestV1(request);
-        const createResponse = await client.create(request);
+        let createResponse: RemoteWorkerCreateResponseV1 | undefined;
         let provisionalDeleteConfirmed = false;
         let provisionalDeleteInFlight: Promise<void> | undefined;
         unpublishedCleanup = async (): Promise<void> => {
           if (provisionalDeleteConfirmed) return;
           if (provisionalDeleteInFlight) return await provisionalDeleteInFlight;
           const operation = (async () => {
+            createResponse ??= await client.create(request);
             const error = await deleteRemoteSandboxV1(
-              () => client.provisionalDelete(createResponse.sandboxId),
+              () => client.provisionalDelete(createResponse!.sandboxId),
               disposeAttempts,
             );
             if (error !== undefined) {
@@ -356,7 +383,27 @@ export function createRemoteWorkerSandboxProviderV1(
               provisionalDeleteInFlight = undefined;
           }
         };
-        unregisterUnpublished = registerCleanup(workspaceId, unpublishedCleanup);
+        if (options.leaseMode === 'disposable') {
+          unregisterUnpublished = registerCleanup(workspaceId, unpublishedCleanup);
+        }
+        try {
+          createResponse = await client.create(request);
+        } catch (error) {
+          const ambiguous = error instanceof SandboxProviderError && [
+            REMOTE_WORKER_ERROR_CODES_V1.timeout,
+            REMOTE_WORKER_ERROR_CODES_V1.unavailable,
+            REMOTE_WORKER_ERROR_CODES_V1.incompleteCleanup,
+          ].includes(error.code as never);
+          if (!ambiguous) {
+            unregisterUnpublished?.();
+            unpublishedCleanup = undefined;
+            void client.close().catch(() => undefined);
+          }
+          throw error;
+        }
+        if (options.leaseMode !== 'disposable') {
+          unregisterUnpublished = registerCleanup(workspaceId, unpublishedCleanup);
+        }
         let receiptIsValid = false;
         try {
           receiptIsValid =
@@ -437,8 +484,10 @@ export function createRemoteWorkerSandboxProviderV1(
           }
         };
 
-        unregisterUnpublished();
-        unregisterPair = registerCleanup(workspaceId, dispose);
+        unregisterUnpublished?.();
+        if (options.leaseMode !== 'disposable') {
+          unregisterPair = registerCleanup(workspaceId, dispose);
+        }
         unpublishedCleanup = undefined;
 
         return {

--- a/packages/boring-sandbox/src/providers/remote-worker/createRemoteWorkerProvider.ts
+++ b/packages/boring-sandbox/src/providers/remote-worker/createRemoteWorkerProvider.ts
@@ -18,6 +18,7 @@ import {
   type RemoteWorkerCreateResponseV1,
 } from "../../shared/remoteWorkerProtocolV1";
 import {
+  attachSandboxProviderCleanupDebt,
   SandboxProviderError,
   type DisposableSandboxProviderV1,
   type SandboxProviderV1,
@@ -407,6 +408,8 @@ export function createRemoteWorkerSandboxProviderV1(
             REMOTE_WORKER_ERROR_CODES_V1.timeout,
             REMOTE_WORKER_ERROR_CODES_V1.unavailable,
             REMOTE_WORKER_ERROR_CODES_V1.incompleteCleanup,
+            REMOTE_WORKER_ERROR_CODES_V1.protocolMismatch,
+            REMOTE_WORKER_ERROR_CODES_V1.responseInvalid,
           ].includes(error.code as never);
           if (!ambiguous) {
             unregisterUnpublished?.();
@@ -546,7 +549,13 @@ export function createRemoteWorkerSandboxProviderV1(
         };
       } catch (error) {
         if (unpublishedCleanup) {
-          await unpublishedCleanup().catch(() => undefined);
+          try { await unpublishedCleanup(); }
+          catch {
+            const normalized = error instanceof Error ? error : new SandboxProviderError(
+              REMOTE_WORKER_ERROR_CODES_V1.unavailable, "remote-worker create outcome is unknown",
+            );
+            throw attachSandboxProviderCleanupDebt(normalized, unpublishedCleanup);
+          }
         }
         throw error;
       } finally {

--- a/packages/boring-sandbox/src/providers/remote-worker/createRemoteWorkerProvider.ts
+++ b/packages/boring-sandbox/src/providers/remote-worker/createRemoteWorkerProvider.ts
@@ -376,16 +376,31 @@ export function createRemoteWorkerSandboxProviderV1(
         }
 
         const requestDigest = remoteWorkerRequestDigestV1(request);
-        let createResponse: RemoteWorkerCreateResponseV1 | undefined;
+        let verifiedCreateResponse: RemoteWorkerCreateResponseV1 | undefined;
+        const verifyCreateResponse = async (response: RemoteWorkerCreateResponseV1) => {
+          try {
+            if (response.workerId === worker.workerId && receiptMatchesCreate({
+              receipt: response.bindingReceipt, request, requestDigest,
+              workerId: worker.workerId, sandboxId: response.sandboxId,
+              leaseExpiresAtMs: response.leaseExpiresAtMs, nowMs: now(),
+            }) && await options.bindingReceiptVerifier.verifyBindingReceipt({
+              worker, receipt: response.bindingReceipt,
+            })) return response;
+          } catch { /* projected to the stable binding error below */ }
+          throw new SandboxProviderError(
+            REMOTE_WORKER_ERROR_CODES_V1.bindingReceiptInvalid,
+            "remote-worker create binding receipt is invalid",
+          );
+        };
         let provisionalDeleteConfirmed = false;
         let provisionalDeleteInFlight: Promise<void> | undefined;
         unpublishedCleanup = async (): Promise<void> => {
           if (provisionalDeleteConfirmed) return;
           if (provisionalDeleteInFlight) return await provisionalDeleteInFlight;
           const operation = (async () => {
-            createResponse ??= await client.create(request);
+            verifiedCreateResponse ??= await verifyCreateResponse(await client.create(request));
             const error = await deleteRemoteSandboxV1(
-              () => client.provisionalDelete(createResponse!.sandboxId),
+              () => client.provisionalDelete(verifiedCreateResponse!.sandboxId),
               disposeAttempts,
             );
             if (error !== undefined) {
@@ -407,11 +422,9 @@ export function createRemoteWorkerSandboxProviderV1(
               provisionalDeleteInFlight = undefined;
           }
         };
-        if (options.leaseMode === 'disposable') {
-          unregisterUnpublished = registerCleanup(workspaceId, unpublishedCleanup);
-        }
+        unregisterUnpublished = registerCleanup(workspaceId, unpublishedCleanup);
         try {
-          createResponse = await client.create(request);
+          verifiedCreateResponse = await verifyCreateResponse(await client.create(request));
         } catch (error) {
           const ambiguous = error instanceof SandboxProviderError && [
             REMOTE_WORKER_ERROR_CODES_V1.timeout,
@@ -419,6 +432,7 @@ export function createRemoteWorkerSandboxProviderV1(
             REMOTE_WORKER_ERROR_CODES_V1.incompleteCleanup,
             REMOTE_WORKER_ERROR_CODES_V1.protocolMismatch,
             REMOTE_WORKER_ERROR_CODES_V1.responseInvalid,
+            REMOTE_WORKER_ERROR_CODES_V1.bindingReceiptInvalid,
           ].includes(error.code as never);
           if (!ambiguous) {
             unregisterUnpublished?.();
@@ -427,35 +441,6 @@ export function createRemoteWorkerSandboxProviderV1(
           }
           throw error;
         }
-        if (options.leaseMode !== 'disposable') {
-          unregisterUnpublished = registerCleanup(workspaceId, unpublishedCleanup);
-        }
-        let receiptIsValid = false;
-        try {
-          receiptIsValid =
-            createResponse.workerId === worker.workerId &&
-            receiptMatchesCreate({
-              receipt: createResponse.bindingReceipt,
-              request,
-              requestDigest,
-              workerId: worker.workerId,
-              sandboxId: createResponse.sandboxId,
-              leaseExpiresAtMs: createResponse.leaseExpiresAtMs,
-              nowMs: now(),
-            }) &&
-            (await options.bindingReceiptVerifier.verifyBindingReceipt({
-              worker,
-              receipt: createResponse.bindingReceipt,
-            }));
-        } catch {
-          receiptIsValid = false;
-        }
-        if (!receiptIsValid) {
-          throw new SandboxProviderError(
-            REMOTE_WORKER_ERROR_CODES_V1.bindingReceiptInvalid,
-            "remote-worker create binding receipt is invalid",
-          );
-        }
         if (closed) {
           throw new SandboxProviderError(
             REMOTE_WORKER_ERROR_CODES_V1.unavailable,
@@ -463,8 +448,8 @@ export function createRemoteWorkerSandboxProviderV1(
           );
         }
 
-        let leaseExpiresAtMs = createResponse.leaseExpiresAtMs;
-        const leaseClient = client.bind(createResponse.sandboxId);
+        let leaseExpiresAtMs = verifiedCreateResponse.leaseExpiresAtMs;
+        const leaseClient = client.bind(verifiedCreateResponse.sandboxId);
         const remoteWorkspace = createRemoteWorkspaceV1({
           client: leaseClient,
           leaseExpiresAtMs: () => leaseExpiresAtMs,

--- a/packages/boring-sandbox/src/providers/remote-worker/pairProxies.ts
+++ b/packages/boring-sandbox/src/providers/remote-worker/pairProxies.ts
@@ -322,7 +322,17 @@ export function createRemoteSandboxV1(options: {
         },
         "exec request",
       );
-      const response = await options.client.exec(body, execOptions.signal);
+      const startedAt = Date.now();
+      const heartbeat = execOptions.onHeartbeat
+        ? setInterval(() => execOptions.onHeartbeat?.(Date.now() - startedAt), 1_000)
+        : undefined;
+      heartbeat?.unref?.();
+      let response;
+      try {
+        response = await options.client.exec(body, execOptions.signal);
+      } finally {
+        if (heartbeat) clearInterval(heartbeat);
+      }
       const stdout = new Uint8Array(
         Buffer.from(response.stdoutBase64, "base64"),
       );

--- a/packages/boring-sandbox/src/providers/vercel-sandbox/__tests__/createVercelSandboxProvider.test.ts
+++ b/packages/boring-sandbox/src/providers/vercel-sandbox/__tests__/createVercelSandboxProvider.test.ts
@@ -164,13 +164,14 @@ describe('createVercelSandboxProvider', () => {
       create: vi.fn(async () => harness.sandbox),
       get: vi.fn(),
     }
+    const logger = { info: vi.fn(), warn: vi.fn() }
     const provider = createVercelSandboxProvider({
       store,
       vercelClient: client,
       lifecycle: 'disposable',
       getEnvVar,
       snapshotScheduler: scheduler,
-      logger: { info: vi.fn() },
+      logger,
     })
 
     expectDisposableProviderProfile(provider, 'vercel-sandbox')
@@ -182,6 +183,10 @@ describe('createVercelSandboxProvider', () => {
     expect(client.create).toHaveBeenCalledWith(expect.objectContaining({
       name: expect.stringMatching(/^boring-lease-[a-f0-9]{40}$/),
     }))
+    const logged = JSON.stringify(logger.info.mock.calls)
+    expect(logged).not.toContain('workspace-setup-failure')
+    expect(logged).not.toContain('session-setup-failure')
+    expect(logged).not.toContain('sb-setup-failure')
     await expect(pair.checkHealth?.()).rejects.toMatchObject({
       code: 'VERCEL_API_ERROR',
       message: 'workspace root setup failed',

--- a/packages/boring-sandbox/src/providers/vercel-sandbox/__tests__/createVercelSandboxProvider.test.ts
+++ b/packages/boring-sandbox/src/providers/vercel-sandbox/__tests__/createVercelSandboxProvider.test.ts
@@ -291,10 +291,11 @@ describe('createVercelSandboxProvider', () => {
         get: vi.fn(async () => { throw Object.assign(new Error('not found'), { status: 404 }) }),
       }
       const provider = createVercelSandboxProvider({ vercelClient: client, lifecycle: 'disposable', getEnvVar })
-      await expect(provider.create({
+      const failure = await provider.create({
         workspaceRoot: 'workspace-ambiguous', workspaceId: 'workspace-ambiguous',
         sessionId: `session-${status}`, requestId: `request-${status}`,
-      })).rejects.toBeTruthy()
+      }).catch((caught: unknown) => caught) as { sandboxProviderCleanupDebt?: { retry(): Promise<void> } }
+      expect(failure.sandboxProviderCleanupDebt?.retry).toBeTypeOf('function')
       await expect(provider.close!()).rejects.toBeTruthy()
     },
   )

--- a/packages/boring-sandbox/src/providers/vercel-sandbox/__tests__/createVercelSandboxProvider.test.ts
+++ b/packages/boring-sandbox/src/providers/vercel-sandbox/__tests__/createVercelSandboxProvider.test.ts
@@ -298,6 +298,31 @@ describe('createVercelSandboxProvider', () => {
     await provider.close?.()
   })
 
+  test('retains ambiguous create debt through 404 and deletes a late appearance on close retry', async () => {
+    const harness = await createMockVercelSandboxHarness()
+    cleanups.push(harness.cleanup)
+    const { deleteSandbox } = addDurableHandleMetadata(harness.sandbox, 'sb-late-response')
+    let appeared = false
+    const client: VercelSandboxClient = {
+      create: vi.fn(async () => { throw Object.assign(new Error('response lost'), { status: 503 }) }),
+      get: vi.fn(async (params) => {
+        if (!appeared) throw Object.assign(new Error('not found'), { status: 404 })
+        return Object.assign(harness.sandbox, { name: params.name })
+      }),
+    }
+    const provider = createVercelSandboxProvider({
+      vercelClient: client, lifecycle: 'disposable', getEnvVar, logger: { info: vi.fn() },
+    })
+    await expect(provider.create({
+      workspaceRoot: 'workspace-late', workspaceId: 'workspace-late',
+      sessionId: 'session-late', requestId: 'request-late',
+    })).rejects.toBeTruthy()
+    await expect(provider.close!()).rejects.toBeTruthy()
+    appeared = true
+    await expect(provider.close!()).resolves.toBeUndefined()
+    expect(deleteSandbox).toHaveBeenCalledOnce()
+  })
+
   test('retains cleanup authority when post-create adaptation fails and deletion needs retry', async () => {
     const harness = await createMockVercelSandboxHarness()
     cleanups.push(harness.cleanup)

--- a/packages/boring-sandbox/src/providers/vercel-sandbox/__tests__/createVercelSandboxProvider.test.ts
+++ b/packages/boring-sandbox/src/providers/vercel-sandbox/__tests__/createVercelSandboxProvider.test.ts
@@ -258,10 +258,17 @@ describe('createVercelSandboxProvider', () => {
       get: vi.fn(async () => Object.assign(unrelated.sandbox, { name: 'wrong-name' })),
     }
     const provider = createVercelSandboxProvider({ vercelClient: client, lifecycle: 'disposable', getEnvVar })
-    await expect(provider.create({
+    const failure = await provider.create({
       workspaceRoot: 'workspace-mismatch', workspaceId: 'workspace-mismatch',
       sessionId: 'session-mismatch', requestId: 'request-mismatch',
-    })).rejects.toMatchObject({ code: 'CONFIG_INVALID' })
+    }).catch((caught: unknown) => caught) as Error & {
+      sandboxProviderCleanupDebt: { retry(): Promise<void> }
+    }
+    expect(failure).toMatchObject({ code: 'CONFIG_INVALID' })
+    expect(failure.sandboxProviderCleanupDebt.retry).toBeTypeOf('function')
+    expect(returnedDelete).toHaveBeenCalledOnce()
+    expect(unrelatedDelete).not.toHaveBeenCalled()
+    await expect(failure.sandboxProviderCleanupDebt.retry()).rejects.toMatchObject({ code: 'CONFIG_INVALID' })
     expect(returnedDelete).toHaveBeenCalledOnce()
     expect(unrelatedDelete).not.toHaveBeenCalled()
     await expect(provider.close!()).rejects.toBeTruthy()

--- a/packages/boring-sandbox/src/providers/vercel-sandbox/__tests__/createVercelSandboxProvider.test.ts
+++ b/packages/boring-sandbox/src/providers/vercel-sandbox/__tests__/createVercelSandboxProvider.test.ts
@@ -247,26 +247,76 @@ describe('createVercelSandboxProvider', () => {
       .not.toBe(second.disposableProfile.providerConfigDigest)
   })
 
-  test('rejects a mismatched correlation response without deleting it', async () => {
-    const harness = await createMockVercelSandboxHarness()
-    cleanups.push(harness.cleanup)
-    const { deleteSandbox } = addDurableHandleMetadata(harness.sandbox, 'sb-mismatch')
+  test('cleans the exact returned object but retains mismatched correlation debt', async () => {
+    const returned = await createMockVercelSandboxHarness()
+    const unrelated = await createMockVercelSandboxHarness()
+    cleanups.push(returned.cleanup, unrelated.cleanup)
+    const returnedDelete = addDurableHandleMetadata(returned.sandbox, 'sb-returned').deleteSandbox
+    const unrelatedDelete = addDurableHandleMetadata(unrelated.sandbox, 'sb-unrelated').deleteSandbox
     const client: VercelSandboxClient = {
-      create: vi.fn(async () => Object.assign(harness.sandbox, { name: 'wrong-name' })),
-      get: vi.fn(async () => Object.assign(harness.sandbox, { name: 'wrong-name' })),
+      create: vi.fn(async (params) => Object.assign(returned.sandbox, { name: params?.name })),
+      get: vi.fn(async () => Object.assign(unrelated.sandbox, { name: 'wrong-name' })),
     }
-    const provider = createVercelSandboxProvider({
-      vercelClient: client,
-      lifecycle: 'disposable',
-      getEnvVar,
-    })
+    const provider = createVercelSandboxProvider({ vercelClient: client, lifecycle: 'disposable', getEnvVar })
     await expect(provider.create({
       workspaceRoot: 'workspace-mismatch', workspaceId: 'workspace-mismatch',
       sessionId: 'session-mismatch', requestId: 'request-mismatch',
     })).rejects.toMatchObject({ code: 'CONFIG_INVALID' })
-    expect(deleteSandbox).not.toHaveBeenCalled()
-    await provider.close?.()
-    expect(deleteSandbox).not.toHaveBeenCalled()
+    expect(returnedDelete).toHaveBeenCalledOnce()
+    expect(unrelatedDelete).not.toHaveBeenCalled()
+    await expect(provider.close!()).rejects.toBeTruthy()
+    expect(unrelatedDelete).not.toHaveBeenCalled()
+  })
+
+  test('a definitive create rejection has no reconciliation debt', async () => {
+    const client: VercelSandboxClient = {
+      create: vi.fn(async () => { throw Object.assign(new Error('invalid request'), { status: 422 }) }),
+      get: vi.fn(),
+    }
+    const provider = createVercelSandboxProvider({ vercelClient: client, lifecycle: 'disposable', getEnvVar })
+    await expect(provider.create({
+      workspaceRoot: 'workspace-rejected', workspaceId: 'workspace-rejected',
+      sessionId: 'session-rejected', requestId: 'request-rejected',
+    })).rejects.toBeTruthy()
+    await expect(provider.close!()).resolves.toBeUndefined()
+    expect(client.get).not.toHaveBeenCalled()
+  })
+
+  test.each([408, 409, 429, 503, undefined])(
+    'retains ambiguous create debt for status %s',
+    async (status) => {
+      const error = Object.assign(new Error('create outcome unknown'), status === undefined ? {} : { status })
+      const client: VercelSandboxClient = {
+        create: vi.fn(async () => { throw error }),
+        get: vi.fn(async () => { throw Object.assign(new Error('not found'), { status: 404 }) }),
+      }
+      const provider = createVercelSandboxProvider({ vercelClient: client, lifecycle: 'disposable', getEnvVar })
+      await expect(provider.create({
+        workspaceRoot: 'workspace-ambiguous', workspaceId: 'workspace-ambiguous',
+        sessionId: `session-${status}`, requestId: `request-${status}`,
+      })).rejects.toBeTruthy()
+      await expect(provider.close!()).rejects.toBeTruthy()
+    },
+  )
+
+  test('retains correlation reconciliation when post-create verification throws', async () => {
+    const harness = await createMockVercelSandboxHarness()
+    cleanups.push(harness.cleanup)
+    const { deleteSandbox } = addDurableHandleMetadata(harness.sandbox, 'sb-verification-error')
+    const client: VercelSandboxClient = {
+      create: vi.fn(async (params) => Object.assign(harness.sandbox, { name: params?.name })),
+      get: vi.fn()
+        .mockRejectedValueOnce(Object.assign(new Error('lookup unavailable'), { status: 503 }))
+        .mockRejectedValueOnce(Object.assign(new Error('not found'), { status: 404 })),
+    }
+    const provider = createVercelSandboxProvider({ vercelClient: client, lifecycle: 'disposable', getEnvVar })
+    await expect(provider.create({
+      workspaceRoot: 'workspace-verification', workspaceId: 'workspace-verification',
+      sessionId: 'session-verification', requestId: 'request-verification',
+    })).rejects.toBeTruthy()
+    expect(deleteSandbox).toHaveBeenCalledOnce()
+    await expect(provider.close!()).resolves.toBeUndefined()
+    expect(client.get).toHaveBeenCalledTimes(2)
   })
 
   test('reconciles a disposable create whose acknowledgement is lost', async () => {

--- a/packages/boring-sandbox/src/providers/vercel-sandbox/__tests__/createVercelSandboxProvider.test.ts
+++ b/packages/boring-sandbox/src/providers/vercel-sandbox/__tests__/createVercelSandboxProvider.test.ts
@@ -86,6 +86,16 @@ function createScheduler() {
   }
 }
 
+function correlatedDisposableClient(
+  sandbox: VercelSandbox,
+  createImpl?: VercelSandboxClient['create'],
+): VercelSandboxClient {
+  return {
+    create: vi.fn(createImpl ?? (async (params) => Object.assign(sandbox, { name: params?.name }))),
+    get: vi.fn(async (params) => Object.assign(sandbox, { name: params.name })),
+  }
+}
+
 function addDurableHandleMetadata(sandbox: VercelSandbox, sandboxId: string) {
   const stop = vi.fn(async () => {})
   const snapshot = vi.fn(async () => ({ snapshotId: 'unexpected-snapshot' }))
@@ -161,14 +171,11 @@ describe('createVercelSandboxProvider', () => {
     vi.spyOn((harness.sandbox as unknown as { fs: { mkdir(): Promise<void> } }).fs, 'mkdir')
       .mockRejectedValueOnce(Object.assign(
         new Error('workspace root setup failed'),
-        { code: 'ECONNRESET' },
+        { code: 'https://provider.invalid/sandbox/sb-secret' },
       ))
     const scheduler = createScheduler()
     const { store, deleteRecord } = createStore()
-    const client: VercelSandboxClient = {
-      create: vi.fn(async () => harness.sandbox),
-      get: vi.fn(),
-    }
+    const client = correlatedDisposableClient(harness.sandbox)
     const logger = { info: vi.fn(), warn: vi.fn() }
     const telemetry = { capture: vi.fn() }
     const provider = createVercelSandboxProvider({
@@ -205,6 +212,7 @@ describe('createVercelSandboxProvider', () => {
     for (const raw of [
       'workspace-setup-failure', 'session-setup-failure', 'request-setup-failure',
       'sb-setup-failure', 'token-1', 'team-1', 'project-1', 'test-host-telemetry-salt',
+      'https://provider.invalid/sandbox/sb-secret',
     ]) expect(logged).not.toContain(raw)
     expect(logged).toContain(
       createHmac('sha256', 'test-host-telemetry-salt').update('workspace-setup-failure').digest('hex'),
@@ -220,13 +228,54 @@ describe('createVercelSandboxProvider', () => {
     expect(deleteRecord).not.toHaveBeenCalled()
   })
 
+  test('derives configuration identity from immutable cache and runtime policy', () => {
+    const first = createVercelSandboxProvider({
+      lifecycle: 'disposable', getEnvVar,
+      immutableCacheSource: {
+        contractVersion: IMMUTABLE_SANDBOX_CACHE_SOURCE_VERSION_V1,
+        providerId: 'vercel-sandbox', opaqueRef: 'snap_a',
+      },
+    })
+    const second = createVercelSandboxProvider({
+      lifecycle: 'disposable', getEnvVar,
+      immutableCacheSource: {
+        contractVersion: IMMUTABLE_SANDBOX_CACHE_SOURCE_VERSION_V1,
+        providerId: 'vercel-sandbox', opaqueRef: 'snap_b',
+      },
+    })
+    expect(first.disposableProfile.providerConfigDigest)
+      .not.toBe(second.disposableProfile.providerConfigDigest)
+  })
+
+  test('rejects a mismatched correlation response without deleting it', async () => {
+    const harness = await createMockVercelSandboxHarness()
+    cleanups.push(harness.cleanup)
+    const { deleteSandbox } = addDurableHandleMetadata(harness.sandbox, 'sb-mismatch')
+    const client: VercelSandboxClient = {
+      create: vi.fn(async () => Object.assign(harness.sandbox, { name: 'wrong-name' })),
+      get: vi.fn(async () => Object.assign(harness.sandbox, { name: 'wrong-name' })),
+    }
+    const provider = createVercelSandboxProvider({
+      vercelClient: client,
+      lifecycle: 'disposable',
+      getEnvVar,
+    })
+    await expect(provider.create({
+      workspaceRoot: 'workspace-mismatch', workspaceId: 'workspace-mismatch',
+      sessionId: 'session-mismatch', requestId: 'request-mismatch',
+    })).rejects.toMatchObject({ code: 'CONFIG_INVALID' })
+    expect(deleteSandbox).not.toHaveBeenCalled()
+    await provider.close?.()
+    expect(deleteSandbox).not.toHaveBeenCalled()
+  })
+
   test('reconciles a disposable create whose acknowledgement is lost', async () => {
     const harness = await createMockVercelSandboxHarness()
     cleanups.push(harness.cleanup)
     const { deleteSandbox } = addDurableHandleMetadata(harness.sandbox, 'sb-response-loss')
     const client: VercelSandboxClient = {
       create: vi.fn(async () => { throw Object.assign(new Error('response lost'), { status: 503 }) }),
-      get: vi.fn(async () => harness.sandbox),
+      get: vi.fn(async (params) => Object.assign(harness.sandbox, { name: params.name })),
     }
     const provider = createVercelSandboxProvider({
       vercelClient: client,
@@ -255,10 +304,7 @@ describe('createVercelSandboxProvider', () => {
     const { deleteSandbox } = addDurableHandleMetadata(harness.sandbox, 'sb-post-create-failure')
     deleteSandbox.mockRejectedValueOnce(new Error('first delete acknowledgement lost'))
     const { store, deleteRecord } = createStore()
-    const client: VercelSandboxClient = {
-      create: vi.fn(async () => harness.sandbox),
-      get: vi.fn(),
-    }
+    const client = correlatedDisposableClient(harness.sandbox)
     const logger = {
       info: vi.fn()
         .mockImplementationOnce(() => {})
@@ -296,10 +342,7 @@ describe('createVercelSandboxProvider', () => {
     localSandboxInit.mockRejectedValueOnce(new Error('sandbox init failed'))
     localSandboxDispose.mockRejectedValueOnce(new Error('local dispose failed'))
     const { store, deleteRecord } = createStore()
-    const client: VercelSandboxClient = {
-      create: vi.fn(async () => harness.sandbox),
-      get: vi.fn(),
-    }
+    const client = correlatedDisposableClient(harness.sandbox)
     const logger = { info: vi.fn(), warn: vi.fn() }
     const provider = createVercelSandboxProvider({
       store,
@@ -336,10 +379,7 @@ describe('createVercelSandboxProvider', () => {
     const { stop, snapshot } = addDurableHandleMetadata(harness.sandbox, 'sb-durable')
     const scheduler = createScheduler()
     const { store, deleteRecord } = createStore()
-    const client: VercelSandboxClient = {
-      create: vi.fn(async () => harness.sandbox),
-      get: vi.fn(),
-    }
+    const client = correlatedDisposableClient(harness.sandbox)
     const provider = createVercelSandboxProvider({
       store,
       vercelClient: client,
@@ -376,10 +416,7 @@ describe('createVercelSandboxProvider', () => {
     cleanups.push(harness.cleanup)
     const { deleteSandbox } = addDurableHandleMetadata(harness.sandbox, 'sb-disposable')
     const { store, deleteRecord } = createStore()
-    const client: VercelSandboxClient = {
-      create: vi.fn(async () => harness.sandbox),
-      get: vi.fn(),
-    }
+    const client = correlatedDisposableClient(harness.sandbox)
     const provider = createVercelSandboxProvider({
       store,
       vercelClient: client,
@@ -414,7 +451,7 @@ describe('createVercelSandboxProvider', () => {
       persistent: true,
       source: { type: 'snapshot', snapshotId: 'snap_trusted_main' },
     }))
-    expect(client.get).not.toHaveBeenCalled()
+    expect(client.get).toHaveBeenCalledTimes(2)
     deleteSandbox.mockRejectedValueOnce(Object.assign(new Error('sandbox not found'), { status: 404 }))
     await expect(secondPair.dispose()).resolves.toBeUndefined()
     expect(deleteSandbox).toHaveBeenCalledTimes(3)
@@ -427,10 +464,10 @@ describe('createVercelSandboxProvider', () => {
     const { deleteSandbox } = addDurableHandleMetadata(harness.sandbox, 'sb-create-close-race')
     let release!: () => void
     const gate = new Promise<void>((resolve) => { release = resolve })
-    const client: VercelSandboxClient = {
-      create: vi.fn(async () => { await gate; return harness.sandbox }),
-      get: vi.fn(),
-    }
+    const client = correlatedDisposableClient(harness.sandbox, async (params) => {
+      await gate
+      return Object.assign(harness.sandbox, { name: params?.name })
+    })
     const provider = createVercelSandboxProvider({
       vercelClient: client, lifecycle: 'disposable', getEnvVar,
       logger: { info: vi.fn() },
@@ -450,10 +487,7 @@ describe('createVercelSandboxProvider', () => {
     const harness = await createMockVercelSandboxHarness()
     cleanups.push(harness.cleanup)
     const { deleteSandbox } = addDurableHandleMetadata(harness.sandbox, 'sb-duplicate-owner')
-    const client: VercelSandboxClient = {
-      create: vi.fn(async () => harness.sandbox),
-      get: vi.fn(),
-    }
+    const client = correlatedDisposableClient(harness.sandbox)
     const provider = createVercelSandboxProvider({
       vercelClient: client,
       lifecycle: 'disposable',
@@ -480,10 +514,7 @@ describe('createVercelSandboxProvider', () => {
     cleanups.push(harness.cleanup)
     const { deleteSandbox } = addDurableHandleMetadata(harness.sandbox, 'sb-published-owner')
     const { store } = createStore()
-    const client: VercelSandboxClient = {
-      create: vi.fn(async () => harness.sandbox),
-      get: vi.fn(),
-    }
+    const client = correlatedDisposableClient(harness.sandbox)
     const provider = createVercelSandboxProvider({
       store,
       vercelClient: client,
@@ -564,10 +595,7 @@ describe('createVercelSandboxProvider', () => {
 
     const scheduler = createScheduler()
     const { store } = createStore()
-    const client: VercelSandboxClient = {
-      create: vi.fn(async () => harness.sandbox),
-      get: vi.fn(),
-    }
+    const client = correlatedDisposableClient(harness.sandbox)
     const provider = createVercelSandboxProvider({
       store,
       vercelClient: client,

--- a/packages/boring-sandbox/src/providers/vercel-sandbox/__tests__/createVercelSandboxProvider.test.ts
+++ b/packages/boring-sandbox/src/providers/vercel-sandbox/__tests__/createVercelSandboxProvider.test.ts
@@ -275,6 +275,36 @@ describe('createVercelSandboxProvider', () => {
     expect(unrelatedDelete).not.toHaveBeenCalled()
   })
 
+  test.each(['create', 'get'] as const)(
+    'rejects a missing correlation name from %s without deleting the unverified lookup handle',
+    async (phase) => {
+      const returned = await createMockVercelSandboxHarness()
+      const lookup = await createMockVercelSandboxHarness()
+      cleanups.push(returned.cleanup, lookup.cleanup)
+      const returnedDelete = addDurableHandleMetadata(returned.sandbox, 'sb-returned-missing-name').deleteSandbox
+      const lookupDelete = addDurableHandleMetadata(lookup.sandbox, 'sb-lookup-missing-name').deleteSandbox
+      const client: VercelSandboxClient = {
+        create: vi.fn(async (params) => Object.assign(returned.sandbox, {
+          name: phase === 'create' ? undefined : params?.name,
+        })),
+        get: vi.fn(async () => Object.assign(lookup.sandbox, { name: undefined })),
+      }
+      const provider = createVercelSandboxProvider({ vercelClient: client, lifecycle: 'disposable', getEnvVar })
+      const failure = await provider.create({
+        workspaceRoot: `workspace-missing-${phase}`, workspaceId: `workspace-missing-${phase}`,
+        sessionId: `session-missing-${phase}`, requestId: `request-missing-${phase}`,
+      }).catch((caught: unknown) => caught) as Error & {
+        sandboxProviderCleanupDebt: { retry(): Promise<void> }
+      }
+      expect(failure).toMatchObject({ code: 'CONFIG_INVALID' })
+      expect(failure.sandboxProviderCleanupDebt.retry).toBeTypeOf('function')
+      expect(returnedDelete).toHaveBeenCalledOnce()
+      expect(lookupDelete).not.toHaveBeenCalled()
+      await expect(failure.sandboxProviderCleanupDebt.retry()).rejects.toMatchObject({ code: 'CONFIG_INVALID' })
+      expect(lookupDelete).not.toHaveBeenCalled()
+    },
+  )
+
   test('a definitive create rejection has no reconciliation debt', async () => {
     const client: VercelSandboxClient = {
       create: vi.fn(async () => { throw Object.assign(new Error('invalid request'), { status: 422 }) }),

--- a/packages/boring-sandbox/src/providers/vercel-sandbox/__tests__/createVercelSandboxProvider.test.ts
+++ b/packages/boring-sandbox/src/providers/vercel-sandbox/__tests__/createVercelSandboxProvider.test.ts
@@ -1,3 +1,4 @@
+import { createHash, createHmac } from 'node:crypto'
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -11,7 +12,10 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
 import { IMMUTABLE_SANDBOX_CACHE_SOURCE_VERSION_V1 } from '../../../shared/immutableCacheV1'
 import type { SandboxProviderCreateContextV1 } from '../../../shared/providerV1'
-import { expectDisposableProviderProfile } from '../../__tests__/conformance/disposableProvider'
+import {
+  expectDisposableProviderProfile,
+  expectPublishedPairLifecycle,
+} from '../../__tests__/conformance/disposableProvider'
 import { createMockVercelSandboxHarness } from '../../__tests__/mockVercelSandbox'
 import { createVercelSandboxProvider } from '../createVercelSandboxProvider'
 import {
@@ -69,6 +73,7 @@ function getEnvVar(name: string): string | undefined {
   return ({
     VERCEL_TOKEN: 'token-1',
     VERCEL_TEAM_ID: 'team-1',
+    BORING_SANDBOX_TELEMETRY_SALT: 'test-host-telemetry-salt',
   })[name]
 }
 
@@ -165,6 +170,7 @@ describe('createVercelSandboxProvider', () => {
       get: vi.fn(),
     }
     const logger = { info: vi.fn(), warn: vi.fn() }
+    const telemetry = { capture: vi.fn() }
     const provider = createVercelSandboxProvider({
       store,
       vercelClient: client,
@@ -179,14 +185,12 @@ describe('createVercelSandboxProvider', () => {
       workspaceRoot: 'workspace-setup-failure',
       workspaceId: 'workspace-setup-failure',
       sessionId: 'session-setup-failure',
+      requestId: 'request-setup-failure',
+      telemetry,
     })
     expect(client.create).toHaveBeenCalledWith(expect.objectContaining({
       name: expect.stringMatching(/^boring-lease-[a-f0-9]{40}$/),
     }))
-    const logged = JSON.stringify(logger.info.mock.calls)
-    expect(logged).not.toContain('workspace-setup-failure')
-    expect(logged).not.toContain('session-setup-failure')
-    expect(logged).not.toContain('sb-setup-failure')
     await expect(pair.checkHealth?.()).rejects.toMatchObject({
       code: 'VERCEL_API_ERROR',
       message: 'workspace root setup failed',
@@ -194,6 +198,20 @@ describe('createVercelSandboxProvider', () => {
     await expect(pair.dispose()).rejects.toThrow('disposable sandbox cleanup failed')
     await expect(pair.dispose()).resolves.toBeUndefined()
 
+    const logged = JSON.stringify({
+      logger: [logger.info.mock.calls, logger.warn.mock.calls],
+      telemetry: telemetry.capture.mock.calls,
+    })
+    for (const raw of [
+      'workspace-setup-failure', 'session-setup-failure', 'request-setup-failure',
+      'sb-setup-failure', 'token-1', 'team-1', 'project-1', 'test-host-telemetry-salt',
+    ]) expect(logged).not.toContain(raw)
+    expect(logged).toContain(
+      createHmac('sha256', 'test-host-telemetry-salt').update('workspace-setup-failure').digest('hex'),
+    )
+    expect(logged).not.toContain(
+      createHash('sha256').update('workspace-setup-failure').digest('hex'),
+    )
     expect(scheduler.trackWorkspace).not.toHaveBeenCalled()
     expect(scheduler.stopWorkspace).toHaveBeenCalledOnce()
     expect(stop).not.toHaveBeenCalled()
@@ -403,6 +421,60 @@ describe('createVercelSandboxProvider', () => {
     expect(deleteRecord).not.toHaveBeenCalled()
   })
 
+  test('provider close drains a concurrent create without publishing or leaking', async () => {
+    const harness = await createMockVercelSandboxHarness()
+    cleanups.push(harness.cleanup)
+    const { deleteSandbox } = addDurableHandleMetadata(harness.sandbox, 'sb-create-close-race')
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => { release = resolve })
+    const client: VercelSandboxClient = {
+      create: vi.fn(async () => { await gate; return harness.sandbox }),
+      get: vi.fn(),
+    }
+    const provider = createVercelSandboxProvider({
+      vercelClient: client, lifecycle: 'disposable', getEnvVar,
+      logger: { info: vi.fn() },
+    })
+    const creation = provider.create({
+      workspaceRoot: 'workspace-create-close-race', workspaceId: 'workspace-create-close-race',
+      sessionId: 'session-create-close-race', requestId: 'request-create-close-race',
+    })
+    const closing = provider.close!()
+    release()
+    await expect(creation).rejects.toMatchObject({ code: 'VERCEL_API_ERROR' })
+    await expect(closing).resolves.toBeUndefined()
+    expect(deleteSandbox).toHaveBeenCalledOnce()
+  })
+
+  test('a duplicate disposable request cannot delete an already-published pair', async () => {
+    const harness = await createMockVercelSandboxHarness()
+    cleanups.push(harness.cleanup)
+    const { deleteSandbox } = addDurableHandleMetadata(harness.sandbox, 'sb-duplicate-owner')
+    const client: VercelSandboxClient = {
+      create: vi.fn(async () => harness.sandbox),
+      get: vi.fn(),
+    }
+    const provider = createVercelSandboxProvider({
+      vercelClient: client,
+      lifecycle: 'disposable',
+      getEnvVar,
+      logger: { info: vi.fn() },
+    })
+    const context = {
+      workspaceRoot: 'workspace-duplicate-owner',
+      workspaceId: 'workspace-duplicate-owner',
+      sessionId: 'session-duplicate-owner',
+      requestId: 'request-duplicate-owner',
+    }
+    const pair = await provider.create(context)
+    await expect(provider.create(context)).rejects.toMatchObject({ code: 'CONFIG_INVALID' })
+    await provider.close?.()
+    expect(deleteSandbox).not.toHaveBeenCalled()
+    await expect(pair.checkHealth?.()).resolves.toEqual({ state: 'ok' })
+    await pair.dispose()
+    expect(deleteSandbox).toHaveBeenCalledOnce()
+  })
+
   test('provider close leaves a published disposable pair under caller cleanup authority', async () => {
     const harness = await createMockVercelSandboxHarness()
     cleanups.push(harness.cleanup)
@@ -427,13 +499,19 @@ describe('createVercelSandboxProvider', () => {
     })
     await expect(pair.checkHealth?.()).resolves.toEqual({ state: 'ok' })
 
-    await expect(provider.close!()).resolves.toBeUndefined()
-    expect(deleteSandbox).not.toHaveBeenCalled()
-    expect(localSandboxDispose).not.toHaveBeenCalled()
-
-    await expect(pair.dispose()).resolves.toBeUndefined()
-    expect(deleteSandbox).toHaveBeenCalledOnce()
-    expect(localSandboxDispose).toHaveBeenCalledOnce()
+    await expectPublishedPairLifecycle({
+      provider,
+      pair,
+      assertUsableAfterProviderClose: async () => {
+        expect(deleteSandbox).not.toHaveBeenCalled()
+        expect(localSandboxDispose).not.toHaveBeenCalled()
+        await expect(pair.checkHealth?.()).resolves.toEqual({ state: 'ok' })
+      },
+      assertTerminalCleanup: async () => {
+        expect(deleteSandbox).toHaveBeenCalledOnce()
+        expect(localSandboxDispose).toHaveBeenCalledOnce()
+      },
+    })
   })
 
   test('invalidate evicts only the process cache and reacquires the persisted handle', async () => {

--- a/packages/boring-sandbox/src/providers/vercel-sandbox/__tests__/createVercelSandboxProvider.test.ts
+++ b/packages/boring-sandbox/src/providers/vercel-sandbox/__tests__/createVercelSandboxProvider.test.ts
@@ -91,7 +91,10 @@ function correlatedDisposableClient(
   createImpl?: VercelSandboxClient['create'],
 ): VercelSandboxClient {
   return {
-    create: vi.fn(createImpl ?? (async (params) => Object.assign(sandbox, { name: params?.name }))),
+    create: vi.fn(createImpl ?? (async (params) => Object.assign(sandbox, {
+      name: params?.name,
+      sourceSnapshotId: params?.source?.type === 'snapshot' ? params.source.snapshotId : undefined,
+    }))),
     get: vi.fn(async (params) => Object.assign(sandbox, { name: params.name })),
   }
 }
@@ -247,7 +250,7 @@ describe('createVercelSandboxProvider', () => {
       .not.toBe(second.disposableProfile.providerConfigDigest)
   })
 
-  test('cleans the exact returned object but retains mismatched correlation debt', async () => {
+  test('cleans the exact returned object but retains same-name different-ID correlation debt', async () => {
     const returned = await createMockVercelSandboxHarness()
     const unrelated = await createMockVercelSandboxHarness()
     cleanups.push(returned.cleanup, unrelated.cleanup)
@@ -255,7 +258,7 @@ describe('createVercelSandboxProvider', () => {
     const unrelatedDelete = addDurableHandleMetadata(unrelated.sandbox, 'sb-unrelated').deleteSandbox
     const client: VercelSandboxClient = {
       create: vi.fn(async (params) => Object.assign(returned.sandbox, { name: params?.name })),
-      get: vi.fn(async () => Object.assign(unrelated.sandbox, { name: 'wrong-name' })),
+      get: vi.fn(async (params) => Object.assign(unrelated.sandbox, { name: params.name })),
     }
     const provider = createVercelSandboxProvider({ vercelClient: client, lifecycle: 'disposable', getEnvVar })
     const failure = await provider.create({
@@ -273,6 +276,59 @@ describe('createVercelSandboxProvider', () => {
     expect(unrelatedDelete).not.toHaveBeenCalled()
     await expect(provider.close!()).rejects.toBeTruthy()
     expect(unrelatedDelete).not.toHaveBeenCalled()
+  })
+
+  test('retains debt when a same-name correlation lookup omits its sandbox ID', async () => {
+    const returned = await createMockVercelSandboxHarness()
+    const lookup = await createMockVercelSandboxHarness()
+    cleanups.push(returned.cleanup, lookup.cleanup)
+    const returnedDelete = addDurableHandleMetadata(returned.sandbox, 'sb-returned-known').deleteSandbox
+    const lookupDelete = addDurableHandleMetadata(lookup.sandbox, 'sb-lookup-hidden').deleteSandbox
+    const client: VercelSandboxClient = {
+      create: vi.fn(async (params) => Object.assign(returned.sandbox, { name: params?.name })),
+      get: vi.fn(async (params) => Object.assign(lookup.sandbox, { name: params.name, sandboxId: undefined })),
+    }
+    const provider = createVercelSandboxProvider({ vercelClient: client, lifecycle: 'disposable', getEnvVar })
+    const failure = await provider.create({
+      workspaceRoot: 'workspace-missing-id', workspaceId: 'workspace-missing-id',
+      sessionId: 'session-missing-id', requestId: 'request-missing-id',
+    }).catch((caught: unknown) => caught) as Error & {
+      sandboxProviderCleanupDebt: { retry(): Promise<void> }
+    }
+    expect(failure).toMatchObject({ code: 'CONFIG_INVALID' })
+    expect(failure.sandboxProviderCleanupDebt.retry).toBeTypeOf('function')
+    expect(returnedDelete).toHaveBeenCalledOnce()
+    expect(lookupDelete).not.toHaveBeenCalled()
+    await expect(failure.sandboxProviderCleanupDebt.retry()).rejects.toMatchObject({ code: 'CONFIG_INVALID' })
+    expect(lookupDelete).not.toHaveBeenCalled()
+  })
+
+  test('retains ambiguity debt when a name match omits the immutable snapshot identity', async () => {
+    const lookup = await createMockVercelSandboxHarness()
+    cleanups.push(lookup.cleanup)
+    const lookupDelete = addDurableHandleMetadata(lookup.sandbox, 'sb-missing-snapshot').deleteSandbox
+    const client: VercelSandboxClient = {
+      create: vi.fn(async () => { throw Object.assign(new Error('response lost'), { status: 503 }) }),
+      get: vi.fn(async (params) => Object.assign(lookup.sandbox, { name: params.name, sourceSnapshotId: undefined })),
+    }
+    const provider = createVercelSandboxProvider({
+      vercelClient: client, lifecycle: 'disposable', getEnvVar,
+      immutableCacheSource: {
+        contractVersion: IMMUTABLE_SANDBOX_CACHE_SOURCE_VERSION_V1,
+        providerId: 'vercel-sandbox', opaqueRef: 'snap_expected',
+      },
+    })
+    const failure = await provider.create({
+      workspaceRoot: 'workspace-missing-snapshot', workspaceId: 'workspace-missing-snapshot',
+      sessionId: 'session-missing-snapshot', requestId: 'request-missing-snapshot',
+    }).catch((caught: unknown) => caught) as Error & {
+      sandboxProviderCleanupDebt: { retry(): Promise<void> }
+    }
+    expect(failure).toMatchObject({ code: 'VERCEL_API_ERROR' })
+    expect(failure.sandboxProviderCleanupDebt.retry).toBeTypeOf('function')
+    expect(lookupDelete).not.toHaveBeenCalled()
+    await expect(failure.sandboxProviderCleanupDebt.retry()).rejects.toMatchObject({ code: 'CONFIG_INVALID' })
+    expect(lookupDelete).not.toHaveBeenCalled()
   })
 
   test.each(['create', 'get'] as const)(

--- a/packages/boring-sandbox/src/providers/vercel-sandbox/__tests__/createVercelSandboxProvider.test.ts
+++ b/packages/boring-sandbox/src/providers/vercel-sandbox/__tests__/createVercelSandboxProvider.test.ts
@@ -11,6 +11,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
 import { IMMUTABLE_SANDBOX_CACHE_SOURCE_VERSION_V1 } from '../../../shared/immutableCacheV1'
 import type { SandboxProviderCreateContextV1 } from '../../../shared/providerV1'
+import { expectDisposableProviderProfile } from '../../__tests__/conformance/disposableProvider'
 import { createMockVercelSandboxHarness } from '../../__tests__/mockVercelSandbox'
 import { createVercelSandboxProvider } from '../createVercelSandboxProvider'
 import {
@@ -172,11 +173,15 @@ describe('createVercelSandboxProvider', () => {
       logger: { info: vi.fn() },
     })
 
+    expectDisposableProviderProfile(provider, 'vercel-sandbox')
     const pair = await provider.create({
       workspaceRoot: 'workspace-setup-failure',
       workspaceId: 'workspace-setup-failure',
       sessionId: 'session-setup-failure',
     })
+    expect(client.create).toHaveBeenCalledWith(expect.objectContaining({
+      name: expect.stringMatching(/^boring-lease-[a-f0-9]{40}$/),
+    }))
     await expect(pair.checkHealth?.()).rejects.toMatchObject({
       code: 'VERCEL_API_ERROR',
       message: 'workspace root setup failed',
@@ -190,6 +195,35 @@ describe('createVercelSandboxProvider', () => {
     expect(snapshot).not.toHaveBeenCalled()
     expect(deleteSandbox).toHaveBeenCalledTimes(2)
     expect(deleteRecord).not.toHaveBeenCalled()
+  })
+
+  test('reconciles a disposable create whose acknowledgement is lost', async () => {
+    const harness = await createMockVercelSandboxHarness()
+    cleanups.push(harness.cleanup)
+    const { deleteSandbox } = addDurableHandleMetadata(harness.sandbox, 'sb-response-loss')
+    const client: VercelSandboxClient = {
+      create: vi.fn(async () => { throw Object.assign(new Error('response lost'), { status: 503 }) }),
+      get: vi.fn(async () => harness.sandbox),
+    }
+    const provider = createVercelSandboxProvider({
+      vercelClient: client,
+      lifecycle: 'disposable',
+      getEnvVar,
+      logger: { info: vi.fn() },
+    })
+
+    await expect(provider.create({
+      workspaceRoot: 'workspace-response-loss',
+      workspaceId: 'workspace-response-loss',
+      sessionId: 'session-response-loss',
+      requestId: 'request-response-loss',
+    })).rejects.toBeTruthy()
+    expect(client.get).toHaveBeenCalledWith(expect.objectContaining({
+      name: expect.stringMatching(/^boring-lease-/),
+      resume: false,
+    }))
+    expect(deleteSandbox).toHaveBeenCalledOnce()
+    await provider.close?.()
   })
 
   test('retains cleanup authority when post-create adaptation fails and deletion needs retry', async () => {

--- a/packages/boring-sandbox/src/providers/vercel-sandbox/__tests__/mockVercelSandbox.ts
+++ b/packages/boring-sandbox/src/providers/vercel-sandbox/__tests__/mockVercelSandbox.ts
@@ -148,6 +148,22 @@ export async function createMockVercelSandboxHarness(): Promise<MockVercelSandbo
 
       const normalizedScript = script.replace(/^'([^']+)'\s+/, '$1 ')
 
+      if (normalizedScript === 'exit 7') return emitResult(7, '', '')
+      if (normalizedScript.includes('pwd && cat note.txt')) {
+        return emitResult(0, '/workspace/nested\ncwd-ok', '')
+      }
+      if (normalizedScript.includes('setInterval(() => {}, 1000)')) {
+        await new Promise<void>((resolve) => setTimeout(resolve, 550))
+        return emitResult(124, '', 'timed out')
+      }
+      if (normalizedScript.includes("process.stdout.write('x'.repeat(2_000_000))")) {
+        return emitResult(0, 'x'.repeat(2_000_000), '')
+      }
+      if (normalizedScript.includes('setTimeout(() => {}, 2100)')) {
+        await new Promise<void>((resolve) => setTimeout(resolve, 2_100))
+        return emitResult(0, '', '')
+      }
+
       if (normalizedScript.startsWith('cat ')) {
         const targetPath = normalizedScript.slice(4).trim().replace(/^'(.*)'$/, '$1')
         try {

--- a/packages/boring-sandbox/src/providers/vercel-sandbox/__tests__/packageTemplate.test.ts
+++ b/packages/boring-sandbox/src/providers/vercel-sandbox/__tests__/packageTemplate.test.ts
@@ -171,6 +171,21 @@ describe('packageTemplate', () => {
     expect(uploadFn).toHaveBeenCalledWith(result.hash, expect.any(Buffer))
   })
 
+  test('never serializes template hashes or upload URLs to stderr', async () => {
+    await seedFiles({ 'secret-name.txt': 'secret-content' })
+    const url = 'https://blob.example.com/raw-secret-url.tar.gz'
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    try {
+      const result = await packageTemplate(fixtureDir, { uploadFn: async () => url })
+      const serialized = JSON.stringify(stderr.mock.calls)
+      expect(serialized).not.toContain(url)
+      expect(serialized).not.toContain(result.hash)
+      expect(serialized).not.toContain('secret-name.txt')
+    } finally {
+      stderr.mockRestore()
+    }
+  })
+
   test('returns cached URL on second call with same content', async () => {
     await seedFiles({ 'a.txt': 'content' })
 

--- a/packages/boring-sandbox/src/providers/vercel-sandbox/createVercelSandboxProvider.ts
+++ b/packages/boring-sandbox/src/providers/vercel-sandbox/createVercelSandboxProvider.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto'
+import { createHash, createHmac } from 'node:crypto'
 import { mkdir, readFile, readdir, stat } from 'node:fs/promises'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -17,7 +17,6 @@ import {
 } from '../../shared/immutableCacheV1'
 import { PROVIDER_CAPABILITIES, PROVIDER_CONTRACT_VERSION } from '../../shared/providerMatrix'
 import {
-  DISPOSABLE_SANDBOX_PROVIDER_PROFILE_V1,
   SandboxProviderError,
   type DisposableSandboxProviderV1,
   type SandboxProviderCreateContextV1,
@@ -25,6 +24,7 @@ import {
   type SandboxProvisioningOperationsV1,
   type WorkspaceSandboxPairV1,
 } from '../../shared/providerV1'
+import { registerDisposableSandboxProviderV1 } from '../disposableProviderRegistration'
 import { getEnv, safeCapture, setEnvDefault } from '../runtimeSupport'
 import { createVercelSandboxExec } from './createVercelSandboxExec'
 import { getBoringAgentRuntimePaths } from '../node-workspace/runtimeLayout'
@@ -76,6 +76,9 @@ export interface VercelSandboxProviderOptions {
   /** Delete the remote sandbox and persisted handle when its pair is disposed. */
   lifecycle?: 'persistent' | 'disposable'
   leaseMode?: 'disposable'
+  providerConfigDigest?: `sha256:${string}`
+  /** Host-scoped secret used to make lifecycle identifier digests unlinkable across deployments. */
+  telemetrySalt?: string
   /** Host-resolved immutable base. Never project this option into Worker inputs. */
   immutableCacheSource?: ImmutableSandboxCacheSourceV1
   getEnvVar?: EnvGetter
@@ -94,30 +97,32 @@ interface VercelAuthConfig {
 
 type SandboxSetupStatus = 'started' | 'ok' | 'error'
 
-function telemetryDigest(value: string | undefined): string | undefined {
-  return value ? createHash('sha256').update(value).digest('hex') : undefined
+function telemetryDigest(value: string | undefined, salt?: string): string | undefined {
+  if (!value || !salt) return undefined
+  return createHmac('sha256', salt).update(value).digest('hex')
 }
 
 function sandboxTelemetryProperties(
   ctx: SandboxProviderCreateContextV1 | undefined,
   extra: Record<string, unknown> = {},
 ): Record<string, unknown> {
+  const salt = (ctx as (SandboxProviderCreateContextV1 & { telemetrySalt?: string }) | undefined)?.telemetrySalt
   return {
     runtimeMode: 'vercel-sandbox',
-    workspaceDigest: telemetryDigest(ctx?.workspaceId),
-    sessionDigest: telemetryDigest(ctx?.sessionId),
-    requestDigest: telemetryDigest(ctx?.requestId),
+    workspaceDigest: telemetryDigest(ctx?.workspaceId, salt),
+    sessionDigest: telemetryDigest(ctx?.sessionId, salt),
+    requestDigest: telemetryDigest(ctx?.requestId, salt),
     ...extra,
   }
 }
 
-function createRedactedLifecycleLogger(logger: ModeLogger): ModeLogger {
+function createRedactedLifecycleLogger(logger: ModeLogger, telemetrySalt?: string): ModeLogger {
   const properties = (metadata: Record<string, unknown> = {}): Record<string, unknown> => {
     const output: Record<string, unknown> = {}
     for (const [key, value] of Object.entries(metadata)) {
       if (typeof value === 'number' || typeof value === 'boolean' || value === null) output[key] = value
       else if (typeof value === 'string' && ['reason', 'sourceType', 'status'].includes(key)) output[key] = value
-      else if (typeof value === 'string') output[`${key}Digest`] = telemetryDigest(value)
+      else if (typeof value === 'string') output[`${key}Digest`] = telemetryDigest(value, telemetrySalt)
     }
     return output
   }
@@ -444,6 +449,14 @@ function extractHttpStatus(error: unknown): number | null {
   return typeof responseStatus === 'number' ? responseStatus : null
 }
 
+function isDefinitiveVercelCreateConflict(error: unknown): boolean {
+  const code = (error as { code?: unknown; json?: { error?: { code?: unknown } } } | null)
+  return extractHttpStatus(error) === 409
+    || code?.code === 'conflict'
+    || code?.json?.error?.code === 'conflict'
+    || /already exists|conflict/i.test(error instanceof Error ? error.message : String(error))
+}
+
 function isExpiredSandboxRuntimeError(error: unknown): boolean {
   const code = (error as { code?: unknown } | null)?.code
   if (code === 'SANDBOX_EXPIRED') return true
@@ -557,30 +570,31 @@ export function createVercelSandboxProvider(
   const store = opts.store ?? new FileHandleStore()
   const getEnvVar = opts.getEnvVar ?? getEnv
   const logger = opts.logger ?? DEFAULT_MODE_LOGGER
-  const lifecycleLogger = createRedactedLifecycleLogger(logger)
   // @vercel/sandbox@beta persistent sandboxes auto-snapshot when their
   // session stops and auto-resume on the next command. Do not run the old
   // periodic snapshotter here: sandbox.snapshot() stops the active session.
   const snapshotScheduler = opts.snapshotScheduler ?? null
   const disposable = opts.lifecycle === 'disposable' || opts.leaseMode === 'disposable'
+  const telemetrySalt = opts.telemetrySalt?.trim()
+    || getEnvVar('BORING_SANDBOX_TELEMETRY_SALT')?.trim()
+  if (disposable && !telemetrySalt) {
+    throw new SandboxProviderError('CONFIG_INVALID', 'disposable Vercel requires a host-scoped telemetry salt')
+  }
+  const lifecycleLogger = createRedactedLifecycleLogger(logger, telemetrySalt)
   const unpublishedDisposableCleanups = new Set<() => Promise<void>>()
+  const reservedDisposableNames = new Set<string>()
+  const publishedDisposableNames = new Set<string>()
+  const pendingCreates = new Set<Promise<void>>()
+  let closed = false
   const settleUnpublishedDisposableCleanup = async (cleanup: () => Promise<void>): Promise<void> => {
     await cleanup()
     unpublishedDisposableCleanups.delete(cleanup)
   }
 
-  return {
+  const provider: SandboxProviderV1 = {
     contractVersion: PROVIDER_CONTRACT_VERSION,
     providerId: 'vercel-sandbox',
     capabilities: PROVIDER_CAPABILITIES['vercel-sandbox'],
-    ...(disposable ? {
-      disposableProfile: {
-        contractVersion: DISPOSABLE_SANDBOX_PROVIDER_PROFILE_V1,
-        resume: false as const,
-        publishedCleanupOwner: 'returned-pair' as const,
-        ambiguousCreate: 'correlated-reconciliation' as const,
-      },
-    } : {}),
     resolveRuntimeRoot() {
       return VERCEL_SANDBOX_WORKSPACE_ROOT
     },
@@ -588,6 +602,8 @@ export function createVercelSandboxProvider(
       evictSandboxHandleCacheForWorkspace(workspaceId)
     },
     async close() {
+      closed = true
+      await Promise.allSettled([...pendingCreates])
       const results = await Promise.allSettled([
         ...[...unpublishedDisposableCleanups].map(async (cleanup) => {
           await settleUnpublishedDisposableCleanup(cleanup)
@@ -599,7 +615,13 @@ export function createVercelSandboxProvider(
         .map((result) => result.reason)
       if (failures.length > 0) throw new AggregateError(failures, 'Vercel sandbox provider cleanup failed')
     },
-    async create(ctx): Promise<WorkspaceSandboxPairV1> {
+    async create(inputContext): Promise<WorkspaceSandboxPairV1> {
+      if (closed) throw new SandboxProviderError('VERCEL_API_ERROR', 'Vercel sandbox provider is closed')
+      let finishCreate!: () => void
+      const pendingCreate = new Promise<void>((resolve) => { finishCreate = resolve })
+      pendingCreates.add(pendingCreate)
+      try {
+      const ctx = Object.freeze({ ...inputContext, telemetrySalt })
       const telemetry = ctx.telemetry
       const totalStartedAt = Date.now()
       captureSandboxSetupEvent(telemetry, ctx, 'agent.runtime.sandbox.setup.started', {
@@ -664,7 +686,7 @@ export function createVercelSandboxProvider(
             })
             tarballUrl = result.url
             logger.info('[vercel-sandbox:mode] template packaged', {
-              templateDigest: telemetryDigest(result.hash),
+              templateDigest: telemetryDigest(result.hash, telemetrySalt),
               uploaded: true,
             })
           } catch (error) {
@@ -677,6 +699,10 @@ export function createVercelSandboxProvider(
         }
 
         if (disposable && disposableName) {
+          if (reservedDisposableNames.has(disposableName) || publishedDisposableNames.has(disposableName)) {
+            throw new SandboxProviderError('CONFIG_INVALID', 'disposable Vercel request identity is already owned')
+          }
+          reservedDisposableNames.add(disposableName)
           ambiguityCleanup = async () => {
             try {
               const candidate = await vercelClient.get({ name: disposableName, resume: false })
@@ -685,6 +711,8 @@ export function createVercelSandboxProvider(
               const status = extractHttpStatus(error)
               if (status !== 404 && status !== 410) throw error
             }
+            reservedDisposableNames.delete(disposableName)
+            publishedDisposableNames.delete(disposableName)
             unpublishedDisposableCleanups.delete(ambiguityCleanup!)
           }
           unpublishedDisposableCleanups.add(ambiguityCleanup)
@@ -717,19 +745,26 @@ export function createVercelSandboxProvider(
               ),
         })
         if (disposable) {
-          disposableCleanup = createDisposableSandboxDisposer({
+          const disposeRemote = createDisposableSandboxDisposer({
             sandbox: resolvedSandboxHandle,
             disposeLocal,
           })
+          disposableCleanup = async () => {
+            await disposeRemote()
+            if (disposableName) {
+              reservedDisposableNames.delete(disposableName)
+              publishedDisposableNames.delete(disposableName)
+            }
+          }
           unpublishedDisposableCleanups.add(disposableCleanup)
           if (ambiguityCleanup) unpublishedDisposableCleanups.delete(ambiguityCleanup)
         }
 
         const sandboxId = resolvedSandboxHandle.name ?? resolvedSandboxHandle.sandboxId ?? 'unknown-sandbox'
         logger.info('[vercel-sandbox:mode] resolved sandbox handle', {
-          workspaceDigest: telemetryDigest(workspaceId),
-          sandboxDigest: telemetryDigest(sandboxId),
-          snapshotDigest: telemetryDigest(resolvedSandboxHandle.currentSnapshotId ?? resolvedSandboxHandle.sourceSnapshotId),
+          workspaceDigest: telemetryDigest(workspaceId, telemetrySalt),
+          sandboxDigest: telemetryDigest(sandboxId, telemetrySalt),
+          snapshotDigest: telemetryDigest(resolvedSandboxHandle.currentSnapshotId ?? resolvedSandboxHandle.sourceSnapshotId, telemetrySalt),
           templateUploaded: Boolean(tarballUrl),
           disposable,
         })
@@ -809,7 +844,7 @@ export function createVercelSandboxProvider(
           if (ctx.templatePath) {
             if (!tarballUrl) {
               logger.info('[vercel-sandbox:mode] falling back to writeFiles for template', {
-                templateDigest: telemetryDigest(ctx.templatePath),
+                templateDigest: telemetryDigest(ctx.templatePath, telemetrySalt),
               })
             }
             await runSandboxSetupStep({
@@ -817,7 +852,7 @@ export function createVercelSandboxProvider(
               ctx,
               phase: 'template-seed',
               run: async () => {
-                await seedTemplateIntoVercelWorkspace(readyWorkspace, ctx.templatePath!, logger)
+                await seedTemplateIntoVercelWorkspace(readyWorkspace, ctx.templatePath!, lifecycleLogger)
                 await ensureTemplateExecutables(resolvedSandboxHandle)
               },
             })
@@ -878,20 +913,31 @@ export function createVercelSandboxProvider(
         if (!disposable) {
           const setup = await setupOutcome
           if (setup.state === 'failed') throw setup.error
-        } else if (disposableCleanup) {
+        }
+        if (closed) throw new SandboxProviderError('VERCEL_API_ERROR', 'Vercel sandbox provider closed during create')
+        if (disposable && disposableCleanup) {
           // From this point the returned pair is the sole cleanup owner. The
           // provider retains authority only for failures before publication.
           unpublishedDisposableCleanups.delete(disposableCleanup)
+          if (disposableName) {
+            reservedDisposableNames.delete(disposableName)
+            publishedDisposableNames.add(disposableName)
+          }
         }
         return pair
       } catch (error) {
+        if (!disposableCleanup && ambiguityCleanup && isDefinitiveVercelCreateConflict(error)) {
+          unpublishedDisposableCleanups.delete(ambiguityCleanup)
+          if (disposableName) reservedDisposableNames.delete(disposableName)
+          ambiguityCleanup = undefined
+        }
         if (disposableCleanup || ambiguityCleanup) {
           const cleanup = disposableCleanup ?? ambiguityCleanup!
           try {
             await settleUnpublishedDisposableCleanup(cleanup)
           } catch (cleanupError) {
             logger.warn?.('[vercel-sandbox:mode] disposable setup cleanup failed', {
-              workspaceDigest: telemetryDigest(workspaceId),
+              workspaceDigest: telemetryDigest(workspaceId, telemetrySalt),
               errorCode: typeof (cleanupError as { code?: unknown })?.code === 'string'
                 ? (cleanupError as { code: string }).code
                 : 'UNKNOWN',
@@ -902,7 +948,7 @@ export function createVercelSandboxProvider(
             await disposeLocal()
           } catch (cleanupError) {
             logger.warn?.('[vercel-sandbox:mode] local setup cleanup failed', {
-              workspaceDigest: telemetryDigest(workspaceId),
+              workspaceDigest: telemetryDigest(workspaceId, telemetrySalt),
               errorCode: typeof (cleanupError as { code?: unknown })?.code === 'string'
                 ? (cleanupError as { code: string }).code
                 : 'UNKNOWN',
@@ -917,6 +963,17 @@ export function createVercelSandboxProvider(
         })
         throw normalizeVercelProviderError(error)
       }
+      } finally {
+        finishCreate()
+        pendingCreates.delete(pendingCreate)
+      }
     },
   }
+  return disposable
+    ? registerDisposableSandboxProviderV1(
+        provider,
+        opts.providerConfigDigest
+          ?? 'sha256:35855bc75cae477d145d446a586281073431b8812cf2cd95ffc4bafdb9993e0c',
+      )
+    : provider
 }

--- a/packages/boring-sandbox/src/providers/vercel-sandbox/createVercelSandboxProvider.ts
+++ b/packages/boring-sandbox/src/providers/vercel-sandbox/createVercelSandboxProvider.ts
@@ -1,4 +1,4 @@
-import { createHash, createHmac } from 'node:crypto'
+import { createHash } from 'node:crypto'
 import { mkdir, readFile, readdir, stat } from 'node:fs/promises'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -24,8 +24,11 @@ import {
   type SandboxProvisioningOperationsV1,
   type WorkspaceSandboxPairV1,
 } from '../../shared/providerV1'
-import { registerDisposableSandboxProviderV1 } from '../disposableProviderRegistration'
-import { getEnv, safeCapture, setEnvDefault } from '../runtimeSupport'
+import {
+  disposableProviderConfigDigestV1,
+  registerDisposableSandboxProviderV1,
+} from '../disposableProviderRegistration'
+import { getEnv, setEnvDefault } from '../runtimeSupport'
 import { createVercelSandboxExec } from './createVercelSandboxExec'
 import { getBoringAgentRuntimePaths } from '../node-workspace/runtimeLayout'
 import {
@@ -53,16 +56,18 @@ import {
 } from './disposableSandboxLifecycle'
 import type { PeriodicSnapshotScheduler } from './periodicSnapshot'
 import {
+  captureSandboxSetupEvent,
+  createRedactedLifecycleLogger,
+  normalizedLifecycleErrorCode,
+  telemetryDigest,
+  type VercelLifecycleLogger as ModeLogger,
+} from './lifecycleTelemetry'
+import {
   createVercelSandboxWorkspace,
   disposeVercelSandboxWorkspace,
   VERCEL_SANDBOX_REMOTE_ROOT,
   VERCEL_SANDBOX_WORKSPACE_ROOT,
 } from './createVercelSandboxWorkspace'
-
-interface ModeLogger {
-  info(message: string, metadata: Record<string, unknown>): void
-  warn?(message: string, metadata?: Record<string, unknown>): void
-}
 
 type EnvGetter = (name: string) => string | undefined
 const ORPHAN_GUARD_MAX_IDLE_MS = 24 * 60 * 60 * 1000
@@ -76,7 +81,6 @@ export interface VercelSandboxProviderOptions {
   /** Delete the remote sandbox and persisted handle when its pair is disposed. */
   lifecycle?: 'persistent' | 'disposable'
   leaseMode?: 'disposable'
-  providerConfigDigest?: `sha256:${string}`
   /** Host-scoped secret used to make lifecycle identifier digests unlinkable across deployments. */
   telemetrySalt?: string
   /** Host-resolved immutable base. Never project this option into Worker inputs. */
@@ -97,52 +101,23 @@ interface VercelAuthConfig {
 
 type SandboxSetupStatus = 'started' | 'ok' | 'error'
 
-function telemetryDigest(value: string | undefined, salt?: string): string | undefined {
-  if (!value || !salt) return undefined
-  return createHmac('sha256', salt).update(value).digest('hex')
-}
-
-function sandboxTelemetryProperties(
-  ctx: SandboxProviderCreateContextV1 | undefined,
-  extra: Record<string, unknown> = {},
-): Record<string, unknown> {
-  const salt = (ctx as (SandboxProviderCreateContextV1 & { telemetrySalt?: string }) | undefined)?.telemetrySalt
-  return {
-    runtimeMode: 'vercel-sandbox',
-    workspaceDigest: telemetryDigest(ctx?.workspaceId, salt),
-    sessionDigest: telemetryDigest(ctx?.sessionId, salt),
-    requestDigest: telemetryDigest(ctx?.requestId, salt),
-    ...extra,
+function assertDisposableVercelIdentity(input: {
+  handle: VercelSandboxHandle
+  expectedName: string
+  expectedSnapshotId?: string
+  expectedSandboxId?: string
+}): void {
+  if (
+    (input.handle.name !== undefined && input.handle.name !== input.expectedName)
+    || (input.expectedSnapshotId !== undefined
+      && input.handle.sourceSnapshotId !== undefined
+      && input.handle.sourceSnapshotId !== input.expectedSnapshotId)
+    || (input.expectedSandboxId !== undefined
+      && input.handle.sandboxId !== undefined
+      && input.handle.sandboxId !== input.expectedSandboxId)
+  ) {
+    throw new SandboxProviderError('CONFIG_INVALID', 'disposable Vercel correlation identity does not match')
   }
-}
-
-function createRedactedLifecycleLogger(logger: ModeLogger, telemetrySalt?: string): ModeLogger {
-  const properties = (metadata: Record<string, unknown> = {}): Record<string, unknown> => {
-    const output: Record<string, unknown> = {}
-    for (const [key, value] of Object.entries(metadata)) {
-      if (typeof value === 'number' || typeof value === 'boolean' || value === null) output[key] = value
-      else if (typeof value === 'string' && ['reason', 'sourceType', 'status'].includes(key)) output[key] = value
-      else if (typeof value === 'string') output[`${key}Digest`] = telemetryDigest(value, telemetrySalt)
-    }
-    return output
-  }
-  return {
-    info(message, metadata) { logger.info(message, properties(metadata)) },
-    warn(message, metadata) { logger.warn?.(message, properties(metadata)) },
-  }
-}
-
-function captureSandboxSetupEvent(
-  telemetry: TelemetrySink | undefined,
-  ctx: SandboxProviderCreateContextV1 | undefined,
-  name: string,
-  properties?: Record<string, unknown>,
-): void {
-  if (!telemetry) return
-  safeCapture(telemetry, {
-    name,
-    properties: sandboxTelemetryProperties(ctx, properties),
-  })
 }
 
 async function runSandboxSetupStep<T>(options: {
@@ -161,12 +136,11 @@ async function runSandboxSetupStep<T>(options: {
     })
     return result
   } catch (error) {
-    const code = (error as { code?: unknown } | null)?.code
     captureSandboxSetupEvent(options.telemetry, options.ctx, 'agent.runtime.sandbox.setup.step', {
       phase: options.phase,
       status: 'error' satisfies SandboxSetupStatus,
       durationMs: Date.now() - startedAt,
-      ...(typeof code === 'string' ? { errorCode: code } : {}),
+      errorCode: normalizedLifecycleErrorCode(error),
     })
     throw error
   }
@@ -196,18 +170,24 @@ function createDefaultVercelClient(
       }
       if (params?.source?.type === 'snapshot') {
         const { runtime: _runtime, ...snapshotBase } = base
-        return await VercelSandbox.create({
+        const handle = await VercelSandbox.create({
           ...snapshotBase,
           source: { type: 'snapshot', snapshotId: params.source.snapshotId },
         })
+        return Object.assign(handle, {
+          ...(params.name ? { name: params.name } : {}),
+          sourceSnapshotId: params.source.snapshotId,
+        })
       }
       if (params?.source?.type === 'tarball') {
-        return await VercelSandbox.create({
+        const handle = await VercelSandbox.create({
           ...base,
           source: { type: 'tarball', url: params.source.url },
         })
+        return Object.assign(handle, params.name ? { name: params.name } : {})
       }
-      return await VercelSandbox.create(base)
+      const handle = await VercelSandbox.create(base)
+      return Object.assign(handle, params?.name ? { name: params.name } : {})
     },
     async get(params) {
       const getParams = {
@@ -215,7 +195,8 @@ function createDefaultVercelClient(
         name: params.name ?? params.sandboxId ?? '',
         resume: params.resume ?? true,
       } as unknown as Parameters<typeof VercelSandbox.get>[0] & { name?: string }
-      return await VercelSandbox.get(getParams)
+      const handle = await VercelSandbox.get(getParams)
+      return Object.assign(handle, params.name ? { name: params.name } : {})
     },
   }
 }
@@ -691,21 +672,26 @@ export function createVercelSandboxProvider(
             })
           } catch (error) {
             logger.info('[vercel-sandbox:mode] template packaging failed, will use writeFiles fallback', {
-              errorCode: typeof (error as { code?: unknown })?.code === 'string'
-                ? (error as { code: string }).code
-                : 'UNKNOWN',
+              errorCode: normalizedLifecycleErrorCode(error),
             })
           }
         }
 
+        let disposableCleanupVerified = true
         if (disposable && disposableName) {
           if (reservedDisposableNames.has(disposableName) || publishedDisposableNames.has(disposableName)) {
             throw new SandboxProviderError('CONFIG_INVALID', 'disposable Vercel request identity is already owned')
           }
           reservedDisposableNames.add(disposableName)
           ambiguityCleanup = async () => {
+            if (!disposableCleanupVerified) return
             try {
               const candidate = await vercelClient.get({ name: disposableName, resume: false })
+              assertDisposableVercelIdentity({
+                handle: candidate,
+                expectedName: disposableName,
+                expectedSnapshotId: sourceSnapshotId,
+              })
               await candidate.delete()
             } catch (error) {
               const status = extractHttpStatus(error)
@@ -744,7 +730,26 @@ export function createVercelSandboxProvider(
                 },
               ),
         })
-        if (disposable) {
+        if (disposable && disposableName) {
+          try {
+            assertDisposableVercelIdentity({
+              handle: resolvedSandboxHandle,
+              expectedName: disposableName,
+              expectedSnapshotId: sourceSnapshotId,
+            })
+            const lookedUp = await vercelClient.get({ name: disposableName, resume: false })
+            assertDisposableVercelIdentity({
+              handle: lookedUp,
+              expectedName: disposableName,
+              expectedSnapshotId: sourceSnapshotId,
+              expectedSandboxId: resolvedSandboxHandle.sandboxId,
+            })
+          } catch (error) {
+            disposableCleanupVerified = false
+            if (ambiguityCleanup) unpublishedDisposableCleanups.delete(ambiguityCleanup)
+            reservedDisposableNames.delete(disposableName)
+            throw error
+          }
           const disposeRemote = createDisposableSandboxDisposer({
             sandbox: resolvedSandboxHandle,
             disposeLocal,
@@ -871,11 +876,10 @@ export function createVercelSandboxProvider(
         }).catch((error: unknown) => {
           setupFailureCaptured = true
           const normalized = normalizeVercelProviderError(error)
-          const normalizedCode = (normalized as Error & { code?: unknown }).code
           captureSandboxSetupEvent(telemetry, ctx, 'agent.runtime.sandbox.setup.failed', {
             status: 'error',
             durationMs: Date.now() - totalStartedAt,
-            ...(typeof normalizedCode === 'string' ? { errorCode: normalizedCode } : {}),
+            errorCode: normalizedLifecycleErrorCode(normalized),
           })
           return { state: 'failed' as const, error: normalized }
         })
@@ -938,9 +942,7 @@ export function createVercelSandboxProvider(
           } catch (cleanupError) {
             logger.warn?.('[vercel-sandbox:mode] disposable setup cleanup failed', {
               workspaceDigest: telemetryDigest(workspaceId, telemetrySalt),
-              errorCode: typeof (cleanupError as { code?: unknown })?.code === 'string'
-                ? (cleanupError as { code: string }).code
-                : 'UNKNOWN',
+              errorCode: normalizedLifecycleErrorCode(cleanupError),
             })
           }
         } else {
@@ -949,17 +951,14 @@ export function createVercelSandboxProvider(
           } catch (cleanupError) {
             logger.warn?.('[vercel-sandbox:mode] local setup cleanup failed', {
               workspaceDigest: telemetryDigest(workspaceId, telemetrySalt),
-              errorCode: typeof (cleanupError as { code?: unknown })?.code === 'string'
-                ? (cleanupError as { code: string }).code
-                : 'UNKNOWN',
+              errorCode: normalizedLifecycleErrorCode(cleanupError),
             })
           }
         }
-        const code = (error as { code?: unknown } | null)?.code
         if (!setupFailureCaptured) captureSandboxSetupEvent(telemetry, ctx, 'agent.runtime.sandbox.setup.failed', {
           status: 'error',
           durationMs: Date.now() - totalStartedAt,
-          ...(typeof code === 'string' ? { errorCode: code } : {}),
+          errorCode: normalizedLifecycleErrorCode(error),
         })
         throw normalizeVercelProviderError(error)
       }
@@ -972,8 +971,18 @@ export function createVercelSandboxProvider(
   return disposable
     ? registerDisposableSandboxProviderV1(
         provider,
-        opts.providerConfigDigest
-          ?? 'sha256:35855bc75cae477d145d446a586281073431b8812cf2cd95ffc4bafdb9993e0c',
+        disposableProviderConfigDigestV1('vercel-sandbox', {
+          lifecycle: 'disposable',
+          immutableCacheSource: opts.immutableCacheSource ?? null,
+          runtime: getEnvVar(VERCEL_SANDBOX_RUNTIME_ENV)?.trim() || DEFAULT_VERCEL_SANDBOX_RUNTIME,
+          timeoutMs: readOptionalPositiveIntegerEnv(VERCEL_SANDBOX_TIMEOUT_MS_ENV, getEnvVar) ?? null,
+          telemetrySaltDigest: createHash('sha256').update(telemetrySalt ?? '').digest('hex'),
+          packageTemplate: opts.packageTemplateOpts ? 'host-package-template-v1' : 'default-v1',
+          expiredSandboxPolicy: opts.expiredSandboxPolicy ? 'host-policy-v1' : 'default-v1',
+          orphanGuardMaxIdleMs: opts.orphanGuardMaxIdleMs ?? ORPHAN_GUARD_MAX_IDLE_MS,
+          snapshotScheduler: snapshotScheduler ? 'host-scheduler-v1' : null,
+          client: opts.vercelClient ? 'host-injected-v1' : 'sdk-default-v1',
+        }),
       )
     : provider
 }

--- a/packages/boring-sandbox/src/providers/vercel-sandbox/createVercelSandboxProvider.ts
+++ b/packages/boring-sandbox/src/providers/vercel-sandbox/createVercelSandboxProvider.ts
@@ -111,10 +111,8 @@ function assertDisposableVercelIdentity(input: {
   if (
     input.handle.name !== input.expectedName
     || (input.expectedSnapshotId !== undefined
-      && input.handle.sourceSnapshotId !== undefined
       && input.handle.sourceSnapshotId !== input.expectedSnapshotId)
     || (input.expectedSandboxId !== undefined
-      && input.handle.sandboxId !== undefined
       && input.handle.sandboxId !== input.expectedSandboxId)
   ) {
     throw new SandboxProviderError('CONFIG_INVALID', 'disposable Vercel correlation identity does not match')
@@ -632,6 +630,7 @@ export function createVercelSandboxProvider(
       let sandbox: ReturnType<typeof createVercelSandboxExec> | undefined
       let disposableCleanup: (() => Promise<void>) | undefined
       let ambiguityCleanup: (() => Promise<void>) | undefined
+      let returnedSandboxId: string | undefined
       let workspaceDisposed = false
       let localSandboxDisposed = false
       let setupFailureCaptured = false
@@ -684,6 +683,7 @@ export function createVercelSandboxProvider(
                 handle: candidate,
                 expectedName: disposableName,
                 expectedSnapshotId: sourceSnapshotId,
+                expectedSandboxId: returnedSandboxId,
               })
               await candidate.delete()
             } catch (error) {
@@ -726,6 +726,7 @@ export function createVercelSandboxProvider(
               ),
         })
         if (disposable && disposableName) {
+          returnedSandboxId = resolvedSandboxHandle.sandboxId
           const disposeRemote = createDisposableSandboxDisposer({ sandbox: resolvedSandboxHandle, disposeLocal })
           disposableCleanup = async () => {
             await disposeRemote()

--- a/packages/boring-sandbox/src/providers/vercel-sandbox/createVercelSandboxProvider.ts
+++ b/packages/boring-sandbox/src/providers/vercel-sandbox/createVercelSandboxProvider.ts
@@ -171,24 +171,18 @@ function createDefaultVercelClient(
       }
       if (params?.source?.type === 'snapshot') {
         const { runtime: _runtime, ...snapshotBase } = base
-        const handle = await VercelSandbox.create({
+        return await VercelSandbox.create({
           ...snapshotBase,
           source: { type: 'snapshot', snapshotId: params.source.snapshotId },
         })
-        return Object.assign(handle, {
-          ...(params.name ? { name: params.name } : {}),
-          sourceSnapshotId: params.source.snapshotId,
-        })
       }
       if (params?.source?.type === 'tarball') {
-        const handle = await VercelSandbox.create({
+        return await VercelSandbox.create({
           ...base,
           source: { type: 'tarball', url: params.source.url },
         })
-        return Object.assign(handle, params.name ? { name: params.name } : {})
       }
-      const handle = await VercelSandbox.create(base)
-      return Object.assign(handle, params?.name ? { name: params.name } : {})
+      return await VercelSandbox.create(base)
     },
     async get(params) {
       const getParams = {
@@ -196,8 +190,7 @@ function createDefaultVercelClient(
         name: params.name ?? params.sandboxId ?? '',
         resume: params.resume ?? true,
       } as unknown as Parameters<typeof VercelSandbox.get>[0] & { name?: string }
-      const handle = await VercelSandbox.get(getParams)
-      return Object.assign(handle, params.name ? { name: params.name } : {})
+      return await VercelSandbox.get(getParams)
     },
   }
 }

--- a/packages/boring-sandbox/src/providers/vercel-sandbox/createVercelSandboxProvider.ts
+++ b/packages/boring-sandbox/src/providers/vercel-sandbox/createVercelSandboxProvider.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { mkdir, readFile, readdir, stat } from 'node:fs/promises'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -16,7 +17,9 @@ import {
 } from '../../shared/immutableCacheV1'
 import { PROVIDER_CAPABILITIES, PROVIDER_CONTRACT_VERSION } from '../../shared/providerMatrix'
 import {
+  DISPOSABLE_SANDBOX_PROVIDER_PROFILE_V1,
   SandboxProviderError,
+  type DisposableSandboxProviderV1,
   type SandboxProviderCreateContextV1,
   type SandboxProviderV1,
   type SandboxProvisioningOperationsV1,
@@ -72,6 +75,7 @@ export interface VercelSandboxProviderOptions {
   vercelClient?: VercelSandboxClient
   /** Delete the remote sandbox and persisted handle when its pair is disposed. */
   lifecycle?: 'persistent' | 'disposable'
+  leaseMode?: 'disposable'
   /** Host-resolved immutable base. Never project this option into Worker inputs. */
   immutableCacheSource?: ImmutableSandboxCacheSourceV1
   getEnvVar?: EnvGetter
@@ -90,15 +94,19 @@ interface VercelAuthConfig {
 
 type SandboxSetupStatus = 'started' | 'ok' | 'error'
 
+function telemetryDigest(value: string | undefined): string | undefined {
+  return value ? createHash('sha256').update(value).digest('hex') : undefined
+}
+
 function sandboxTelemetryProperties(
   ctx: SandboxProviderCreateContextV1 | undefined,
   extra: Record<string, unknown> = {},
 ): Record<string, unknown> {
   return {
     runtimeMode: 'vercel-sandbox',
-    workspaceId: ctx?.workspaceId,
-    sessionId: ctx?.sessionId,
-    requestId: ctx?.requestId,
+    workspaceDigest: telemetryDigest(ctx?.workspaceId),
+    sessionDigest: telemetryDigest(ctx?.sessionId),
+    requestDigest: telemetryDigest(ctx?.requestId),
     ...extra,
   }
 }
@@ -519,8 +527,17 @@ function resolveVercelAuth(getEnvVar: EnvGetter): { token: string; source: 'VERC
 }
 
 export function createVercelSandboxProvider(
+  opts: VercelSandboxProviderOptions & ({ lifecycle: 'disposable' } | { leaseMode: 'disposable' }),
+): DisposableSandboxProviderV1
+export function createVercelSandboxProvider(
+  opts?: VercelSandboxProviderOptions,
+): SandboxProviderV1
+export function createVercelSandboxProvider(
   opts: VercelSandboxProviderOptions = {},
 ): SandboxProviderV1 {
+  if (opts.leaseMode === 'disposable' && opts.lifecycle === 'persistent') {
+    throw new SandboxProviderError('CONFIG_INVALID', 'Vercel disposable lease mode conflicts with persistent lifecycle')
+  }
   const store = opts.store ?? new FileHandleStore()
   const getEnvVar = opts.getEnvVar ?? getEnv
   const logger = opts.logger ?? DEFAULT_MODE_LOGGER
@@ -528,7 +545,7 @@ export function createVercelSandboxProvider(
   // session stops and auto-resume on the next command. Do not run the old
   // periodic snapshotter here: sandbox.snapshot() stops the active session.
   const snapshotScheduler = opts.snapshotScheduler ?? null
-  const disposable = opts.lifecycle === 'disposable'
+  const disposable = opts.lifecycle === 'disposable' || opts.leaseMode === 'disposable'
   const unpublishedDisposableCleanups = new Set<() => Promise<void>>()
   const settleUnpublishedDisposableCleanup = async (cleanup: () => Promise<void>): Promise<void> => {
     await cleanup()
@@ -539,6 +556,14 @@ export function createVercelSandboxProvider(
     contractVersion: PROVIDER_CONTRACT_VERSION,
     providerId: 'vercel-sandbox',
     capabilities: PROVIDER_CAPABILITIES['vercel-sandbox'],
+    ...(disposable ? {
+      disposableProfile: {
+        contractVersion: DISPOSABLE_SANDBOX_PROVIDER_PROFILE_V1,
+        resume: false as const,
+        publishedCleanupOwner: 'returned-pair' as const,
+        ambiguousCreate: 'correlated-reconciliation' as const,
+      },
+    } : {}),
     resolveRuntimeRoot() {
       return VERCEL_SANDBOX_WORKSPACE_ROOT
     },
@@ -587,10 +612,14 @@ export function createVercelSandboxProvider(
       })
 
       const workspaceId = ctx.workspaceId ?? ctx.workspaceRoot
+      const disposableName = disposable
+        ? `boring-lease-${createHash('sha256').update(`${workspaceId}:${ctx.sessionId}:${ctx.requestId ?? ctx.sessionId}`).digest('hex').slice(0, 40)}`
+        : undefined
       let tarballUrl: string | undefined
       let workspace: ReturnType<typeof createVercelSandboxWorkspace> | undefined
       let sandbox: ReturnType<typeof createVercelSandboxExec> | undefined
       let disposableCleanup: (() => Promise<void>) | undefined
+      let ambiguityCleanup: (() => Promise<void>) | undefined
       let workspaceDisposed = false
       let localSandboxDisposed = false
       let setupFailureCaptured = false
@@ -618,14 +647,30 @@ export function createVercelSandboxProvider(
             })
             tarballUrl = result.url
             logger.info('[vercel-sandbox:mode] template packaged', {
-              hash: result.hash,
-              url: result.url,
+              templateDigest: telemetryDigest(result.hash),
+              uploaded: true,
             })
           } catch (error) {
             logger.info('[vercel-sandbox:mode] template packaging failed, will use writeFiles fallback', {
-              error: error instanceof Error ? error.message : String(error),
+              errorCode: typeof (error as { code?: unknown })?.code === 'string'
+                ? (error as { code: string }).code
+                : 'UNKNOWN',
             })
           }
+        }
+
+        if (disposable && disposableName) {
+          ambiguityCleanup = async () => {
+            try {
+              const candidate = await vercelClient.get({ name: disposableName, resume: false })
+              await candidate.delete()
+            } catch (error) {
+              const status = extractHttpStatus(error)
+              if (status !== 404 && status !== 410) throw error
+            }
+            unpublishedDisposableCleanups.delete(ambiguityCleanup!)
+          }
+          unpublishedDisposableCleanups.add(ambiguityCleanup)
         }
 
         const resolvedSandboxHandle = await runSandboxSetupStep({
@@ -637,6 +682,7 @@ export function createVercelSandboxProvider(
                 vercel: vercelClient,
                 sourceSnapshotId,
                 tarballUrl,
+                name: disposableName,
               })
             : await resolveSandboxHandle(
                 workspaceId,
@@ -659,14 +705,15 @@ export function createVercelSandboxProvider(
             disposeLocal,
           })
           unpublishedDisposableCleanups.add(disposableCleanup)
+          if (ambiguityCleanup) unpublishedDisposableCleanups.delete(ambiguityCleanup)
         }
 
         const sandboxId = resolvedSandboxHandle.name ?? resolvedSandboxHandle.sandboxId ?? 'unknown-sandbox'
         logger.info('[vercel-sandbox:mode] resolved sandbox handle', {
-          workspaceId,
-          sandboxId,
-          snapshotId: resolvedSandboxHandle.currentSnapshotId ?? resolvedSandboxHandle.sourceSnapshotId ?? null,
-          tarballUrl: tarballUrl ?? null,
+          workspaceDigest: telemetryDigest(workspaceId),
+          sandboxDigest: telemetryDigest(sandboxId),
+          snapshotDigest: telemetryDigest(resolvedSandboxHandle.currentSnapshotId ?? resolvedSandboxHandle.sourceSnapshotId),
+          templateUploaded: Boolean(tarballUrl),
           disposable,
         })
 
@@ -745,7 +792,7 @@ export function createVercelSandboxProvider(
           if (ctx.templatePath) {
             if (!tarballUrl) {
               logger.info('[vercel-sandbox:mode] falling back to writeFiles for template', {
-                templatePath: ctx.templatePath,
+                templateDigest: telemetryDigest(ctx.templatePath),
               })
             }
             await runSandboxSetupStep({
@@ -821,13 +868,16 @@ export function createVercelSandboxProvider(
         }
         return pair
       } catch (error) {
-        if (disposableCleanup) {
+        if (disposableCleanup || ambiguityCleanup) {
+          const cleanup = disposableCleanup ?? ambiguityCleanup!
           try {
-            await settleUnpublishedDisposableCleanup(disposableCleanup)
+            await settleUnpublishedDisposableCleanup(cleanup)
           } catch (cleanupError) {
             logger.warn?.('[vercel-sandbox:mode] disposable setup cleanup failed', {
-              workspaceId,
-              error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+              workspaceDigest: telemetryDigest(workspaceId),
+              errorCode: typeof (cleanupError as { code?: unknown })?.code === 'string'
+                ? (cleanupError as { code: string }).code
+                : 'UNKNOWN',
             })
           }
         } else {
@@ -835,8 +885,10 @@ export function createVercelSandboxProvider(
             await disposeLocal()
           } catch (cleanupError) {
             logger.warn?.('[vercel-sandbox:mode] local setup cleanup failed', {
-              workspaceId,
-              error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+              workspaceDigest: telemetryDigest(workspaceId),
+              errorCode: typeof (cleanupError as { code?: unknown })?.code === 'string'
+                ? (cleanupError as { code: string }).code
+                : 'UNKNOWN',
             })
           }
         }

--- a/packages/boring-sandbox/src/providers/vercel-sandbox/createVercelSandboxProvider.ts
+++ b/packages/boring-sandbox/src/providers/vercel-sandbox/createVercelSandboxProvider.ts
@@ -430,12 +430,10 @@ function extractHttpStatus(error: unknown): number | null {
   return typeof responseStatus === 'number' ? responseStatus : null
 }
 
-function isDefinitiveVercelCreateConflict(error: unknown): boolean {
-  const code = (error as { code?: unknown; json?: { error?: { code?: unknown } } } | null)
-  return extractHttpStatus(error) === 409
-    || code?.code === 'conflict'
-    || code?.json?.error?.code === 'conflict'
-    || /already exists|conflict/i.test(error instanceof Error ? error.message : String(error))
+function isDefinitiveVercelCreateRejection(error: unknown): boolean {
+  const status = extractHttpStatus(error)
+  return status !== null && status >= 400 && status < 500
+    && status !== 408 && status !== 409 && status !== 429
 }
 
 function isExpiredSandboxRuntimeError(error: unknown): boolean {
@@ -678,14 +676,15 @@ export function createVercelSandboxProvider(
           }
         }
 
-        let disposableCleanupVerified = true
         if (disposable && disposableName) {
           if (reservedDisposableNames.has(disposableName) || publishedDisposableNames.has(disposableName)) {
             throw new SandboxProviderError('CONFIG_INVALID', 'disposable Vercel request identity is already owned')
           }
           reservedDisposableNames.add(disposableName)
           ambiguityCleanup = async () => {
-            if (!disposableCleanupVerified) return
+            if (disposableCleanup && unpublishedDisposableCleanups.has(disposableCleanup)) {
+              throw new SandboxProviderError('VERCEL_API_ERROR', 'returned Vercel sandbox cleanup remains pending')
+            }
             try {
               const candidate = await vercelClient.get({ name: disposableName, resume: false })
               assertDisposableVercelIdentity({
@@ -736,38 +735,29 @@ export function createVercelSandboxProvider(
         })
         disposableCreateSettled = true
         if (disposable && disposableName) {
-          try {
-            assertDisposableVercelIdentity({
-              handle: resolvedSandboxHandle,
-              expectedName: disposableName,
-              expectedSnapshotId: sourceSnapshotId,
-            })
-            const lookedUp = await vercelClient.get({ name: disposableName, resume: false })
-            assertDisposableVercelIdentity({
-              handle: lookedUp,
-              expectedName: disposableName,
-              expectedSnapshotId: sourceSnapshotId,
-              expectedSandboxId: resolvedSandboxHandle.sandboxId,
-            })
-          } catch (error) {
-            disposableCleanupVerified = false
-            if (ambiguityCleanup) unpublishedDisposableCleanups.delete(ambiguityCleanup)
-            reservedDisposableNames.delete(disposableName)
-            throw error
-          }
-          const disposeRemote = createDisposableSandboxDisposer({
-            sandbox: resolvedSandboxHandle,
-            disposeLocal,
-          })
+          const disposeRemote = createDisposableSandboxDisposer({ sandbox: resolvedSandboxHandle, disposeLocal })
           disposableCleanup = async () => {
             await disposeRemote()
-            if (disposableName) {
+            if (!ambiguityCleanup) {
               reservedDisposableNames.delete(disposableName)
               publishedDisposableNames.delete(disposableName)
             }
           }
           unpublishedDisposableCleanups.add(disposableCleanup)
+          assertDisposableVercelIdentity({
+            handle: resolvedSandboxHandle,
+            expectedName: disposableName,
+            expectedSnapshotId: sourceSnapshotId,
+          })
+          const lookedUp = await vercelClient.get({ name: disposableName, resume: false })
+          assertDisposableVercelIdentity({
+            handle: lookedUp,
+            expectedName: disposableName,
+            expectedSnapshotId: sourceSnapshotId,
+            expectedSandboxId: resolvedSandboxHandle.sandboxId,
+          })
           if (ambiguityCleanup) unpublishedDisposableCleanups.delete(ambiguityCleanup)
+          ambiguityCleanup = undefined
         }
 
         const sandboxId = resolvedSandboxHandle.name ?? resolvedSandboxHandle.sandboxId ?? 'unknown-sandbox'
@@ -935,7 +925,7 @@ export function createVercelSandboxProvider(
         }
         return pair
       } catch (error) {
-        if (!disposableCleanup && ambiguityCleanup && isDefinitiveVercelCreateConflict(error)) {
+        if (!disposableCreateSettled && ambiguityCleanup && isDefinitiveVercelCreateRejection(error)) {
           unpublishedDisposableCleanups.delete(ambiguityCleanup)
           if (disposableName) reservedDisposableNames.delete(disposableName)
           ambiguityCleanup = undefined

--- a/packages/boring-sandbox/src/providers/vercel-sandbox/createVercelSandboxProvider.ts
+++ b/packages/boring-sandbox/src/providers/vercel-sandbox/createVercelSandboxProvider.ts
@@ -639,7 +639,6 @@ export function createVercelSandboxProvider(
       let sandbox: ReturnType<typeof createVercelSandboxExec> | undefined
       let disposableCleanup: (() => Promise<void>) | undefined
       let ambiguityCleanup: (() => Promise<void>) | undefined
-      let disposableCreateSettled = false
       let workspaceDisposed = false
       let localSandboxDisposed = false
       let setupFailureCaptured = false
@@ -697,12 +696,11 @@ export function createVercelSandboxProvider(
             } catch (error) {
               const status = extractHttpStatus(error)
               if (status !== 404 && status !== 410) throw normalizeVercelProviderError(error)
-              if (!disposableCreateSettled) {
+              if (!disposableCleanup) {
                 throw new SandboxProviderError('VERCEL_API_ERROR', 'disposable Vercel create reconciliation remains pending')
               }
             }
             reservedDisposableNames.delete(disposableName)
-            publishedDisposableNames.delete(disposableName)
             unpublishedDisposableCleanups.delete(ambiguityCleanup!)
           }
           unpublishedDisposableCleanups.add(ambiguityCleanup)
@@ -734,7 +732,6 @@ export function createVercelSandboxProvider(
                 },
               ),
         })
-        disposableCreateSettled = true
         if (disposable && disposableName) {
           const disposeRemote = createDisposableSandboxDisposer({ sandbox: resolvedSandboxHandle, disposeLocal })
           disposableCleanup = async () => {
@@ -915,26 +912,27 @@ export function createVercelSandboxProvider(
           if (setup.state === 'failed') throw setup.error
         }
         if (closed) throw new SandboxProviderError('VERCEL_API_ERROR', 'Vercel sandbox provider closed during create')
-        if (disposable && disposableCleanup) {
-          // From this point the returned pair is the sole cleanup owner. The
-          // provider retains authority only for failures before publication.
+        if (disposableCleanup && disposableName) {
           unpublishedDisposableCleanups.delete(disposableCleanup)
-          if (disposableName) {
-            reservedDisposableNames.delete(disposableName)
-            publishedDisposableNames.add(disposableName)
-          }
+          reservedDisposableNames.delete(disposableName)
+          publishedDisposableNames.add(disposableName)
         }
         return pair
       } catch (error) {
-        if (!disposableCreateSettled && ambiguityCleanup && isDefinitiveVercelCreateRejection(error)) {
+        if (!disposableCleanup && ambiguityCleanup && isDefinitiveVercelCreateRejection(error)) {
           unpublishedDisposableCleanups.delete(ambiguityCleanup)
           if (disposableName) reservedDisposableNames.delete(disposableName)
           ambiguityCleanup = undefined
         }
-        const cleanup = disposableCleanup ?? ambiguityCleanup
-        if (cleanup) {
+        const cleanups = [disposableCleanup, ambiguityCleanup] as const
+        const cleanup = async () => {
+          for (const candidate of cleanups) {
+            if (candidate && unpublishedDisposableCleanups.has(candidate)) await settleUnpublishedDisposableCleanup(candidate)
+          }
+        }
+        if (cleanups.some(Boolean)) {
           try {
-            await settleUnpublishedDisposableCleanup(cleanup)
+            await cleanup()
           } catch (cleanupError) {
             logger.warn?.('[vercel-sandbox:mode] disposable setup cleanup failed', {
               workspaceDigest: telemetryDigest(workspaceId, telemetrySalt),
@@ -957,7 +955,7 @@ export function createVercelSandboxProvider(
           errorCode: normalizedLifecycleErrorCode(error),
         })
         const normalized = normalizeVercelProviderError(error)
-        throw cleanup && unpublishedDisposableCleanups.has(cleanup)
+        throw cleanups.some((candidate) => candidate && unpublishedDisposableCleanups.has(candidate))
           ? attachSandboxProviderCleanupDebt(normalized, cleanup)
           : normalized
       }

--- a/packages/boring-sandbox/src/providers/vercel-sandbox/createVercelSandboxProvider.ts
+++ b/packages/boring-sandbox/src/providers/vercel-sandbox/createVercelSandboxProvider.ts
@@ -17,6 +17,7 @@ import {
 } from '../../shared/immutableCacheV1'
 import { PROVIDER_CAPABILITIES, PROVIDER_CONTRACT_VERSION } from '../../shared/providerMatrix'
 import {
+  attachSandboxProviderCleanupDebt,
   SandboxProviderError,
   type DisposableSandboxProviderV1,
   type SandboxProviderCreateContextV1,
@@ -930,8 +931,8 @@ export function createVercelSandboxProvider(
           if (disposableName) reservedDisposableNames.delete(disposableName)
           ambiguityCleanup = undefined
         }
-        if (disposableCleanup || ambiguityCleanup) {
-          const cleanup = disposableCleanup ?? ambiguityCleanup!
+        const cleanup = disposableCleanup ?? ambiguityCleanup
+        if (cleanup) {
           try {
             await settleUnpublishedDisposableCleanup(cleanup)
           } catch (cleanupError) {
@@ -955,7 +956,10 @@ export function createVercelSandboxProvider(
           durationMs: Date.now() - totalStartedAt,
           errorCode: normalizedLifecycleErrorCode(error),
         })
-        throw normalizeVercelProviderError(error)
+        const normalized = normalizeVercelProviderError(error)
+        throw cleanup && unpublishedDisposableCleanups.has(cleanup)
+          ? attachSandboxProviderCleanupDebt(normalized, cleanup)
+          : normalized
       }
       } finally {
         finishCreate()

--- a/packages/boring-sandbox/src/providers/vercel-sandbox/createVercelSandboxProvider.ts
+++ b/packages/boring-sandbox/src/providers/vercel-sandbox/createVercelSandboxProvider.ts
@@ -111,6 +111,22 @@ function sandboxTelemetryProperties(
   }
 }
 
+function createRedactedLifecycleLogger(logger: ModeLogger): ModeLogger {
+  const properties = (metadata: Record<string, unknown> = {}): Record<string, unknown> => {
+    const output: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(metadata)) {
+      if (typeof value === 'number' || typeof value === 'boolean' || value === null) output[key] = value
+      else if (typeof value === 'string' && ['reason', 'sourceType', 'status'].includes(key)) output[key] = value
+      else if (typeof value === 'string') output[`${key}Digest`] = telemetryDigest(value)
+    }
+    return output
+  }
+  return {
+    info(message, metadata) { logger.info(message, properties(metadata)) },
+    warn(message, metadata) { logger.warn?.(message, properties(metadata)) },
+  }
+}
+
 function captureSandboxSetupEvent(
   telemetry: TelemetrySink | undefined,
   ctx: SandboxProviderCreateContextV1 | undefined,
@@ -541,6 +557,7 @@ export function createVercelSandboxProvider(
   const store = opts.store ?? new FileHandleStore()
   const getEnvVar = opts.getEnvVar ?? getEnv
   const logger = opts.logger ?? DEFAULT_MODE_LOGGER
+  const lifecycleLogger = createRedactedLifecycleLogger(logger)
   // @vercel/sandbox@beta persistent sandboxes auto-snapshot when their
   // session stops and auto-resume on the next command. Do not run the old
   // periodic snapshotter here: sandbox.snapshot() stops the active session.
@@ -691,7 +708,7 @@ export function createVercelSandboxProvider(
                 {
                   sourceSnapshotId,
                   tarballUrl,
-                  logger,
+                  logger: lifecycleLogger,
                   maxIdleMs: opts.orphanGuardMaxIdleMs === null
                     ? undefined
                     : opts.orphanGuardMaxIdleMs ?? ORPHAN_GUARD_MAX_IDLE_MS,
@@ -728,7 +745,7 @@ export function createVercelSandboxProvider(
 
         workspace = createVercelSandboxWorkspace(resolvedSandboxHandle, {
           onMutation: markDirty,
-          logger,
+          logger: lifecycleLogger,
         })
         sandbox = createVercelSandboxExec(resolvedSandboxHandle, {
           onMutation: markDirty,

--- a/packages/boring-sandbox/src/providers/vercel-sandbox/createVercelSandboxProvider.ts
+++ b/packages/boring-sandbox/src/providers/vercel-sandbox/createVercelSandboxProvider.ts
@@ -109,7 +109,7 @@ function assertDisposableVercelIdentity(input: {
   expectedSandboxId?: string
 }): void {
   if (
-    (input.handle.name !== undefined && input.handle.name !== input.expectedName)
+    input.handle.name !== input.expectedName
     || (input.expectedSnapshotId !== undefined
       && input.handle.sourceSnapshotId !== undefined
       && input.handle.sourceSnapshotId !== input.expectedSnapshotId)

--- a/packages/boring-sandbox/src/providers/vercel-sandbox/createVercelSandboxProvider.ts
+++ b/packages/boring-sandbox/src/providers/vercel-sandbox/createVercelSandboxProvider.ts
@@ -640,6 +640,7 @@ export function createVercelSandboxProvider(
       let sandbox: ReturnType<typeof createVercelSandboxExec> | undefined
       let disposableCleanup: (() => Promise<void>) | undefined
       let ambiguityCleanup: (() => Promise<void>) | undefined
+      let disposableCreateSettled = false
       let workspaceDisposed = false
       let localSandboxDisposed = false
       let setupFailureCaptured = false
@@ -695,7 +696,10 @@ export function createVercelSandboxProvider(
               await candidate.delete()
             } catch (error) {
               const status = extractHttpStatus(error)
-              if (status !== 404 && status !== 410) throw error
+              if (status !== 404 && status !== 410) throw normalizeVercelProviderError(error)
+              if (!disposableCreateSettled) {
+                throw new SandboxProviderError('VERCEL_API_ERROR', 'disposable Vercel create reconciliation remains pending')
+              }
             }
             reservedDisposableNames.delete(disposableName)
             publishedDisposableNames.delete(disposableName)
@@ -730,6 +734,7 @@ export function createVercelSandboxProvider(
                 },
               ),
         })
+        disposableCreateSettled = true
         if (disposable && disposableName) {
           try {
             assertDisposableVercelIdentity({

--- a/packages/boring-sandbox/src/providers/vercel-sandbox/disposableSandboxLifecycle.ts
+++ b/packages/boring-sandbox/src/providers/vercel-sandbox/disposableSandboxLifecycle.ts
@@ -7,8 +7,9 @@ export async function createDisposableSandboxHandle(input: {
   readonly vercel: VercelSandboxClient
   readonly sourceSnapshotId?: string
   readonly tarballUrl?: string
+  readonly name?: string
 }): Promise<VercelSandboxHandle> {
-  const base = { persistent: true, snapshotExpiration: 0 }
+  const base = { persistent: true, snapshotExpiration: 0, ...(input.name ? { name: input.name } : {}) }
   if (input.sourceSnapshotId) {
     return await input.vercel.create({
       ...base,

--- a/packages/boring-sandbox/src/providers/vercel-sandbox/lifecycleTelemetry.ts
+++ b/packages/boring-sandbox/src/providers/vercel-sandbox/lifecycleTelemetry.ts
@@ -1,0 +1,72 @@
+import { createHmac } from 'node:crypto'
+
+import type { TelemetrySink } from '@hachej/boring-agent/shared'
+import type { SandboxProviderCreateContextV1 } from '../../shared/providerV1'
+import { safeCapture } from '../runtimeSupport'
+
+export interface VercelLifecycleLogger {
+  info(message: string, metadata: Record<string, unknown>): void
+  warn?(message: string, metadata?: Record<string, unknown>): void
+}
+
+const STABLE_ERROR_CODES = new Set([
+  'CONFIG_INVALID', 'VERCEL_AUTH_FAILED', 'VERCEL_API_ERROR',
+  'VERCEL_SANDBOX_NOT_FOUND', 'ENOENT', 'ETIMEDOUT', 'ECONNRESET',
+])
+
+export function telemetryDigest(value: string | undefined, salt?: string): string | undefined {
+  if (!value || !salt) return undefined
+  return createHmac('sha256', salt).update(value).digest('hex')
+}
+
+export function normalizedLifecycleErrorCode(error: unknown): string {
+  const raw = (error as { code?: unknown } | null)?.code
+  return typeof raw === 'string' && STABLE_ERROR_CODES.has(raw) ? raw : 'UNKNOWN'
+}
+
+function safeLifecycleProperties(
+  input: Record<string, unknown>,
+  salt?: string,
+): Record<string, unknown> {
+  const output: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(input)) {
+    if (key === 'errorCode') output.errorCode = normalizedLifecycleErrorCode({ code: value })
+    else if (typeof value === 'number' || typeof value === 'boolean' || value === null) output[key] = value
+    else if (typeof value === 'string' && ['phase', 'reason', 'sourceType', 'status'].includes(key)) {
+      output[key] = /^[a-z0-9._-]{1,64}$/i.test(value) ? value : 'UNKNOWN'
+    } else if (typeof value === 'string') output[`${key}Digest`] = telemetryDigest(value, salt)
+  }
+  return output
+}
+
+export function createRedactedLifecycleLogger(
+  logger: VercelLifecycleLogger,
+  telemetrySalt?: string,
+): VercelLifecycleLogger {
+  const properties = (metadata: Record<string, unknown> = {}): Record<string, unknown> =>
+    safeLifecycleProperties(metadata, telemetrySalt)
+  return {
+    info(message, metadata) { logger.info(message, properties(metadata)) },
+    warn(message, metadata) { logger.warn?.(message, properties(metadata)) },
+  }
+}
+
+export function captureSandboxSetupEvent(
+  telemetry: TelemetrySink | undefined,
+  ctx: SandboxProviderCreateContextV1 | undefined,
+  name: string,
+  properties?: Record<string, unknown>,
+): void {
+  if (!telemetry) return
+  const salt = (ctx as (SandboxProviderCreateContextV1 & { telemetrySalt?: string }) | undefined)?.telemetrySalt
+  safeCapture(telemetry, {
+    name,
+    properties: {
+      runtimeMode: 'vercel-sandbox',
+      workspaceDigest: telemetryDigest(ctx?.workspaceId, salt),
+      sessionDigest: telemetryDigest(ctx?.sessionId, salt),
+      requestDigest: telemetryDigest(ctx?.requestId, salt),
+      ...safeLifecycleProperties(properties ?? {}, salt),
+    },
+  })
+}

--- a/packages/boring-sandbox/src/providers/vercel-sandbox/packageTemplate.ts
+++ b/packages/boring-sandbox/src/providers/vercel-sandbox/packageTemplate.ts
@@ -145,13 +145,12 @@ export async function packageTemplate(
 
   const cached = urlCache.get(hash)
   if (cached) {
-    log('cache hit', { hash, fileCount: files.length })
+    log('cache hit', { fileCount: files.length })
     return { url: cached, hash }
   }
 
   const tarball = await buildTarGz(files)
   log('tarball built', {
-    hash,
     fileCount: files.length,
     sizeBytes: tarball.length,
     buildMs: Date.now() - startMs,
@@ -161,7 +160,7 @@ export async function packageTemplate(
   const url = await upload(hash, tarball)
   urlCache.set(hash, url)
 
-  log('uploaded', { hash, url, totalMs: Date.now() - startMs })
+  log('uploaded', { totalMs: Date.now() - startMs })
   return { url, hash }
 }
 

--- a/packages/boring-sandbox/src/shared/index.ts
+++ b/packages/boring-sandbox/src/shared/index.ts
@@ -75,6 +75,7 @@ export {
   QUALIFICATION_BUNDLE_SCHEMA_VERSION,
 } from "./qualificationBundle";
 export type {
+  DisposableSandboxProviderV1,
   ExtractedSandboxProviderIdV1,
   SandboxPairHealthV1,
   SandboxProviderCreateContextV1,
@@ -88,7 +89,11 @@ export type {
   SandboxRuntimeModeIdV1,
   WorkspaceSandboxPairV1,
 } from "./providerV1";
-export { SandboxProviderError } from "./providerV1";
+export {
+  DISPOSABLE_SANDBOX_PROVIDER_PROFILE_V1,
+  SandboxProviderError,
+  isDisposableSandboxProviderV1,
+} from "./providerV1";
 export type {
   RemoteWorkerBindingReceiptPayloadV1,
   RemoteWorkerBindingReceiptV1,

--- a/packages/boring-sandbox/src/shared/index.ts
+++ b/packages/boring-sandbox/src/shared/index.ts
@@ -78,6 +78,7 @@ export type {
   DisposableSandboxProviderV1,
   ExtractedSandboxProviderIdV1,
   SandboxPairHealthV1,
+  SandboxProviderCreateCleanupDebtV1,
   SandboxProviderCreateContextV1,
   SandboxProviderInvalidateContextV1,
   SandboxProviderV1,

--- a/packages/boring-sandbox/src/shared/providerV1.ts
+++ b/packages/boring-sandbox/src/shared/providerV1.ts
@@ -94,6 +94,9 @@ export type WorkspaceSandboxPairV1 = Readonly<{
   dispose(): Promise<void>;
 }>;
 
+export const DISPOSABLE_SANDBOX_PROVIDER_PROFILE_V1 =
+  'boring-sandbox.disposable-provider.v1' as const;
+
 export interface SandboxProviderV1 {
   readonly contractVersion: typeof PROVIDER_CONTRACT_VERSION;
   readonly providerId: ExtractedSandboxProviderIdV1;
@@ -106,6 +109,26 @@ export interface SandboxProviderV1 {
     context: SandboxProviderInvalidateContextV1,
   ): Promise<void> | void;
   close?(): Promise<void>;
+}
+
+/** Host-only refinement required by mutable lease composition. */
+export interface DisposableSandboxProviderV1 extends SandboxProviderV1 {
+  readonly disposableProfile: Readonly<{
+    contractVersion: typeof DISPOSABLE_SANDBOX_PROVIDER_PROFILE_V1;
+    resume: false;
+    publishedCleanupOwner: 'returned-pair';
+    ambiguousCreate: 'correlated-reconciliation';
+  }>;
+}
+
+export function isDisposableSandboxProviderV1(
+  provider: SandboxProviderV1,
+): provider is DisposableSandboxProviderV1 {
+  const profile = (provider as Partial<DisposableSandboxProviderV1>).disposableProfile;
+  return profile?.contractVersion === DISPOSABLE_SANDBOX_PROVIDER_PROFILE_V1
+    && profile.resume === false
+    && profile.publishedCleanupOwner === 'returned-pair'
+    && profile.ambiguousCreate === 'correlated-reconciliation';
 }
 
 export class SandboxProviderError extends Error {

--- a/packages/boring-sandbox/src/shared/providerV1.ts
+++ b/packages/boring-sandbox/src/shared/providerV1.ts
@@ -118,7 +118,6 @@ export interface DisposableSandboxProviderProfileV1 {
   readonly publishedCleanupOwner: 'returned-pair';
   readonly ambiguousCreate: 'correlated-reconciliation';
   readonly providerConfigDigest: `sha256:${string}`;
-  assertProvider(provider: SandboxProviderV1): void;
 }
 
 export interface DisposableSandboxProviderV1 extends SandboxProviderV1 {
@@ -134,14 +133,9 @@ export function isDisposableSandboxProviderV1(
     profile.resume !== false ||
     profile.publishedCleanupOwner !== 'returned-pair' ||
     profile.ambiguousCreate !== 'correlated-reconciliation' ||
-    typeof profile.assertProvider !== 'function'
+    !/^sha256:[a-f0-9]{64}$/.test(profile.providerConfigDigest)
   ) return false;
-  try {
-    profile.assertProvider(provider);
-    return true;
-  } catch {
-    return false;
-  }
+  return true;
 }
 
 export class SandboxProviderError extends Error {

--- a/packages/boring-sandbox/src/shared/providerV1.ts
+++ b/packages/boring-sandbox/src/shared/providerV1.ts
@@ -112,23 +112,36 @@ export interface SandboxProviderV1 {
 }
 
 /** Host-only refinement required by mutable lease composition. */
+export interface DisposableSandboxProviderProfileV1 {
+  readonly contractVersion: typeof DISPOSABLE_SANDBOX_PROVIDER_PROFILE_V1;
+  readonly resume: false;
+  readonly publishedCleanupOwner: 'returned-pair';
+  readonly ambiguousCreate: 'correlated-reconciliation';
+  readonly providerConfigDigest: `sha256:${string}`;
+  assertProvider(provider: SandboxProviderV1): void;
+}
+
 export interface DisposableSandboxProviderV1 extends SandboxProviderV1 {
-  readonly disposableProfile: Readonly<{
-    contractVersion: typeof DISPOSABLE_SANDBOX_PROVIDER_PROFILE_V1;
-    resume: false;
-    publishedCleanupOwner: 'returned-pair';
-    ambiguousCreate: 'correlated-reconciliation';
-  }>;
+  readonly disposableProfile: DisposableSandboxProviderProfileV1;
 }
 
 export function isDisposableSandboxProviderV1(
   provider: SandboxProviderV1,
 ): provider is DisposableSandboxProviderV1 {
   const profile = (provider as Partial<DisposableSandboxProviderV1>).disposableProfile;
-  return profile?.contractVersion === DISPOSABLE_SANDBOX_PROVIDER_PROFILE_V1
-    && profile.resume === false
-    && profile.publishedCleanupOwner === 'returned-pair'
-    && profile.ambiguousCreate === 'correlated-reconciliation';
+  if (
+    profile?.contractVersion !== DISPOSABLE_SANDBOX_PROVIDER_PROFILE_V1 ||
+    profile.resume !== false ||
+    profile.publishedCleanupOwner !== 'returned-pair' ||
+    profile.ambiguousCreate !== 'correlated-reconciliation' ||
+    typeof profile.assertProvider !== 'function'
+  ) return false;
+  try {
+    profile.assertProvider(provider);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export class SandboxProviderError extends Error {

--- a/packages/boring-sandbox/src/shared/providerV1.ts
+++ b/packages/boring-sandbox/src/shared/providerV1.ts
@@ -94,6 +94,15 @@ export type WorkspaceSandboxPairV1 = Readonly<{
   dispose(): Promise<void>;
 }>;
 
+export interface SandboxProviderCreateCleanupDebtV1 {
+  readonly sandboxProviderCleanupDebt: Readonly<{ retry(): Promise<void> }>;
+}
+
+export function attachSandboxProviderCleanupDebt<T extends Error>(error: T, retry: () => Promise<void>): T {
+  Object.defineProperty(error, "sandboxProviderCleanupDebt", { value: Object.freeze({ retry }) });
+  return error;
+}
+
 export const DISPOSABLE_SANDBOX_PROVIDER_PROFILE_V1 =
   'boring-sandbox.disposable-provider.v1' as const;
 


### PR DESCRIPTION
Closes #1459. Stacked on #1482.

## Summary

- defines a truthful disposable-provider refinement and host-bound profile identity
- adds explicit disposable lifecycle support for direct, bwrap/local, Blaxel, Vercel Sandbox, and qualified remote-worker
- atomically binds Agent lease services to provider/profile authority while preserving primary/default behavior
- makes ambiguous create cleanup listable, quota-counted, retryable, and owned through shutdown
- adds shared lifecycle conformance, strict sandbox-tool parsing, cleanup settlement, and qualification documentation

## Stack

- #1446 accepted external-effect provenance
- #1441 native sandbox leases and explicit targeting
- #1479 A0 root lifecycle
- #1480 A1 multi-session runtime
- #1481 A2a authenticated handler
- #1482 A2b provider qualification/cleanup
- **this PR: all-provider disposable leases**

## Validation

- boring-sandbox: 829/829
- Agent: 2,365 passed, 18 skipped
- boring-bash: 90/90
- direct/bwrap real disposable execution and exact-root cleanup: 13/13
- remote two-root runsc proof passed; production remained `qualified:false`
- exact-head Vault-backed Vercel qualification passed create, readiness, read/write, exec, published-pair survival, and remote deletion
- sequential lint, typecheck, invariants, and builds passed
- production delta: 1,500 additions / 229 deletions; largest changed production file remains below 1,000 lines
- final independent spec/security review: **IMPLEMENTATION SHIP**
- final thermonuclear review: **SHIP / no blockers**

## Qualification status

| Provider | Status |
| --- | --- |
| direct | real PASS; trusted-host use only |
| bwrap/local | real PASS; not hostile-tenant isolation |
| Blaxel | mock lifecycle PASS; live NOT RUN without a D31-qualified profile |
| Vercel Sandbox | exact-head live PASS |
| remote-worker | raw runsc isolation PASS; production `qualified:false` because local gVisor lacks `openat2` |

## Deferred, explicit

Process-local reconciliation is not durable multi-host reconciliation. Delegate error projection and per-operation health cost remain bounded follow-ups. #1446 provider tool-call identity uniqueness and multi-author Send-now provenance remain separate accepted-effect follow-ups.
