### PR TITLE
direction: merge-queue refresh — #1382 sole remaining item

### DIFF
--- a/docs/direction/DIRECTION.md
+++ b/docs/direction/DIRECTION.md
@@ -418,7 +418,8 @@ model is not decided**. Full program:
    Does not block a view library over files and built-in views.
 5. **[merge-queue]** (formerly P5) — a standing obligation, not a bead: this
    list gets a pass **before any premise bead is dispatched**. Current path
-   items: #1382 (and the eval suite stacked behind it), #1343, #1376, #1386;
+   items: #1382 (and the eval suite stacked behind it) — the sole remaining
+   item as of 2026-08-31 (#1343 closed superseded; #1376, #1386 merged);
    kernel-adjacent but off-path: #1145, #1166, #1288. #1409 is MERGED and
    #1416 is closed-absorbed into it — neither is a queue item. Also decide
    the two orphaned weekend branches (`weekend/k7-agent-packages`,


### PR DESCRIPTION
One-line queue refresh satisfying the merge-queue-preflight gate bead (wt-391-forward-ru7v, disposition comment there): #1343 closed, #1376/#1386 merged, leaving #1382 (+ stacked eval suite) as the only queue item. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqY6ZfkFNk7NU4VrEuZhgE