### PR TITLE
feat: scope authored agent commands and filesystems

### DIFF
--- a/packages/agent/src/server/agent-host/__tests__/createAgentHost.test.ts
+++ b/packages/agent/src/server/agent-host/__tests__/createAgentHost.test.ts
@@ -423,6 +423,8 @@ describe('createAgentHost', () => {
     const company = binding('company_context', 'company')
     const nutritionist = binding('nutritionist_context', 'nutritionist')
     const legal = binding('legal_context', 'legal')
+    const humanOnly = { ...binding('human_only_context', 'human'), agentTypeIds: [] as readonly string[] }
+    const dynamicSibling = { ...binding('dynamic_sibling_context', 'sibling'), agentTypeIds: ['other'] as readonly string[] }
     const toolsByAgent = new Map<string, Parameters<AgentHarnessFactory>[0]['tools']>()
     const harnessFactory: AgentHarnessFactory = async (input) => {
       toolsByAgent.set(input.systemPromptAppend!, input.tools)
@@ -431,6 +433,7 @@ describe('createAgentHost', () => {
     const resolveAgentBindings = vi.fn(async (agentTypeId: string) => [
       company,
       agentTypeId === 'nutritionist' ? nutritionist : legal,
+      dynamicSibling,
     ])
     const created = await createAgentHost({
       ...options(workspaceRoot),
@@ -443,7 +446,7 @@ describe('createAgentHost', () => {
         placementIdentity: 'context-catalog-environment',
         workspaceRoot,
         provisioningFingerprint: 'context-catalog-environment-v1',
-        resolveFilesystemBindings: async () => [company, nutritionist, legal],
+        resolveFilesystemBindings: async () => [company, nutritionist, legal, humanOnly],
       }),
       resolveAuthorizedAgentRuntimeScope: async ({ agentTypeId }) => ({
         identity: `context-runtime:${agentTypeId}`,
@@ -467,6 +470,7 @@ describe('createAgentHost', () => {
         'company_context',
         'nutritionist_context',
         'legal_context',
+        'human_only_context',
       ])
 
       await created.gateway.createSession({
@@ -501,6 +505,16 @@ describe('createAgentHost', () => {
         toolContext('nutritionist-foreign-read'),
       )).rejects.toThrow('No filesystem binding is available for legal_context')
       expect(legal.operations.read).not.toHaveBeenCalled()
+      await expect(nutritionistRead.execute(
+        { filesystem: 'human_only_context', path: 'knowledge.md' },
+        toolContext('nutritionist-human-only-read'),
+      )).rejects.toThrow('No filesystem binding is available for human_only_context')
+      expect(humanOnly.operations.read).not.toHaveBeenCalled()
+      await expect(nutritionistRead.execute(
+        { filesystem: 'dynamic_sibling_context', path: 'knowledge.md' },
+        toolContext('nutritionist-dynamic-sibling-read'),
+      )).rejects.toThrow('No filesystem binding is available for dynamic_sibling_context')
+      expect(dynamicSibling.operations.read).not.toHaveBeenCalled()
 
       const ownLegal = await legalRead.execute(
         { filesystem: 'legal_context', path: 'knowledge.md' },
@@ -509,6 +523,8 @@ describe('createAgentHost', () => {
       expect(ownLegal.isError).not.toBe(true)
       expect(legal.operations.read).toHaveBeenCalledOnce()
       expect(resolveAgentBindings.mock.calls.map(([agentTypeId]) => agentTypeId)).toEqual([
+        'nutritionist',
+        'nutritionist',
         'nutritionist',
         'nutritionist',
         'legal',
@@ -556,6 +572,7 @@ describe('createAgentHost', () => {
       created,
       authorizeAgentRequest: async () => scope,
     })
+    await app.register(created.registerDirectRoutes({ authorizeAgentRequest: async () => scope }))
 
     try {
       // The computed definition digest is surfaced as identity on describe().
@@ -569,9 +586,11 @@ describe('createAgentHost', () => {
       // Environment-level filesystem catalog.
       const catalog = await app.inject({ method: 'GET', url: '/api/v1/filesystems' })
       expect(catalog.statusCode).toBe(200)
-      expect(catalog.json().filesystems.map((entry: { filesystem: string }) => entry.filesystem))
-        .not.toContain('agent_knowledge')
-
+      expect(catalog.json().filesystems).toEqual([
+        expect.objectContaining({ filesystem: 'user', label: 'Workspace', access: 'readwrite' }),
+      ])
+      expect(catalog.body).not.toContain('agent_knowledge')
+      expect(catalog.body).not.toContain('agent_resources')
       await created.gateway.createSession({ scope, agentTypeId: 'scholar', requestId: 'scholar-knowledge-session' })
       await created.gateway.createSession({ scope, agentTypeId: 'plain', requestId: 'plain-knowledge-session' })
       const toolContext = (requestId: string) => ({
@@ -830,6 +849,10 @@ describe('createAgentHost', () => {
     }))
     const created = await createAgentHost({
       ...options(workspaceRoot),
+      agents: [
+        { agentTypeId: 'alpha', definition: { instructions: 'alpha', label: 'Alpha' } },
+        { agentTypeId: 'beta', definition: { instructions: 'beta', label: 'Beta' } },
+      ],
       inMemoryRequestLedgerMode: 'test',
       metering: {
         isEnabled: () => meteringEnabled,
@@ -934,6 +957,23 @@ describe('createAgentHost', () => {
       expect(missing.statusCode, url).toBe(404)
       expect(missing.json(), url).toMatchObject({ error: { code: AgentGatewayErrorCode.AGENT_SESSION_NOT_FOUND } })
     }
+    const betaSession = await app.inject({
+      method: 'POST',
+      url: '/api/v1/agents/beta/sessions',
+      payload: { requestId: 'create-beta-direct' },
+    })
+    const betaSessionId = betaSession.json<{ sessionId: string }>().sessionId
+    const alphaCommands = await app.inject({
+      method: 'GET',
+      url: `/api/v1/agents/alpha/commands?sessionId=${sessionId}`,
+    })
+    const betaCommands = await app.inject({
+      method: 'GET',
+      url: `/api/v1/agents/beta/commands?sessionId=${betaSessionId}`,
+    })
+    expect(alphaCommands.json<{ commands: Array<{ name: string }> }>().commands.map(({ name }) => name)).toEqual(['check'])
+    expect(betaCommands.json<{ commands: Array<{ name: string }> }>().commands.map(({ name }) => name)).toEqual(['check'])
+
     const commandPayload = {
       requestId: 'command-direct',
       sessionId,

--- a/packages/agent/src/server/agent-host/buildAgentComposition.ts
+++ b/packages/agent/src/server/agent-host/buildAgentComposition.ts
@@ -142,6 +142,7 @@ export interface BuiltAgentComposition {
   readonly pi: ResolvedPiHarnessOptions
   readonly runtimeBundle: RuntimeBundle
   readonly readyTracker: ReadyStatusTracker
+  readonly getFilesystemBindings?: (ctx: { sessionId?: string; userId?: string; requestId?: string }) => Promise<readonly RuntimeFilesystemBinding[]>
   dispose(): Promise<void>
 }
 
@@ -162,7 +163,12 @@ export async function buildAgentComposition(
   input: BuildAgentCompositionInput,
 ): Promise<BuiltAgentComposition> {
   const { runtimeScope, options } = input
-  const runtimeBundle = input.runtimeBundle
+  const bindingIsVisible = (binding: RuntimeFilesystemBinding) =>
+    binding.agentTypeIds === undefined || binding.agentTypeIds.includes(input.agent.agentTypeId)
+  const visibleBindings = input.runtimeBundle.filesystemBindings?.filter(bindingIsVisible)
+  const runtimeBundle = visibleBindings === input.runtimeBundle.filesystemBindings
+    ? input.runtimeBundle
+    : { ...input.runtimeBundle, filesystemBindings: visibleBindings }
   // Resource loading is host authority: only the mode adapter's explicit
   // storageRoot proves that guest workspace bytes are mirrored on this host.
   const hostStorageRoot = runtimeBundle.storageRoot
@@ -176,9 +182,10 @@ export async function buildAgentComposition(
   // gets it without per-host wiring, and sibling agents never see it. A
   // declared-but-unmountable knowledge folder fails this agent's composition
   // closed.
-  const knowledgeRootDir = input.agent.knowledge?.rootDir
+  const authoredAgent = input.agent
+  const knowledgeRootDir = authoredAgent.knowledge?.rootDir
   let knowledgeBinding: RuntimeFilesystemBinding | undefined
-  if (knowledgeRootDir !== undefined) {
+  if (knowledgeRootDir !== undefined && authoredAgent) {
     const runtimeHostOperations = options.runtimeHost ?? runtimeBundle.runtimeHost
     if (!runtimeHostOperations) {
       throw Object.assign(
@@ -191,6 +198,11 @@ export async function buildAgentComposition(
         AGENT_KNOWLEDGE_FILESYSTEM_ID,
         [{ logicalRoot: '/', sourceRoot: knowledgeRootDir }],
       ),
+      catalog: {
+        visible: true,
+        label: authoredAgent.definition.label,
+        rootDir: '/' as const,
+      },
     })
   }
   const scopedKnowledgeBinding = knowledgeBinding
@@ -200,7 +212,7 @@ export async function buildAgentComposition(
   // filesystem — same merge seam as origin/feat/1107-s1-discovery.
   const getFilesystemBindings = runtimeScope.getFilesystemBindings || scopedKnowledgeBinding
     ? async (ctx: { sessionId?: string; userId?: string; requestId?: string }) => [
-        ...mergeRuntimeFilesystemBindings(
+        ...(mergeRuntimeFilesystemBindings(
           runtimeBundle.filesystemBindings,
           [
             ...await runtimeScope.getFilesystemBindings?.({
@@ -213,7 +225,7 @@ export async function buildAgentComposition(
             }) ?? [],
             ...(scopedKnowledgeBinding ? [scopedKnowledgeBinding] : []),
           ],
-        ) ?? [],
+        ) ?? []).filter(bindingIsVisible),
       ]
     : undefined
   const standardTools: AgentTool[] = [
@@ -342,6 +354,7 @@ export async function buildAgentComposition(
     pi,
     runtimeBundle,
     readyTracker,
+    ...(getFilesystemBindings ? { getFilesystemBindings } : {}),
     dispose() {
       disposed ??= backend.close().finally(() => durableEventStore?.close())
       return disposed

--- a/packages/agent/src/server/runtime/mode.ts
+++ b/packages/agent/src/server/runtime/mode.ts
@@ -98,10 +98,20 @@ export interface RuntimeFilesystemBindingOperations {
   rejectMutation(operation: string, descriptor: { filesystem: string; path: string }): never
 }
 
+export interface RuntimeFilesystemCatalogPresentation {
+  readonly visible?: boolean
+  readonly label?: string
+  readonly rootDir?: '.' | `/${string}`
+}
+
 export interface RuntimeFilesystemBinding {
   readonly filesystem: string
   readonly access: 'readonly' | 'readwrite'
   readonly operations: RuntimeFilesystemBindingOperations
+  /** User-facing catalog projection; internal routing continues to use filesystem. */
+  readonly catalog?: RuntimeFilesystemCatalogPresentation
+  /** When present, only these addressed Agents receive this user-visible binding. */
+  readonly agentTypeIds?: readonly string[]
 }
 
 

--- a/packages/boring-bash/src/agent/runtime/types.ts
+++ b/packages/boring-bash/src/agent/runtime/types.ts
@@ -57,10 +57,23 @@ export interface RuntimeFilesystemBindingOperations {
   rejectMutation(operation: string, descriptor: { filesystem: string; path: string }): never
 }
 
+export interface RuntimeFilesystemCatalogPresentation {
+  readonly visible?: boolean
+  readonly label?: string
+  readonly rootDir?: '.' | `/${string}`
+}
+
 export interface RuntimeFilesystemBinding {
   readonly filesystem: string
   readonly access: 'readonly' | 'readwrite'
   readonly operations: RuntimeFilesystemBindingOperations
+  /**
+   * User-facing catalog projection for file pickers. This never changes the
+   * internal filesystem id used by tools/routes.
+   */
+  readonly catalog?: RuntimeFilesystemCatalogPresentation
+  /** When present, only these addressed Agents receive this user-visible binding. */
+  readonly agentTypeIds?: readonly string[]
 }
 
 export interface RuntimeHostOperations {

--- a/packages/boring-bash/src/server/agentResourceOperations.ts
+++ b/packages/boring-bash/src/server/agentResourceOperations.ts
@@ -42,7 +42,7 @@ export async function createAgentResourceFilesystemBinding(
       pathStyle: 'absolute',
       symlinks: 'confined',
     })
-    return { filesystem, access: 'readonly', operations }
+    return { filesystem, access: 'readonly', operations, catalog: { visible: false } }
   } catch (error) {
     if (error instanceof ReadonlyProjectionOperationError) throw error
     throw invalidMount(filesystem)

--- a/packages/boring-bash/src/server/routes/filesystems.test.ts
+++ b/packages/boring-bash/src/server/routes/filesystems.test.ts
@@ -111,6 +111,24 @@ describe('filesystemsRoutes', () => {
     await app.close()
   })
 
+  it('projects user-facing labels and hides internal-only bindings without renaming ids', async () => {
+    const app = Fastify()
+    await app.register(filesystemsRoutes, {
+      filesystemBindings: [
+        binding({ filesystem: 'agent_resources', catalog: { visible: false } }),
+        binding({ filesystem: 'agent_knowledge:author', catalog: { visible: true, label: 'Author', rootDir: '/' } }),
+      ],
+    })
+
+    const response = await app.inject({ method: 'GET', url: '/api/v1/filesystems' })
+    expect(response.json().filesystems).toEqual([
+      expect.objectContaining({ filesystem: 'user', label: 'Workspace', access: 'readwrite' }),
+      expect.objectContaining({ filesystem: 'agent_knowledge:author', label: 'Author', access: 'readonly' }),
+    ])
+    expect(response.body).not.toContain('agent_resources')
+    await app.close()
+  })
+
   it('uses first-binding identity semantics and ignores user shadows and invalid identities', async () => {
     const app = Fastify()
     await app.register(filesystemsRoutes, {

--- a/packages/boring-bash/src/server/routes/filesystems.ts
+++ b/packages/boring-bash/src/server/routes/filesystems.ts
@@ -66,10 +66,15 @@ function capabilitiesFor(binding: RuntimeFilesystemBinding): FilesystemCatalogCa
 
 function catalogEntry(binding: RuntimeFilesystemBinding): FilesystemCatalogEntry | undefined {
   if (!validFilesystem(binding.filesystem) || binding.filesystem === USER_FILESYSTEM_ID) return undefined
+  if (binding.catalog?.visible === false) return undefined
+  const label = binding.catalog?.label ?? binding.filesystem
+  const rootDir = binding.catalog?.rootDir ?? '/'
+  if (!isValidCatalogString(label, CATALOG_STRING_MAX_LENGTH)) return undefined
+  if (!isValidCatalogString(rootDir, CATALOG_STRING_MAX_LENGTH)) return undefined
   return {
     filesystem: binding.filesystem,
-    label: binding.filesystem,
-    rootDir: '/',
+    label,
+    rootDir,
     access: binding.access === 'readwrite' ? 'readwrite' : 'readonly',
     capabilities: capabilitiesFor(binding),
   }

--- a/packages/cli/docs/README.md
+++ b/packages/cli/docs/README.md
@@ -30,7 +30,15 @@ Both are built in `src/server/modeApps.ts`.
 
 - **Folder mode** — `createFolderModeApp({ workspaceRoot, mode })`. One folder
   = one workspace (`workspaceId: "default"`). Wraps
-  `@hachej/boring-workspace/app/server`'s `createWorkspaceAgentServer`.
+  `@hachej/boring-workspace/app/server`'s `createWorkspaceAgentServer`. When
+  the launched root is a valid trusted `boring.agent` package, folder mode
+  activates that Agent instead of the anonymous default, including only its
+  package-local Pi resources and readonly `agent_knowledge` internal binding.
+  The human-facing shared catalog shows writable **Workspace** plus every
+  user-visible authored knowledge root; Agent composition filters those human
+  aliases and mounts only the addressed Agent's canonical knowledge binding.
+  Package-resource skill mounts use internal `agent_resources` and remain
+  hidden from file pickers.
 - **Workspaces mode** — `createWorkspacesModeApp({ mode })`. A multi-workspace
   hub. Builds a bare Fastify app and registers the workspace runtime backend
   gateway, agent routes, and UI routes. Each workspace is resolved per-request

--- a/packages/cli/src/server/__tests__/modeApps.agentHost.test.ts
+++ b/packages/cli/src/server/__tests__/modeApps.agentHost.test.ts
@@ -178,6 +178,87 @@ async function fixtureApp(useConfiguredSessionRoot: boolean) {
 }
 
 describe.sequential("CLI Agent Host composition", () => {
+  it("folder mode activates a launched authored agent package with scoped skills and knowledge", async () => {
+    const home = await temporaryRoot("boring-cli-authored-home-")
+    const workspaceRoot = await temporaryRoot("boring-cli-authored-workspace-")
+    process.env.HOME = home
+    await mkdir(join(workspaceRoot, "knowledge"))
+    await mkdir(join(workspaceRoot, "plugin", "agent"), { recursive: true })
+    await mkdir(join(workspaceRoot, "plugin", "front"), { recursive: true })
+    await mkdir(join(workspaceRoot, "skills", "local"), { recursive: true })
+    await writeFile(join(workspaceRoot, "instructions.md"), "You are Alpha.\n")
+    await writeFile(join(workspaceRoot, "knowledge", "facts.md"), "alpha knowledge\n")
+    await writeFile(join(workspaceRoot, "skills", "local", "SKILL.md"), "---\nname: local\ndescription: Local skill\n---\n\nUse local knowledge.\n")
+    await writeFile(join(workspaceRoot, "plugin", "agent", "index.ts"), `export default function (pi: any) { pi.registerCommand("book-alpha", { description: "Book alpha", handler: async () => undefined }) }\n`)
+    await writeFile(join(workspaceRoot, "plugin", "front", "index.tsx"), `import { definePlugin } from "@hachej/boring-workspace/plugin"\nexport default definePlugin({ id: "alpha-agent" })\n`)
+    await writeFile(join(workspaceRoot, "package.json"), JSON.stringify({
+      name: "alpha-agent",
+      version: "1.0.0",
+      boring: {
+        agent: { definitionId: "alpha", version: "1.0.0", label: "Alpha", instructionsRef: "instructions.md" },
+        front: "plugin/front/index.tsx",
+      },
+      pi: { extensions: ["plugin/agent/index.ts"], skills: ["skills/local"] },
+    }))
+    const app = await createFolderModeApp({
+      workspaceRoot,
+      mode: "direct",
+      provisionWorkspace: false,
+      loadAmbientSkills: false,
+      loadAmbientContext: false,
+    })
+    try {
+      const meta = await app.inject({ method: "GET", url: "/api/v1/workspace/meta" })
+      expect(meta.json<{ defaultAgentTypeId: string }>().defaultAgentTypeId).toBe("alpha")
+      const agents = await app.inject({ method: "GET", url: "/api/v1/agents" })
+      expect(agents.json<Array<{ agentTypeId: string }>>().map(({ agentTypeId }) => agentTypeId)).toEqual(["alpha"])
+      const created = await app.inject({
+        method: "POST",
+        url: "/api/v1/agents/alpha/sessions",
+        payload: { requestId: "create-alpha" },
+      })
+      const sessionId = created.json<{ sessionId: string }>().sessionId
+      const commands = await app.inject({
+        method: "GET",
+        url: `/api/v1/agents/alpha/commands?sessionId=${sessionId}`,
+      })
+      expect(commands.json().commands).toEqual(expect.arrayContaining([
+        expect.objectContaining({ name: "book-alpha", source: "extension" }),
+        expect.objectContaining({ name: "skill:local", source: "skill" }),
+      ]))
+      const commandResult = await app.inject({
+        method: "POST",
+        url: "/api/v1/agents/alpha/commands/execute",
+        payload: { requestId: "execute-alpha", sessionId, name: "book-alpha", args: "" },
+      })
+      expect(commandResult.json()).toEqual({ ok: true, sessionId, name: "book-alpha" })
+      const skills = await app.inject({ method: "GET", url: "/api/v1/agents/alpha/skills" })
+      expect(skills.json().skills).toEqual(expect.arrayContaining([
+        expect.objectContaining({ name: "local" }),
+      ]))
+      expect((await app.inject({ method: "GET", url: "/api/v1/agents/default/skills" })).statusCode)
+        .toBeGreaterThanOrEqual(400)
+      const humanFilesystems = await app.inject({ method: "GET", url: "/api/v1/filesystems" })
+      expect(humanFilesystems.json().filesystems).toEqual(expect.arrayContaining([
+        expect.objectContaining({ filesystem: "user", access: "readwrite" }),
+        expect.objectContaining({ filesystem: "agent_knowledge:alpha", label: "Alpha", access: "readonly" }),
+      ]))
+      const humanKnowledge = await app.inject({
+        method: "GET",
+        url: "/api/v1/files?filesystem=agent_knowledge%3Aalpha&path=facts.md",
+      })
+      expect(humanKnowledge.json()).toMatchObject({ content: "alpha knowledge\n", access: "readonly" })
+      expect((await app.inject({ method: "GET", url: "/api/v1/agents/default/commands" })).statusCode).toBeGreaterThanOrEqual(400)
+      expect((await app.inject({
+        method: "POST",
+        url: "/api/v1/agents/default/commands/execute",
+        payload: { requestId: "wrong-agent-skill", sessionId, name: "skill:local", args: "" },
+      })).statusCode).toBeGreaterThanOrEqual(400)
+    } finally {
+      await app.close()
+    }
+  }, 30_000)
+
   it("folder mode resolves workspace AGENTS.md into Pi context by default", async () => {
     const home = await temporaryRoot("boring-cli-folder-context-home-")
     const workspaceRoot = await temporaryRoot("boring-cli-folder-context-workspace-")

--- a/packages/cli/src/server/modeApps.ts
+++ b/packages/cli/src/server/modeApps.ts
@@ -442,11 +442,53 @@ export async function createFolderModeApp(opts: {
 }): Promise<FastifyInstance> {
   const workspaceRoot = resolve(opts.workspaceRoot)
   const projectName = opts.projectName ?? (basename(workspaceRoot) || "workspace")
-  const [{ createWorkspaceAgentServer, readWorkspacePluginPackageRuntimePlugins }, { createPluginFrontRuntimeHost }, pluginDiscovery] = await Promise.all([
+  const [
+    { createWorkspaceAgentServer, readWorkspacePluginPackageRuntimePlugins },
+    workspaceServer,
+    agentServer,
+    { createPluginFrontRuntimeHost },
+    pluginDiscovery,
+  ] = await Promise.all([
     import("@hachej/boring-workspace/app/server"),
+    import("@hachej/boring-workspace/server"),
+    import("@hachej/boring-agent/server"),
     import("./pluginFrontRuntime.js"),
     import("./pluginDiscovery.js"),
   ])
+  const rootAgentPackage = (await workspaceServer.discoverAgentPackagesAtRoots([workspaceRoot]))
+    .find((descriptor) => resolve(descriptor.rootDir) === workspaceRoot)
+  let authoredAgent: Awaited<ReturnType<typeof agentServer.createConfiguredAgentHostAgentSpec>> | undefined
+  let authoredAgentResourcePlugin: {
+    id: string
+    contentDigest: string
+    packageResources: Array<{ packageName: string; packageRoot: string }>
+  } | undefined
+  if (rootAgentPackage) {
+    if (!rootAgentPackage.preflight.ok) {
+      throw new Error(`authored agent package is invalid: ${rootAgentPackage.preflight.errors.map((entry) => entry.message).join('; ')}`)
+    }
+    const source = await agentServer.materializeAgentDirectory({
+      directory: workspaceRoot,
+      expectedAgentTypeId: rootAgentPackage.manifest.boring.agent.definitionId,
+      manifest: "package.json",
+    })
+    const packageName = packageNameAtRoot(workspaceRoot)
+    const resourcePluginId = rootAgentPackage.pluginId
+    authoredAgentResourcePlugin = packageName
+      ? {
+          id: resourcePluginId,
+          contentDigest: source.definitionDigest ?? `${resourcePluginId}:v1`,
+          packageResources: [{ packageName, packageRoot: workspaceRoot }],
+        }
+      : undefined
+    authoredAgent = await agentServer.createConfiguredAgentHostAgentSpec({
+      source,
+      policy: {
+        fallbackLabel: rootAgentPackage.manifest.boring.agent.label ?? projectName,
+        ...(authoredAgentResourcePlugin ? { plugins: [{ name: resourcePluginId }] } : {}),
+      },
+    })
+  }
   const liveTranscriptEnabled = opts.liveTranscripts?.enabled ?? process.env.BORING_LIVE_TRANSCRIPTS_ENABLED === "1"
   if (liveTranscriptEnabled && !opts.liveTranscripts) {
     throw new Error("live_transcript_local_only: folder-mode live transcripts require explicit listener and canonical browser authority")
@@ -465,7 +507,7 @@ export async function createFolderModeApp(opts: {
   const liveTranscriptPlugin = liveTranscriptEnabled && opts.liveTranscripts
     ? (await import("@hachej/boring-transcription/server")).createLiveTranscriptServerPlugin({
         dispatcherResolver: liveTranscriptDispatcherProxy,
-        agentTypeId: "default",
+        agentTypeId: authoredAgent?.agentTypeId ?? "default",
         actorResolver: () => ({ workspaceId: "default", userId: "local" }),
         authority: {
           listenerHost: opts.liveTranscripts.listenerHost,
@@ -482,7 +524,10 @@ export async function createFolderModeApp(opts: {
         reviewIntervalMs: opts.liveTranscripts.reviewIntervalMs,
       })
     : undefined
-  const pluginDirs = pluginDiscovery.resolveCliBoringPluginDirs(workspaceRoot, { includeFolderModeAutomation: true })
+  const pluginDirs = [
+    ...(authoredAgent ? [{ rootDir: workspaceRoot, kind: "internal" as const, registered: true }] : []),
+    ...pluginDiscovery.resolveCliBoringPluginDirs(workspaceRoot, { includeFolderModeAutomation: true }),
+  ]
   const defaultPluginPackagePaths = pluginDiscovery.resolveCliDefaultPluginPackagePaths({ includeFolderModeAutomation: true })
   const tasksPluginPackage = defaultPluginPackagePaths.find((packageRoot) => packageNameAtRoot(packageRoot) === "@hachej/boring-tasks")
   const taskProviders = await detectFolderModeTaskProviders(workspaceRoot)
@@ -505,6 +550,7 @@ export async function createFolderModeApp(opts: {
       workspaceRoot,
       mode: opts.mode,
       logger: false,
+      ...(authoredAgent ? { agents: [authoredAgent], defaultAgentTypeId: authoredAgent.agentTypeId } : {}),
       provisionWorkspace: false,
       runtimeProvisioning,
       // Agent governance lives in `.agents`: readable by agents, never writable
@@ -529,6 +575,7 @@ export async function createFolderModeApp(opts: {
       // leaving arbitrary/workspace-local plugins on the explicit binding path.
       workspaceScopedDefaultPluginAgentContributions: true,
       plugins: [
+        ...(authoredAgentResourcePlugin ? [authoredAgentResourcePlugin] : []),
         ...(tasksPluginPackage
           ? [{
               dir: tasksPluginPackage,
@@ -596,6 +643,7 @@ export async function createFolderModeApp(opts: {
     workspaceId: "default",
     workspaceRoot,
     projectName,
+    defaultAgentTypeId: authoredAgent?.agentTypeId ?? "default",
     version: CLI_VERSION,
     runtimePluginFrontLoadingEnabled: true,
     runtimePluginTrustLabel: RUNTIME_PLUGIN_TRUST_LABEL,
@@ -1377,6 +1425,7 @@ export async function createWorkspacesModeApp(opts: {
   app.get("/api/v1/workspace/meta", async () => ({
     projectName: "Boring UI",
     workspacesMode: true,
+    defaultAgentTypeId: "default",
     version: CLI_VERSION,
     runtimePluginFrontLoadingEnabled: true,
     runtimePluginTrustLabel: RUNTIME_PLUGIN_TRUST_LABEL,

--- a/packages/workspace/src/app/server/__tests__/createWorkspaceAgentServer.test.ts
+++ b/packages/workspace/src/app/server/__tests__/createWorkspaceAgentServer.test.ts
@@ -1503,9 +1503,10 @@ describe("createWorkspaceAgentServer plugin runtime options", () => {
       const packageRoot = await makeTempDir(`boring-agent-${name}-resource-`)
       await mkdir(join(packageRoot, "skills", name), { recursive: true })
       await writeFile(join(packageRoot, "skills", name, "SKILL.md"), `---\nname: ${name}-skill\ndescription: ${name}.\n---\n`)
+      await writeFile(join(packageRoot, `${name}-extension.ts`), `export default function () {}\n`)
       await writeFile(join(packageRoot, "package.json"), JSON.stringify({
         name: `@example/${name}`,
-        pi: { skills: [`skills/${name}`], systemPrompt: prompt },
+        pi: { extensions: [`${name}-extension.ts`], skills: [`skills/${name}`], systemPrompt: prompt },
       }))
       return packageRoot
     }
@@ -1579,7 +1580,7 @@ describe("createWorkspaceAgentServer plugin runtime options", () => {
             packages?: unknown[]
             extensionPaths?: string[]
             additionalSkillPaths?: string[]
-            getHotReloadableResources?: () => { additionalSkillPaths?: string[] }
+            getHotReloadableResources?: () => { additionalSkillPaths?: string[]; extensionPaths?: string[] }
             locateSkillResource?: (filePath: string) => { filesystem: string; path: string } | undefined
           }
           getFilesystemBindings?: (ctx: { scope: { workspaceScopeId: string; authSubjectId: string }; requestId: string }) => Promise<Array<{
@@ -1597,6 +1598,8 @@ describe("createWorkspaceAgentServer plugin runtime options", () => {
         hostOptions.resolveDirectRuntimeScopeForTest({ agentTypeId: "beta", scope }),
         hostOptions.resolveDirectRuntimeScopeForTest({ agentTypeId: "default", scope }),
       ])
+      await expect(hostOptions.resolveDirectRuntimeScopeForTest({ agentTypeId: "missing", scope }))
+        .rejects.toMatchObject({ code: "AGENT_TYPE_UNKNOWN" })
 
       expect(alpha.extraTools?.map((tool) => tool.name)).toContain("alpha_tool")
       expect(alpha.extraTools?.map((tool) => tool.name)).not.toContain("beta_tool")
@@ -1614,6 +1617,9 @@ describe("createWorkspaceAgentServer plugin runtime options", () => {
       expect(alphaSkillPaths).not.toContain(join(betaPackageRoot, "skills", "beta"))
       expect(alphaSkillPaths.some((path) => path.endsWith("/beta-plugin/beta-runtime"))).toBe(false)
       expect(alphaSkillPaths.some((path) => path.endsWith("/.boring-agent/skills"))).toBe(false)
+      const alphaExtensions = alpha.pi?.getHotReloadableResources?.().extensionPaths ?? []
+      expect(alphaExtensions).toContain(join(alphaPackageRoot, "alpha-extension.ts"))
+      expect(alphaExtensions).not.toContain(join(betaPackageRoot, "beta-extension.ts"))
       expect(await alpha.loadSystemPromptAppend?.()).toContain("ALPHA_MANIFEST_PROMPT")
       expect(await alpha.loadSystemPromptAppend?.()).not.toContain("BETA_MANIFEST_PROMPT")
       const alphaSkillFile = join(alphaPackageRoot, "skills", "alpha", "SKILL.md")
@@ -1650,6 +1656,9 @@ describe("createWorkspaceAgentServer plugin runtime options", () => {
       expect(betaSkillPaths).not.toContain(join(alphaPackageRoot, "skills", "alpha"))
       expect(betaSkillPaths.some((path) => path.endsWith("/alpha-plugin/alpha-runtime"))).toBe(false)
       expect(betaSkillPaths.some((path) => path.endsWith("/.boring-agent/skills"))).toBe(false)
+      const betaExtensions = beta.pi?.getHotReloadableResources?.().extensionPaths ?? []
+      expect(betaExtensions).toContain(join(betaPackageRoot, "beta-extension.ts"))
+      expect(betaExtensions).not.toContain(join(alphaPackageRoot, "alpha-extension.ts"))
       expect(await beta.loadSystemPromptAppend?.()).toContain("BETA_MANIFEST_PROMPT")
       expect(await beta.loadSystemPromptAppend?.()).not.toContain("ALPHA_MANIFEST_PROMPT")
       expect(beta.pi?.locateSkillResource?.(join(betaPackageRoot, "skills", "beta", "SKILL.md"))).toEqual({
@@ -1665,6 +1674,11 @@ describe("createWorkspaceAgentServer plugin runtime options", () => {
       expect(legacy.systemPromptAppend).toContain("ALPHA_PLUGIN_PROMPT")
       expect(legacy.systemPromptAppend).toContain("BETA_PLUGIN_PROMPT")
       expect(legacy.pi?.packages).toEqual(expect.arrayContaining(["npm:alpha-pi", "npm:beta-pi"]))
+      const legacyExtensions = legacy.pi?.getHotReloadableResources?.().extensionPaths ?? []
+      expect(legacyExtensions).toEqual(expect.arrayContaining([
+        join(alphaPackageRoot, "alpha-extension.ts"),
+        join(betaPackageRoot, "beta-extension.ts"),
+      ]))
     } finally {
       await app.close()
     }

--- a/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
+++ b/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
@@ -1359,6 +1359,23 @@ export async function createWorkspaceAgentServer(
         ...agents.slice(1),
       ]
     : agents
+  const humanKnowledgeBindingsPromise = Promise.all(hostAgents.flatMap((agent) => {
+    if (!("knowledge" in agent) || !agent.knowledge?.rootDir) return []
+    return [runtimeHost.createAgentResourceFilesystemBinding(
+      `agent_knowledge:${agent.agentTypeId}`,
+      [{ logicalRoot: "/", sourceRoot: agent.knowledge.rootDir }],
+    ).then((binding) => ({
+      ...binding,
+      catalog: {
+        visible: true,
+        label: agent.definition.label ?? agent.agentTypeId,
+        rootDir: "/" as const,
+      },
+      // Human routes expose this alias. Agent composition filters it and
+      // mounts only the addressed Agent's canonical `agent_knowledge` binding.
+      agentTypeIds: [] as readonly string[],
+    }))]
+  }))
   const defaultPluginPackagePaths = pluginCollection.defaultPluginPackagePaths
   const ctx: WorkspaceAgentServerPluginContext = { workspaceRoot, bridge }
   const allPluginEntries: WorkspacePluginEntry[] = pluginCollection.resolvedPluginArtifacts
@@ -1434,6 +1451,11 @@ export async function createWorkspaceAgentServer(
         ...discovered.additionalSkillPaths.filter((path) => !registry || !packageResourceHandlesPath(path, registry.handledPackageRoots)),
         ...(registry?.additionalSkillPaths ?? []),
       ]),
+      // Package-registry extensions are executable and selected per Agent
+      // below; never reintroduce them through the ambient discovery path.
+      extensionPaths: discovered.extensionPaths.filter((path) =>
+        !registry || !packageResourceHandlesPath(path, registry.handledPackageRoots),
+      ),
     }
   }
 
@@ -1761,6 +1783,7 @@ export async function createWorkspaceAgentServer(
             userId: verifiedClaim.authSubjectId,
             requestId,
           }) ?? []
+          const humanKnowledgeBindings = await humanKnowledgeBindingsPromise
           const packageRegistry = currentPackageResourceSnapshot?.registry
           const packageBinding = hostOwnedDefaultAgentTypeId && packageRegistry?.readonlyMounts.length
             ? await runtimeHost.createAgentResourceFilesystemBinding(
@@ -1768,7 +1791,7 @@ export async function createWorkspaceAgentServer(
                 packageRegistry.readonlyMounts,
               )
             : undefined
-          return [...callerBindings, ...(packageBinding ? [packageBinding] : [])]
+          return [...callerBindings, ...humanKnowledgeBindings, ...(packageBinding ? [packageBinding] : [])]
         },
       }
     },
@@ -1781,7 +1804,12 @@ export async function createWorkspaceAgentServer(
     }) {
       scopeIssuer.context(authorizedScope)
       const contribution = normalizedRuntimeContributions.get(agentTypeId)
-      if (!contribution) throw new Error(`Agent runtime contribution was not compiled: ${agentTypeId}`)
+      if (!contribution) {
+        throw new AgentGatewayError(
+          AgentGatewayErrorCode.AGENT_TYPE_UNKNOWN,
+          `Unknown agent type: ${agentTypeId}`,
+        )
+      }
       // Reload resolves one immutable package candidate before admission. The
       // same candidate drives digest, prompt, locator, binding, and commit.
       const stagedPackageResourceSnapshot = intent.operation === "reload"
@@ -1875,6 +1903,7 @@ export async function createWorkspaceAgentServer(
               ]),
               extensionPaths: uniqueStrings([
                 ...(baseHot.extensionPaths ?? []),
+                ...(packageView?.extensionPaths ?? []),
                 ...discovered.extensionPaths,
               ]),
             }

--- a/packages/workspace/src/server/__tests__/agentPlugins.test.ts
+++ b/packages/workspace/src/server/__tests__/agentPlugins.test.ts
@@ -122,6 +122,7 @@ describe("boring agent plugin assets", () => {
     expect(result.errors).toEqual([])
     expect(manager.inspectAgentPackages()).toEqual([{
       rootDir: root,
+      pluginId: "agent-package",
       manifest: {
         boring: { agent: expect.objectContaining({ definitionId: "fixture-persona" }) },
         pi: { skills: ["shared-skill"] },

--- a/packages/workspace/src/server/agentPlugins/discoverAgentPackages.ts
+++ b/packages/workspace/src/server/agentPlugins/discoverAgentPackages.ts
@@ -20,6 +20,17 @@ export interface DiscoverRepositoryAgentPackagesOptions {
  * the resulting plain descriptors across the package boundary; packages/agent
  * never depends on workspace discovery code.
  */
+export async function discoverAgentPackagesAtRoots(
+  packageRoots: readonly string[],
+): Promise<readonly DiscoveredBoringAgentPackage[]> {
+  const manager = new BoringPluginAssetManager({
+    pluginDirs: packageRoots.map((rootDir) => ({ rootDir: resolve(rootDir), kind: "internal" as const, registered: true })),
+    errorRoot: join(resolve(packageRoots[0] ?? process.cwd()), ".pi", "extensions"),
+  })
+  await manager.load()
+  return Object.freeze(manager.inspectAgentPackages())
+}
+
 export async function discoverRepositoryAgentPackages(
   repositoryRoot: string,
   options: DiscoverRepositoryAgentPackagesOptions = {},

--- a/packages/workspace/src/server/agentPlugins/scan.ts
+++ b/packages/workspace/src/server/agentPlugins/scan.ts
@@ -360,6 +360,7 @@ export function scanBoringPlugins(pluginDirs: BoringPluginSourceInput[]): Boring
     })
   }
 
+  const pluginIdByRoot = new Map(plugins.map((plugin) => [resolve(plugin.rootDir), plugin.id]))
   const agentPackages = [...rawPackages].flatMap(([rootDir, raw]) => {
     const projected = agentPackageManifest(raw)
     if (!projected) return []
@@ -372,6 +373,7 @@ export function scanBoringPlugins(pluginDirs: BoringPluginSourceInput[]): Boring
     ]
     return [{
       rootDir,
+      pluginId: pluginIdByRoot.get(resolve(rootDir)) ?? manifest.boring.agent.definitionId,
       manifest,
       preflight: { ok: packageErrors.length === 0, errors: packageErrors },
     }]

--- a/packages/workspace/src/server/agentPlugins/types.ts
+++ b/packages/workspace/src/server/agentPlugins/types.ts
@@ -30,6 +30,7 @@ export type BoringPluginSourceInput = string | BoringPluginSource
 
 export interface DiscoveredBoringAgentPackage {
   readonly rootDir: string
+  readonly pluginId: string
   readonly manifest: {
     readonly boring: { readonly agent: NonNullable<BoringPackageBoringField["agent"]> }
     readonly pi?: { readonly skills?: readonly string[] }

--- a/packages/workspace/src/server/index.ts
+++ b/packages/workspace/src/server/index.ts
@@ -190,7 +190,7 @@ export type {
 export { buildBoringSystemPrompt } from "./boringSystemPrompt"
 export { BoringPluginAssetManager } from "./agentPlugins/manager"
 export type { DiscoveredBoringAgentPackage } from "./agentPlugins/types"
-export { discoverRepositoryAgentPackages } from "./agentPlugins/discoverAgentPackages"
+export { discoverAgentPackagesAtRoots, discoverRepositoryAgentPackages } from "./agentPlugins/discoverAgentPackages"
 export type { DiscoverRepositoryAgentPackagesOptions } from "./agentPlugins/discoverAgentPackages"
 export { isRemoteMaterializedPiPackageRoot } from "./agentPlugins/settingsSources"
 export { boringPluginRoutes, collectRestartWarnings } from "./agentPlugins/routes"

--- a/packages/workspace/src/server/plugins/__tests__/packageResources.test.ts
+++ b/packages/workspace/src/server/plugins/__tests__/packageResources.test.ts
@@ -236,12 +236,49 @@ describe('resolveWorkspacePackageResources', () => {
     await expect(resolveOne(packageRoot)).rejects.toMatchObject({ code: PACKAGE_RESOURCE_INVALID_CODE })
   })
 
+  test('confines executable extension paths and fingerprints their bytes', async () => {
+    const root = await tempRoot()
+    const packageRoot = await packageFixture(root)
+    const extensionPath = join(packageRoot, 'extension.ts')
+    await writeFile(extensionPath, 'export default 1\n', 'utf8')
+    const writeManifest = async (extensions: string[]) => await writeFile(
+      join(packageRoot, 'package.json'),
+      JSON.stringify({ name: '@example/plugin', pi: { extensions, skills: ['skills/authoring'] } }),
+      'utf8',
+    )
+
+    await writeManifest(['extension.ts'])
+    const first = await resolveOne(packageRoot, { pluginId: 'owner' })
+    expect(first.extensions).toEqual([{ pluginIds: ['owner'], path: await realpath(extensionPath) }])
+    await writeFile(extensionPath, 'export default 2\n', 'utf8')
+    const changed = await resolveOne(packageRoot, { pluginId: 'owner' })
+    expect(changed.generation).not.toBe(first.generation)
+
+    for (const declaration of ['/tmp/escape.ts', '../escape.ts']) {
+      await writeManifest([declaration])
+      await expect(resolveOne(packageRoot, { pluginId: 'owner' }))
+        .rejects.toMatchObject({ code: PACKAGE_RESOURCE_INVALID_CODE })
+    }
+    const outside = join(root, 'outside-extension.ts')
+    await writeFile(outside, 'export default 3\n', 'utf8')
+    await symlink(outside, join(packageRoot, 'extension-link.ts'))
+    await writeManifest(['extension-link.ts'])
+    await expect(resolveOne(packageRoot, { pluginId: 'owner' }))
+      .rejects.toMatchObject({ code: PACKAGE_RESOURCE_INVALID_CODE })
+    await mkdir(join(packageRoot, 'extension-dir'))
+    await writeManifest(['extension-dir'])
+    await expect(resolveOne(packageRoot, { pluginId: 'owner' }))
+      .rejects.toMatchObject({ code: PACKAGE_RESOURCE_INVALID_CODE })
+  })
+
   test('adds enumerated shared skills and deduplicates exact manifest prompts', async () => {
     const root = await tempRoot()
     const packageRoot = await packageFixture(root)
+    const extensionPath = join(packageRoot, 'extension.ts')
+    await writeFile(extensionPath, 'export default function () {}\n', 'utf8')
     await writeFile(join(packageRoot, 'package.json'), JSON.stringify({
       name: '@example/plugin',
-      pi: { skills: ['skills/authoring'], systemPrompt: '  Use authoring.  ' },
+      pi: { extensions: ['extension.ts'], skills: ['skills/authoring'], systemPrompt: '  Use authoring.  ' },
     }), 'utf8')
     const sharedRoot = join(root, 'global-skills', 'shared-authoring')
     await mkdir(sharedRoot, { recursive: true })
@@ -281,11 +318,13 @@ describe('resolveWorkspacePackageResources', () => {
       filesystem: AGENT_RESOURCES_FILESYSTEM_ID,
       path: 'shared/pi-agent/shared-authoring/SKILL.md',
     })
+    expect(selected.extensionPaths).toEqual([await realpath(extensionPath)])
     const isolated = selectAgentPackageResourceView(registry, {
       pluginIds: new Set(['unrelated']),
       includeAll: false,
     })
     expect(isolated.skills.map((skill) => skill.packageName)).toEqual(['shared/pi-agent'])
+    expect(isolated.extensionPaths).toEqual([])
     expect(isolated.locateSkill(join(packageRoot, 'skills', 'authoring', 'SKILL.md'))).toBeUndefined()
     const catchAll = selectAgentPackageResourceView(registry, {
       pluginIds: new Set(),
@@ -293,6 +332,7 @@ describe('resolveWorkspacePackageResources', () => {
     })
     expect(catchAll.skills).toHaveLength(2)
     expect(catchAll.systemPrompts).toEqual(['Use authoring.'])
+    expect(catchAll.extensionPaths).toEqual([])
 
     await writeFile(join(packageRoot, 'package.json'), JSON.stringify({
       name: '@example/plugin',

--- a/packages/workspace/src/server/plugins/packageResources.ts
+++ b/packages/workspace/src/server/plugins/packageResources.ts
@@ -35,7 +35,7 @@ export class WorkspacePackageResourceRegistryError extends Error {
 
 interface PackageManifest {
   name?: unknown
-  pi?: { skills?: unknown; systemPrompt?: unknown }
+  pi?: { extensions?: unknown; skills?: unknown; systemPrompt?: unknown }
 }
 
 function parseManifest(packageName: string, bytes: string): PackageManifest {
@@ -80,6 +80,7 @@ export interface ResolvedWorkspacePackageResourceRegistry {
   readonly handledPackageRoots: readonly string[]
   readonly readonlyMounts: readonly AgentResourceReadonlyMount[]
   readonly systemPrompts: readonly { readonly pluginIds: readonly string[]; readonly content: string }[]
+  readonly extensions: readonly { readonly pluginIds: readonly string[]; readonly path: string }[]
   locateSkill(filePath: string): AgentSkillResource | undefined
 }
 
@@ -90,6 +91,7 @@ export interface ResolvedAgentPackageResourceView {
   readonly additionalSkillPaths: readonly string[]
   readonly readonlyMounts: readonly AgentResourceReadonlyMount[]
   readonly systemPrompts: readonly string[]
+  readonly extensionPaths: readonly string[]
   locateSkill(filePath: string): AgentSkillResource | undefined
 }
 
@@ -127,6 +129,11 @@ export function selectAgentPackageResourceView(
     systemPrompts: registry.systemPrompts
       .filter((prompt) => policy.includeAll || prompt.pluginIds.some((pluginId) => policy.pluginIds.has(pluginId)))
       .map((prompt) => prompt.content),
+    extensionPaths: registry.extensions
+      // Executable extensions always require an explicit plugin grant. The
+      // legacy includeAll path is safe for shared prompt/skill resources, not code.
+      .filter((extension) => extension.pluginIds.some((pluginId) => policy.pluginIds.has(pluginId)))
+      .map((extension) => extension.path),
     locateSkill(filePath: string) {
       const resource = registry.locateSkill(filePath)
       return resource && selectedResourcePaths.has(resource.path) ? resource : undefined
@@ -364,6 +371,40 @@ async function resolvePackageSkills(
   return drafts
 }
 
+/** Resolve package-declared Pi extensions as canonical, contained files. */
+async function resolvePackageExtensions(
+  packageName: string,
+  canonicalRoot: string,
+  manifest: PackageManifest,
+): Promise<string[]> {
+  const declarations = manifest.pi?.extensions
+  if (declarations === undefined) return []
+  if (!Array.isArray(declarations) || declarations.some((entry) => typeof entry !== 'string')) {
+    throw invalid(packageName, 'pi.extensions must be an array of relative file paths')
+  }
+  const extensions: string[] = []
+  for (const declaration of [...new Set(declarations as string[])].sort()) {
+    if (!declaration || declaration.includes('\0') || declaration.includes('\\') || isAbsolute(declaration) || declaration.split('/').includes('..')) {
+      throw invalid(packageName, 'pi.extensions entries must be safe relative paths')
+    }
+    let extensionPath: string
+    try {
+      extensionPath = await realpath(resolve(canonicalRoot, declaration))
+      if (!(await stat(extensionPath)).isFile()) throw invalid(packageName, 'pi.extensions entries must be regular files')
+    } catch (error) {
+      if (error instanceof WorkspacePackageResourceRegistryError) throw error
+      if (!isExpectedPathAdmissionError(error)) throw error
+      throw invalid(packageName, `Pi extension is not readable: ${declaration}`)
+    }
+    const rel = relative(canonicalRoot, extensionPath)
+    if (rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
+      throw invalid(packageName, `Pi extension escapes package root: ${declaration}`)
+    }
+    extensions.push(extensionPath)
+  }
+  return extensions
+}
+
 /** Resolve one shared skill. Never called more than once per entry. */
 async function resolveSharedSkill(shared: SharedSkillPath): Promise<ResolvedSkillDraft & { sourceFile: string }> {
   if (!shared.id || shared.id.includes('/') || shared.id.includes('\\') || shared.id === '.' || shared.id === '..') {
@@ -511,10 +552,14 @@ async function resolveWorkspacePackageResourcesWithDiagnostics(
   }
 
   const skills: ResolvedAgentPackageSkill[] = []
+  const extensions: Array<{ pluginIds: string[]; path: string }> = []
   for (const [packageName, record] of [...packageRecords.entries()].sort(([a], [b]) => a.localeCompare(b))) {
     const pluginIds = [...record.pluginIds].sort()
     for (const draft of draftsByPackage.get(packageKey(packageName, record.root)) ?? []) {
       skills.push({ ...draft, pluginIds })
+    }
+    for (const path of await resolvePackageExtensions(packageName, record.root, record.manifest)) {
+      extensions.push({ pluginIds, path })
     }
   }
 
@@ -567,6 +612,12 @@ async function resolveWorkspacePackageResourcesWithDiagnostics(
   const generationHash = createHash('sha256')
   generationHash.update(JSON.stringify(systemPrompts))
   generationHash.update('\0')
+  for (const extension of extensions) {
+    generationHash.update(JSON.stringify({ pluginIds: extension.pluginIds, path: extension.path }))
+    generationHash.update('\0')
+    generationHash.update(await readFile(extension.path))
+    generationHash.update('\0')
+  }
   const locatorByFile = new Map<string, AgentSkillResource>(sharedLocatorAliases)
   for (const skill of skills) {
     generationHash.update(JSON.stringify({
@@ -620,6 +671,7 @@ async function resolveWorkspacePackageResourcesWithDiagnostics(
         sourceRoot: skill.mountRoot,
       })),
       systemPrompts,
+      extensions,
       locateSkill(filePath) {
         return locatorByFile.get(resolve(filePath))
       },


### PR DESCRIPTION
## Summary

- load package-authored declarative commands into the owning authored agent only
- deny command discovery/execution across sibling agent identities
- expose agent-addressed filesystem catalogs and file operations without leaking agent resources through shared routes
- present writable `Workspace` plus labeled read-only agent knowledge roots
- propagate the active authored-agent identity through the CLI/workspace frontend
- keep package skill resources internal while retaining scoped skill discovery

## Validation

- Agent invariants passed
- focused Agent tests: 25 passed
- focused boring-bash route tests: 16 passed
- focused Workspace filesystem tests: 50 passed
- typechecks passed for Agent, boring-bash, Workspace, and CLI
- Charlotte source CLI smoke passed for addressed command discovery/execution, writable workspace, read-only knowledge, actual knowledge tree/file reads, and cross-agent denial
- Playwright verified Files -> agent knowledge root -> nested Markdown file, with every scoped tree/file request using `/api/v1/agents/:agentTypeId/...`

## Review

Independent review: ACCEPT / SHIP, with no blocking findings.
