### PR TITLE
Stabilize diarization and add optional private audio recording

### DIFF
--- a/plugins/live-transcription/README.md
+++ b/plugins/live-transcription/README.md
@@ -9,8 +9,11 @@ V0 provides a microphone button in the composer for short in-memory dictation;
 stopping inserts the returned French text into the editable draft. The same
 short-dictation control becomes a stop button with an elapsed-time counter while
 capturing. Live mode streams microphone PCM to the
-loopback service and writes only a Markdown transcript. It intentionally does
-not retain audio. Anonymous `Speaker N`
+loopback service and writes a Markdown transcript. By default it does not
+retain audio. Trusted local hosts may opt into private AAC/M4A recording by
+passing an absolute `audioRecordingDirectory` (and optionally
+`audioRecordingFfmpegPath`) to `createLiveTranscriptServerPlugin`; PCM is piped
+directly through FFmpeg and never accumulated in memory. Anonymous `Speaker N`
 labels and French text may be inaccurate. Kyutai word events are grouped into
 readable pause-bounded transcript paragraphs. While capture is active, the live
 process is the only supported transcript writer: byte/mtime conflict checks are
@@ -54,8 +57,9 @@ setup/runtime failures do not interrupt capture. See
 `services/sortformer/README.md` for the PoC service contract. See
 `services/lifecycle/README.md` for secure on-demand GPU operation.
 With Kyutai selected, the composer microphone streams each `Word` event directly
-into the editable draft without creating a transcript file. `/live start` keeps
-the separate Markdown transcript and agent-review sink.
+into the editable draft without creating a transcript or recording file.
+`/live start` keeps the separate Markdown transcript and agent-review sink, and
+creates a matching `.m4a` only when local recording is explicitly configured.
 
 ## Robustness gates
 

--- a/plugins/live-transcription/services/sortformer/README.md
+++ b/plugins/live-transcription/services/sortformer/README.md
@@ -40,8 +40,11 @@ diarizer URL and restart the app for immediate rollback.
    revisions and `{speaker,startSeconds,endSeconds}` segments.
 5. Client sends `{ "type": "stop", "id": N }`; server replies `stopped`.
 
-Speaker slots are anonymous, arrival-ordered, session-local, and capped at four
-by the model. The follow-up LLM may infer conversational roles; the sidecar does
-not claim biometric identity. MacWhisper uses the same anonymous-label product
+Speaker slots are anonymous, arrival-ordered, session-local, and deliberately
+capped at two for clinic consultations. The sidecar applies confidence gating
+and requires sustained evidence before changing speakers; this suppresses brief
+four-channel Sortformer fluctuations that would otherwise create false speaker
+turns. The follow-up LLM may infer conversational roles; the sidecar does not
+claim biometric identity. MacWhisper uses the same anonymous-label product
 pattern but performs local speaker recognition after transcription completes;
 this PoC emits revisable labels during `/live` capture.

--- a/plugins/live-transcription/services/sortformer/sidecar.py
+++ b/plugins/live-transcription/services/sortformer/sidecar.py
@@ -18,6 +18,11 @@ PROTOCOL = "boring.sortformer.v1"
 FRAME_BYTES = 3_200
 MAX_MESSAGE_BYTES = 1_000_000
 MAX_SEGMENTS = 2_000
+MAX_SPEAKERS = 2
+SPEECH_THRESHOLD = 0.50
+NEW_SPEAKER_THRESHOLD = 0.70
+SWITCH_MARGIN = 0.12
+SWITCH_CONFIRM_FRAMES = 5
 
 
 @dataclass(frozen=True)
@@ -25,6 +30,13 @@ class Segment:
     speaker: int
     startSeconds: float
     endSeconds: float
+
+
+@dataclass(frozen=True)
+class SimpleSpeakerSegment:
+    speaker: int
+    start: float
+    end: float
 
 
 def parse_start(raw: str) -> None:
@@ -52,6 +64,74 @@ def parse_stop(raw: str) -> int:
     if not isinstance(value, dict) or value.get("type") != "stop" or not isinstance(value.get("id"), int):
         raise ValueError("unsupported control message")
     return value["id"]
+
+
+class TwoSpeakerStabilizer:
+    """Convert four raw Sortformer channels into two stable session labels."""
+
+    def __init__(self) -> None:
+        self.raw_slots: list[int] = []
+        self.current_raw: int | None = None
+        self.pending_raw: int | None = None
+        self.pending_frames = 0
+
+    def assign(self, scores: np.ndarray) -> list[int]:
+        if scores.ndim != 2 or scores.shape[1] < MAX_SPEAKERS:
+            raise ValueError("Sortformer returned invalid speaker scores")
+        labels: list[int] = []
+        for frame in scores:
+            candidate = int(np.argmax(frame))
+            candidate_score = float(frame[candidate])
+            if candidate_score < SPEECH_THRESHOLD:
+                self._clear_pending()
+                labels.append(-1)
+                continue
+
+            if self.current_raw is None:
+                self._admit(candidate)
+                self.current_raw = candidate
+
+            allowed = self.raw_slots
+            if candidate not in allowed:
+                current_score = float(frame[self.current_raw])
+                if len(allowed) < MAX_SPEAKERS and candidate_score >= NEW_SPEAKER_THRESHOLD and candidate_score - current_score >= SWITCH_MARGIN:
+                    if self._confirm(candidate):
+                        self._admit(candidate)
+                        self.current_raw = candidate
+                else:
+                    self._clear_pending()
+            elif candidate != self.current_raw:
+                current_score = float(frame[self.current_raw])
+                if candidate_score >= SPEECH_THRESHOLD and candidate_score - current_score >= SWITCH_MARGIN:
+                    if self._confirm(candidate):
+                        self.current_raw = candidate
+                else:
+                    self._clear_pending()
+            else:
+                self._clear_pending()
+
+            labels.append(self.raw_slots.index(self.current_raw))
+        return labels
+
+    def _admit(self, raw_speaker: int) -> None:
+        if raw_speaker not in self.raw_slots and len(self.raw_slots) < MAX_SPEAKERS:
+            self.raw_slots.append(raw_speaker)
+        self._clear_pending()
+
+    def _confirm(self, raw_speaker: int) -> bool:
+        if self.pending_raw == raw_speaker:
+            self.pending_frames += 1
+        else:
+            self.pending_raw = raw_speaker
+            self.pending_frames = 1
+        if self.pending_frames < SWITCH_CONFIRM_FRAMES:
+            return False
+        self._clear_pending()
+        return True
+
+    def _clear_pending(self) -> None:
+        self.pending_raw = None
+        self.pending_frames = 0
 
 
 def append_segments(segments: list[Segment], new_segments, audio_through: float) -> None:
@@ -82,7 +162,37 @@ class Sidecar:
             SortformerDiarization,
             SortformerDiarizationOnline,
         )
-        self.online_type = SortformerDiarizationOnline
+
+        class StableSortformerDiarizationOnline(SortformerDiarizationOnline):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.two_speaker_stabilizer = TwoSpeakerStabilizer()
+
+            def _process_predictions(self):
+                predictions = self.total_preds[0].cpu().numpy()
+                if self._len_prediction is None:
+                    self._len_prediction = len(predictions)
+                frame_count = self._len_prediction
+                current_scores = predictions[-frame_count:]
+                labels = self.two_speaker_stabilizer.assign(current_scores)
+                frame_duration = self.chunk_duration_seconds / frame_count
+                base_time = self._chunk_index * self.chunk_duration_seconds + self.global_time_offset
+                output = []
+                current = None
+                start = None
+                for index, speaker in enumerate(labels):
+                    frame_start = base_time + index * frame_duration
+                    if speaker == current:
+                        continue
+                    if current is not None and current >= 0 and start is not None:
+                        output.append(SimpleSpeakerSegment(current, start, frame_start))
+                    current = speaker
+                    start = frame_start
+                if current is not None and current >= 0 and start is not None:
+                    output.append(SimpleSpeakerSegment(current, start, base_time + frame_count * frame_duration))
+                return output
+
+        self.online_type = StableSortformerDiarizationOnline
         self.shared_model = SortformerDiarization(model_path=model_path) if model_path else SortformerDiarization()
         self.token = token
         self.session = asyncio.Semaphore(1)
@@ -114,7 +224,7 @@ class Sidecar:
                 raise ValueError("start message must be text")
             parse_start(first)
             online = self.online_type(shared_model=self.shared_model)
-            await socket.send(json.dumps({"type": "ready", "protocol": PROTOCOL, "maxSpeakers": 4}))
+            await socket.send(json.dumps({"type": "ready", "protocol": PROTOCOL, "maxSpeakers": MAX_SPEAKERS}))
             segments: list[Segment] = []
             revision = 0
             samples = 0

--- a/plugins/live-transcription/services/sortformer/test_sidecar.py
+++ b/plugins/live-transcription/services/sortformer/test_sidecar.py
@@ -2,7 +2,9 @@ import json
 import unittest
 from types import SimpleNamespace
 
-from sidecar import Segment, append_segments, parse_start, parse_stop
+import numpy as np
+
+from sidecar import Segment, TwoSpeakerStabilizer, append_segments, parse_start, parse_stop
 
 
 class ProtocolTests(unittest.TestCase):
@@ -31,6 +33,37 @@ class ProtocolTests(unittest.TestCase):
             SimpleNamespace(speaker=1, start=1.2, end=2.5),
         ], 2.0)
         self.assertEqual(segments, [Segment(0, 0.0, 1.2), Segment(1, 1.2, 2.0)])
+
+    def test_ignores_short_false_speaker_spikes(self):
+        stabilizer = TwoSpeakerStabilizer()
+        scores = np.array([
+            [0.90, 0.10, 0.05, 0.05],
+            [0.82, 0.12, 0.05, 0.05],
+            [0.30, 0.75, 0.05, 0.05],
+            [0.28, 0.78, 0.05, 0.05],
+            [0.88, 0.08, 0.05, 0.05],
+        ])
+        self.assertEqual(stabilizer.assign(scores), [0, 0, 0, 0, 0])
+
+    def test_admits_only_one_sustained_second_speaker(self):
+        stabilizer = TwoSpeakerStabilizer()
+        first = np.tile([0.90, 0.10, 0.05, 0.05], (3, 1))
+        second = np.tile([0.10, 0.90, 0.05, 0.05], (6, 1))
+        third_channel = np.tile([0.05, 0.10, 0.92, 0.05], (6, 1))
+        labels = stabilizer.assign(np.vstack([first, second, third_channel]))
+        self.assertEqual(labels[:3], [0, 0, 0])
+        self.assertEqual(labels[3:7], [0, 0, 0, 0])
+        self.assertEqual(labels[7:9], [1, 1])
+        self.assertEqual(set(labels), {0, 1})
+        self.assertEqual(labels[-1], 1)
+
+    def test_marks_low_confidence_frames_as_silence(self):
+        stabilizer = TwoSpeakerStabilizer()
+        labels = stabilizer.assign(np.array([
+            [0.90, 0.10, 0.05, 0.05],
+            [0.20, 0.20, 0.20, 0.20],
+        ]))
+        self.assertEqual(labels, [0, -1])
 
 
 if __name__ == "__main__":

--- a/plugins/live-transcription/src/server/__tests__/audioRecorder.test.ts
+++ b/plugins/live-transcription/src/server/__tests__/audioRecorder.test.ts
@@ -1,0 +1,38 @@
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+import { LocalAudioRecorder } from "../audioRecorder"
+
+const roots: string[] = []
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe("LocalAudioRecorder", () => {
+  it("streams PCM into a finalized M4A without retaining the source", async () => {
+    const root = await mkdtemp(join(tmpdir(), "boring-live-audio-"))
+    roots.push(root)
+    const recorder = new LocalAudioRecorder({
+      directory: root,
+      filename: "session.m4a",
+      sampleRate: 24_000,
+    })
+    await recorder.start()
+    await recorder.write(new Uint8Array(4_800))
+    await recorder.write(new Uint8Array(4_800))
+    await recorder.finalize()
+
+    expect((await stat(join(root, "session.m4a"))).size).toBeGreaterThan(100)
+    expect((await readFile(join(root, "session.m4a"))).subarray(4, 8).toString()).toBe("ftyp")
+    await expect(stat(join(root, "session.m4a.partial.m4a"))).rejects.toMatchObject({ code: "ENOENT" })
+  })
+
+  it("rejects untrusted filenames", () => {
+    expect(() => new LocalAudioRecorder({
+      directory: "/tmp",
+      filename: "../escape.m4a",
+      sampleRate: 24_000,
+    })).toThrow("filename is invalid")
+  })
+})

--- a/plugins/live-transcription/src/server/__tests__/audioRecorder.test.ts
+++ b/plugins/live-transcription/src/server/__tests__/audioRecorder.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, stat } from "node:fs/promises"
+import { chmod, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, describe, expect, it } from "vitest"
@@ -13,10 +13,23 @@ describe("LocalAudioRecorder", () => {
   it("streams PCM into a finalized M4A without retaining the source", async () => {
     const root = await mkdtemp(join(tmpdir(), "boring-live-audio-"))
     roots.push(root)
+    const encoderPath = join(root, "fake-ffmpeg.mjs")
+    await writeFile(encoderPath, `#!/usr/bin/env node
+import { writeFileSync } from "node:fs"
+const chunks = []
+process.stdin.on("data", (chunk) => chunks.push(chunk))
+process.stdin.on("end", () => {
+  const input = Buffer.concat(chunks)
+  const header = Buffer.concat([Buffer.from([0, 0, 0, 24]), Buffer.from("ftyp"), Buffer.alloc(120)])
+  writeFileSync(process.argv.at(-1), Buffer.concat([header, input.subarray(0, 16)]))
+})
+`)
+    await chmod(encoderPath, 0o755)
     const recorder = new LocalAudioRecorder({
       directory: root,
       filename: "session.m4a",
       sampleRate: 24_000,
+      ffmpegPath: encoderPath,
     })
     await recorder.start()
     await recorder.write(new Uint8Array(4_800))

--- a/plugins/live-transcription/src/server/audioRecorder.ts
+++ b/plugins/live-transcription/src/server/audioRecorder.ts
@@ -1,0 +1,98 @@
+import { mkdir, rename, rm } from "node:fs/promises"
+import { isAbsolute } from "node:path"
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process"
+import { once } from "node:events"
+import { LiveTranscriptError } from "./errors"
+
+const FINALIZE_TIMEOUT_MS = 15_000
+
+export interface LocalAudioRecorderOptions {
+  directory: string
+  filename: string
+  sampleRate: number
+  ffmpegPath?: string
+}
+
+/** Streams private PCM directly into a local AAC/M4A file without retaining audio in memory. */
+export class LocalAudioRecorder {
+  readonly outputPath: string
+  private readonly partialPath: string
+  private child: ChildProcessWithoutNullStreams | undefined
+  private failed: Error | undefined
+
+  constructor(private readonly options: LocalAudioRecorderOptions) {
+    if (!isAbsolute(options.directory)) throw new Error("Audio recording directory must be absolute")
+    if (!/^[a-zA-Z0-9._-]+\.m4a$/.test(options.filename)) throw new Error("Audio recording filename is invalid")
+    this.outputPath = `${options.directory}/${options.filename}`
+    this.partialPath = `${this.outputPath}.partial.m4a`
+  }
+
+  async start(): Promise<void> {
+    await mkdir(this.options.directory, { recursive: true })
+    const child = spawn(this.options.ffmpegPath ?? "ffmpeg", [
+      "-nostdin", "-hide_banner", "-loglevel", "error",
+      "-f", "s16le", "-ar", String(this.options.sampleRate), "-ac", "1", "-i", "pipe:0",
+      "-vn", "-c:a", "aac", "-b:a", "64k", "-movflags", "+faststart",
+      "-f", "ipod", "-y", this.partialPath,
+    ], { stdio: ["pipe", "pipe", "pipe"] })
+    this.child = child
+    child.stdout.resume()
+    let stderr = ""
+    child.stderr.setEncoding("utf8")
+    child.stderr.on("data", (chunk: string) => { stderr = `${stderr}${chunk}`.slice(-4_096) })
+    child.once("error", (error) => { this.failed = error })
+    child.once("close", (code) => {
+      if (code !== 0 && !this.failed) this.failed = new Error(stderr.trim() || `FFmpeg exited with code ${code}`)
+    })
+    await Promise.race([
+      once(child, "spawn"),
+      once(child, "error").then(([error]) => { throw error }),
+    ])
+  }
+
+  async write(data: Uint8Array): Promise<void> {
+    const child = this.child
+    if (!child || child.stdin.destroyed || this.failed) throw this.recordingError()
+    if (!child.stdin.write(data)) await once(child.stdin, "drain")
+    if (this.failed) throw this.recordingError()
+  }
+
+  async finalize(): Promise<void> {
+    const child = this.child
+    if (!child) return
+    if (!child.stdin.destroyed) child.stdin.end()
+    let timer: ReturnType<typeof setTimeout> | undefined
+    try {
+      if (child.exitCode === null) {
+        await Promise.race([
+          once(child, "close"),
+          new Promise<never>((_, reject) => {
+            timer = setTimeout(() => {
+              child.kill("SIGKILL")
+              reject(new Error("Audio recording finalization timed out"))
+            }, FINALIZE_TIMEOUT_MS)
+          }),
+        ])
+      }
+      if (this.failed) throw this.recordingError()
+      await rename(this.partialPath, this.outputPath)
+    } catch (error) {
+      await rm(this.partialPath, { force: true }).catch(() => undefined)
+      throw error
+    } finally {
+      if (timer) clearTimeout(timer)
+      this.child = undefined
+    }
+  }
+
+  async abort(): Promise<void> {
+    const child = this.child
+    if (child && child.exitCode === null) child.kill("SIGKILL")
+    await rm(this.partialPath, { force: true }).catch(() => undefined)
+    this.child = undefined
+  }
+
+  private recordingError(): LiveTranscriptError {
+    return new LiveTranscriptError("live_transcript_upstream_failed", `Local audio recording failed: ${this.failed?.message ?? "unknown error"}`)
+  }
+}

--- a/plugins/live-transcription/src/server/index.ts
+++ b/plugins/live-transcription/src/server/index.ts
@@ -1,5 +1,6 @@
 import fastifyWebsocket from "@fastify/websocket"
 import type { FastifyReply, FastifyRequest } from "fastify"
+import { isAbsolute } from "node:path"
 import type { WorkspaceAgentDispatcherResolver } from "@hachej/boring-agent/server"
 import { defineServerPlugin, type WorkspaceServerPlugin } from "@hachej/boring-workspace/server"
 import { LIVE_TRANSCRIPT_BASE_PATH } from "../shared"
@@ -30,6 +31,9 @@ export interface LiveTranscriptServerPluginOptions {
   maxDurationMs?: number
   maxTranscriptBytes?: number
   maxUpstreamMessages?: number
+  /** Trusted absolute local directory where `/live` audio is saved as AAC/M4A. */
+  audioRecordingDirectory?: string
+  audioRecordingFfmpegPath?: string
   reviewIntervalMs?: number
   reviewRetryMs?: number
   createUpstreamForTest?: LiveTranscriptManagerOptions["createUpstreamForTest"]
@@ -39,6 +43,7 @@ export interface LiveTranscriptServerPluginOptions {
 export function createLiveTranscriptServerPlugin(options: LiveTranscriptServerPluginOptions): WorkspaceServerPlugin {
   validateLocalAuthority(options.authority, options.upstreamUrl, options.upstreamProvider)
   if (options.diarizerUrl) validateLocalAuthority(options.authority, options.diarizerUrl, "sortformer")
+  if (options.audioRecordingDirectory && !isAbsolute(options.audioRecordingDirectory)) throw new LiveTranscriptError("live_transcript_local_only", "Audio recording directory must be absolute.", 500)
   if (options.lifecycleUrl && (!options.lifecycleBearerToken || options.lifecycleBearerToken.length < 32)) throw new LiveTranscriptError("live_transcript_local_only", "Lifecycle bearer token must contain at least 32 characters.", 500)
   const lifecycle = new ComputeLifecycleCoordinator(options.lifecycleUrl
     ? new ComputeLifecycleClient(validateLifecycleUrl(options.lifecycleUrl), options.lifecycleBearerToken!)
@@ -57,6 +62,8 @@ export function createLiveTranscriptServerPlugin(options: LiveTranscriptServerPl
     maxDurationMs: options.maxDurationMs,
     maxTranscriptBytes: options.maxTranscriptBytes,
     maxUpstreamMessages: options.maxUpstreamMessages,
+    audioRecordingDirectory: options.audioRecordingDirectory,
+    audioRecordingFfmpegPath: options.audioRecordingFfmpegPath,
     reviewIntervalMs: options.reviewIntervalMs,
     reviewRetryMs: options.reviewRetryMs,
     createUpstreamForTest: options.createUpstreamForTest,

--- a/plugins/live-transcription/src/server/manager.ts
+++ b/plugins/live-transcription/src/server/manager.ts
@@ -20,6 +20,7 @@ import { KyutaiDiarizedConnection } from "./kyutaiDiarized"
 import { groupKyutaiTranscriptSnapshot } from "./kyutaiTranscript"
 import { WhisperLiveKitConnection, type WhisperLiveKitSnapshot } from "./whisperLiveKit"
 import { LiveReviewBroker } from "./reviewBroker"
+import { LocalAudioRecorder } from "./audioRecorder"
 
 interface UpstreamConnection {
   connect(): Promise<void>
@@ -31,6 +32,8 @@ interface UpstreamConnection {
 interface LiveSession {
   id: string
   transcriptPath: string
+  audioPath?: string
+  audioRecorder?: LocalAudioRecorder
   originatingSessionId: string
   startedAt: string
   title: string
@@ -70,6 +73,9 @@ export interface LiveTranscriptManagerOptions {
   maxDurationMs?: number
   maxTranscriptBytes?: number
   maxUpstreamMessages?: number
+  /** Optional trusted local directory for streaming AAC/M4A consultation recordings. */
+  audioRecordingDirectory?: string
+  audioRecordingFfmpegPath?: string
   now?: () => number
   reviewIntervalMs?: number
   reviewRetryMs?: number
@@ -206,7 +212,9 @@ export class LiveTranscriptManager {
     }
     const title = cleanTitle(inputTitle)
     const startedAt = new Date(this.now()).toISOString()
-    const path = `live-transcripts/${startedAt.slice(0, 10)}-${randomBytes(12).toString("hex")}.md`
+    const stem = `${startedAt.slice(0, 10)}-${randomBytes(12).toString("hex")}`
+    const path = `live-transcripts/${stem}.md`
+    const audioPath = this.options.audioRecordingDirectory ? `live-transcripts/${stem}.m4a` : undefined
     await workspace.mkdir("live-transcripts", { recursive: true })
     const initialDocument: TranscriptDocument = {
       title,
@@ -222,6 +230,7 @@ export class LiveTranscriptManager {
     const session: LiveSession = {
       id,
       transcriptPath: path,
+      audioPath,
       originatingSessionId: sessionId,
       startedAt,
       title,
@@ -260,6 +269,7 @@ export class LiveTranscriptManager {
     return {
       liveSessionId: id,
       transcriptPath: path,
+      ...(audioPath ? { audioPath } : {}),
       socketNonce,
       reviewIntervalMs: this.options.reviewIntervalMs ?? 60_000,
       state: "setup",
@@ -273,6 +283,7 @@ export class LiveTranscriptManager {
         active: session.phase !== "terminal",
         liveSessionId: session.id,
         transcriptPath: session.transcriptPath,
+        ...(session.audioPath ? { audioPath: session.audioPath } : {}),
         originatingSessionId: session.originatingSessionId,
         state: session.phase === "terminal" ? "interrupted" : session.phase,
         projectionRevision: session.projector.projectionRevision,
@@ -361,6 +372,15 @@ export class LiveTranscriptManager {
           session.upstream = this.options.createUpstreamForTest?.(callbacks) ?? this.createUpstream(callbacks)
           try {
             await session.upstream.connect()
+            if (session.audioPath && this.options.audioRecordingDirectory) {
+              session.audioRecorder = new LocalAudioRecorder({
+                directory: this.options.audioRecordingDirectory,
+                filename: session.audioPath.slice("live-transcripts/".length),
+                sampleRate: this.options.upstreamProvider === "kyutai" ? 24_000 : 16_000,
+                ffmpegPath: this.options.audioRecordingFfmpegPath,
+              })
+              await session.audioRecorder.start()
+            }
           } catch {
             await this.terminate(session, "interrupted", "live_transcript_upstream_failed")
             return
@@ -388,6 +408,7 @@ export class LiveTranscriptManager {
           return
         }
         try {
+          await session.audioRecorder?.write(data)
           await session.upstream?.sendPcm(data)
           await sendAck(socket)
         } catch (error) {
@@ -505,12 +526,24 @@ export class LiveTranscriptManager {
         finalState = "interrupted"
         finalOutcome = error instanceof LiveTranscriptError ? error.code : "live_transcript_upstream_failed"
       }
+      let audioStored = false
+      if (session.audioRecorder) {
+        try {
+          await session.audioRecorder.finalize()
+          audioStored = true
+        } catch {
+          finalState = "interrupted"
+          finalOutcome = "live_transcript_upstream_failed"
+          await session.audioRecorder.abort()
+        }
+      }
       if (finalState === "complete") await session.reviewBroker?.final()
       else session.reviewBroker?.interrupt()
       session.upstream?.close()
       const result: LiveTranscriptTerminalResponse = {
         liveSessionId: session.id,
         transcriptPath: session.transcriptPath,
+        ...(audioStored && session.audioPath ? { audioPath: session.audioPath } : {}),
         state: finalState,
         ...(finalOutcome ? { outcome: finalOutcome } : {}),
         projectionRevision: session.projector.projectionRevision,

--- a/plugins/live-transcription/src/shared/index.ts
+++ b/plugins/live-transcription/src/shared/index.ts
@@ -39,6 +39,7 @@ export type LiveTranscriptState = "setup" | "active" | "stopping" | "complete" |
 export interface LiveTranscriptStartResponse {
   liveSessionId: string
   transcriptPath: string
+  audioPath?: string
   socketNonce: string
   reviewIntervalMs: number
   state: "setup"
@@ -48,6 +49,7 @@ export interface LiveTranscriptStatusResponse {
   active: boolean
   liveSessionId?: string
   transcriptPath?: string
+  audioPath?: string
   originatingSessionId?: string
   state?: LiveTranscriptState
   outcome?: LiveTranscriptErrorCode
@@ -57,6 +59,7 @@ export interface LiveTranscriptStatusResponse {
 export interface LiveTranscriptTerminalResponse {
   liveSessionId: string
   transcriptPath: string
+  audioPath?: string
   state: "complete" | "interrupted"
   outcome?: LiveTranscriptErrorCode
   projectionRevision: number


### PR DESCRIPTION
## Summary
- cap clinic Sortformer output at two anonymous speakers
- gate low-confidence activity and require sustained evidence before speaker switches
- add optional trusted local AAC/M4A recording for `/live` sessions
- stream PCM directly through FFmpeg without retaining raw audio in memory
- add regression tests for speaker stability and M4A finalization

## Validation
- transcription package typecheck
- 106 package tests passed
- Sortformer sidecar unit and inference/drain smoke tests
- deployed live route produced a valid one-second M4A and matching transcript