### PR TITLE
fix(factory): admit addressed trusted app plugins

### DIFF
--- a/packages/agent/src/server/harness/pi-coding-agent/__tests__/createHarness.test.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/__tests__/createHarness.test.ts
@@ -440,7 +440,7 @@ describe("createPiCodingAgentHarness", () => {
 });
 
 describe("pi extension path hot reload", () => {
-  it("reloads changed extension source from Pi extension paths instead of using inline factories", async () => {
+  it("reloads an explicit host extension path while ambient extensions remain disabled", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "pi-extension-cwd-"));
     const agentDir = await mkdtemp(join(tmpdir(), "pi-extension-agent-"));
     const extensionPath = join(cwd, "plugin-agent.ts");
@@ -465,6 +465,7 @@ describe("pi extension path hot reload", () => {
         cwd,
         agentDir,
         additionalExtensionPaths: [extensionPath],
+        noExtensions: true,
         noSkills: true,
         noPromptTemplates: true,
         noThemes: true,

--- a/packages/core/src/app/server/__tests__/addressedAgentRuntimeScope.test.ts
+++ b/packages/core/src/app/server/__tests__/addressedAgentRuntimeScope.test.ts
@@ -114,6 +114,32 @@ describe('addressed Agent runtime composition', () => {
     },
   )
 
+  it.each(['vercel-sandbox', 'blaxel', 'remote-worker', 'runsc-remote'] as const)(
+    'admits only the addressed host-installed pi-mono-loop entry in %s mode',
+    (runtimeMode) => {
+      const loopPath = '/app/node_modules/pi-mono-loop/index.ts'
+      expect(normalizeAgentPiCapabilityOptions({ extensionPaths: [loopPath] }, runtimeMode, [loopPath])).toEqual({
+        additionalSkillPaths: [],
+        packages: [],
+        extensionPaths: [loopPath],
+      })
+      expect(() => normalizeAgentPiCapabilityOptions({
+        extensionPaths: [loopPath, '/app/node_modules/other-extension/index.ts'],
+      }, runtimeMode, [loopPath])).toThrow(`getAgentPi cannot grant host Pi extensions in ${runtimeMode} mode`)
+      expect(() => normalizeAgentPiCapabilityOptions({
+        extensionPaths: ['node_modules/pi-mono-loop/index.ts'],
+      }, runtimeMode, [loopPath])).toThrow(`getAgentPi cannot grant host Pi extensions in ${runtimeMode} mode`)
+      expect(() => normalizeAgentPiCapabilityOptions({
+        extensionPaths: ['/workspace/node_modules/pi-mono-loop/index.ts'],
+      }, runtimeMode, [loopPath])).toThrow(`getAgentPi cannot grant host Pi extensions in ${runtimeMode} mode`)
+
+      // The same entry remains forbidden in static/ambient composition. Only
+      // the addressed trusted-host callback may admit it.
+      expect(() => applyRuntimePiExtensionIsolation({ extensionPaths: [loopPath] }, runtimeMode))
+        .toThrow(`Pi options cannot grant host Pi extensions in ${runtimeMode} mode`)
+    },
+  )
+
   it.each(['direct', 'local'] as const)('preserves explicit trusted extensions in %s mode', (runtimeMode) => {
     const pi = { extensionPaths: ['/host/trusted-extension.ts'] }
     expect(applyRuntimePiExtensionIsolation(pi, runtimeMode)).toBe(pi)

--- a/packages/core/src/app/server/__tests__/addressedAgentRuntimeScope.test.ts
+++ b/packages/core/src/app/server/__tests__/addressedAgentRuntimeScope.test.ts
@@ -115,27 +115,21 @@ describe('addressed Agent runtime composition', () => {
   )
 
   it.each(['vercel-sandbox', 'blaxel', 'remote-worker', 'runsc-remote'] as const)(
-    'admits only the addressed host-installed pi-mono-loop entry in %s mode',
+    'admits absolute extensions from addressed trusted app composition in %s mode',
     (runtimeMode) => {
-      const loopPath = '/app/node_modules/pi-mono-loop/index.ts'
-      expect(normalizeAgentPiCapabilityOptions({ extensionPaths: [loopPath] }, runtimeMode, [loopPath])).toEqual({
+      const pluginExtensionPath = '/app/plugins/trusted-loop/index.ts'
+      expect(normalizeAgentPiCapabilityOptions({ extensionPaths: [pluginExtensionPath] }, runtimeMode)).toEqual({
         additionalSkillPaths: [],
         packages: [],
-        extensionPaths: [loopPath],
+        extensionPaths: [pluginExtensionPath],
       })
       expect(() => normalizeAgentPiCapabilityOptions({
-        extensionPaths: [loopPath, '/app/node_modules/other-extension/index.ts'],
-      }, runtimeMode, [loopPath])).toThrow(`getAgentPi cannot grant host Pi extensions in ${runtimeMode} mode`)
-      expect(() => normalizeAgentPiCapabilityOptions({
-        extensionPaths: ['node_modules/pi-mono-loop/index.ts'],
-      }, runtimeMode, [loopPath])).toThrow(`getAgentPi cannot grant host Pi extensions in ${runtimeMode} mode`)
-      expect(() => normalizeAgentPiCapabilityOptions({
-        extensionPaths: ['/workspace/node_modules/pi-mono-loop/index.ts'],
-      }, runtimeMode, [loopPath])).toThrow(`getAgentPi cannot grant host Pi extensions in ${runtimeMode} mode`)
+        extensionPaths: ['plugins/trusted-loop/index.ts'],
+      }, runtimeMode)).toThrow(`getAgentPi must grant absolute trusted app extension paths in ${runtimeMode} mode`)
 
-      // The same entry remains forbidden in static/ambient composition. Only
-      // the addressed trusted-host callback may admit it.
-      expect(() => applyRuntimePiExtensionIsolation({ extensionPaths: [loopPath] }, runtimeMode))
+      // The same app plugin remains forbidden in static/ambient composition.
+      // Only the addressed trusted-host callback may admit it.
+      expect(() => applyRuntimePiExtensionIsolation({ extensionPaths: [pluginExtensionPath] }, runtimeMode))
         .toThrow(`Pi options cannot grant host Pi extensions in ${runtimeMode} mode`)
     },
   )

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
@@ -1,6 +1,6 @@
 import { AgentGatewayErrorCode, ErrorCode, type AgentTool, type AuthorizedAgentScope } from '@hachej/boring-agent/shared'
 import { randomUUID } from 'node:crypto'
-import { access, mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from 'node:fs/promises'
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { expect, test, vi } from 'vitest'
@@ -1197,7 +1197,7 @@ test.each(['vercel-sandbox', 'blaxel', 'remote-worker'] as const)(
 )
 
 test.each(['vercel-sandbox', 'blaxel', 'remote-worker'] as const)(
-  'core/full-app rejects explicit host extension paths in %s mode',
+  'core/full-app rejects static and unauthorized addressed host extension paths in %s mode',
   async (runtimeMode) => {
     mocks.collectWorkspaceAgentServerPlugins.mockReturnValue({
       runtimePlugins: [],
@@ -1253,7 +1253,7 @@ test.each(['vercel-sandbox', 'blaxel', 'remote-worker'] as const)(
           placementIdentity: 'workspace-a',
           provisioningFingerprint: 'test-provisioning',
         },
-      })).rejects.toThrow(`getAgentPi cannot grant host Pi extensions in ${runtimeMode} mode`)
+      })).rejects.toThrow('Pi resource path is outside authorized roots')
     } finally {
       await addressedApp.close()
     }
@@ -1261,7 +1261,7 @@ test.each(['vercel-sandbox', 'blaxel', 'remote-worker'] as const)(
   30_000,
 )
 
-test('core/full-app admits only the addressed trusted loop entry while Blaxel keeps ambient extensions disabled', async () => {
+test('core/full-app admits an addressed trusted app plugin while Blaxel keeps ambient extensions disabled', async () => {
   mocks.collectWorkspaceAgentServerPlugins.mockReturnValue({
     runtimePlugins: [],
     provisioningContributions: [],
@@ -1273,22 +1273,15 @@ test('core/full-app admits only the addressed trusted loop entry while Blaxel ke
     preservedUiStateKeys: [],
     routeContributions: [],
   })
-  const appRoot = await mkdtemp(join(tmpdir(), 'boring-trusted-loop-'))
-  const packageRoot = join(
-    appRoot,
-    'node_modules',
-    '.pnpm',
-    'pi-mono-loop@1.7.3',
-    'node_modules',
-    'pi-mono-loop',
-  )
+  const appRoot = await mkdtemp(join(tmpdir(), 'boring-trusted-plugin-'))
+  const packageRoot = join(appRoot, 'plugins', 'trusted-loop')
+  const extensionPath = join(packageRoot, 'index.ts')
   await mkdir(packageRoot, { recursive: true })
-  await writeFile(join(packageRoot, 'index.ts'), 'export default function loop() {}\n')
-  await symlink(
-    join('.pnpm', 'pi-mono-loop@1.7.3', 'node_modules', 'pi-mono-loop'),
-    join(appRoot, 'node_modules', 'pi-mono-loop'),
-  )
-  const loopPath = await realpath(join(appRoot, 'node_modules', 'pi-mono-loop', 'index.ts'))
+  await writeFile(join(packageRoot, 'package.json'), JSON.stringify({
+    name: '@app/trusted-loop',
+    pi: { extensions: ['./index.ts'] },
+  }))
+  await writeFile(extensionPath, 'export default function loop() {}\n')
 
   const { createCoreWorkspaceAgentServer } = await import('../createCoreWorkspaceAgentServer.js')
   const app = await createCoreWorkspaceAgentServer({
@@ -1303,7 +1296,7 @@ test('core/full-app admits only the addressed trusted loop entry while Blaxel ke
     },
     piResourceAuthorizedRoots: [appRoot],
     getAgentPi: async ({ agentTypeId }) => agentTypeId === 'factory-orchestrator'
-      ? { extensionPaths: [loopPath] }
+      ? { extensionPaths: [extensionPath] }
       : undefined,
     serveFrontend: false,
   })
@@ -1323,7 +1316,7 @@ test('core/full-app admits only the addressed trusted loop entry while Blaxel ke
         provisioningFingerprint: 'test-provisioning',
       },
     })).resolves.toMatchObject({
-      pi: { noExtensions: true, extensionPaths: [loopPath] },
+      pi: { noExtensions: true, extensionPaths: [extensionPath] },
     })
     await expect(hostOptions.resolveAuthorizedAgentRuntimeScope({
       authorizedScope: scope,

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
@@ -1,6 +1,6 @@
 import { AgentGatewayErrorCode, ErrorCode, type AgentTool, type AuthorizedAgentScope } from '@hachej/boring-agent/shared'
 import { randomUUID } from 'node:crypto'
-import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { access, mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { expect, test, vi } from 'vitest'
@@ -1260,6 +1260,87 @@ test.each(['vercel-sandbox', 'blaxel', 'remote-worker'] as const)(
   },
   30_000,
 )
+
+test('core/full-app admits only the addressed trusted loop entry while Blaxel keeps ambient extensions disabled', async () => {
+  mocks.collectWorkspaceAgentServerPlugins.mockReturnValue({
+    runtimePlugins: [],
+    provisioningContributions: [],
+    agentOptions: {
+      extraTools: [],
+      pi: { additionalSkillPaths: [], packages: [] },
+      systemPromptAppend: undefined,
+    },
+    preservedUiStateKeys: [],
+    routeContributions: [],
+  })
+  const appRoot = await mkdtemp(join(tmpdir(), 'boring-trusted-loop-'))
+  const packageRoot = join(
+    appRoot,
+    'node_modules',
+    '.pnpm',
+    'pi-mono-loop@1.7.3',
+    'node_modules',
+    'pi-mono-loop',
+  )
+  await mkdir(packageRoot, { recursive: true })
+  await writeFile(join(packageRoot, 'index.ts'), 'export default function loop() {}\n')
+  await symlink(
+    join('.pnpm', 'pi-mono-loop@1.7.3', 'node_modules', 'pi-mono-loop'),
+    join(appRoot, 'node_modules', 'pi-mono-loop'),
+  )
+  const loopPath = await realpath(join(appRoot, 'node_modules', 'pi-mono-loop', 'index.ts'))
+
+  const { createCoreWorkspaceAgentServer } = await import('../createCoreWorkspaceAgentServer.js')
+  const app = await createCoreWorkspaceAgentServer({
+    config: createTestCoreConfig({ stores: 'postgres', databaseUrl: 'postgres://test' }),
+    appRoot,
+    workspaceRoot: '/tmp/full-app-workspaces',
+    runtimeModeAdapter: {
+      id: 'blaxel',
+      getRuntimeLayoutRoot: () => '/workspace',
+      runtimeHost: mocks.runtimeHost as any,
+      create: vi.fn(),
+    },
+    piResourceAuthorizedRoots: [appRoot],
+    getAgentPi: async ({ agentTypeId }) => agentTypeId === 'factory-orchestrator'
+      ? { extensionPaths: [loopPath] }
+      : undefined,
+    serveFrontend: false,
+  })
+
+  try {
+    const hostOptions = (mocks.createAgentHost as any).mock.calls.at(-1)?.[0]
+    const projection = (mocks.hostRegisterDirectRoutes as any).mock.calls.at(-1)?.[0]
+    const scope = await projection.authorizeAgentRequest(fakeRequest('workspace-a', 'user-a'))
+    await expect(hostOptions.resolveAuthorizedAgentRuntimeScope({
+      authorizedScope: scope,
+      verifiedClaim: { workspaceScopeId: 'workspace-a', authSubjectId: 'user-a' },
+      agentTypeId: 'factory-orchestrator',
+      environment: {
+        runtimeWorkspaceId: 'workspace-a',
+        workspaceRoot: '/tmp/full-app-workspaces/workspace-a',
+        placementIdentity: 'workspace-a',
+        provisioningFingerprint: 'test-provisioning',
+      },
+    })).resolves.toMatchObject({
+      pi: { noExtensions: true, extensionPaths: [loopPath] },
+    })
+    await expect(hostOptions.resolveAuthorizedAgentRuntimeScope({
+      authorizedScope: scope,
+      verifiedClaim: { workspaceScopeId: 'workspace-a', authSubjectId: 'user-a' },
+      agentTypeId: 'factory-worker',
+      environment: {
+        runtimeWorkspaceId: 'workspace-a',
+        workspaceRoot: '/tmp/full-app-workspaces/workspace-a',
+        placementIdentity: 'workspace-a',
+        provisioningFingerprint: 'test-provisioning',
+      },
+    })).resolves.toMatchObject({ pi: { noExtensions: true } })
+  } finally {
+    await app.close()
+    await rm(appRoot, { recursive: true, force: true })
+  }
+}, 30_000)
 
 test('core/full-app composition honors BORING_AGENT_WORKSPACE_ROOT for workspace provisioning while keeping plugin collection rooted at cwd', async () => {
   mocks.collectWorkspaceAgentServerPlugins.mockReturnValue({

--- a/packages/core/src/app/server/addressedAgentRuntimeScope.ts
+++ b/packages/core/src/app/server/addressedAgentRuntimeScope.ts
@@ -1,4 +1,6 @@
 import { createHash } from 'node:crypto'
+import { realpathSync } from 'node:fs'
+import path from 'node:path'
 
 import {
   compactPiPackages,
@@ -26,6 +28,21 @@ export interface AddressedAgentCapabilityContext {
 }
 
 const HOST_EXTENSION_RUNTIME_MODES = new Set<RuntimeModeId>(['direct', 'local'])
+const TRUSTED_PI_MONO_LOOP_ENTRY = path.join('node_modules', 'pi-mono-loop', 'index.ts')
+
+/** Resolve the sole host-installed extension entry admitted in isolated modes. */
+export function resolveTrustedPiMonoLoopExtensionPath(appRoot: string): string {
+  return realpathSync(path.resolve(appRoot, TRUSTED_PI_MONO_LOOP_ENTRY))
+}
+
+function isTrustedIsolatedAddressedExtension(
+  extensionPath: string,
+  trustedExtensionPaths: readonly string[],
+): boolean {
+  if (!path.isAbsolute(extensionPath)) return false
+  const normalized = path.resolve(extensionPath)
+  return trustedExtensionPaths.some((trustedPath) => normalized === path.resolve(trustedPath))
+}
 
 function isolatesHostExtensions(runtimeMode: RuntimeModeId): boolean {
   // Custom modes fail closed until their adapter contract grows an explicit
@@ -43,9 +60,13 @@ function assertNoExplicitExtensions(
   extensionFactories: readonly unknown[] | undefined,
   runtimeMode: RuntimeModeId,
   source: string,
+  trustedExtensionPaths: readonly string[] = [],
 ): void {
   if (!isolatesHostExtensions(runtimeMode)) return
-  if ((extensionPaths?.length ?? 0) > 0 || (extensionFactories?.length ?? 0) > 0) {
+  const forbiddenPaths = (extensionPaths ?? []).filter(
+    (extensionPath) => !isTrustedIsolatedAddressedExtension(extensionPath, trustedExtensionPaths),
+  )
+  if (forbiddenPaths.length > 0 || (extensionFactories?.length ?? 0) > 0) {
     throw Object.assign(
       new Error(`${source} cannot grant host Pi extensions in ${runtimeMode} mode`),
       { code: ErrorCode.enum.CONFIG_INVALID, statusCode: 500 },
@@ -111,9 +132,13 @@ export function mergePiOptions(
 export function normalizeAgentPiCapabilityOptions(
   pi: AgentPiCapabilityOptions | undefined,
   runtimeMode: RuntimeModeId,
+  trustedExtensionPaths: readonly string[] = [],
 ): AgentPiCapabilityOptions | undefined {
   if (!pi) return undefined
-  assertNoExplicitExtensions(pi.extensionPaths, undefined, runtimeMode, 'getAgentPi')
+  // The initial Factory slice admits only the exact host-resolved loop entry
+  // supplied by Core. Static, ambient, hot-reloaded, authored, and every other
+  // addressed extension remain blocked by the isolated-runtime policy.
+  assertNoExplicitExtensions(pi.extensionPaths, undefined, runtimeMode, 'getAgentPi', trustedExtensionPaths)
   const normalized = {
     additionalSkillPaths: dedupeStrings(pi.additionalSkillPaths ?? []),
     packages: compactPiPackages(pi.packages ?? []),

--- a/packages/core/src/app/server/addressedAgentRuntimeScope.ts
+++ b/packages/core/src/app/server/addressedAgentRuntimeScope.ts
@@ -1,6 +1,5 @@
 import { createHash } from 'node:crypto'
-import { realpathSync } from 'node:fs'
-import path from 'node:path'
+import { isAbsolute } from 'node:path'
 
 import {
   compactPiPackages,
@@ -28,21 +27,6 @@ export interface AddressedAgentCapabilityContext {
 }
 
 const HOST_EXTENSION_RUNTIME_MODES = new Set<RuntimeModeId>(['direct', 'local'])
-const TRUSTED_PI_MONO_LOOP_ENTRY = path.join('node_modules', 'pi-mono-loop', 'index.ts')
-
-/** Resolve the sole host-installed extension entry admitted in isolated modes. */
-export function resolveTrustedPiMonoLoopExtensionPath(appRoot: string): string {
-  return realpathSync(path.resolve(appRoot, TRUSTED_PI_MONO_LOOP_ENTRY))
-}
-
-function isTrustedIsolatedAddressedExtension(
-  extensionPath: string,
-  trustedExtensionPaths: readonly string[],
-): boolean {
-  if (!path.isAbsolute(extensionPath)) return false
-  const normalized = path.resolve(extensionPath)
-  return trustedExtensionPaths.some((trustedPath) => normalized === path.resolve(trustedPath))
-}
 
 function isolatesHostExtensions(runtimeMode: RuntimeModeId): boolean {
   // Custom modes fail closed until their adapter contract grows an explicit
@@ -60,13 +44,9 @@ function assertNoExplicitExtensions(
   extensionFactories: readonly unknown[] | undefined,
   runtimeMode: RuntimeModeId,
   source: string,
-  trustedExtensionPaths: readonly string[] = [],
 ): void {
   if (!isolatesHostExtensions(runtimeMode)) return
-  const forbiddenPaths = (extensionPaths ?? []).filter(
-    (extensionPath) => !isTrustedIsolatedAddressedExtension(extensionPath, trustedExtensionPaths),
-  )
-  if (forbiddenPaths.length > 0 || (extensionFactories?.length ?? 0) > 0) {
+  if ((extensionPaths?.length ?? 0) > 0 || (extensionFactories?.length ?? 0) > 0) {
     throw Object.assign(
       new Error(`${source} cannot grant host Pi extensions in ${runtimeMode} mode`),
       { code: ErrorCode.enum.CONFIG_INVALID, statusCode: 500 },
@@ -132,13 +112,20 @@ export function mergePiOptions(
 export function normalizeAgentPiCapabilityOptions(
   pi: AgentPiCapabilityOptions | undefined,
   runtimeMode: RuntimeModeId,
-  trustedExtensionPaths: readonly string[] = [],
 ): AgentPiCapabilityOptions | undefined {
   if (!pi) return undefined
-  // The initial Factory slice admits only the exact host-resolved loop entry
-  // supplied by Core. Static, ambient, hot-reloaded, authored, and every other
-  // addressed extension remain blocked by the isolated-runtime policy.
-  assertNoExplicitExtensions(pi.extensionPaths, undefined, runtimeMode, 'getAgentPi', trustedExtensionPaths)
+  // `getAgentPi` is trusted app composition for one already-authorized seat.
+  // Its explicit paths are loaded while ambient extension discovery remains
+  // disabled. Static, authored, and hot-reloaded paths still pass through the
+  // isolated-runtime rejection above. Isolated app composition must use the
+  // absolute paths emitted by trusted package scanning, never cwd-relative
+  // workspace inputs.
+  if (isolatesHostExtensions(runtimeMode) && pi.extensionPaths?.some((entry) => !isAbsolute(entry))) {
+    throw Object.assign(
+      new Error(`getAgentPi must grant absolute trusted app extension paths in ${runtimeMode} mode`),
+      { code: ErrorCode.enum.CONFIG_INVALID, statusCode: 500 },
+    )
+  }
   const normalized = {
     additionalSkillPaths: dedupeStrings(pi.additionalSkillPaths ?? []),
     packages: compactPiPackages(pi.packages ?? []),

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -79,7 +79,6 @@ import {
   composeAddressedAgentRuntimeScope,
   mergePiOptions,
   normalizeAgentPiCapabilityOptions,
-  resolveTrustedPiMonoLoopExtensionPath,
   type AddressedAgentCapabilityContext,
   type AgentPiCapabilityOptions,
 } from './addressedAgentRuntimeScope.js'
@@ -268,10 +267,10 @@ export interface CreateCoreWorkspaceAgentServerOptions {
    * Paths must remain under the workspace, plugin roots, or an explicitly
    * configured `piResourceAuthorizedRoots` entry. Grant changes alter semantic
    * identity and therefore require a Host process restart once a binding has
-   * been published. In isolated modes, Core rejects every explicit extension
-   * except the exact realpath of the host-installed `pi-mono-loop` entry, and
-   * only when returned by this addressed policy. Scoped skills and packages
-   * remain supported.
+   * been published. In isolated modes, static, authored, and hot-reloaded host
+   * extensions remain blocked; explicit resources returned here are trusted
+   * app composition for this addressed seat. Scoped skills and packages remain
+   * supported.
    */
   getAgentPi?: (
     ctx: AddressedAgentCapabilityContext,
@@ -1154,15 +1153,6 @@ export async function createCoreWorkspaceAgentServer(
     options.resolveInitialAgentSeat,
   )
   const appRoot = options.appRoot
-  let trustedPiMonoLoopExtensionPath: string | undefined
-  if (appRoot) {
-    try {
-      trustedPiMonoLoopExtensionPath = resolveTrustedPiMonoLoopExtensionPath(appRoot)
-    } catch {
-      // Most apps do not install the optional Factory loop package. If an
-      // addressed policy requests it anyway, normalization remains fail-closed.
-    }
-  }
   const serveFrontend =
     options.serveFrontend ?? (process.env.NODE_ENV !== 'development' && Boolean(appRoot))
   const pluginWorkspaceRoot = process.cwd()
@@ -1820,11 +1810,7 @@ export async function createCoreWorkspaceAgentServer(
         options.getAgentExtraTools?.(context) ?? [],
         options.getAgentPi?.(context),
       ])
-      const addressedPi = normalizeAgentPiCapabilityOptions(
-        agentPi,
-        runtimeModeAdapter.id,
-        trustedPiMonoLoopExtensionPath ? [trustedPiMonoLoopExtensionPath] : [],
-      )
+      const addressedPi = normalizeAgentPiCapabilityOptions(agentPi, runtimeModeAdapter.id)
       const addressedResourceFence = addressedPi
         ? await createPiResourceDigestFence(async () => createPiResourceDigestInput({
             piCwd: environment.workspaceRoot,

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -79,6 +79,7 @@ import {
   composeAddressedAgentRuntimeScope,
   mergePiOptions,
   normalizeAgentPiCapabilityOptions,
+  resolveTrustedPiMonoLoopExtensionPath,
   type AddressedAgentCapabilityContext,
   type AgentPiCapabilityOptions,
 } from './addressedAgentRuntimeScope.js'
@@ -267,8 +268,10 @@ export interface CreateCoreWorkspaceAgentServerOptions {
    * Paths must remain under the workspace, plugin roots, or an explicitly
    * configured `piResourceAuthorizedRoots` entry. Grant changes alter semantic
    * identity and therefore require a Host process restart once a binding has
-   * been published. Remote modes reject explicit host extension paths; scoped
-   * skills and packages remain supported.
+   * been published. In isolated modes, Core rejects every explicit extension
+   * except the exact realpath of the host-installed `pi-mono-loop` entry, and
+   * only when returned by this addressed policy. Scoped skills and packages
+   * remain supported.
    */
   getAgentPi?: (
     ctx: AddressedAgentCapabilityContext,
@@ -1151,6 +1154,15 @@ export async function createCoreWorkspaceAgentServer(
     options.resolveInitialAgentSeat,
   )
   const appRoot = options.appRoot
+  let trustedPiMonoLoopExtensionPath: string | undefined
+  if (appRoot) {
+    try {
+      trustedPiMonoLoopExtensionPath = resolveTrustedPiMonoLoopExtensionPath(appRoot)
+    } catch {
+      // Most apps do not install the optional Factory loop package. If an
+      // addressed policy requests it anyway, normalization remains fail-closed.
+    }
+  }
   const serveFrontend =
     options.serveFrontend ?? (process.env.NODE_ENV !== 'development' && Boolean(appRoot))
   const pluginWorkspaceRoot = process.cwd()
@@ -1808,7 +1820,11 @@ export async function createCoreWorkspaceAgentServer(
         options.getAgentExtraTools?.(context) ?? [],
         options.getAgentPi?.(context),
       ])
-      const addressedPi = normalizeAgentPiCapabilityOptions(agentPi, runtimeModeAdapter.id)
+      const addressedPi = normalizeAgentPiCapabilityOptions(
+        agentPi,
+        runtimeModeAdapter.id,
+        trustedPiMonoLoopExtensionPath ? [trustedPiMonoLoopExtensionPath] : [],
+      )
       const addressedResourceFence = addressedPi
         ? await createPiResourceDigestFence(async () => createPiResourceDigestInput({
             piCwd: environment.workspaceRoot,

--- a/packages/core/src/app/server/index.ts
+++ b/packages/core/src/app/server/index.ts
@@ -5,7 +5,6 @@ export {
   type CoreFrontendRootHandler,
   type CreateCoreWorkspaceAgentServerOptions,
 } from './createCoreWorkspaceAgentServer.js'
-export { resolveTrustedPiMonoLoopExtensionPath } from './addressedAgentRuntimeScope.js'
 export type {
   AddressedAgentCapabilityContext,
   AgentPiCapabilityOptions,

--- a/packages/core/src/app/server/index.ts
+++ b/packages/core/src/app/server/index.ts
@@ -5,6 +5,7 @@ export {
   type CoreFrontendRootHandler,
   type CreateCoreWorkspaceAgentServerOptions,
 } from './createCoreWorkspaceAgentServer.js'
+export { resolveTrustedPiMonoLoopExtensionPath } from './addressedAgentRuntimeScope.js'
 export type {
   AddressedAgentCapabilityContext,
   AgentPiCapabilityOptions,


### PR DESCRIPTION
## What

Allow trusted app/internal Boring plugin extensions through the existing addressed `getAgentPi` policy in isolated runtime modes, without weakening ambient extension isolation.

- Core remains plugin-agnostic: it contains no `pi-mono-loop` or Factory package knowledge;
- static, authored, ambient, and hot-reloaded extensions remain blocked in isolated modes;
- addressed trusted app composition may return absolute extension paths emitted by normal package scanning;
- relative addressed paths are rejected;
- absolute paths outside configured authorized roots fail the existing resource fence;
- `noExtensions: true` remains set, so only the explicit addressed app plugin loads;
- resource digest, symlink, authorized-root, and revalidation fences remain mandatory;
- Worker and ordinary-agent bindings receive no addressed extension unless the trusted app grants one.

Seneca composes `pi-mono-loop` exactly like another app/internal Pi plugin: resolve its installed package root, read `package.json#pi` through `readWorkspacePluginPackagePiSnapshot`, and grant the resulting extension only to `factory-orchestrator`.

Vercel Worker-created sandboxes are unaffected.

## Proof

- Agent explicit-path loader test: 83 passed
- Core addressed/runtime integration tests: 41 passed
- Agent/Core typecheck
- Core build
- `pnpm lint:invariants`
- `git diff --check`
- independent security review: initial suffix-origin BLOCK fixed; hardcoded plugin design rejected by owner and removed; final plugin-agnostic re-review **PASS**

## Boundaries

This does not activate Factory, add Seats/dispatch, publish npm packages, change sandbox providers, or grant `/loop` to Workers/ordinary agents. The trusted app remains the authority that chooses which plugin is granted to each addressed Seat.

Closes #1495.
