### PR TITLE
feat(factory): package portable profiles and procedures

### DIFF
--- a/.agents/factory/fleet.yaml
+++ b/.agents/factory/fleet.yaml
@@ -86,7 +86,7 @@ seats:
     agentTypeId: boring-orchestrator
     skills:
       - name: plan
-        digest: sha256:c348aabea4210bba37068e20cffc0a0cb600dcde8e21f3826ee3ee36cf1c0108
+        digest: sha256:5d5c2b0f796967eaf4b18c47eb921dfdaeddbda43d1b2a206d90425ba3221ac1
       - name: feedback
         digest: sha256:707ae8fd12ace225be7d6de8c345c7d73cf9aa07763f138419f6d6b26b92a9af
       - name: owner-gate

--- a/.agents/skills/plan/SKILL.md
+++ b/.agents/skills/plan/SKILL.md
@@ -32,9 +32,12 @@ canonical contracts: `docs/procedures/{boring-loop.md,MODEL-CARD.md}` and
   proof path, file scope, fits one session), and set bead priority at plan time.
 - Before Beads handoff run `br dep cycles` and `bv --robot-insights`; never bare
   `bv`.
-- Use `/skill:fresh-eyes` as tier 1, then continue the required Model Card ladder.
-  Use `ask_user` for unresolved intent, risk, or approval. A plan-approval
-  intention links the visual plan doc from `docs/procedures/visual-review-doc.md`.
+- Request tier-1 fresh-eyes review through the host-provided independent-review
+  mechanism (`/skill:fresh-eyes` when that command is explicitly granted), then
+  continue the required Model Card ladder. If no independent-review mechanism is
+  available, stop rather than self-certifying. Use `ask_user` for unresolved
+  intent, risk, or approval. A plan-approval intention links the visual plan doc
+  from `docs/procedures/visual-review-doc.md`.
 - **The Steward never self-certifies: an adversarial plan review
   (cross-model per the Model Card) runs BEFORE the owner gate, always** — even
   when every design decision was pre-ratified by the owner via grill. Grill →

--- a/.agents/skills/present-pr/SKILL.md
+++ b/.agents/skills/present-pr/SKILL.md
@@ -155,10 +155,14 @@ already reviewed, and state the open questions.
    lane (never the canonical checkout or live hub) with
    `pnpm exec playwright install chromium`.
 
+   Resolve `<present-pr-skill-dir>` as the directory containing this `SKILL.md`;
+   skill-relative support files belong to the skill and never to the current repository.
+   Omit `--repo` so `gh` resolves the repository from the current workspace. Pass it only
+   when the PR intentionally belongs to a different repository.
+
    ```bash
    mkdir -p .handoff
-   node scripts/present-pr.mjs <pr-number> \
-     --repo hachej/boring-ui \
+   node <present-pr-skill-dir>/../../../scripts/present-pr.mjs <pr-number> \
      --context <scratchpad>/pr-<n>-context.md \
      --audit "deep audit <date>: N findings closed, M deferred" \
      --out .handoff/pr-<n>-presentation.html

--- a/plugins/boring-factory/README.md
+++ b/plugins/boring-factory/README.md
@@ -1,0 +1,45 @@
+# @hachej/boring-factory
+
+Trusted, portable Factory identity and procedure resources for Boring applications.
+This package is intentionally inert: installing it creates no Agent seat and grants no
+Pi extension, skill, tool, provider, credential, or dispatch authority.
+
+## Canonical sources
+
+- Profiles: `agents/factory-orchestrator` and `agents/factory-worker` in this package.
+- Worker procedures: repository-canonical `.agents/skills/plan` and
+  `.agents/skills/exec`.
+- Procedure companions: `.agents/skill-references/plan` and
+  `.agents/skill-references/exec`.
+
+`pnpm build` copies those procedure resources byte-for-byte into `dist/resources`
+and writes a SHA-256 manifest. Generated resources are package output and must not
+be edited directly.
+
+## Trusted host composition
+
+```ts
+import { resolveBoringFactoryResources } from '@hachej/boring-factory/server'
+
+const resources = resolveBoringFactoryResources()
+```
+
+The embedding app may compile `resources.agentSources` into an allowlisted internal
+fleet and project `resources.skillRoot` only to the addressed Worker runtime. The app
+continues to own seats, `/loop`, sandbox tools, reviewer/dispatch capabilities,
+providers, credentials, quotas, and activation policy.
+
+Do not add the skill root as a global package default and do not infer authority from
+these authored files.
+
+## Private vendoring
+
+No npm publication is required. From an exact reviewed Boring UI commit:
+
+```bash
+pnpm --filter @hachej/boring-factory build
+pnpm --filter @hachej/boring-factory pack --pack-destination <trusted-output-dir>
+```
+
+The consuming private app commits the tarball, its source commit, and its SHA-256,
+then installs it through a frozen `file:` dependency.

--- a/plugins/boring-factory/README.md
+++ b/plugins/boring-factory/README.md
@@ -12,9 +12,12 @@ Pi extension, skill, tool, provider, credential, or dispatch authority.
 - Procedure companions: `.agents/skill-references/plan` and
   `.agents/skill-references/exec`.
 
-`pnpm build` copies those procedure resources byte-for-byte into `dist/resources`
-and writes a SHA-256 manifest. Generated resources are package output and must not
-be edited directly.
+`pnpm build` copies those procedures, their direct read-only procedure/reference
+closure, and both profiles byte-for-byte into `dist/resources`. The manifest maps
+every packaged path to its canonical repository source and SHA-256. Generated
+resources are package output and must not be edited directly. Only the top-level
+`skills/plan` and `skills/exec` directories are projected as discoverable Worker
+skills; bundled support skills and documents remain references, not extra grants.
 
 ## Trusted host composition
 

--- a/plugins/boring-factory/agents/factory-orchestrator/agent.json
+++ b/plugins/boring-factory/agents/factory-orchestrator/agent.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "definitionId": "factory-orchestrator",
+  "version": "1.0.0",
+  "label": "Factory Orchestrator",
+  "instructionsRef": "instructions.md"
+}

--- a/plugins/boring-factory/agents/factory-orchestrator/instructions.md
+++ b/plugins/boring-factory/agents/factory-orchestrator/instructions.md
@@ -1,0 +1,18 @@
+You are the **Factory Orchestrator**. You retain process custody while Workers perform implementation.
+
+## Mission
+
+- Turn an approved objective into bounded work with explicit acceptance and proof.
+- Delegate execution to Factory Worker sessions; do not perform Worker implementation yourself.
+- Track acceptance, tangible progress, blockers, evidence, and completion. A heartbeat is not progress.
+- Recover stalled work in the same supervised session when possible; escalate genuine owner decisions through the approved human-intention surface.
+
+## Operating rules
+
+- Use `/loop` only for bounded supervision cadence. Name what each tick checks, stop loops when the supervised work ends, and never treat a timer firing as evidence of progress.
+- Dispatch is not success. Completion requires exact-SHA proof and independent review evidence.
+- Never merge, deploy, publish packages, mutate production, disclose secrets, or perform destructive Git/filesystem operations without explicit authority.
+- Do not grant yourself or a Worker capabilities. Host policy is authoritative.
+- Do not write product code. If no Worker-dispatch capability is available, report the missing capability instead of impersonating a Worker.
+
+Be concise, factual, and explicit about custody state.

--- a/plugins/boring-factory/agents/factory-worker/agent.json
+++ b/plugins/boring-factory/agents/factory-worker/agent.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "definitionId": "factory-worker",
+  "version": "1.0.0",
+  "label": "Factory Worker",
+  "instructionsRef": "instructions.md"
+}

--- a/plugins/boring-factory/agents/factory-worker/instructions.md
+++ b/plugins/boring-factory/agents/factory-worker/instructions.md
@@ -1,0 +1,21 @@
+You are a **Factory Worker**. You own the intellectual and implementation work for one bounded assignment while the Factory Orchestrator retains process custody.
+
+## Required procedure
+
+1. Load and follow the `plan` skill before changing code.
+2. After the plan is bounded and its proof path is explicit, load and follow the `exec` skill.
+3. Return exact-SHA evidence, checks run, review dispositions, residual risks, and a concise handoff.
+
+Pi exposes these procedures as `/skill:plan` and `/skill:exec`. You do not have `/loop`; supervision belongs to the Orchestrator.
+
+## Operating rules
+
+- Work only on the assigned objective and inspect existing state before editing.
+- Use canonical `bash`, filesystem, and Git tools. When a disposable lease is available, target it explicitly on every non-primary operation; never assume a mutable current sandbox.
+- Treat omitted sandbox targeting as the primary workspace. Never claim sandbox isolation unless the tool receipt proves it.
+- Add or update focused tests for behavior changes and run the narrowest relevant checks.
+- Use fresh, read-only review context for independent review; never self-certify completion.
+- Never merge, deploy, publish packages, mutate production, expose secrets, delete files, or perform destructive Git/filesystem operations without explicit authority.
+- If a required capability is absent, stop and report the missing capability rather than inventing another path.
+
+Be direct and evidence-led.

--- a/plugins/boring-factory/package.json
+++ b/plugins/boring-factory/package.json
@@ -26,10 +26,15 @@
   "sideEffects": false,
   "scripts": {
     "build": "tsup && node scripts/build-resources.mjs",
+    "prepack": "pnpm run build",
     "typecheck": "pnpm run build && tsc --noEmit",
     "test": "pnpm run build && vitest run",
     "lint": "pnpm run typecheck",
     "clean": "rm -rf dist .tsbuildinfo"
+  },
+  "dependencies": {
+    "@playwright/test": "^1.62.1",
+    "mermaid": "11.16.1"
   },
   "devDependencies": {
     "@hachej/boring-agent": "workspace:*",

--- a/plugins/boring-factory/package.json
+++ b/plugins/boring-factory/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@hachej/boring-factory",
+  "version": "0.0.0",
+  "type": "module",
+  "private": true,
+  "license": "MIT",
+  "description": "Trusted portable Factory profiles and procedure resources for Boring applications.",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/server/index.d.ts",
+      "import": "./dist/server/index.js"
+    },
+    "./server": {
+      "types": "./dist/server/index.d.ts",
+      "import": "./dist/server/index.js"
+    },
+    "./shared": {
+      "types": "./dist/shared/index.d.ts",
+      "import": "./dist/shared/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsup && node scripts/build-resources.mjs",
+    "typecheck": "pnpm run build && tsc --noEmit",
+    "test": "pnpm run build && vitest run",
+    "lint": "pnpm run typecheck",
+    "clean": "rm -rf dist .tsbuildinfo"
+  },
+  "devDependencies": {
+    "@types/node": "^22.20.0",
+    "tsup": "^8.4.0",
+    "typescript": "~6.0.3",
+    "vitest": "^4.1.11"
+  }
+}

--- a/plugins/boring-factory/package.json
+++ b/plugins/boring-factory/package.json
@@ -32,6 +32,7 @@
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "devDependencies": {
+    "@hachej/boring-agent": "workspace:*",
     "@types/node": "^22.20.0",
     "tsup": "^8.4.0",
     "typescript": "~6.0.3",

--- a/plugins/boring-factory/scripts/build-resources.mjs
+++ b/plugins/boring-factory/scripts/build-resources.mjs
@@ -19,10 +19,63 @@ const sources = [
     source: path.join(repositoryRoot, '.agents/skill-references/exec'),
     target: 'skill-references/exec',
   },
+  ...[
+    'boring-loop.md',
+    'MODEL-CARD.md',
+    'issue-plans.md',
+    'bead-ready.md',
+  ].map((name) => ({
+    source: path.join(repositoryRoot, 'docs/procedures', name),
+    target: path.posix.join('skills/plan/docs/procedures', name),
+  })),
+  {
+    source: path.join(repositoryRoot, '.agents/skills/fresh-eyes'),
+    target: 'skills/plan/.agents/skills/fresh-eyes',
+  },
+  ...[
+    'boring-loop.md',
+    'MODEL-CARD.md',
+    'worktree-agent.md',
+    'proof-of-work.md',
+    'visual-review.md',
+    'owner-review-card.md',
+  ].map((name) => ({
+    source: path.join(repositoryRoot, 'docs/procedures', name),
+    target: path.posix.join('skills/exec/docs/procedures', name),
+  })),
+  {
+    source: path.join(repositoryRoot, '.agents/factory/README.md'),
+    target: 'skills/exec/.agents/factory/README.md',
+  },
+  {
+    source: path.join(repositoryRoot, '.agents/skills/present-pr'),
+    target: 'skills/exec/.agents/skills/present-pr',
+  },
+  {
+    source: path.join(repositoryRoot, '.agents/skills/show-me'),
+    target: 'skills/exec/.agents/skills/show-me',
+  },
+  {
+    source: path.join(repositoryRoot, 'scripts/present-pr.mjs'),
+    target: 'skills/exec/scripts/present-pr.mjs',
+  },
+  ...[
+    'present-pr-context.mjs',
+    'present-pr-files.mjs',
+    'present-pr-html.mjs',
+    'present-pr-links.mjs',
+    'present-pr-theme.mjs',
+    'render-mermaid.mjs',
+  ].map((name) => ({
+    source: path.join(repositoryRoot, 'scripts/lib', name),
+    target: path.posix.join('skills/exec/scripts/lib', name),
+  })),
 ]
 
 /** @type {Record<string, string>} */
 const files = {}
+/** @type {Record<string, string>} */
+const sourceFiles = {}
 
 function sha256(bytes) {
   return createHash('sha256').update(bytes).digest('hex')
@@ -53,6 +106,10 @@ async function copyTree(sourceRoot, targetRelative, relative = '') {
   await mkdir(path.dirname(destination), { recursive: true })
   await copyFile(source, destination)
   files[destinationRelative] = sha256(await readFile(destination))
+  sourceFiles[destinationRelative] = path.posix.join(
+    path.relative(repositoryRoot, sourceRoot).split(path.sep).join(path.posix.sep),
+    relative.split(path.sep).join(path.posix.sep),
+  )
 }
 
 await rm(outputRoot, { recursive: true, force: true })
@@ -63,7 +120,8 @@ for (const entry of sources) {
 
 const manifest = {
   contractVersion: 'boring.factory.resources.v1',
-  files: Object.fromEntries(Object.entries(files).sort(([a], [b]) => a.localeCompare(b))),
+  files: Object.fromEntries(Object.entries(files).sort()),
+  sources: Object.fromEntries(Object.entries(sourceFiles).sort()),
 }
 await writeFile(
   path.join(outputRoot, 'resource-manifest.json'),

--- a/plugins/boring-factory/scripts/build-resources.mjs
+++ b/plugins/boring-factory/scripts/build-resources.mjs
@@ -33,21 +33,10 @@ const sources = [
     target: path.posix.join('skills/plan/docs/procedures', name),
   })),
   {
-    source: path.join(repositoryRoot, '.agents/factory/README.md'),
-    target: 'skills/plan/.agents/factory/README.md',
-  },
-  {
     source: path.join(repositoryRoot, '.agents/skills/fresh-eyes'),
     target: 'skills/plan/.agents/skills/fresh-eyes',
   },
-  {
-    source: path.join(repositoryRoot, '.agents/skills/ui/visual-report-bundle.md'),
-    target: 'skills/plan/.agents/skills/ui/visual-report-bundle.md',
-  },
-  {
-    source: path.join(repositoryRoot, '.agents/skills/ui/visual-report-bundle'),
-    target: 'skills/plan/.agents/skills/ui/visual-report-bundle',
-  },
+
   ...[
     'boring-loop.md',
     'MODEL-CARD.md',
@@ -58,6 +47,7 @@ const sources = [
     'visual-review-doc.md',
     'owner-review-card.md',
     'rolling-small-fixes.md',
+    'session-handoff.md',
   ].map((name) => ({
     source: path.join(repositoryRoot, 'docs/procedures', name),
     target: path.posix.join('skills/exec/docs/procedures', name),
@@ -75,12 +65,8 @@ const sources = [
     target: 'skills/exec/.agents/skills/present-pr',
   },
   {
-    source: path.join(repositoryRoot, '.agents/skills/ui/visual-report-bundle.md'),
-    target: 'skills/exec/.agents/skills/ui/visual-report-bundle.md',
-  },
-  {
-    source: path.join(repositoryRoot, '.agents/skills/ui/visual-report-bundle'),
-    target: 'skills/exec/.agents/skills/ui/visual-report-bundle',
+    source: path.join(repositoryRoot, '.agents/skills/handoff'),
+    target: 'skills/exec/.agents/skills/handoff',
   },
   {
     source: path.join(repositoryRoot, '.agents/skills/show-me'),

--- a/plugins/boring-factory/scripts/build-resources.mjs
+++ b/plugins/boring-factory/scripts/build-resources.mjs
@@ -24,22 +24,40 @@ const sources = [
     'MODEL-CARD.md',
     'issue-plans.md',
     'bead-ready.md',
+    'proof-of-work.md',
     'visual-review-doc.md',
+    'owner-review-card.md',
+    'rolling-small-fixes.md',
   ].map((name) => ({
     source: path.join(repositoryRoot, 'docs/procedures', name),
     target: path.posix.join('skills/plan/docs/procedures', name),
   })),
   {
+    source: path.join(repositoryRoot, '.agents/factory/README.md'),
+    target: 'skills/plan/.agents/factory/README.md',
+  },
+  {
     source: path.join(repositoryRoot, '.agents/skills/fresh-eyes'),
     target: 'skills/plan/.agents/skills/fresh-eyes',
+  },
+  {
+    source: path.join(repositoryRoot, '.agents/skills/ui/visual-report-bundle.md'),
+    target: 'skills/plan/.agents/skills/ui/visual-report-bundle.md',
+  },
+  {
+    source: path.join(repositoryRoot, '.agents/skills/ui/visual-report-bundle'),
+    target: 'skills/plan/.agents/skills/ui/visual-report-bundle',
   },
   ...[
     'boring-loop.md',
     'MODEL-CARD.md',
     'worktree-agent.md',
+    'bead-ready.md',
     'proof-of-work.md',
     'visual-review.md',
+    'visual-review-doc.md',
     'owner-review-card.md',
+    'rolling-small-fixes.md',
   ].map((name) => ({
     source: path.join(repositoryRoot, 'docs/procedures', name),
     target: path.posix.join('skills/exec/docs/procedures', name),
@@ -49,8 +67,20 @@ const sources = [
     target: 'skills/exec/.agents/factory/README.md',
   },
   {
+    source: path.join(repositoryRoot, '.agents/factory/tools.md'),
+    target: 'skills/exec/.agents/factory/tools.md',
+  },
+  {
     source: path.join(repositoryRoot, '.agents/skills/present-pr'),
     target: 'skills/exec/.agents/skills/present-pr',
+  },
+  {
+    source: path.join(repositoryRoot, '.agents/skills/ui/visual-report-bundle.md'),
+    target: 'skills/exec/.agents/skills/ui/visual-report-bundle.md',
+  },
+  {
+    source: path.join(repositoryRoot, '.agents/skills/ui/visual-report-bundle'),
+    target: 'skills/exec/.agents/skills/ui/visual-report-bundle',
   },
   {
     source: path.join(repositoryRoot, '.agents/skills/show-me'),

--- a/plugins/boring-factory/scripts/build-resources.mjs
+++ b/plugins/boring-factory/scripts/build-resources.mjs
@@ -24,6 +24,7 @@ const sources = [
     'MODEL-CARD.md',
     'issue-plans.md',
     'bead-ready.md',
+    'visual-review-doc.md',
   ].map((name) => ({
     source: path.join(repositoryRoot, 'docs/procedures', name),
     target: path.posix.join('skills/plan/docs/procedures', name),
@@ -54,6 +55,10 @@ const sources = [
   {
     source: path.join(repositoryRoot, '.agents/skills/show-me'),
     target: 'skills/exec/.agents/skills/show-me',
+  },
+  {
+    source: path.join(repositoryRoot, '.agents/skill-references/show-me'),
+    target: 'skills/exec/.agents/skill-references/show-me',
   },
   {
     source: path.join(repositoryRoot, 'scripts/present-pr.mjs'),

--- a/plugins/boring-factory/scripts/build-resources.mjs
+++ b/plugins/boring-factory/scripts/build-resources.mjs
@@ -1,0 +1,72 @@
+import { createHash } from 'node:crypto'
+import { lstat, mkdir, readFile, readdir, rm, copyFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const pluginRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const repositoryRoot = path.resolve(pluginRoot, '../..')
+const outputRoot = path.join(pluginRoot, 'dist/resources')
+
+const sources = [
+  { source: path.join(pluginRoot, 'agents'), target: 'agents' },
+  { source: path.join(repositoryRoot, '.agents/skills/plan'), target: 'skills/plan' },
+  { source: path.join(repositoryRoot, '.agents/skills/exec'), target: 'skills/exec' },
+  {
+    source: path.join(repositoryRoot, '.agents/skill-references/plan'),
+    target: 'skill-references/plan',
+  },
+  {
+    source: path.join(repositoryRoot, '.agents/skill-references/exec'),
+    target: 'skill-references/exec',
+  },
+]
+
+/** @type {Record<string, string>} */
+const files = {}
+
+function sha256(bytes) {
+  return createHash('sha256').update(bytes).digest('hex')
+}
+
+async function copyTree(sourceRoot, targetRelative, relative = '') {
+  const source = path.join(sourceRoot, relative)
+  const info = await lstat(source)
+  if (info.isSymbolicLink()) {
+    throw new Error(`factory resource source must not contain symlinks: ${source}`)
+  }
+  if (info.isDirectory()) {
+    const entries = (await readdir(source)).sort()
+    for (const entry of entries) {
+      await copyTree(sourceRoot, targetRelative, path.join(relative, entry))
+    }
+    return
+  }
+  if (!info.isFile()) {
+    throw new Error(`factory resource source must contain regular files only: ${source}`)
+  }
+
+  const destinationRelative = path.posix.join(
+    targetRelative,
+    relative.split(path.sep).join(path.posix.sep),
+  )
+  const destination = path.join(outputRoot, destinationRelative)
+  await mkdir(path.dirname(destination), { recursive: true })
+  await copyFile(source, destination)
+  files[destinationRelative] = sha256(await readFile(destination))
+}
+
+await rm(outputRoot, { recursive: true, force: true })
+await mkdir(outputRoot, { recursive: true })
+for (const entry of sources) {
+  await copyTree(entry.source, entry.target)
+}
+
+const manifest = {
+  contractVersion: 'boring.factory.resources.v1',
+  files: Object.fromEntries(Object.entries(files).sort(([a], [b]) => a.localeCompare(b))),
+}
+await writeFile(
+  path.join(outputRoot, 'resource-manifest.json'),
+  `${JSON.stringify(manifest, null, 2)}\n`,
+  'utf8',
+)

--- a/plugins/boring-factory/src/server/index.ts
+++ b/plugins/boring-factory/src/server/index.ts
@@ -1,0 +1,135 @@
+import { createHash } from 'node:crypto'
+import { lstatSync, readFileSync, readdirSync, realpathSync, statSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import {
+  BORING_FACTORY_RESOURCE_CONTRACT_VERSION,
+  FACTORY_ORCHESTRATOR_AGENT_TYPE_ID,
+  FACTORY_WORKER_AGENT_TYPE_ID,
+} from '../shared/constants'
+import type {
+  BoringFactoryResourceManifestV1,
+  BoringFactoryResources,
+} from '../shared/types'
+
+export {
+  BORING_FACTORY_RESOURCE_CONTRACT_VERSION,
+  FACTORY_AGENT_TYPE_IDS,
+  FACTORY_ORCHESTRATOR_AGENT_TYPE_ID,
+  FACTORY_WORKER_AGENT_TYPE_ID,
+} from '../shared/constants'
+export type {
+  BoringFactoryResourceManifestV1,
+  BoringFactoryResources,
+  FactoryAgentTypeId,
+} from '../shared/types'
+
+const SHA256 = /^[a-f0-9]{64}$/
+
+function sha256(bytes: string | Buffer): string {
+  return createHash('sha256').update(bytes).digest('hex')
+}
+
+function readManifest(resourceRoot: string): {
+  readonly bytes: string
+  readonly manifest: BoringFactoryResourceManifestV1
+} {
+  const bytes = readFileSync(path.join(resourceRoot, 'resource-manifest.json'), 'utf8')
+  const parsed = JSON.parse(bytes) as Partial<BoringFactoryResourceManifestV1>
+  if (
+    parsed.contractVersion !== BORING_FACTORY_RESOURCE_CONTRACT_VERSION
+    || !parsed.files
+    || typeof parsed.files !== 'object'
+    || Array.isArray(parsed.files)
+  ) {
+    throw new Error('invalid Boring Factory resource manifest')
+  }
+  return { bytes, manifest: parsed as BoringFactoryResourceManifestV1 }
+}
+
+function listResourceFiles(
+  resourceRoot: string,
+  relativeDirectory = '',
+): string[] {
+  const directory = path.join(resourceRoot, relativeDirectory)
+  const files: string[] = []
+  for (const name of readdirSync(directory).sort()) {
+    const relativePath = path.posix.join(relativeDirectory.split(path.sep).join('/'), name)
+    if (relativePath === 'resource-manifest.json') continue
+    const absolutePath = path.join(resourceRoot, relativePath)
+    const info = lstatSync(absolutePath)
+    if (info.isSymbolicLink()) {
+      throw new Error(`Boring Factory resource must not be a symlink: ${relativePath}`)
+    }
+    if (info.isDirectory()) {
+      files.push(...listResourceFiles(resourceRoot, relativePath))
+    } else if (info.isFile()) {
+      files.push(relativePath)
+    } else {
+      throw new Error(`Boring Factory resource must be a regular file: ${relativePath}`)
+    }
+  }
+  return files
+}
+
+function verifyResources(resourceRoot: string, manifest: BoringFactoryResourceManifestV1): void {
+  const canonicalRoot = realpathSync(resourceRoot)
+  const manifestFiles = Object.keys(manifest.files).sort()
+  const actualFiles = listResourceFiles(resourceRoot)
+  if (JSON.stringify(actualFiles) !== JSON.stringify(manifestFiles)) {
+    throw new Error('Boring Factory resource file set does not match manifest')
+  }
+  for (const [relativePath, expectedDigest] of Object.entries(manifest.files)) {
+    if (
+      !relativePath
+      || path.isAbsolute(relativePath)
+      || relativePath.split('/').includes('..')
+      || !SHA256.test(expectedDigest)
+    ) {
+      throw new Error(`invalid Boring Factory resource entry: ${relativePath}`)
+    }
+    const absolutePath = realpathSync(path.resolve(resourceRoot, relativePath))
+    const relativeToRoot = path.relative(canonicalRoot, absolutePath)
+    if (relativeToRoot.startsWith('..') || path.isAbsolute(relativeToRoot)) {
+      throw new Error(`Boring Factory resource escapes package root: ${relativePath}`)
+    }
+    if (!statSync(absolutePath).isFile()) {
+      throw new Error(`Boring Factory resource is not a file: ${relativePath}`)
+    }
+    if (sha256(readFileSync(absolutePath)) !== expectedDigest) {
+      throw new Error(`Boring Factory resource digest mismatch: ${relativePath}`)
+    }
+  }
+}
+
+/**
+ * Resolves and verifies the inert Factory profiles and Worker procedures from
+ * this exact installed artifact. The caller still decides which seats and
+ * addressed runtimes receive them; this function grants no executable authority.
+ */
+export function resolveBoringFactoryResources(): BoringFactoryResources {
+  const distRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+  const resourceRoot = path.join(distRoot, 'resources')
+  const { bytes, manifest } = readManifest(resourceRoot)
+  verifyResources(resourceRoot, manifest)
+
+  return Object.freeze({
+    resourceRoot,
+    skillRoot: path.join(resourceRoot, 'skills'),
+    resourceDigest: `sha256:${sha256(bytes)}`,
+    manifest,
+    agentSources: Object.freeze({
+      [FACTORY_ORCHESTRATOR_AGENT_TYPE_ID]: path.join(
+        resourceRoot,
+        'agents',
+        FACTORY_ORCHESTRATOR_AGENT_TYPE_ID,
+      ),
+      [FACTORY_WORKER_AGENT_TYPE_ID]: path.join(
+        resourceRoot,
+        'agents',
+        FACTORY_WORKER_AGENT_TYPE_ID,
+      ),
+    }),
+  })
+}

--- a/plugins/boring-factory/src/server/index.ts
+++ b/plugins/boring-factory/src/server/index.ts
@@ -8,6 +8,10 @@ import {
   FACTORY_ORCHESTRATOR_AGENT_TYPE_ID,
   FACTORY_WORKER_AGENT_TYPE_ID,
 } from '../shared/constants'
+import {
+  BORING_FACTORY_RESOURCE_ERROR_CODES,
+  BoringFactoryResourceError,
+} from '../shared/errors'
 import type {
   BoringFactoryResourceManifestV1,
   BoringFactoryResources,
@@ -19,6 +23,11 @@ export {
   FACTORY_ORCHESTRATOR_AGENT_TYPE_ID,
   FACTORY_WORKER_AGENT_TYPE_ID,
 } from '../shared/constants'
+export {
+  BORING_FACTORY_RESOURCE_ERROR_CODES,
+  BoringFactoryResourceError,
+} from '../shared/errors'
+export type { BoringFactoryResourceErrorCode } from '../shared/errors'
 export type {
   BoringFactoryResourceManifestV1,
   BoringFactoryResources,
@@ -38,10 +47,22 @@ function readManifest(resourceRoot: string): {
   const manifestPath = path.join(resourceRoot, 'resource-manifest.json')
   const manifestInfo = lstatSync(manifestPath)
   if (manifestInfo.isSymbolicLink() || !manifestInfo.isFile()) {
-    throw new Error('Boring Factory resource manifest must be a regular file')
+    throw new BoringFactoryResourceError(
+      BORING_FACTORY_RESOURCE_ERROR_CODES.MANIFEST_INVALID,
+      'Boring Factory resource manifest must be a regular file',
+    )
   }
   const bytes = readFileSync(manifestPath, 'utf8')
-  const parsed = JSON.parse(bytes) as Partial<BoringFactoryResourceManifestV1>
+  let parsed: Partial<BoringFactoryResourceManifestV1>
+  try {
+    parsed = JSON.parse(bytes) as Partial<BoringFactoryResourceManifestV1>
+  } catch (cause) {
+    throw new BoringFactoryResourceError(
+      BORING_FACTORY_RESOURCE_ERROR_CODES.MANIFEST_INVALID,
+      'invalid Boring Factory resource manifest',
+      { cause },
+    )
+  }
   if (
     parsed.contractVersion !== BORING_FACTORY_RESOURCE_CONTRACT_VERSION
     || !parsed.files
@@ -51,7 +72,10 @@ function readManifest(resourceRoot: string): {
     || typeof parsed.sources !== 'object'
     || Array.isArray(parsed.sources)
   ) {
-    throw new Error('invalid Boring Factory resource manifest')
+    throw new BoringFactoryResourceError(
+      BORING_FACTORY_RESOURCE_ERROR_CODES.MANIFEST_INVALID,
+      'invalid Boring Factory resource manifest',
+    )
   }
   return { bytes, manifest: parsed as BoringFactoryResourceManifestV1 }
 }
@@ -68,14 +92,20 @@ function listResourceFiles(
     const absolutePath = path.join(resourceRoot, relativePath)
     const info = lstatSync(absolutePath)
     if (info.isSymbolicLink()) {
-      throw new Error(`Boring Factory resource must not be a symlink: ${relativePath}`)
+      throw new BoringFactoryResourceError(
+        BORING_FACTORY_RESOURCE_ERROR_CODES.ENTRY_INVALID,
+        `Boring Factory resource must not be a symlink: ${relativePath}`,
+      )
     }
     if (info.isDirectory()) {
       files.push(...listResourceFiles(resourceRoot, relativePath))
     } else if (info.isFile()) {
       files.push(relativePath)
     } else {
-      throw new Error(`Boring Factory resource must be a regular file: ${relativePath}`)
+      throw new BoringFactoryResourceError(
+        BORING_FACTORY_RESOURCE_ERROR_CODES.ENTRY_INVALID,
+        `Boring Factory resource must be a regular file: ${relativePath}`,
+      )
     }
   }
   return files
@@ -88,22 +118,31 @@ function verifyResources(
 ): void {
   const rootInfo = lstatSync(resourceRoot)
   if (rootInfo.isSymbolicLink() || !rootInfo.isDirectory()) {
-    throw new Error('Boring Factory resource root must be a regular directory')
+    throw new BoringFactoryResourceError(
+      BORING_FACTORY_RESOURCE_ERROR_CODES.ROOT_INVALID,
+      'Boring Factory resource root must be a regular directory',
+    )
   }
   const canonicalDistRoot = realpathSync(distRoot)
   const canonicalRoot = realpathSync(resourceRoot)
   const relativeToDist = path.relative(canonicalDistRoot, canonicalRoot)
   if (relativeToDist.startsWith('..') || path.isAbsolute(relativeToDist)) {
-    throw new Error('Boring Factory resource root escapes installed artifact')
+    throw new BoringFactoryResourceError(
+      BORING_FACTORY_RESOURCE_ERROR_CODES.ROOT_INVALID,
+      'Boring Factory resource root escapes installed artifact',
+    )
   }
   const manifestFiles = Object.keys(manifest.files).sort()
   const sourceFiles = Object.keys(manifest.sources).sort()
-  const actualFiles = listResourceFiles(resourceRoot)
+  const actualFiles = listResourceFiles(resourceRoot).sort()
   if (
     JSON.stringify(actualFiles) !== JSON.stringify(manifestFiles)
     || JSON.stringify(sourceFiles) !== JSON.stringify(manifestFiles)
   ) {
-    throw new Error('Boring Factory resource file set does not match manifest')
+    throw new BoringFactoryResourceError(
+      BORING_FACTORY_RESOURCE_ERROR_CODES.FILE_SET_INVALID,
+      'Boring Factory resource file set does not match manifest',
+    )
   }
   for (const [relativePath, expectedDigest] of Object.entries(manifest.files)) {
     if (
@@ -115,18 +154,30 @@ function verifyResources(
       || path.isAbsolute(manifest.sources[relativePath])
       || manifest.sources[relativePath].split('/').includes('..')
     ) {
-      throw new Error(`invalid Boring Factory resource entry: ${relativePath}`)
+      throw new BoringFactoryResourceError(
+        BORING_FACTORY_RESOURCE_ERROR_CODES.ENTRY_INVALID,
+        `invalid Boring Factory resource entry: ${relativePath}`,
+      )
     }
     const absolutePath = realpathSync(path.resolve(resourceRoot, relativePath))
     const relativeToRoot = path.relative(canonicalRoot, absolutePath)
     if (relativeToRoot.startsWith('..') || path.isAbsolute(relativeToRoot)) {
-      throw new Error(`Boring Factory resource escapes package root: ${relativePath}`)
+      throw new BoringFactoryResourceError(
+        BORING_FACTORY_RESOURCE_ERROR_CODES.ENTRY_INVALID,
+        `Boring Factory resource escapes package root: ${relativePath}`,
+      )
     }
     if (!statSync(absolutePath).isFile()) {
-      throw new Error(`Boring Factory resource is not a file: ${relativePath}`)
+      throw new BoringFactoryResourceError(
+        BORING_FACTORY_RESOURCE_ERROR_CODES.ENTRY_INVALID,
+        `Boring Factory resource is not a file: ${relativePath}`,
+      )
     }
     if (sha256(readFileSync(absolutePath)) !== expectedDigest) {
-      throw new Error(`Boring Factory resource digest mismatch: ${relativePath}`)
+      throw new BoringFactoryResourceError(
+        BORING_FACTORY_RESOURCE_ERROR_CODES.DIGEST_MISMATCH,
+        `Boring Factory resource digest mismatch: ${relativePath}`,
+      )
     }
   }
 }
@@ -137,27 +188,36 @@ function verifyResources(
  * addressed runtimes receive them; this function grants no executable authority.
  */
 export function resolveBoringFactoryResources(): BoringFactoryResources {
-  const distRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
-  const resourceRoot = path.join(distRoot, 'resources')
-  const { bytes, manifest } = readManifest(resourceRoot)
-  verifyResources(distRoot, resourceRoot, manifest)
+  try {
+    const distRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+    const resourceRoot = path.join(distRoot, 'resources')
+    const { bytes, manifest } = readManifest(resourceRoot)
+    verifyResources(distRoot, resourceRoot, manifest)
 
-  return Object.freeze({
-    resourceRoot,
-    skillRoot: path.join(resourceRoot, 'skills'),
-    resourceDigest: `sha256:${sha256(bytes)}`,
-    manifest,
-    agentSources: Object.freeze({
-      [FACTORY_ORCHESTRATOR_AGENT_TYPE_ID]: path.join(
-        resourceRoot,
-        'agents',
-        FACTORY_ORCHESTRATOR_AGENT_TYPE_ID,
-      ),
-      [FACTORY_WORKER_AGENT_TYPE_ID]: path.join(
-        resourceRoot,
-        'agents',
-        FACTORY_WORKER_AGENT_TYPE_ID,
-      ),
-    }),
-  })
+    return Object.freeze({
+      resourceRoot,
+      skillRoot: path.join(resourceRoot, 'skills'),
+      resourceDigest: `sha256:${sha256(bytes)}`,
+      manifest,
+      agentSources: Object.freeze({
+        [FACTORY_ORCHESTRATOR_AGENT_TYPE_ID]: path.join(
+          resourceRoot,
+          'agents',
+          FACTORY_ORCHESTRATOR_AGENT_TYPE_ID,
+        ),
+        [FACTORY_WORKER_AGENT_TYPE_ID]: path.join(
+          resourceRoot,
+          'agents',
+          FACTORY_WORKER_AGENT_TYPE_ID,
+        ),
+      }),
+    })
+  } catch (cause) {
+    if (cause instanceof BoringFactoryResourceError) throw cause
+    throw new BoringFactoryResourceError(
+      BORING_FACTORY_RESOURCE_ERROR_CODES.RESOLUTION_FAILED,
+      'Boring Factory resources could not be resolved',
+      { cause },
+    )
+  }
 }

--- a/plugins/boring-factory/src/server/index.ts
+++ b/plugins/boring-factory/src/server/index.ts
@@ -35,13 +35,21 @@ function readManifest(resourceRoot: string): {
   readonly bytes: string
   readonly manifest: BoringFactoryResourceManifestV1
 } {
-  const bytes = readFileSync(path.join(resourceRoot, 'resource-manifest.json'), 'utf8')
+  const manifestPath = path.join(resourceRoot, 'resource-manifest.json')
+  const manifestInfo = lstatSync(manifestPath)
+  if (manifestInfo.isSymbolicLink() || !manifestInfo.isFile()) {
+    throw new Error('Boring Factory resource manifest must be a regular file')
+  }
+  const bytes = readFileSync(manifestPath, 'utf8')
   const parsed = JSON.parse(bytes) as Partial<BoringFactoryResourceManifestV1>
   if (
     parsed.contractVersion !== BORING_FACTORY_RESOURCE_CONTRACT_VERSION
     || !parsed.files
     || typeof parsed.files !== 'object'
     || Array.isArray(parsed.files)
+    || !parsed.sources
+    || typeof parsed.sources !== 'object'
+    || Array.isArray(parsed.sources)
   ) {
     throw new Error('invalid Boring Factory resource manifest')
   }
@@ -73,11 +81,28 @@ function listResourceFiles(
   return files
 }
 
-function verifyResources(resourceRoot: string, manifest: BoringFactoryResourceManifestV1): void {
+function verifyResources(
+  distRoot: string,
+  resourceRoot: string,
+  manifest: BoringFactoryResourceManifestV1,
+): void {
+  const rootInfo = lstatSync(resourceRoot)
+  if (rootInfo.isSymbolicLink() || !rootInfo.isDirectory()) {
+    throw new Error('Boring Factory resource root must be a regular directory')
+  }
+  const canonicalDistRoot = realpathSync(distRoot)
   const canonicalRoot = realpathSync(resourceRoot)
+  const relativeToDist = path.relative(canonicalDistRoot, canonicalRoot)
+  if (relativeToDist.startsWith('..') || path.isAbsolute(relativeToDist)) {
+    throw new Error('Boring Factory resource root escapes installed artifact')
+  }
   const manifestFiles = Object.keys(manifest.files).sort()
+  const sourceFiles = Object.keys(manifest.sources).sort()
   const actualFiles = listResourceFiles(resourceRoot)
-  if (JSON.stringify(actualFiles) !== JSON.stringify(manifestFiles)) {
+  if (
+    JSON.stringify(actualFiles) !== JSON.stringify(manifestFiles)
+    || JSON.stringify(sourceFiles) !== JSON.stringify(manifestFiles)
+  ) {
     throw new Error('Boring Factory resource file set does not match manifest')
   }
   for (const [relativePath, expectedDigest] of Object.entries(manifest.files)) {
@@ -86,6 +111,9 @@ function verifyResources(resourceRoot: string, manifest: BoringFactoryResourceMa
       || path.isAbsolute(relativePath)
       || relativePath.split('/').includes('..')
       || !SHA256.test(expectedDigest)
+      || !manifest.sources[relativePath]
+      || path.isAbsolute(manifest.sources[relativePath])
+      || manifest.sources[relativePath].split('/').includes('..')
     ) {
       throw new Error(`invalid Boring Factory resource entry: ${relativePath}`)
     }
@@ -112,7 +140,7 @@ export function resolveBoringFactoryResources(): BoringFactoryResources {
   const distRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
   const resourceRoot = path.join(distRoot, 'resources')
   const { bytes, manifest } = readManifest(resourceRoot)
-  verifyResources(resourceRoot, manifest)
+  verifyResources(distRoot, resourceRoot, manifest)
 
   return Object.freeze({
     resourceRoot,

--- a/plugins/boring-factory/src/server/packaging.test.ts
+++ b/plugins/boring-factory/src/server/packaging.test.ts
@@ -1,0 +1,93 @@
+import { execFileSync } from 'node:child_process'
+import {
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rename,
+  rm,
+  symlink,
+  unlink,
+  writeFile,
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { pathToFileURL, fileURLToPath } from 'node:url'
+
+import { compileAgentDirectory } from '@hachej/boring-agent/server'
+import { describe, expect, it } from 'vitest'
+
+const pluginRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+
+function runPnpm(args: string[], cwd: string): void {
+  execFileSync('pnpm', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+}
+
+describe('private Boring Factory tarball', () => {
+  it('packs, installs frozen through file:, compiles profiles, and rejects symlinked authority bytes', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'boring-factory-pack-'))
+    try {
+      const packRoot = path.join(root, 'pack')
+      const consumerRoot = path.join(root, 'consumer')
+      await Promise.all([
+        mkdir(packRoot, { recursive: true }),
+        mkdir(consumerRoot, { recursive: true }),
+      ])
+
+      runPnpm(['pack', '--pack-destination', packRoot], pluginRoot)
+      const packedName = 'hachej-boring-factory-0.0.0.tgz'
+      await copyFile(path.join(packRoot, packedName), path.join(consumerRoot, 'factory.tgz'))
+      await writeFile(path.join(consumerRoot, 'package.json'), JSON.stringify({
+        name: 'factory-artifact-consumer',
+        private: true,
+        type: 'module',
+        dependencies: {
+          '@hachej/boring-factory': 'file:factory.tgz',
+        },
+      }))
+      runPnpm(['install', '--lockfile-only'], consumerRoot)
+      runPnpm(['install', '--frozen-lockfile', '--offline'], consumerRoot)
+
+      const installedServer = path.join(
+        consumerRoot,
+        'node_modules/@hachej/boring-factory/dist/server/index.js',
+      )
+      const installed = await import(`${pathToFileURL(installedServer).href}?test=${Date.now()}`) as {
+        resolveBoringFactoryResources(): {
+          resourceRoot: string
+          agentSources: Record<string, string>
+        }
+      }
+      const resources = installed.resolveBoringFactoryResources()
+      await expect(compileAgentDirectory(resources.agentSources['factory-orchestrator']))
+        .resolves.toMatchObject({ definition: { definitionId: 'factory-orchestrator' } })
+      await expect(compileAgentDirectory(resources.agentSources['factory-worker']))
+        .resolves.toMatchObject({ definition: { definitionId: 'factory-worker' } })
+
+      const lockfile = await readFile(path.join(consumerRoot, 'pnpm-lock.yaml'), 'utf8')
+      expect(lockfile).toContain('file:factory.tgz')
+      expect(lockfile).not.toContain(pluginRoot)
+
+      const manifestPath = path.join(resources.resourceRoot, 'resource-manifest.json')
+      const realManifestPath = path.join(resources.resourceRoot, 'resource-manifest.real.json')
+      await rename(manifestPath, realManifestPath)
+      await symlink('resource-manifest.real.json', manifestPath)
+      expect(() => installed.resolveBoringFactoryResources()).toThrow(/manifest must be a regular file/)
+      await unlink(manifestPath)
+      await rename(realManifestPath, manifestPath)
+
+      const realResourceRoot = `${resources.resourceRoot}-real`
+      await rename(resources.resourceRoot, realResourceRoot)
+      await symlink(path.basename(realResourceRoot), resources.resourceRoot)
+      expect(() => installed.resolveBoringFactoryResources()).toThrow(/root must be a regular directory/)
+      await unlink(resources.resourceRoot)
+      await rename(realResourceRoot, resources.resourceRoot)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  }, 60_000)
+})

--- a/plugins/boring-factory/src/server/packaging.test.ts
+++ b/plugins/boring-factory/src/server/packaging.test.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from 'node:child_process'
 import {
   copyFile,
+  cp,
   mkdir,
   mkdtemp,
   readFile,
@@ -20,25 +21,48 @@ import { describe, expect, it } from 'vitest'
 const pluginRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
 
 function runPnpm(args: string[], cwd: string): void {
-  execFileSync('pnpm', args, {
-    cwd,
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-  })
+  try {
+    execFileSync('pnpm', args, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+  } catch (cause) {
+    const failure = cause as { stdout?: string; stderr?: string }
+    throw new Error(
+      `pnpm ${args.join(' ')} failed\n${failure.stdout ?? ''}${failure.stderr ?? ''}`,
+      { cause },
+    )
+  }
+}
+
+function captureError(run: () => unknown): unknown {
+  try {
+    run()
+    throw new Error('expected operation to fail')
+  } catch (cause) {
+    return cause
+  }
 }
 
 describe('private Boring Factory tarball', () => {
   it('packs, installs frozen through file:, compiles profiles, and rejects symlinked authority bytes', async () => {
     const root = await mkdtemp(path.join(tmpdir(), 'boring-factory-pack-'))
+    const cleanPluginRoot = await mkdtemp(path.join(path.dirname(pluginRoot), '.boring-factory-pack-'))
     try {
       const packRoot = path.join(root, 'pack')
       const consumerRoot = path.join(root, 'consumer')
       await Promise.all([
         mkdir(packRoot, { recursive: true }),
         mkdir(consumerRoot, { recursive: true }),
+        cp(pluginRoot, cleanPluginRoot, {
+          recursive: true,
+          filter: (source) => path.relative(pluginRoot, source).split(path.sep)[0] !== 'dist',
+        }),
       ])
 
-      runPnpm(['pack', '--pack-destination', packRoot], pluginRoot)
+      expect(await readFile(path.join(cleanPluginRoot, 'package.json'), 'utf8')).toContain('"prepack"')
+      runPnpm(['pack', '--pack-destination', packRoot], cleanPluginRoot)
       const packedName = 'hachej-boring-factory-0.0.0.tgz'
       await copyFile(path.join(packRoot, packedName), path.join(consumerRoot, 'factory.tgz'))
       await writeFile(path.join(consumerRoot, 'package.json'), JSON.stringify({
@@ -50,6 +74,7 @@ describe('private Boring Factory tarball', () => {
         },
       }))
       runPnpm(['install', '--lockfile-only'], consumerRoot)
+      runPnpm(['fetch'], consumerRoot)
       runPnpm(['install', '--frozen-lockfile', '--offline'], consumerRoot)
 
       const installedServer = path.join(
@@ -57,8 +82,10 @@ describe('private Boring Factory tarball', () => {
         'node_modules/@hachej/boring-factory/dist/server/index.js',
       )
       const installed = await import(`${pathToFileURL(installedServer).href}?test=${Date.now()}`) as {
+        BORING_FACTORY_RESOURCE_ERROR_CODES: Record<string, string>
         resolveBoringFactoryResources(): {
           resourceRoot: string
+          skillRoot: string
           agentSources: Record<string, string>
         }
       }
@@ -68,26 +95,48 @@ describe('private Boring Factory tarball', () => {
       await expect(compileAgentDirectory(resources.agentSources['factory-worker']))
         .resolves.toMatchObject({ definition: { definitionId: 'factory-worker' } })
 
+      const presentPrSkill = path.join(resources.skillRoot, 'exec/.agents/skills/present-pr/SKILL.md')
+      const presentPrScript = path.resolve(path.dirname(presentPrSkill), '../../../scripts/present-pr.mjs')
+      expect(await readFile(presentPrSkill, 'utf8')).not.toContain('--repo hachej/boring-ui')
+      expect(captureError(() => execFileSync(process.execPath, [presentPrScript], {
+        cwd: consumerRoot,
+        encoding: 'utf8',
+      }))).toMatchObject({ status: 2, stderr: expect.stringContaining('usage: present-pr.mjs') })
+
       const lockfile = await readFile(path.join(consumerRoot, 'pnpm-lock.yaml'), 'utf8')
       expect(lockfile).toContain('file:factory.tgz')
       expect(lockfile).not.toContain(pluginRoot)
 
       const manifestPath = path.join(resources.resourceRoot, 'resource-manifest.json')
+      const manifestBytes = await readFile(manifestPath)
+      await writeFile(manifestPath, '{')
+      expect(captureError(() => installed.resolveBoringFactoryResources())).toMatchObject({
+        code: installed.BORING_FACTORY_RESOURCE_ERROR_CODES.MANIFEST_INVALID,
+      })
+      await writeFile(manifestPath, manifestBytes)
+
       const realManifestPath = path.join(resources.resourceRoot, 'resource-manifest.real.json')
       await rename(manifestPath, realManifestPath)
       await symlink('resource-manifest.real.json', manifestPath)
-      expect(() => installed.resolveBoringFactoryResources()).toThrow(/manifest must be a regular file/)
+      expect(captureError(() => installed.resolveBoringFactoryResources())).toMatchObject({
+        code: installed.BORING_FACTORY_RESOURCE_ERROR_CODES.MANIFEST_INVALID,
+      })
       await unlink(manifestPath)
       await rename(realManifestPath, manifestPath)
 
       const realResourceRoot = `${resources.resourceRoot}-real`
       await rename(resources.resourceRoot, realResourceRoot)
       await symlink(path.basename(realResourceRoot), resources.resourceRoot)
-      expect(() => installed.resolveBoringFactoryResources()).toThrow(/root must be a regular directory/)
+      expect(captureError(() => installed.resolveBoringFactoryResources())).toMatchObject({
+        code: installed.BORING_FACTORY_RESOURCE_ERROR_CODES.ROOT_INVALID,
+      })
       await unlink(resources.resourceRoot)
       await rename(realResourceRoot, resources.resourceRoot)
     } finally {
-      await rm(root, { recursive: true, force: true })
+      await Promise.all([
+        rm(root, { recursive: true, force: true }),
+        rm(cleanPluginRoot, { recursive: true, force: true }),
+      ])
     }
   }, 60_000)
 })

--- a/plugins/boring-factory/src/server/resources.test.ts
+++ b/plugins/boring-factory/src/server/resources.test.ts
@@ -26,34 +26,56 @@ async function expectExactFile(source: string, packaged: string): Promise<void> 
   expect(packagedBytes).toEqual(sourceBytes)
 }
 
-function referencedMarkdownPaths(relativePath: string, content: string): string[] {
-  const references = Array.from(
-    content.matchAll(/\[[^\]]*\]\(([^)#]+\.md)(?:#[^)]+)?\)/g),
-  ).filter((match) => {
-    if (match[1]!.includes('://')) return false
-    const context = content.slice(Math.max(0, (match.index ?? 0) - 160), match.index)
-    return /\b(?:read|follow|required|requires|per|governed|together|guidance)\b/i.test(context)
-  }).map((match) => match[1]!)
+const HOST_OWNED_MARKDOWN_REFERENCES = new Set([
+  '.agents/factory/README.md -> AGENTS.md',
+  '.agents/factory/README.md -> docs/factory/TODO.md',
+  '.agents/factory/README.md -> docs/factory/VISION.md',
+  '.agents/factory/README.md -> issue-plans.md',
+  '.agents/factory/tools.md -> .agents/skills/owner-gate/SKILL.md',
+  '.agents/factory/tools.md -> docs/factory/VISION.md',
+  '.agents/skill-references/show-me/humanlayer-show-me/SOURCE.md -> plugins/show-me/skills/show-me/SKILL.md',
+  '.agents/skills/present-pr/SKILL.md -> packages/workspace/docs/URL_PANE.md',
+  'docs/procedures/MODEL-CARD.md -> documentation-refresh-tasks.md',
+  'docs/procedures/boring-loop.md -> .agents/factory/README.md',
+  'docs/procedures/visual-review-doc.md -> .agents/skills/ui/visual-report-bundle.md',
+])
 
-  if (relativePath === 'SKILL.md') {
-    references.push(...Array.from(
-      content.matchAll(/`((?:\.{1,2}\/|docs\/|\.agents\/)[A-Za-z0-9_./-]+\.md)`/g),
+function referencedMarkdownPaths(content: string): string[] {
+  const references = [
+    ...Array.from(
+      content.matchAll(/\[[^\]]*\]\(([^)#]+\.md)(?:#[^)]+)?\)/g),
       (match) => match[1]!,
-    ))
-  }
-  if (relativePath.endsWith('/index.md')) {
-    references.push(...Array.from(
-      content.matchAll(/\*\*Read:\*\* `([^`]+\.md)`/g),
+    ),
+    ...Array.from(
+      content.matchAll(/`((?:\.{1,2}\/|[A-Za-z0-9_.-]+\/)*[A-Za-z0-9_.-]+\.md)`/g),
       (match) => match[1]!,
-    ))
-  }
-  if (relativePath.startsWith('docs/procedures/')) {
-    references.push(...Array.from(
-      content.matchAll(/`((?:docs\/|\.agents\/)[A-Za-z0-9_./-]+\.md)`/g),
-      (match) => match[1]!,
-    ))
-  }
+    ),
+  ].filter((reference) => !reference.includes('://'))
   return [...new Set(references)]
+}
+
+function resolvePackagedReference(
+  skillPrefix: string,
+  packagedPath: string,
+  skillRelativePath: string,
+  reference: string,
+): string {
+  if (/^(?:docs|\.agents|packages|plugins)\//.test(reference) || reference === 'AGENTS.md') {
+    return path.posix.join(skillPrefix, reference)
+  }
+  if (
+    (skillRelativePath === 'SKILL.md' || skillRelativePath === '.agents/factory/README.md')
+    && !reference.includes('/')
+  ) {
+    return path.posix.join(skillPrefix, 'docs/procedures', reference)
+  }
+  if (skillRelativePath === 'docs/procedures/session-handoff.md' && reference === 'CONTRACT.md') {
+    return path.posix.join(skillPrefix, '.agents/skills/handoff/CONTRACT.md')
+  }
+  if (skillRelativePath.startsWith('docs/procedures/') && reference.startsWith('procedures/')) {
+    return path.posix.join(skillPrefix, 'docs', reference)
+  }
+  return path.posix.normalize(path.posix.join(path.posix.dirname(packagedPath), reference))
 }
 
 describe('Boring Factory resource artifact', () => {
@@ -96,6 +118,7 @@ describe('Boring Factory resource artifact', () => {
     const resources = resolveBoringFactoryResources()
     const packagedFiles = new Set(Object.keys(resources.manifest.files))
 
+    const unresolved: string[] = []
     for (const skillName of ['plan', 'exec']) {
       const skillPrefix = `skills/${skillName}/`
       const markdownFiles = [...packagedFiles]
@@ -104,18 +127,20 @@ describe('Boring Factory resource artifact', () => {
       for (const packagedPath of markdownFiles) {
         const skillRelativePath = packagedPath.slice(skillPrefix.length)
         const content = await readFile(path.join(resources.resourceRoot, packagedPath), 'utf8')
-        for (const reference of referencedMarkdownPaths(skillRelativePath, content)) {
-          const target = reference.startsWith('docs/') || reference.startsWith('.agents/')
-            ? path.posix.join(skillPrefix, reference)
-            : path.posix.normalize(path.posix.join(path.posix.dirname(packagedPath), reference))
-          expect(
-            target.startsWith('skills/') || target.startsWith('skill-references/'),
-            `${packagedPath} reference escapes the packaged runtime root: ${reference}`,
-          ).toBe(true)
-          expect(packagedFiles.has(target), `${packagedPath} -> ${reference} (${target})`).toBe(true)
+        for (const reference of referencedMarkdownPaths(content)) {
+          const edge = `${skillRelativePath} -> ${reference}`
+          if (HOST_OWNED_MARKDOWN_REFERENCES.has(edge)) continue
+          const target = resolvePackagedReference(
+            skillPrefix,
+            packagedPath,
+            skillRelativePath,
+            reference,
+          )
+          if (!packagedFiles.has(target)) unresolved.push(`${packagedPath} -> ${reference} (${target})`)
         }
       }
     }
+    expect(unresolved).toEqual([])
   })
 
   it('keeps profile manifests aligned with their addressed directory identities', async () => {

--- a/plugins/boring-factory/src/server/resources.test.ts
+++ b/plugins/boring-factory/src/server/resources.test.ts
@@ -47,14 +47,38 @@ describe('Boring Factory resource artifact', () => {
     )
   })
 
-  it('records the exact digest of every packaged regular file', async () => {
+  it('records the exact digest and canonical source bytes of every packaged file', async () => {
     const resources = resolveBoringFactoryResources()
     const entries = Object.entries(resources.manifest.files)
 
-    expect(entries.length).toBeGreaterThan(10)
+    expect(entries.length).toBeGreaterThan(30)
+    expect(Object.keys(resources.manifest.sources).sort())
+      .toEqual(Object.keys(resources.manifest.files).sort())
     for (const [relativePath, expectedDigest] of entries) {
-      expect(sha256(await readFile(path.join(resources.resourceRoot, relativePath))))
-        .toBe(expectedDigest)
+      const packagedPath = path.join(resources.resourceRoot, relativePath)
+      const sourcePath = path.join(repositoryRoot, resources.manifest.sources[relativePath])
+      expect(sha256(await readFile(packagedPath))).toBe(expectedDigest)
+      await expectExactFile(sourcePath, packagedPath)
+    }
+  })
+
+  it('packages the direct read-only reference closure without discovering support skills', () => {
+    const resources = resolveBoringFactoryResources()
+    const files = new Set(Object.keys(resources.manifest.files))
+
+    for (const required of [
+      'skills/plan/docs/procedures/boring-loop.md',
+      'skills/plan/docs/procedures/MODEL-CARD.md',
+      'skills/plan/.agents/skills/fresh-eyes/SKILL.md',
+      'skills/exec/docs/procedures/worktree-agent.md',
+      'skills/exec/docs/procedures/proof-of-work.md',
+      'skills/exec/.agents/factory/README.md',
+      'skills/exec/.agents/skills/present-pr/SKILL.md',
+      'skills/exec/.agents/skills/show-me/SKILL.md',
+      'skills/exec/scripts/present-pr.mjs',
+      'skills/exec/scripts/lib/render-mermaid.mjs',
+    ]) {
+      expect(files.has(required), required).toBe(true)
     }
   })
 

--- a/plugins/boring-factory/src/server/resources.test.ts
+++ b/plugins/boring-factory/src/server/resources.test.ts
@@ -26,6 +26,36 @@ async function expectExactFile(source: string, packaged: string): Promise<void> 
   expect(packagedBytes).toEqual(sourceBytes)
 }
 
+function referencedMarkdownPaths(relativePath: string, content: string): string[] {
+  const references = Array.from(
+    content.matchAll(/\[[^\]]*\]\(([^)#]+\.md)(?:#[^)]+)?\)/g),
+  ).filter((match) => {
+    if (match[1]!.includes('://')) return false
+    const context = content.slice(Math.max(0, (match.index ?? 0) - 160), match.index)
+    return /\b(?:read|follow|required|requires|per|governed|together|guidance)\b/i.test(context)
+  }).map((match) => match[1]!)
+
+  if (relativePath === 'SKILL.md') {
+    references.push(...Array.from(
+      content.matchAll(/`((?:\.{1,2}\/|docs\/|\.agents\/)[A-Za-z0-9_./-]+\.md)`/g),
+      (match) => match[1]!,
+    ))
+  }
+  if (relativePath.endsWith('/index.md')) {
+    references.push(...Array.from(
+      content.matchAll(/\*\*Read:\*\* `([^`]+\.md)`/g),
+      (match) => match[1]!,
+    ))
+  }
+  if (relativePath.startsWith('docs/procedures/')) {
+    references.push(...Array.from(
+      content.matchAll(/`((?:docs\/|\.agents\/)[A-Za-z0-9_./-]+\.md)`/g),
+      (match) => match[1]!,
+    ))
+  }
+  return [...new Set(references)]
+}
+
 describe('Boring Factory resource artifact', () => {
   it('resolves verified addressed profiles and only the canonical plan/exec skill root', async () => {
     const resources = resolveBoringFactoryResources()
@@ -62,27 +92,29 @@ describe('Boring Factory resource artifact', () => {
     }
   })
 
-  it('packages the direct read-only reference closure without discovering support skills', () => {
+  it('resolves the packaged Markdown dependency graph from each runtime skill directory', async () => {
     const resources = resolveBoringFactoryResources()
-    const files = new Set(Object.keys(resources.manifest.files))
+    const packagedFiles = new Set(Object.keys(resources.manifest.files))
 
-    for (const required of [
-      'skills/plan/docs/procedures/boring-loop.md',
-      'skills/plan/docs/procedures/MODEL-CARD.md',
-      'skills/plan/docs/procedures/visual-review-doc.md',
-      'skills/plan/.agents/skills/fresh-eyes/SKILL.md',
-      'skills/exec/docs/procedures/worktree-agent.md',
-      'skills/exec/docs/procedures/proof-of-work.md',
-      'skills/exec/.agents/factory/README.md',
-      'skills/exec/.agents/skills/present-pr/SKILL.md',
-      'skills/exec/.agents/skills/show-me/SKILL.md',
-      'skills/exec/.agents/skill-references/show-me/humanlayer-show-me/SOURCE.md',
-      'skills/exec/.agents/skill-references/show-me/humanlayer-show-me/SKILL.md',
-      'skills/exec/.agents/skill-references/show-me/humanlayer-show-me/LICENSE.txt',
-      'skills/exec/scripts/present-pr.mjs',
-      'skills/exec/scripts/lib/render-mermaid.mjs',
-    ]) {
-      expect(files.has(required), required).toBe(true)
+    for (const skillName of ['plan', 'exec']) {
+      const skillPrefix = `skills/${skillName}/`
+      const markdownFiles = [...packagedFiles]
+        .filter((relativePath) => relativePath.startsWith(skillPrefix) && relativePath.endsWith('.md'))
+        .sort()
+      for (const packagedPath of markdownFiles) {
+        const skillRelativePath = packagedPath.slice(skillPrefix.length)
+        const content = await readFile(path.join(resources.resourceRoot, packagedPath), 'utf8')
+        for (const reference of referencedMarkdownPaths(skillRelativePath, content)) {
+          const target = reference.startsWith('docs/') || reference.startsWith('.agents/')
+            ? path.posix.join(skillPrefix, reference)
+            : path.posix.normalize(path.posix.join(path.posix.dirname(packagedPath), reference))
+          expect(
+            target.startsWith('skills/') || target.startsWith('skill-references/'),
+            `${packagedPath} reference escapes the packaged runtime root: ${reference}`,
+          ).toBe(true)
+          expect(packagedFiles.has(target), `${packagedPath} -> ${reference} (${target})`).toBe(true)
+        }
+      }
     }
   })
 

--- a/plugins/boring-factory/src/server/resources.test.ts
+++ b/plugins/boring-factory/src/server/resources.test.ts
@@ -69,12 +69,16 @@ describe('Boring Factory resource artifact', () => {
     for (const required of [
       'skills/plan/docs/procedures/boring-loop.md',
       'skills/plan/docs/procedures/MODEL-CARD.md',
+      'skills/plan/docs/procedures/visual-review-doc.md',
       'skills/plan/.agents/skills/fresh-eyes/SKILL.md',
       'skills/exec/docs/procedures/worktree-agent.md',
       'skills/exec/docs/procedures/proof-of-work.md',
       'skills/exec/.agents/factory/README.md',
       'skills/exec/.agents/skills/present-pr/SKILL.md',
       'skills/exec/.agents/skills/show-me/SKILL.md',
+      'skills/exec/.agents/skill-references/show-me/humanlayer-show-me/SOURCE.md',
+      'skills/exec/.agents/skill-references/show-me/humanlayer-show-me/SKILL.md',
+      'skills/exec/.agents/skill-references/show-me/humanlayer-show-me/LICENSE.txt',
       'skills/exec/scripts/present-pr.mjs',
       'skills/exec/scripts/lib/render-mermaid.mjs',
     ]) {

--- a/plugins/boring-factory/src/server/resources.test.ts
+++ b/plugins/boring-factory/src/server/resources.test.ts
@@ -1,0 +1,78 @@
+import { createHash } from 'node:crypto'
+import { readFile, readdir } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  FACTORY_ORCHESTRATOR_AGENT_TYPE_ID,
+  FACTORY_WORKER_AGENT_TYPE_ID,
+  resolveBoringFactoryResources,
+} from '../../dist/server/index.js'
+
+const pluginRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const repositoryRoot = path.resolve(pluginRoot, '../..')
+
+function sha256(bytes: string | Buffer): string {
+  return createHash('sha256').update(bytes).digest('hex')
+}
+
+async function expectExactFile(source: string, packaged: string): Promise<void> {
+  const [sourceBytes, packagedBytes] = await Promise.all([
+    readFile(source),
+    readFile(packaged),
+  ])
+  expect(packagedBytes).toEqual(sourceBytes)
+}
+
+describe('Boring Factory resource artifact', () => {
+  it('resolves verified addressed profiles and only the canonical plan/exec skill root', async () => {
+    const resources = resolveBoringFactoryResources()
+
+    expect(resources.resourceDigest).toMatch(/^sha256:[a-f0-9]{64}$/)
+    expect(await readdir(resources.skillRoot)).toEqual(['exec', 'plan'])
+    expect(Object.keys(resources.agentSources).sort()).toEqual([
+      FACTORY_ORCHESTRATOR_AGENT_TYPE_ID,
+      FACTORY_WORKER_AGENT_TYPE_ID,
+    ])
+
+    await expectExactFile(
+      path.join(repositoryRoot, '.agents/skills/plan/SKILL.md'),
+      path.join(resources.skillRoot, 'plan/SKILL.md'),
+    )
+    await expectExactFile(
+      path.join(repositoryRoot, '.agents/skills/exec/SKILL.md'),
+      path.join(resources.skillRoot, 'exec/SKILL.md'),
+    )
+  })
+
+  it('records the exact digest of every packaged regular file', async () => {
+    const resources = resolveBoringFactoryResources()
+    const entries = Object.entries(resources.manifest.files)
+
+    expect(entries.length).toBeGreaterThan(10)
+    for (const [relativePath, expectedDigest] of entries) {
+      expect(sha256(await readFile(path.join(resources.resourceRoot, relativePath))))
+        .toBe(expectedDigest)
+    }
+  })
+
+  it('keeps profile manifests aligned with their addressed directory identities', async () => {
+    const resources = resolveBoringFactoryResources()
+
+    for (const agentTypeId of [
+      FACTORY_ORCHESTRATOR_AGENT_TYPE_ID,
+      FACTORY_WORKER_AGENT_TYPE_ID,
+    ] as const) {
+      const source = resources.agentSources[agentTypeId]
+      const manifest = JSON.parse(await readFile(path.join(source, 'agent.json'), 'utf8')) as {
+        definitionId?: string
+        instructionsRef?: string
+      }
+      expect(manifest.definitionId).toBe(agentTypeId)
+      expect(manifest.instructionsRef).toBe('instructions.md')
+      expect((await readFile(path.join(source, 'instructions.md'), 'utf8')).trim()).not.toBe('')
+    }
+  })
+})

--- a/plugins/boring-factory/src/shared/constants.ts
+++ b/plugins/boring-factory/src/shared/constants.ts
@@ -1,0 +1,7 @@
+export const BORING_FACTORY_RESOURCE_CONTRACT_VERSION = 'boring.factory.resources.v1' as const
+export const FACTORY_ORCHESTRATOR_AGENT_TYPE_ID = 'factory-orchestrator' as const
+export const FACTORY_WORKER_AGENT_TYPE_ID = 'factory-worker' as const
+export const FACTORY_AGENT_TYPE_IDS = [
+  FACTORY_ORCHESTRATOR_AGENT_TYPE_ID,
+  FACTORY_WORKER_AGENT_TYPE_ID,
+] as const

--- a/plugins/boring-factory/src/shared/errors.ts
+++ b/plugins/boring-factory/src/shared/errors.ts
@@ -1,0 +1,21 @@
+export const BORING_FACTORY_RESOURCE_ERROR_CODES = Object.freeze({
+  MANIFEST_INVALID: 'BORING_FACTORY_RESOURCE_MANIFEST_INVALID',
+  ROOT_INVALID: 'BORING_FACTORY_RESOURCE_ROOT_INVALID',
+  FILE_SET_INVALID: 'BORING_FACTORY_RESOURCE_FILE_SET_INVALID',
+  ENTRY_INVALID: 'BORING_FACTORY_RESOURCE_ENTRY_INVALID',
+  DIGEST_MISMATCH: 'BORING_FACTORY_RESOURCE_DIGEST_MISMATCH',
+  RESOLUTION_FAILED: 'BORING_FACTORY_RESOURCE_RESOLUTION_FAILED',
+} as const)
+
+export type BoringFactoryResourceErrorCode =
+  (typeof BORING_FACTORY_RESOURCE_ERROR_CODES)[keyof typeof BORING_FACTORY_RESOURCE_ERROR_CODES]
+
+export class BoringFactoryResourceError extends Error {
+  readonly code: BoringFactoryResourceErrorCode
+
+  constructor(code: BoringFactoryResourceErrorCode, message: string, options?: ErrorOptions) {
+    super(message, options)
+    this.name = 'BoringFactoryResourceError'
+    this.code = code
+  }
+}

--- a/plugins/boring-factory/src/shared/index.ts
+++ b/plugins/boring-factory/src/shared/index.ts
@@ -1,2 +1,3 @@
 export * from './constants'
+export * from './errors'
 export type * from './types'

--- a/plugins/boring-factory/src/shared/index.ts
+++ b/plugins/boring-factory/src/shared/index.ts
@@ -1,0 +1,2 @@
+export * from './constants'
+export type * from './types'

--- a/plugins/boring-factory/src/shared/types.ts
+++ b/plugins/boring-factory/src/shared/types.ts
@@ -1,0 +1,19 @@
+import type {
+  BORING_FACTORY_RESOURCE_CONTRACT_VERSION,
+  FACTORY_AGENT_TYPE_IDS,
+} from './constants'
+
+export type FactoryAgentTypeId = (typeof FACTORY_AGENT_TYPE_IDS)[number]
+
+export interface BoringFactoryResourceManifestV1 {
+  readonly contractVersion: typeof BORING_FACTORY_RESOURCE_CONTRACT_VERSION
+  readonly files: Readonly<Record<string, string>>
+}
+
+export interface BoringFactoryResources {
+  readonly resourceRoot: string
+  readonly skillRoot: string
+  readonly resourceDigest: `sha256:${string}`
+  readonly manifest: BoringFactoryResourceManifestV1
+  readonly agentSources: Readonly<Record<FactoryAgentTypeId, string>>
+}

--- a/plugins/boring-factory/src/shared/types.ts
+++ b/plugins/boring-factory/src/shared/types.ts
@@ -8,6 +8,8 @@ export type FactoryAgentTypeId = (typeof FACTORY_AGENT_TYPE_IDS)[number]
 export interface BoringFactoryResourceManifestV1 {
   readonly contractVersion: typeof BORING_FACTORY_RESOURCE_CONTRACT_VERSION
   readonly files: Readonly<Record<string, string>>
+  /** Packaged path -> canonical repository-relative source path. */
+  readonly sources: Readonly<Record<string, string>>
 }
 
 export interface BoringFactoryResources {

--- a/plugins/boring-factory/tsconfig.json
+++ b/plugins/boring-factory/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "types": ["node", "vitest/globals"],
+    "ignoreDeprecations": "6.0"
+  },
+  "include": ["src/**/*"]
+}

--- a/plugins/boring-factory/tsup.config.ts
+++ b/plugins/boring-factory/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: {
+    'server/index': 'src/server/index.ts',
+    'shared/index': 'src/shared/index.ts',
+  },
+  format: ['esm'],
+  dts: true,
+  splitting: false,
+  clean: true,
+  outDir: 'dist',
+  platform: 'node',
+  target: 'es2022',
+})

--- a/plugins/boring-factory/vitest.config.ts
+++ b/plugins/boring-factory/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1242,6 +1242,9 @@ importers:
 
   plugins/boring-factory:
     devDependencies:
+      '@hachej/boring-agent':
+        specifier: workspace:*
+        version: link:../../packages/agent
       '@types/node':
         specifier: ^22.20.0
         version: 22.20.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1241,6 +1241,13 @@ importers:
         version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
   plugins/boring-factory:
+    dependencies:
+      '@playwright/test':
+        specifier: ^1.62.1
+        version: 1.62.1
+      mermaid:
+        specifier: 11.16.1
+        version: 11.16.1
     devDependencies:
       '@hachej/boring-agent':
         specifier: workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1240,6 +1240,21 @@ importers:
         specifier: ^4.1.11
         version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
+  plugins/boring-factory:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.20.0
+        version: 22.20.1
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.12)(typescript@6.0.3)(yaml@2.9.0)
+      typescript:
+        specifier: ~6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.11
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+
   plugins/boring-governance:
     dependencies:
       proper-lockfile:


### PR DESCRIPTION
## What

- adds private app/internal `@hachej/boring-factory` under `plugins/boring-factory`;
- moves the portable `factory-orchestrator` and `factory-worker` profile sources into Boring UI;
- packages canonical `.agents/skills/plan` and `.agents/skills/exec` plus their direct read-only procedure/reference closure;
- emits a deterministic resource manifest mapping every packaged path to its canonical source and SHA-256;
- exports an inert resolver for exact installed profile and skill paths;
- updates canonical plan review wording so `/skill:fresh-eyes` is used only when host-granted, otherwise work stops rather than self-certifies.

The package creates no Seat and grants no Pi extension, skill, tool, provider, credential, or dispatch authority.

## Private distribution

No npm publication is used. `pnpm pack` produces a reproducible tarball for a reviewed Boring UI SHA. Seneca PR #148 commits that tarball as a frozen relative `file:` dependency with exact source/SHA-256 provenance.

## Proof

- `pnpm --filter @hachej/boring-factory typecheck`
- `pnpm --filter @hachej/boring-factory test` — 5 passed
  - builds and packs the plugin
  - frozen offline `file:` install in a temporary consumer
  - imports the installed resolver
  - compiles both profiles through the canonical Agent compiler
  - compares every packaged byte with its canonical source
  - rejects symlinked manifest/resource-root authority
- two independent packs were byte-identical
- `pnpm lint:invariants`
- `pnpm check:skill-digests`
- `git diff --check`

Independent review: initial REVISE findings on closure, pack proof, symlink roots, deterministic ordering, and host-scoped review were fixed. Exact-head re-review: **PASS**.

## Boundaries

- only top-level `plan` and `exec` are discoverable Worker skills;
- Seneca remains the authority for internal Seats, `/loop`, sandbox tools, review/dispatch capabilities, providers, credentials, quotas, and activation;
- no deployment, npm publication, or production activation.

Closes #1491.
