### PR TITLE
#1498 feat(workspace): centralize RuntimeWebView projection

### DIFF
--- a/docs/plans/boring-browser-plugin-plan.md
+++ b/docs/plans/boring-browser-plugin-plan.md
@@ -1,0 +1,350 @@
+# Runtime-neutral browser plugin implementation plan
+
+**State:** `ready-for-agent` for Slice 1. Architecture and V0 product decisions are final; later rollout gates are explicit below.
+
+## Problem Statement
+
+Add `plugins/browser` as a trusted, statically composed shared app/internal plugin. It must let Boring's Agent observe and act in a Chromium session that the user can watch and exclusively take over through noVNC, without creating a second agent loop or a browser-specific runtime layer.
+
+The feature must remain runtime/provider-neutral:
+
+- the Host remains authoritative for workspace/user/Agent-session identity, selected runtime, capability/effect admission, approvals, records, models, metering, credentials, and environment lifecycle;
+- the plugin reuses existing boring-bash/runtime exec, the existing environment generation/lease lifecycle, and PR [#1493](https://github.com/hachej/boring-ui/pull/1493)'s runtime-preview projection;
+- Chromium, Browser-Use, Xvfb, VNC, noVNC/websockify, and the fixed launcher are bounded processes in the already selected workspace runtime;
+- the plugin contains no `BrowserRuntimeCapability`, provider adapter, process platform, runtime selection, provider branch, provider credential, or plugin-selected image;
+- Boring is the sole agent/model/record/metering authority. Browser-Use is the pinned browser-control mechanism, not another agent authority.
+
+## Repository Findings and Reuse Seams
+
+- `packages/agent/src/server/agent-host/environmentLease.ts` owns sharing/disposal of the selected environment generation.
+- `packages/agent/src/server/agent-host/buildAgentComposition.ts` and boring-bash already bind execution to that generation's runtime bundle.
+- `packages/boring-bash/src/agent/tools/harness/index.ts` and `packages/boring-bash/src/agent/tools/operations/remoteSandbox.ts` are the existing local/hosted execution path.
+- `packages/workspace/src/plugins/urlPanePlugin/front/UrlPane.tsx` currently owns iframe behavior that should move to a central shared `RuntimeWebView`.
+- PR [#1493](https://github.com/hachej/boring-ui/pull/1493) adds the Host-selected runtime-preview projection. Reconcile its final merged shape; do not duplicate it.
+- `packages/workspace/src/server/plugins/defineServerPlugin.ts` is the trusted server contribution seam. App composition may inject narrow server-only callbacks for fixed browser intents, identity verification, environment reference acquisition/release, and runtime preview. It must not expose arbitrary exec or runtime objects to authored/runtime plugins.
+- Browser-Use's open-source project supplies the [Python library/CLI](https://github.com/browser-use/browser-use), [official coding-agent skill](https://github.com/browser-use/browser-use/blob/main/skills/browser-use/SKILL.md), and [local MCP server](https://docs.browser-use.com/open-source/customize/integrations/mcp-server).
+
+## Solution
+
+### 1. Central shared `RuntimeWebView`
+
+Create one workspace-owned `RuntimeWebView` seam and reuse it in both:
+
+- `url-pane.panel`, preserving generic absolute-URL and selected-runtime-port behavior; and
+- `BrowserPanel`, targeting only the fixed noVNC endpoint.
+
+The shared seam owns target validation, local loopback projection, hosted authenticated HTTPS/WSS projection through #1493, iframe/WebSocket policy, expiry/refresh, retry/reload, cancellation, safe open-external behavior, and sanitized errors. A caller may supply only a validated runtime port/path target; never an upstream host, credentials, runtime/provider identity, or preview secret.
+
+Local projection is explicitly loopback-only (`localhost`, `127.0.0.1`, or `[::1]`, bounded port). Hosted projection stays authenticated and short-lived. noVNC WebSocket auth, upgrade, relative-path, refresh, and revocation behavior are part of this shared contract.
+
+### 2. Trusted `plugins/browser` package
+
+Create `plugins/browser` with front/server/shared/runtime boundaries:
+
+- `BrowserPanel` supplies status, start/stop, viewer, takeover, and return UX and composes the shared `RuntimeWebView` for noVNC;
+- authenticated plugin routes own session start/status/stop/view/takeover/return;
+- an in-process browser-domain controller owns session state, control epoch, bounded lifecycle, and fixed-launcher intents;
+- runtime assets include the fixed launcher and exact dependency locks/digests.
+
+Session start, stop, status/view, takeover, and return are authenticated plugin routes/UI operations, **not model tools**. Routes derive and verify workspace, user, addressed Agent, and Agent session from Host state. Presented IDs are lookup hints and must match Host-owned identity.
+
+The front never receives arbitrary command text, raw MCP/CDP/VNC endpoints, VNC passwords, launcher secrets, runtime/provider credentials or identifiers, placement IDs, or provider credentials. It receives only sanitized domain state and a short-lived `RuntimeWebView` projection.
+
+### 3. Browser-Use directly, pinned, over the same Chromium
+
+Use the open-source Browser-Use project directly rather than reimplementing its browser-control stack:
+
+- pin the Browser-Use CLI/library to one exact released version and integrity digest in the plugin runtime lock;
+- vendor or install the matching official `skills/browser-use/SKILL.md` at an exact repository commit/digest; no floating `main`, `latest`, or unreviewed remote skill at runtime;
+- run Browser-Use's local MCP server as a bounded launcher-managed process where its supported API is the appropriate local bridge;
+- attach Browser-Use to the fixed server-internal CDP endpoint for the **same Chromium** whose display is exported by VNC/noVNC;
+- add a compatibility manifest for the pinned Browser-Use version/skill, Python, Chromium, noVNC, and launcher protocol, plus an upgrade test and review procedure.
+
+The official skill contributes bounded browser-operation instructions to Boring's Agent. It does not create a Browser-Use Agent, select or call a model, own history, or become an authority source. Browser-Use cloud models/services and Browser-Use provider credentials are out of scope.
+
+The local Browser-Use MCP server is an implementation detail behind the plugin's thin server-side adapter. Do **not** register its whole catalog as provider-native Boring tools, pass MCP descriptors to the provider, expose raw MCP calls to the model/front, or implement generic OpenCode-style `call_tool`/`execute` dispatch in this feature.
+
+### 4. Exactly two native Boring Agent tools
+
+V0 exposes exactly:
+
+1. `browser_observe` — returns a bounded, redacted structured observation and approved screenshot/artifact references for the current session/control epoch.
+2. `browser_act` — accepts one immutable, validated discriminated action plan and executes it through a thin Browser-Use adapter.
+
+No `browser_start`, `browser_stop`, `browser_view`, `browser_takeover`, `browser_return`, generic MCP tool, raw CDP tool, JavaScript evaluator, shell tool, or one-native-tool-per-MCP-operation is added.
+
+A `browser_act` request has a closed schema conceptually equivalent to:
+
+```ts
+type BrowserAction =
+  | { readonly kind: "navigate"; readonly url: string }
+  | { readonly kind: "click"; readonly target: BrowserTarget }
+  | { readonly kind: "type"; readonly target: BrowserTarget; readonly text: string }
+  | { readonly kind: "select"; readonly target: BrowserTarget; readonly value: string }
+  | { readonly kind: "upload"; readonly target: BrowserTarget; readonly resourceRef: string }
+  | { readonly kind: "download"; readonly target: BrowserTarget };
+
+type BrowserActionPlan = {
+  readonly sessionId: string;
+  readonly controlEpoch: number;
+  readonly actions: readonly BrowserAction[];
+};
+```
+
+The implementation may refine target/action variants, but the plan remains a bounded closed discriminated union: no arbitrary tool name, MCP method, command, code, CDP payload, URL credentials, filesystem path, or provider/runtime field.
+
+Processing order is fail-closed:
+
+1. parse and normalize once;
+2. validate bounds, destination/resource policy, session identity, and control epoch;
+3. deep-freeze/canonically encode and hash the exact normalized plan;
+4. perform Host capability/effect admission and bind approval evidence to that exact plan/hash;
+5. before each action, recheck session/control epoch and admit that action; every consequential action requires valid action-specific evidence even when the enclosing plan was admitted;
+6. map only the admitted variant to the pinned Browser-Use adapter and record the canonical result/unknown outcome.
+
+The adapter cannot silently expand, reorder, retry, or substitute actions after admission. Any changed plan is a new tool call and needs fresh validation/admission. Navigation follows Host egress policy. Submissions, messages, purchases, remote mutations, uploads/download publication, and credentialed effects require applicable durable approval. Passwords/tokens are never tool arguments.
+
+Browser-specific progress may be recorded/emitted as typed browser-domain events correlated to the canonical `browser_act` call. UI and audit may render those events honestly as browser progress. They must not claim that Pi/provider emitted generic nested tool calls or that each Browser-Use/MCP operation has native Pi tool identity.
+
+### 5. Why generic dispatch is rejected
+
+The ratified historical decision [R-33-06](long-term/ratified/recommendations/R-33-06-bounded-tool-catalog/RECOMMENDATION.md) and its spike found that plain `call_tool` preserves only `toolName:"call_tool"`; the called child's identity is lost. Renderers, metering, and per-call approval key off real tool identity, and approval must bind to canonical arguments. The broader architecture history likewise says any future generic dispatch requires first-class recorded child events rather than pretending provider-wire identity exists ([ARCHITECTURE-PLAN-v2-history.md](long-term/ratified/ARCHITECTURE-PLAN-v2-history.md)).
+
+Therefore closed/deferred issue [#1226](https://github.com/hachej/boring-ui/issues/1226) is evidence for a **rejected alternative**, not scope for this feature. This plan does not revive its generic catalog/dispatcher, implement OpenCode `call_tool`/`execute`, invent generic child-event identity, or solve catalog rendering/approval/metering. The two native browser tools keep truthful canonical identity; browser-domain progress stays domain-specific. Generic child-event/catalog work belongs in a separate architecture effort, if ever approved.
+
+### 6. Fixed launcher and bounded lifecycle through existing exec
+
+The plugin ships one fixed launcher with a closed intent vocabulary such as `ensure`, `status`, `observe`, `act`, `takeover`, `return`, and `stop`. Typed server input maps to fixed argv/data. No route, model, or front caller supplies shell, executable, cwd, environment, image, port, upstream URL, daemon option, or provider/runtime identifier.
+
+The launcher uses existing runtime exec to start/check/stop bounded Chromium, Xvfb, VNC/noVNC, Browser-Use CLI/library worker, and local MCP processes. It retains a reference to the existing selected environment generation; it does not create a runtime lease, durable service registry, provider adapter, process platform, or host-global fallback.
+
+Initial bounds: one browser per addressed Agent session, 15-minute idle TTL, 60-minute absolute TTL, fixed start/readiness/stop deadlines, and trusted Host-configured workspace/user quotas. Stop, TTL, flag disable, Host shutdown, runtime invalidation, or health failure revokes view/control, invokes fixed stop when reachable, destroys ephemeral profile/quarantine according to policy, and releases the environment reference exactly once.
+
+### 7. Exclusive Agent/human control
+
+Server state is epoch-fenced:
+
+```text
+starting -> agent-controlled <-> human-controlled -> stopping -> stopped
+                              \-> error
+```
+
+Every observe/action verifies owner and current monotonic `controlEpoch`. Takeover first changes owner/increments epoch and rejects or boundedly settles in-flight Agent work, then revokes/rotates projection and enables VNC input. Return first revokes human input, requires informed consent after credential entry/authentication, captures a fresh observation, then changes owner/increments epoch. Interrupted actions never auto-resume. Client `viewOnly` is defense in depth, not authority.
+
+### 8. Security and data hardening
+
+- Enforce public-destination policy at the strongest existing runtime/network boundary, with Chromium/launcher checks as defense in depth. Deny private/link-local/metadata/control-plane/internal destinations, alternate IP encodings, redirect/DNS-rebinding bypasses, and uncontrolled WebRTC/QUIC escape.
+- Human credentials are entered only during human control. Never put them in tools, route queries, launcher argv, logs, records, screenshots intentionally returned to the Agent, or audit events.
+- Uploads use authorized workspace resource references only; reject traversal, symlinks, absolute paths, and over-limit files. Downloads stay in bounded quarantine and require an explicit admitted publication step; never auto-execute them.
+- Redact DOM secrets, cookies, storage, typed values, raw URLs where sensitive, MCP/CDP/VNC targets, and preview secrets. Raw CDP, cookie/storage export, arbitrary JavaScript, and arbitrary file access are not exposed.
+- Audit sanitized session lifecycle, owner/epoch transitions, projection issue/revoke, exact plan hash, action requested/admitted/settled/denied/unknown, approval reference, normalized origin, and artifact metadata under Host-derived accepted-work identity.
+- Supply-chain checks verify dependency/skill lock integrity, license/SBOM, vulnerability policy, and upgrade compatibility before rollout.
+
+## User Stories / Scenarios
+
+1. Local CLI user starts a browser from `BrowserPanel`; existing exec launches bounded processes and `RuntimeWebView` displays noVNC over loopback.
+2. Boring's Agent calls `browser_observe`, submits one admitted `browser_act` plan, and the user sees Browser-Use control that same Chromium.
+3. The user takes over through authenticated UI; a stale/racing Agent action is rejected. After explicit return, the Agent receives a fresh observation.
+4. A consequential action lacking exact current approval fails before execution; a later action in an admitted plan is rechecked and denied if its evidence is stale.
+5. A hosted workspace uses unchanged plugin bytes, launcher protocol, exec path, and runtime-preview seam; only Host-selected runtime behavior differs.
+6. Cross-workspace/session projection replay, private-network navigation, raw MCP/CDP access, and forged session identity fail closed.
+7. Stop, expiry, runtime loss, and flag rollback revoke access and release the existing environment reference without introducing a separate process/runtime authority.
+
+## Decisions
+
+- `plugins/browser` is trusted shared app/internal composition and runtime/provider-neutral.
+- Existing runtime exec, environment lifecycle, and #1493 projection are reused; no browser capability/provider/process abstraction is introduced.
+- `RuntimeWebView` is centralized and shared by URL pane and BrowserPanel/noVNC.
+- Browser-Use CLI/library and official skill are exact-pinned; Browser-Use controls the displayed Chromium while Boring alone owns agent/model/record/metering.
+- Browser-Use local MCP remains behind a thin adapter; its catalog is not provider-native and no generic dispatcher/child-event project is included.
+- V0 has exactly two native tools: `browser_observe` and `browser_act`.
+- Session lifecycle/view/control operations remain authenticated routes/UI, never model tools.
+- Profiles are ephemeral for V0; Agent/human control is exclusive and epoch-fenced.
+
+## Flag / Abstraction
+
+- **Needed?:** One Host-owned rollout flag; no new browser runtime/provider abstraction.
+- **Path:** trusted Host config `BORING_BROWSER_PLUGIN_ENABLED` -> static front/server composition -> narrow server-private callbacks over existing identity, environment, exec, and runtime-preview seams.
+- **Rollback:** disable flag, reject starts/tools, revoke projections/control, fixed-stop known sessions when reachable, release environment references, and hide panel/tools. Keep shared `RuntimeWebView`/URL-pane behavior. Never fall back to host-global Chromium or direct upstream access.
+
+## Test Seams
+
+- **Highest public seam:** authenticated browser routes and exactly two native tool registrations using fake fixed exec/Browser-Use adapter/runtime-preview projector; shared `RuntimeWebView` component/route tests; Playwright against composed BrowserPanel and controlled fixtures.
+- **Existing prior art:** URL-pane tests, #1493 preview conformance, ask-user package/front/server patterns, live-transcription bounded lifecycle, environment lease tests, and boring-bash local/remote parity.
+- **Avoid testing:** Browser-Use/Chromium/noVNC internals, provider SDK details, raw React state, or a generic MCP dispatcher not in the feature.
+
+Required negative tests include:
+
+- exactly two model tools are registered; lifecycle/view/control and Browser-Use MCP catalog are absent from provider-native tools;
+- schemas make arbitrary MCP names/args, CDP, command/code, provider/runtime fields, credentials, ports, paths, and upstream URLs impossible or reject them;
+- plan canonicalization/deep immutability, tamper-after-approval, action reorder/substitution, stale epoch, exact-plan mismatch, per-consequential-action denial, and unknown-outcome/no-auto-retry;
+- no generic child identity/rendering claim; browser progress remains correlated domain events under the canonical `browser_act` call;
+- disabled flag, forged/cross-scope identity, replayed/expired projection, simultaneous takeover/action, return-before-input-revocation, and viewer disconnect races;
+- local non-loopback and malformed runtime targets; hosted expiry/WSS refresh/revocation;
+- private/link-local/metadata IPv4/IPv6, alternate encodings, redirects, DNS rebinding, WebRTC/QUIC, and raw WebSocket bypass;
+- credentials/secrets absent from tool args/results, logs, errors, records, snapshots, and audit;
+- launcher crash/hang/partial start/stale metadata, MCP worker loss, runtime invalidation, TTL, Host shutdown, and flag disable release lifecycle references exactly once;
+- pinned lock/skill digest mismatch fails provisioning; no Browser-Use Agent/model constructor or second metering/record loop is invoked.
+
+## Acceptance
+
+- URL pane behavior is preserved while both URL pane and BrowserPanel/noVNC reuse central `RuntimeWebView`.
+- Local HTTP/WS loopback and hosted authenticated HTTPS/WSS projection pass expiry, retry, cancellation, and revocation tests without leaking upstream/provider data.
+- The plugin is unchanged across local and hosted runtimes and contains no forbidden runtime/provider/process abstraction.
+- Exact Browser-Use CLI/library and official-skill commit/digests are checked in and verified; both drive the same Chromium displayed by noVNC.
+- Provider-native registration contains exactly `browser_observe` and `browser_act`.
+- `browser_act` executes only its immutable admitted plan through the thin adapter, with exact-plan and per-consequential-action checks and truthful domain progress.
+- Start/stop/view/takeover/return work only as authenticated plugin routes/UI.
+- Fixed launcher processes use existing exec and selected-environment lifecycle; no model/front input can reach raw MCP/CDP/VNC, arbitrary exec, or credentials.
+- Security tests and local tracer pass before hosted proof; hosted proof uses unchanged plugin/runtime-preview; rollout and rollback drills leave no usable grants or leaked environment reference.
+
+## Proof
+
+### Planning validation
+
+```bash
+git diff --check -- docs/plans/boring-browser-plugin-plan.md
+rg -n 'browser_observe|browser_act|RuntimeWebView|#1226|Browser-Use|runtime-preview' docs/plans/boring-browser-plugin-plan.md
+rg -n 'browser_open|browser_click|BrowserRuntimeCapability|provider adapter|generic OpenCode' docs/plans/boring-browser-plugin-plan.md
+```
+
+The last command may match only explicit rejected alternatives, negative tests, or prohibitions.
+
+### Implementation commands
+
+```bash
+pnpm --filter @hachej/boring-workspace typecheck
+pnpm --filter @hachej/boring-workspace test
+pnpm --filter @hachej/boring-browser typecheck
+pnpm --filter @hachej/boring-browser test
+pnpm --filter @hachej/boring-browser build
+pnpm --filter @hachej/boring-agent test
+pnpm --filter @hachej/boring-bash test
+pnpm lint:invariants
+pnpm test:changed
+git diff --check
+```
+
+Narrow test paths may be used during slices, but final proof must include workspace shared-view/URL-pane tests, browser package tests, Agent tool-registration/admission tests, environment lifecycle tests, and boring-bash local/hosted parity.
+
+### Local usable tracer
+
+1. Enable the flag in normal local runtime mode and start through authenticated BrowserPanel UI.
+2. Verify fixed launcher invocation through existing runtime exec and exact dependency/skill lock integrity.
+3. Display noVNC through shared `RuntimeWebView` loopback projection.
+4. On a controlled fixture, call `browser_observe`, then one small `browser_act` plan; capture trace/video showing Browser-Use controlling the identical displayed Chromium.
+5. Race action with takeover, change state as human, explicitly return, and observe the exact changed state.
+6. Prove one denied consequential action and one correctly approved exact action.
+7. Stop, expire, and disable flag in separate runs; preserve sanitized cleanup/reference-release evidence.
+
+Artifacts: Playwright trace/video, accessibility snapshot, narrow/wide screenshots, sanitized route/audit IDs and plan hashes, lock verification, and process cleanup evidence.
+
+### Hosted proof
+
+In one qualified non-production hosted runtime selected by the Host, deploy the **unchanged** plugin bytes, lock, launcher, and protocol:
+
+1. provision/start through existing exec and environment lifecycle;
+2. show authenticated HTTPS iframe + WSS noVNC through #1493/shared `RuntimeWebView`;
+3. repeat observe/action/takeover/return and same-Chromium proof;
+4. reject cross-workspace/session projection replay and private/metadata navigation;
+5. exercise projection refresh, MCP/launcher failure, TTL/runtime invalidation cleanup, and flag rollback;
+6. preserve sanitized Host audit IDs and cleanup evidence.
+
+If prerequisites, enforceable egress, or authenticated WebSocket preview are unavailable, rollout remains blocked; do not add provider-specific code.
+
+## Slices
+
+### Slice 1: expand central `RuntimeWebView` and migrate URL pane
+
+**Delivers:** Shared target schema/component/client/route over #1493, local loopback and hosted HTTPS/WSS behavior, and URL-pane behavior parity.
+
+**Blocked by:** Reconcile #1493's final merged shape; do not duplicate its Host projection.
+
+**Proof:** Workspace typecheck/tests, loopback HTTP/WS fixture, hosted projection contract fake, URL-pane visual parity.
+
+**Review budget:** Inside one focused slice; security review required for projection policy.
+
+### Slice 2: local usable browser tracer
+
+**Delivers:** Trusted plugin shell, exact Browser-Use/skill pins, fixed launcher through existing exec/environment lifecycle, BrowserPanel using shared view, authenticated lifecycle/control routes, exactly two native tools, controlled-fixture observe + one bounded act, and same-Chromium noVNC proof.
+
+**Blocked by:** Slice 1 and a reviewed compatible dependency lock.
+
+**Proof:** Local usable tracer above, tool-registration/schema/admission tests, same-display trace, fixed-process cleanup.
+
+**Review budget:** Exceeds normal package review; Agent authority, runtime, and security review required.
+
+### Slice 3: security and lifecycle hardening
+
+**Delivers:** Full closed action union, immutable canonical plan/hash, per-action effect checks, epoch races, egress bypass defenses, credential consent/redaction, upload/download quarantine, quotas/TTL/recovery, and sanitized browser-domain audit events.
+
+**Blocked by:** Slice 2 and existing durable approval evidence for any consequential production action.
+
+**Proof:** Required negative suites, credential canaries, tamper/replay/unknown-outcome tests, crash/TTL lifecycle tests, threat-model review.
+
+**Review budget:** Exceeds; authority/security/privacy review required.
+
+### Slice 4: hosted proof with unchanged plugin
+
+**Delivers:** Deployment qualification only; generic fixes are allowed, provider branches are not.
+
+**Blocked by:** Slice 3, merged #1493 seam, bounded-process prerequisites, authenticated WSS preview, cleanup, and enforceable egress in the selected deployment.
+
+**Proof:** Hosted proof above and existing runtime-preview/runtime conformance suites.
+
+**Review budget:** Exceeds; deployment/runtime/security review required.
+
+### Slice 5: flagged rollout and rollback
+
+**Delivers:** Allowlist, metrics/alerts, runbook, canary, retention/quotas, dependency-update cadence, and tested flag rollback before limited production enablement.
+
+**Blocked by:** Slice 4; named operational/security owner and all production gates passing.
+
+**Proof:** Canary artifact, dashboards/alerts, dependency-lock verification, cleanup and rollback drill, owner approval.
+
+**Review budget:** Exceeds; production-owner approval required.
+
+## Wide Refactor Strategy
+
+`RuntimeWebView` is an expand → migrate → contract refactor: introduce the shared seam, migrate URL pane and BrowserPanel, then remove duplicate URL-pane projection/iframe ownership only after parity tests. Do not combine this mechanical contraction with browser process/security work.
+
+## Rollout and Rollback Gates
+
+Production remains off until dependency/SBOM review, authenticated WSS preview, egress enforcement, exact effect approval, credential-return consent, cleanup, audit, quotas, monitoring, and hosted unchanged-plugin proof pass. Start with a non-production allowlist, then a small tenant/workspace canary.
+
+Rollback is the Host flag path described above. The drill must prove tool/panel disappearance, start rejection, projection/control revocation, fixed stop, environment-reference release, and no host-global fallback. Shared `RuntimeWebView` and URL pane remain operational.
+
+## Out of Scope
+
+Browser-Use Agent/model/cloud authority; generic MCP catalog residency or OpenCode `call_tool`/`execute`; generic child-event identity/rendering/approval/metering; new runtime capability/provider/process layers; provider-specific plugin code; arbitrary shell/MCP/CDP/JavaScript/filesystem APIs; plugin-selected runtimes/images; durable/synced browser profiles; public port forwarding; browser automation inside URL pane; simultaneous controllers; CAPTCHA/stealth/evasion; credential vault; autonomous consequential effects without Host authority.
+
+## Open Questions
+
+No open architecture/product question blocks Slice 1. Exact compatible dependency versions/digests are selected and reviewed as the lock artifact at the start of Slice 2; floating versions are never acceptable. Production operations/retention values are rollout inputs, not permission to change the architecture above.
+
+## Adversarial Consistency Review
+
+**Triggered:** yes. This plan crosses runtime projection, browser supply chain, network egress, credentials, external effects, interactive control, and bounded background processes.
+
+**Reviewer:** plan self-check against the model-card adversarial dimensions and ratified R-33-06/#1226 evidence; independent required reviewer gate remains before implementation.
+
+**Accepted findings and revisions:**
+
+- The prior plan exposed many native browser tools and direct BrowserSession operations, conflicting with the final two-tool decision -> replaced with exactly `browser_observe` and immutable-plan `browser_act` over a thin pinned Browser-Use adapter.
+- Merely saying Browser-Use remains subordinate did not prove direct project reuse -> added exact CLI/library and official-skill pins, local MCP containment, same-CDP/same-Chromium proof, and compatibility/SBOM gates.
+- A local MCP server could accidentally become a generic catalog feature -> explicitly prohibited catalog projection, raw MCP inputs, OpenCode dispatch, and generic child-event work; cited R-33-06 and closed/deferred #1226 as the rejected alternative.
+- Plan-level approval alone permits later actions to escape changed state/authority -> exact normalized plan hash plus per-action epoch/admission and action-specific consequential approval are mandatory; no expansion/reorder/retry.
+- Browser progress could be misrendered as nested Pi tools -> constrained it to typed domain events correlated under the canonical native tool call, with no provider-wire child-identity claim.
+- Lifecycle operations could leak into the model surface -> made start/stop/view/takeover/return route/UI-only and added exact tool-registration tests.
+- Browser-local viewing would duplicate URL pane/#1493 -> retained central `RuntimeWebView`, expand/migrate/contract sequencing, and unchanged hosted proof.
+- Provider/runtime and raw endpoint leakage remained a pressure point -> fixed launcher inputs and front/model schemas categorically exclude commands, raw MCP/CDP/VNC, ports/upstreams, credentials, and provider/runtime fields.
+- A local demo alone would not validate runtime neutrality -> added hosted proof with unchanged plugin bytes and fail-closed qualification rather than provider branches.
+- Rollback language did not fully prove cleanup -> added a drill for revocation, fixed stop, exactly-once environment release, and no host-global fallback.
+
+**Remaining non-blocking risks:** Browser-Use/Chromium compatibility and supply-chain churn; availability of durable approval/audit and enforceable egress in production; #1493 merge shape; hosted noVNC WSS behavior. Each is assigned to a lock, slice gate, or rollout blocker rather than widening plugin architecture.
+
+**Verdict:** revised plan is internally consistent, contains all final decisions, and is `ready-for-agent` for Slice 1. Independent reviewer gate is still required before implementation.
+
+## Next Action
+
+`ready-for-agent`: implement Slice 1 only after independent plan review. Do not scaffold browser tools/processes, generic MCP dispatch, child-event infrastructure, or provider/runtime abstractions in that slice.

--- a/packages/workspace/docs/RUNTIME_WEB_VIEW.md
+++ b/packages/workspace/docs/RUNTIME_WEB_VIEW.md
@@ -1,0 +1,40 @@
+# RuntimeWebView
+
+`RuntimeWebView` is the workspace-owned iframe/projection boundary shared by
+trusted built-in panels. URL pane is its first caller; browser/noVNC may compose
+it in a later gated slice.
+
+## Caller contract
+
+Callers choose one closed source:
+
+- `{ kind: "url", url }` for a browser-direct absolute URL. The component reads
+  the URL-pane origin policy and applies it before setting `iframe.src`.
+- `{ kind: "runtime", port, path? }` for the Host-selected runtime. The strict
+  schema accepts only port 1024–65535 and an absolute bounded path. Hosts,
+  upstream URLs, credentials, runtime/provider IDs, and unknown fields are
+  rejected.
+
+Runtime sources are projected through authenticated
+`POST /api/v1/ui/runtime-web-view/preview`. The #1493 URL-pane route remains as
+a compatibility alias but new callers use the central route. The Host derives
+the workspace and active runtime; callers cannot select either.
+
+The returned projection is revalidated before framing. Hosted targets must be
+credential-free HTTPS. Local HTTP targets must be exactly `localhost`,
+`127.0.0.1`, or `[::1]` with an explicit bounded port. A supplied expiry causes
+a refresh thirty seconds before expiration. Failed refreshes fail closed and
+show a sanitized message. Reload retries projection and remounts the iframe;
+unmount/source changes fence late responses.
+
+## iframe and WebSocket behavior
+
+The iframe uses `referrerPolicy="no-referrer"`, `noopener noreferrer` for
+external opening, and the URL-pane sandbox policy. `allow-same-origin` is never
+granted when the framed origin equals the workspace origin.
+
+Interactive applications such as noVNC must use a relative WebSocket path. In
+local mode that resolves to loopback HTTP/WS. In hosted mode it resolves through
+the same authenticated HTTPS/WSS projection origin. RuntimeWebView never accepts
+or exposes a separate WebSocket host, token, CDP endpoint, VNC password, or
+provider address.

--- a/packages/workspace/docs/URL_PANE.md
+++ b/packages/workspace/docs/URL_PANE.md
@@ -10,10 +10,10 @@ the workspace and without a `localhost:5xxx` line pasted into chat.
 | --- | --- |
 | Plugin id | `url-pane` (built-in, registered by `captureWorkspaceFrontPlugins`) |
 | Panel component id | `url-pane.panel` |
-| Params | `{ url: string; title?: string }` |
+| Params | `{ url: string; title?: string }` or `{ runtimePreview: { port; path? }; title? }` |
 | Policy source | `GET /api/v1/ui/url-pane/policy` → `{ origins: string[] }` |
 | Config | `BORING_URL_PANE_ALLOWED_ORIGINS` |
-| Decision code | `packages/workspace/src/shared/urlPane.ts` |
+| Decision code | `packages/workspace/src/shared/urlPane.ts`, composed through central `RuntimeWebView` |
 
 ## Opening it
 
@@ -35,6 +35,10 @@ sandbox. Ask the host to project the active runtime port instead:
     "component": "url-pane.panel",
     "params": { "runtimePreview": { "port": 5173, "path": "/" }, "title": "remote demo" } } }
 ```
+
+The pane delegates iframe and runtime-projection behavior to the shared
+[`RuntimeWebView`](./RUNTIME_WEB_VIEW.md); it no longer owns a second projection
+implementation.
 
 The current provider implementation creates a private, 15-minute Blaxel preview
 token over HTTPS; the underlying preview has a one-hour TTL. The pane resolves

--- a/packages/workspace/src/front/components/RuntimeWebView.tsx
+++ b/packages/workspace/src/front/components/RuntimeWebView.tsx
@@ -1,0 +1,230 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { ErrorState, IconButton, Spinner } from "@hachej/boring-ui-kit"
+import { ExternalLink, RefreshCcw } from "lucide-react"
+import { cn } from "../lib/utils"
+import { useOptionalWorkspacePluginClient } from "../plugin/useWorkspacePluginClient"
+import {
+  RUNTIME_WEB_VIEW_PREVIEW_PATH,
+  resolveRuntimeWebViewProjection,
+  runtimeWebViewRefreshDelay,
+  type RuntimeWebViewTarget,
+} from "../../shared/runtimeWebView"
+import { resolveUrlPaneTarget, type UrlPanePolicy } from "../../shared/urlPane"
+
+export type RuntimeWebViewSource =
+  | { readonly kind: "url"; readonly url?: string }
+  | ({ readonly kind: "runtime" } & RuntimeWebViewTarget)
+
+export interface RuntimeWebViewProps {
+  source: RuntimeWebViewSource
+  title?: string
+  className?: string
+  /** Direct URLs require the URL-pane policy. This is primarily a test seam. */
+  directUrlPolicyOverride?: UrlPanePolicy
+  loadingLabel?: string
+  unavailableTitle?: string
+  reloadLabel?: string
+  openExternalLabel?: string
+}
+
+type PolicyState =
+  | { status: "loading" }
+  | { status: "ready"; policy: UrlPanePolicy }
+  | { status: "error"; message: string }
+
+type ProjectionState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "ready"; url: string; expiresAt?: string }
+  | { status: "error"; message: string }
+
+const POLICY_PATH = "/api/v1/ui/url-pane/policy"
+const BASE_SANDBOX = "allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox"
+
+function workspaceOrigin(): string | null {
+  if (typeof window === "undefined") return null
+  return window.location?.origin ?? null
+}
+
+/** The framed app gets same-origin semantics only when it is not the workspace itself. */
+export function runtimeWebViewSandbox(targetOrigin: string, hostOrigin: string | null): string {
+  if (hostOrigin && targetOrigin.toLowerCase() === hostOrigin.toLowerCase()) return BASE_SANDBOX
+  return `${BASE_SANDBOX} allow-same-origin`
+}
+
+function safeFailureMessage(kind: "policy" | "projection"): string {
+  return kind === "policy"
+    ? "Could not read the URL allowlist."
+    : "Could not create the runtime preview."
+}
+
+export function RuntimeWebView({
+  source,
+  title,
+  className,
+  directUrlPolicyOverride,
+  loadingLabel = "Loading view...",
+  unavailableTitle = "Web view unavailable",
+  reloadLabel = "Reload view",
+  openExternalLabel = "Open view in new tab",
+}: RuntimeWebViewProps) {
+  const client = useOptionalWorkspacePluginClient()
+  const [policyState, setPolicyState] = useState<PolicyState>(
+    directUrlPolicyOverride ? { status: "ready", policy: directUrlPolicyOverride } : { status: "loading" },
+  )
+  const [projectionState, setProjectionState] = useState<ProjectionState>({ status: "idle" })
+  const [reloadToken, setReloadToken] = useState(0)
+  const reload = useCallback(() => setReloadToken((token) => token + 1), [])
+
+  useEffect(() => {
+    if (source.kind !== "url") return
+    if (directUrlPolicyOverride) {
+      setPolicyState({ status: "ready", policy: directUrlPolicyOverride })
+      return
+    }
+    if (!client) {
+      setPolicyState({ status: "error", message: "The web view needs a workspace connection." })
+      return
+    }
+    let cancelled = false
+    setPolicyState({ status: "loading" })
+    client
+      .getJson<{ origins?: unknown }>(POLICY_PATH)
+      .then((body) => {
+        if (cancelled) return
+        const origins = Array.isArray(body?.origins)
+          ? body.origins.filter((entry): entry is string => typeof entry === "string")
+          : []
+        setPolicyState({ status: "ready", policy: { origins } })
+      })
+      .catch(() => {
+        if (!cancelled) setPolicyState({ status: "error", message: safeFailureMessage("policy") })
+      })
+    return () => { cancelled = true }
+  }, [client, directUrlPolicyOverride, source.kind])
+
+  useEffect(() => {
+    if (source.kind !== "runtime") {
+      setProjectionState({ status: "idle" })
+      return
+    }
+    if (!client) {
+      setProjectionState({ status: "error", message: "Runtime previews need a workspace connection." })
+      return
+    }
+    let cancelled = false
+    setProjectionState({ status: "loading" })
+    client
+      .postJson<{ url?: unknown; expiresAt?: unknown }>(RUNTIME_WEB_VIEW_PREVIEW_PATH, {
+        port: source.port,
+        ...(source.path === undefined ? {} : { path: source.path }),
+      })
+      .then((body) => {
+        if (cancelled) return
+        if (typeof body?.url !== "string") throw new Error("invalid projection response")
+        setProjectionState({
+          status: "ready",
+          url: body.url,
+          ...(typeof body.expiresAt === "string" ? { expiresAt: body.expiresAt } : {}),
+        })
+      })
+      .catch(() => {
+        if (!cancelled) setProjectionState({ status: "error", message: safeFailureMessage("projection") })
+      })
+    return () => { cancelled = true }
+  }, [client, reloadToken, source.kind, source.kind === "runtime" ? source.path : undefined, source.kind === "runtime" ? source.port : undefined])
+
+  useEffect(() => {
+    if (projectionState.status !== "ready") return
+    const delay = runtimeWebViewRefreshDelay(projectionState.expiresAt)
+    if (delay === null) return
+    const timer = window.setTimeout(reload, delay)
+    return () => window.clearTimeout(timer)
+  }, [projectionState, reload])
+
+  const resolution = useMemo(() => {
+    if (source.kind === "runtime") {
+      return projectionState.status === "ready"
+        ? resolveRuntimeWebViewProjection(projectionState.url)
+        : null
+    }
+    return policyState.status === "ready" ? resolveUrlPaneTarget(source.url, policyState.policy) : null
+  }, [policyState, projectionState, source])
+
+  const loading = source.kind === "runtime"
+    ? projectionState.status === "idle" || projectionState.status === "loading"
+    : policyState.status === "loading"
+  const failure = source.kind === "runtime"
+    ? projectionState.status === "error" ? projectionState.message : null
+    : policyState.status === "error" ? policyState.message : null
+  const sandbox = resolution?.ok
+    ? runtimeWebViewSandbox(resolution.origin, workspaceOrigin())
+    : BASE_SANDBOX
+  const displayTarget = source.kind === "runtime" ? `runtime port ${source.port}` : source.url ?? "no URL"
+
+  return (
+    <div className={cn("flex h-full min-h-0 w-full flex-col bg-background", className)}>
+      <div className="flex items-center gap-2 border-b border-border px-3 py-1.5">
+        <span className="truncate text-xs font-medium text-foreground">{title ?? "Live demo"}</span>
+        <span className="truncate font-mono text-[11px] text-muted-foreground" title={displayTarget}>
+          {displayTarget}
+        </span>
+        <div className="ml-auto flex items-center gap-1">
+          <IconButton
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            className="text-muted-foreground hover:text-foreground"
+            onClick={reload}
+            disabled={loading}
+            aria-label={reloadLabel}
+            title={reloadLabel}
+          >
+            <RefreshCcw className="h-3.5 w-3.5" strokeWidth={1.75} />
+          </IconButton>
+          {resolution?.ok ? (
+            <IconButton asChild variant="ghost" size="icon-xs" className="text-muted-foreground hover:text-foreground" aria-label={openExternalLabel} title={openExternalLabel}>
+              <a href={resolution.url} target="_blank" rel="noreferrer noopener">
+                <ExternalLink className="h-3.5 w-3.5" strokeWidth={1.75} />
+              </a>
+            </IconButton>
+          ) : null}
+        </div>
+      </div>
+      <div className="relative min-h-0 flex-1">
+        {loading ? (
+          <div className="flex h-full items-center justify-center gap-2 text-sm text-muted-foreground">
+            <Spinner className="size-3.5" />
+            <span>{loadingLabel}</span>
+          </div>
+        ) : failure ? (
+          <div className="flex h-full items-center justify-center p-6">
+            <ErrorState title={unavailableTitle} description={failure} />
+          </div>
+        ) : resolution?.ok ? (
+          <iframe
+            key={`${resolution.url}#${reloadToken}`}
+            src={resolution.url}
+            title={title ?? resolution.url}
+            className="h-full w-full border-0 bg-white"
+            sandbox={sandbox}
+            referrerPolicy="no-referrer"
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center p-6">
+            <ErrorState
+              title="URL blocked"
+              description={source.kind === "runtime"
+                ? resolution?.message ?? "This runtime preview cannot be embedded."
+                : `${resolution?.message ?? "This URL cannot be embedded."} Allowed origins: ${
+                    policyState.status === "ready" ? policyState.policy.origins.join(", ") || "(none configured)" : "(unavailable)"
+                  }`}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -93,6 +93,8 @@ export { filesystemEvents } from "./plugins/filesystemPlugin/shared/events"
 export type { FilesystemEventMap, FilesystemEventMeta } from "./plugins/filesystemPlugin/shared/events"
 // Utility
 export { cn } from "./front/lib/utils"
+export { RuntimeWebView, runtimeWebViewSandbox } from "./front/components/RuntimeWebView"
+export type { RuntimeWebViewProps, RuntimeWebViewSource } from "./front/components/RuntimeWebView"
 
 // Registry & panel management
 export { PanelRegistry } from "./front/registry/PanelRegistry"

--- a/packages/workspace/src/plugins/urlPanePlugin/front/UrlPane.tsx
+++ b/packages/workspace/src/plugins/urlPanePlugin/front/UrlPane.tsx
@@ -1,227 +1,35 @@
 "use client"
 
-import { useEffect, useMemo, useState } from "react"
-import { ErrorState, IconButton, Spinner } from "@hachej/boring-ui-kit"
-import { ExternalLink, RefreshCcw } from "lucide-react"
-import { cn } from "../../../front/lib/utils"
-import { useOptionalWorkspacePluginClient } from "../../../front/plugin/useWorkspacePluginClient"
-import {
-  resolveRuntimePreviewUrl,
-  resolveUrlPaneTarget,
-  type RuntimePreviewTarget,
-  type UrlPanePolicy,
-} from "../../../shared/urlPane"
+import { RuntimeWebView, runtimeWebViewSandbox } from "../../../front/components/RuntimeWebView"
+import type { RuntimeWebViewTarget } from "../../../shared/runtimeWebView"
+import type { UrlPanePolicy } from "../../../shared/urlPane"
 
 export interface UrlPaneProps {
   url?: string
-  runtimePreview?: RuntimePreviewTarget
+  runtimePreview?: RuntimeWebViewTarget
   title?: string
   className?: string
   /** Test seam: skip the policy fetch and decide against this policy directly. */
   policyOverride?: UrlPanePolicy
 }
 
-type PolicyState =
-  | { status: "loading" }
-  | { status: "ready"; policy: UrlPanePolicy }
-  | { status: "error"; message: string }
+/** Compatibility export for callers/tests of the original URL-pane component. */
+export const urlPaneSandbox = runtimeWebViewSandbox
 
-type RuntimePreviewState =
-  | { status: "idle" }
-  | { status: "loading" }
-  | { status: "ready"; url: string }
-  | { status: "error"; message: string }
-
-const POLICY_PATH = "/api/v1/ui/url-pane/policy"
-
-const BASE_SANDBOX = "allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox"
-
-function workspaceOrigin(): string | null {
-  if (typeof window === "undefined") return null
-  return window.location?.origin ?? null
-}
-
-/**
- * `allow-same-origin` is what makes a real app work in here: without it the
- * frame runs on an opaque origin, and every module script the demo loads is
- * fetched in CORS mode from `origin: null` — a plain Vite dev server then
- * renders blank. It is only dangerous when the framed document is same-origin
- * with the *workspace*, because then `allow-scripts allow-same-origin` lets the
- * frame reach into the parent's origin and remove its own sandbox. Different
- * port means different origin, which covers every real worker demo; a workspace
- * embedding itself keeps the strict sandbox.
- */
-export function urlPaneSandbox(targetOrigin: string, hostOrigin: string | null): string {
-  if (hostOrigin && targetOrigin.toLowerCase() === hostOrigin.toLowerCase()) return BASE_SANDBOX
-  return `${BASE_SANDBOX} allow-same-origin`
-}
-
+/** URL pane is now a thin adapter over the central runtime-neutral web view. */
 export function UrlPane({ url, runtimePreview, title, className, policyOverride }: UrlPaneProps) {
-  const client = useOptionalWorkspacePluginClient()
-  const [policyState, setPolicyState] = useState<PolicyState>(
-    policyOverride ? { status: "ready", policy: policyOverride } : { status: "loading" },
-  )
-  const [runtimePreviewState, setRuntimePreviewState] = useState<RuntimePreviewState>({ status: "idle" })
-  // Bumping this remounts the iframe, which is the only reliable cross-origin
-  // reload — we cannot touch contentWindow.location on a sandboxed frame.
-  const [reloadToken, setReloadToken] = useState(0)
-
-  useEffect(() => {
-    if (runtimePreview) return
-    if (policyOverride) {
-      setPolicyState({ status: "ready", policy: policyOverride })
-      return
-    }
-    if (!client) {
-      setPolicyState({
-        status: "error",
-        message: "The URL pane needs a workspace connection to read its origin allowlist.",
-      })
-      return
-    }
-    let cancelled = false
-    setPolicyState({ status: "loading" })
-    client
-      .getJson<{ origins?: unknown }>(POLICY_PATH)
-      .then((body) => {
-        if (cancelled) return
-        const origins = Array.isArray(body?.origins)
-          ? body.origins.filter((entry): entry is string => typeof entry === "string")
-          : []
-        setPolicyState({ status: "ready", policy: { origins } })
-      })
-      .catch((error: unknown) => {
-        if (cancelled) return
-        // Fail closed: an unreachable policy endpoint must never widen the
-        // allowlist to "anything".
-        setPolicyState({
-          status: "error",
-          message: error instanceof Error ? error.message : "Could not read the URL pane allowlist.",
-        })
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [client, policyOverride, runtimePreview])
-
-  useEffect(() => {
-    if (!runtimePreview) {
-      setRuntimePreviewState({ status: "idle" })
-      return
-    }
-    if (!client) {
-      setRuntimePreviewState({ status: "error", message: "Runtime previews need a workspace connection." })
-      return
-    }
-    let cancelled = false
-    setRuntimePreviewState({ status: "loading" })
-    client
-      .postJson<{ url?: unknown }>("/api/v1/ui/url-pane/runtime-preview", runtimePreview)
-      .then((body) => {
-        if (cancelled) return
-        if (typeof body?.url !== "string") throw new Error("The runtime preview did not return a URL.")
-        setRuntimePreviewState({ status: "ready", url: body.url })
-      })
-      .catch((error: unknown) => {
-        if (cancelled) return
-        setRuntimePreviewState({
-          status: "error",
-          message: error instanceof Error ? error.message : "Could not create the runtime preview.",
-        })
-      })
-    return () => { cancelled = true }
-  }, [client, runtimePreview?.path, runtimePreview?.port])
-
-  const resolution = useMemo(() => {
-    if (runtimePreview) {
-      return runtimePreviewState.status === "ready"
-        ? resolveRuntimePreviewUrl(runtimePreviewState.url)
-        : null
-    }
-    return policyState.status === "ready" ? resolveUrlPaneTarget(url, policyState.policy) : null
-  }, [policyState, runtimePreview, runtimePreviewState, url])
-
-  const sandbox = useMemo(
-    () => (resolution?.ok ? urlPaneSandbox(resolution.origin, workspaceOrigin()) : BASE_SANDBOX),
-    [resolution],
-  )
-
   return (
-    <div className={cn("flex h-full min-h-0 w-full flex-col bg-background", className)}>
-      <div className="flex items-center gap-2 border-b border-border px-3 py-1.5">
-        <span className="truncate text-xs font-medium text-foreground">{title ?? "Live demo"}</span>
-        <span className="truncate font-mono text-[11px] text-muted-foreground" title={resolution?.ok ? resolution.url : url}>
-          {runtimePreview ? `sandbox port ${runtimePreview.port}` : url ?? "no URL"}
-        </span>
-        <div className="ml-auto flex items-center gap-1">
-          <IconButton
-            type="button"
-            variant="ghost"
-            size="icon-xs"
-            className="text-muted-foreground hover:text-foreground"
-            onClick={() => setReloadToken((token) => token + 1)}
-            disabled={!resolution?.ok}
-            aria-label="Reload demo"
-            title="Reload demo"
-          >
-            <RefreshCcw className="h-3.5 w-3.5" strokeWidth={1.75} />
-          </IconButton>
-          {resolution?.ok ? (
-            <IconButton
-              asChild
-              variant="ghost"
-              size="icon-xs"
-              className="text-muted-foreground hover:text-foreground"
-              aria-label="Open demo in new tab"
-              title="Open demo in new tab"
-            >
-              <a href={resolution.url} target="_blank" rel="noreferrer noopener">
-                <ExternalLink className="h-3.5 w-3.5" strokeWidth={1.75} />
-              </a>
-            </IconButton>
-          ) : null}
-        </div>
-      </div>
-
-      <div className="relative min-h-0 flex-1">
-        {(runtimePreview
-          ? runtimePreviewState.status === "idle" || runtimePreviewState.status === "loading"
-          : policyState.status === "loading") ? (
-          <div className="flex h-full items-center justify-center gap-2 text-sm text-muted-foreground">
-            <Spinner className="size-3.5" />
-            <span>Loading demo...</span>
-          </div>
-        ) : (runtimePreview ? runtimePreviewState.status === "error" : policyState.status === "error") ? (
-          <div className="flex h-full items-center justify-center p-6">
-            <ErrorState
-              title="URL pane unavailable"
-              description={runtimePreviewState.status === "error"
-                ? runtimePreviewState.message
-                : policyState.status === "error" ? policyState.message : "URL pane unavailable"}
-            />
-          </div>
-        ) : resolution?.ok ? (
-          <iframe
-            key={`${resolution.url}#${reloadToken}`}
-            src={resolution.url}
-            title={title ?? resolution.url}
-            className="h-full w-full border-0 bg-white"
-            sandbox={sandbox}
-            referrerPolicy="no-referrer"
-          />
-        ) : (
-          <div className="flex h-full items-center justify-center p-6">
-            <ErrorState
-              title="URL blocked"
-              description={runtimePreview
-                ? resolution?.message ?? "This runtime preview cannot be embedded."
-                : `${resolution?.message ?? "This URL cannot be embedded."} Allowed origins: ${
-                    policyState.status === "ready" ? policyState.policy.origins.join(", ") || "(none configured)" : "(unavailable)"
-                  }`}
-            />
-          </div>
-        )}
-      </div>
-    </div>
+    <RuntimeWebView
+      source={runtimePreview
+        ? { kind: "runtime", port: runtimePreview.port, ...(runtimePreview.path === undefined ? {} : { path: runtimePreview.path }) }
+        : { kind: "url", url }}
+      title={title}
+      className={className}
+      directUrlPolicyOverride={policyOverride}
+      loadingLabel="Loading demo..."
+      unavailableTitle="URL pane unavailable"
+      reloadLabel="Reload demo"
+      openExternalLabel="Open demo in new tab"
+    />
   )
 }

--- a/packages/workspace/src/plugins/urlPanePlugin/front/__tests__/urlPanePlugin.test.tsx
+++ b/packages/workspace/src/plugins/urlPanePlugin/front/__tests__/urlPanePlugin.test.tsx
@@ -49,9 +49,22 @@ describe("UrlPane", () => {
       "https://sandbox-preview.test/demo?bl_preview_token=short-lived",
     )
     expect(fetchMock).toHaveBeenCalledWith(
-      expect.stringContaining("/api/v1/ui/url-pane/runtime-preview"),
+      expect.stringContaining("/api/v1/ui/runtime-web-view/preview"),
       expect.objectContaining({ method: "POST", credentials: "include" }),
     )
+  })
+
+  it("sanitizes projection failures instead of rendering server details", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("provider-secret-host failed", { status: 502 })))
+    const { container } = render(
+      <WorkspacePluginClientProvider agentTypeId="default" apiBaseUrl="" workspaceId="workspace-a">
+        <UrlPane runtimePreview={{ port: 8_000 }} />
+      </WorkspacePluginClientProvider>,
+    )
+    await screen.findByText("URL pane unavailable")
+    expect(container.querySelector("iframe")).toBeNull()
+    expect(screen.getByText("Could not create the runtime preview.")).toBeInTheDocument()
+    expect(screen.queryByText(/provider-secret-host/)).toBeNull()
   })
 
   it("renders a blocked state naming the allowlist instead of an iframe", () => {

--- a/packages/workspace/src/server/ui-control/http/__tests__/uiRoutes.test.ts
+++ b/packages/workspace/src/server/ui-control/http/__tests__/uiRoutes.test.ts
@@ -440,7 +440,7 @@ describe("uiRoutes", () => {
 
     const response = await app.inject({
       method: "POST",
-      url: "/api/v1/ui/url-pane/runtime-preview",
+      url: "/api/v1/ui/runtime-web-view/preview",
       payload: { port: 8_000, path: "/demo" },
     })
     expect(response.statusCode).toBe(200)
@@ -457,10 +457,24 @@ describe("uiRoutes", () => {
 
     const invalid = await app.inject({
       method: "POST",
-      url: "/api/v1/ui/url-pane/runtime-preview",
+      url: "/api/v1/ui/runtime-web-view/preview",
       payload: { port: 80 },
     })
     expect(invalid.statusCode).toBe(400)
+
+    const injectedUpstream = await app.inject({
+      method: "POST",
+      url: "/api/v1/ui/runtime-web-view/preview",
+      payload: { port: 8_000, upstream: "https://attacker.test" },
+    })
+    expect(injectedUpstream.statusCode).toBe(400)
+
+    const legacy = await app.inject({
+      method: "POST",
+      url: "/api/v1/ui/url-pane/runtime-preview",
+      payload: { port: 8_000 },
+    })
+    expect(legacy.statusCode).toBe(200)
     await app.close()
   })
 })

--- a/packages/workspace/src/server/ui-control/http/uiRoutes.ts
+++ b/packages/workspace/src/server/ui-control/http/uiRoutes.ts
@@ -2,7 +2,13 @@ import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
 import { z, type ZodSchema } from "zod";
 import type { SequencedUiCommand, UiBridge, UiCommand } from "../../../shared/ui-bridge";
 import { updateUiState } from "../../bridge/updateUiState";
-import { resolveRuntimePreviewUrl, resolveUrlPaneTarget, URL_PANE_PANEL_ID, type UrlPanePolicy } from "../../../shared/urlPane";
+import { resolveUrlPaneTarget, URL_PANE_PANEL_ID, type UrlPanePolicy } from "../../../shared/urlPane";
+import {
+  LEGACY_URL_PANE_RUNTIME_PREVIEW_PATH,
+  RUNTIME_WEB_VIEW_PREVIEW_PATH,
+  resolveRuntimeWebViewProjection,
+  runtimeWebViewTargetSchema,
+} from "../../../shared/runtimeWebView";
 import { resolveUrlPanePolicyFromEnv } from "../urlPanePolicy";
 import { createPaneRenderStatusStore, type PaneRenderStatusStore } from "../panelStatus/paneRenderStatusStore";
 import { paneRenderStatusRoutes, resolvePaneStatusWorkspaceId } from "./paneRenderStatusRoutes";
@@ -18,11 +24,6 @@ const setStateBodySchema = z.object({
 const postCommandBodySchema = z.object({
   kind: z.string().min(1),
   params: z.record(z.unknown()).default({}),
-});
-
-const runtimePreviewRequestSchema = z.object({
-  port: z.number().int().min(1024).max(65_535),
-  path: z.string().startsWith('/').max(2_048).refine((path) => !path.includes('\\')).optional(),
 });
 
 // Inlined to avoid pulling on @hachej/boring-agent's internal http/middleware module.
@@ -114,7 +115,7 @@ function urlPaneCommandRejection(
   if (paneParams?.runtimePreview !== undefined) {
     if (paneParams.url !== undefined) return "URL pane accepts either url or runtimePreview, not both.";
     if (!runtimePreviewEnabled) return "Runtime previews are unavailable for this host.";
-    const parsed = runtimePreviewRequestSchema.safeParse(paneParams.runtimePreview);
+    const parsed = runtimeWebViewTargetSchema.safeParse(paneParams.runtimePreview);
     return parsed.success ? undefined : parsed.error.issues[0]?.message ?? "Invalid runtime preview target.";
   }
   const resolved = resolveUrlPaneTarget(typeof paneParams?.url === "string" ? paneParams.url : "", policy);
@@ -135,7 +136,7 @@ export function uiRoutes(
   };
   const validateSetState = createBodyValidator(setStateBodySchema);
   const validatePostCommand = createBodyValidator(postCommandBodySchema);
-  const validateRuntimePreview = createBodyValidator(runtimePreviewRequestSchema);
+  const validateRuntimePreview = createBodyValidator(runtimeWebViewTargetSchema);
   const resolveBridge = async (request: FastifyRequest): Promise<UiBridge> => {
     if (opts.getBridge) return await opts.getBridge(request);
     if (fallbackBridge) return fallbackBridge;
@@ -209,27 +210,26 @@ export function uiRoutes(
   // src, and to render an actionable "blocked" state naming the allowlist.
   app.get("/api/v1/ui/url-pane/policy", async () => ({ origins: urlPanePolicy.origins }));
 
-  app.post(
-    "/api/v1/ui/url-pane/runtime-preview",
-    { preHandler: validateRuntimePreview },
-    async (request, reply) => {
-      if (!opts.resolveRuntimePreview) {
-        return reply.code(404).send({ error: "runtime_preview_unavailable", message: "Runtime previews are unavailable for this host." });
-      }
-      const workspaceId = await getPaneWorkspaceId(request);
-      if (!workspaceId) {
-        return reply.code(400).send({ error: "workspace_required", message: "workspace id is required" });
-      }
-      const body = request.body as z.infer<typeof runtimePreviewRequestSchema>;
-      const preview = await opts.resolveRuntimePreview(request, { workspaceId, ...body });
-      const resolved = resolveRuntimePreviewUrl(preview.url);
-      if (!resolved.ok) {
-        return reply.code(502).send({ error: "runtime_preview_invalid", message: resolved.message });
-      }
-      reply.header("Cache-Control", "private, no-store");
-      return { url: resolved.url, expiresAt: preview.expiresAt };
-    },
-  );
+  const runtimePreviewHandler = async (request: FastifyRequest, reply: FastifyReply) => {
+    if (!opts.resolveRuntimePreview) {
+      return reply.code(404).send({ error: "runtime_preview_unavailable", message: "Runtime previews are unavailable for this host." });
+    }
+    const workspaceId = await getPaneWorkspaceId(request);
+    if (!workspaceId) {
+      return reply.code(400).send({ error: "workspace_required", message: "workspace id is required" });
+    }
+    const body = request.body as z.infer<typeof runtimeWebViewTargetSchema>;
+    const preview = await opts.resolveRuntimePreview(request, { workspaceId, ...body });
+    const resolved = resolveRuntimeWebViewProjection(preview.url);
+    if (!resolved.ok) {
+      return reply.code(502).send({ error: "runtime_preview_invalid", message: resolved.message });
+    }
+    reply.header("Cache-Control", "private, no-store");
+    return { url: resolved.url, expiresAt: preview.expiresAt };
+  };
+  app.post(RUNTIME_WEB_VIEW_PREVIEW_PATH, { preHandler: validateRuntimePreview }, runtimePreviewHandler);
+  // Preserve #1493 clients while callers migrate to the central shared route.
+  app.post(LEGACY_URL_PANE_RUNTIME_PREVIEW_PATH, { preHandler: validateRuntimePreview }, runtimePreviewHandler);
 
   app.get("/api/v1/ui/commands/next", async (request, reply) => {
     await touchUi(request);

--- a/packages/workspace/src/shared/__tests__/runtimeWebView.test.ts
+++ b/packages/workspace/src/shared/__tests__/runtimeWebView.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest"
+import {
+  resolveRuntimeWebViewProjection,
+  runtimeWebViewRefreshDelay,
+  runtimeWebViewTargetSchema,
+} from "../runtimeWebView"
+
+describe("runtimeWebViewTargetSchema", () => {
+  it("accepts only a bounded port and absolute path", () => {
+    expect(runtimeWebViewTargetSchema.safeParse({ port: 8_000, path: "/vnc.html" }).success).toBe(true)
+    for (const target of [
+      { port: 80 },
+      { port: 8_000, path: "relative" },
+      { port: 8_000, path: "/ok", upstream: "https://attacker.test" },
+      { port: 8_000, provider: "hosted" },
+    ]) {
+      expect(runtimeWebViewTargetSchema.safeParse(target).success).toBe(false)
+    }
+  })
+})
+
+describe("resolveRuntimeWebViewProjection", () => {
+  it("accepts credential-free hosted HTTPS and bounded local loopback", () => {
+    expect(resolveRuntimeWebViewProjection("https://preview.example/vnc.html?token=short-lived")).toMatchObject({ ok: true })
+    expect(resolveRuntimeWebViewProjection("http://localhost:6080/vnc.html")).toMatchObject({ ok: true })
+    expect(resolveRuntimeWebViewProjection("http://127.0.0.1:6080/vnc.html")).toMatchObject({ ok: true })
+    expect(resolveRuntimeWebViewProjection("http://[::1]:6080/vnc.html")).toMatchObject({ ok: true })
+  })
+
+  it("rejects credentials, non-loopback HTTP, implicit or privileged local ports, and active schemes", () => {
+    for (const url of [
+      "https://user:pass@preview.example/vnc.html",
+      "http://preview.example:6080/vnc.html",
+      "http://localhost/vnc.html",
+      "http://localhost:80/vnc.html",
+      "https://localhost/vnc.html",
+      "http://2130706433:6080/vnc.html",
+      "http://0177.0.0.1:6080/vnc.html",
+      "ws://localhost:6080/websockify",
+      "javascript:alert(1)",
+    ]) {
+      expect(resolveRuntimeWebViewProjection(url).ok).toBe(false)
+    }
+  })
+})
+
+describe("runtimeWebViewRefreshDelay", () => {
+  it("refreshes thirty seconds before expiry without creating a tight loop", () => {
+    expect(runtimeWebViewRefreshDelay("2027-01-01T00:02:00.000Z", Date.parse("2027-01-01T00:00:00.000Z"))).toBe(90_000)
+    expect(runtimeWebViewRefreshDelay("2027-01-01T00:00:01.000Z", Date.parse("2027-01-01T00:00:00.000Z"))).toBe(1_000)
+    expect(runtimeWebViewRefreshDelay("not-a-date", 0)).toBeNull()
+  })
+})

--- a/packages/workspace/src/shared/__tests__/urlPane.test.ts
+++ b/packages/workspace/src/shared/__tests__/urlPane.test.ts
@@ -8,8 +8,9 @@ import {
 } from "../urlPane"
 
 describe("resolveRuntimePreviewUrl", () => {
-  it("accepts only credential-free HTTPS provider projections", () => {
+  it("accepts credential-free HTTPS or bounded HTTP loopback projections", () => {
     expect(resolveRuntimePreviewUrl("https://preview.example/demo")).toMatchObject({ ok: true })
+    expect(resolveRuntimePreviewUrl("http://localhost:6080/demo")).toMatchObject({ ok: true })
     expect(resolveRuntimePreviewUrl("http://preview.example/demo")).toMatchObject({
       ok: false,
       reason: "protocol-not-allowed",

--- a/packages/workspace/src/shared/index.ts
+++ b/packages/workspace/src/shared/index.ts
@@ -61,6 +61,18 @@ export type {
 export { WORKSPACE_OPEN_PATH_SURFACE_KIND } from "./types/surface"
 export { definePanel } from "./types/panel"
 export type { UrlPanePolicy, UrlPanePaneParams, UrlPaneResolution, UrlPaneRejectionReason } from "./urlPane"
+export type {
+  RuntimeWebViewProjectionRejectionReason,
+  RuntimeWebViewProjectionResolution,
+  RuntimeWebViewTarget,
+} from "./runtimeWebView"
+export {
+  LEGACY_URL_PANE_RUNTIME_PREVIEW_PATH,
+  RUNTIME_WEB_VIEW_PREVIEW_PATH,
+  resolveRuntimeWebViewProjection,
+  runtimeWebViewRefreshDelay,
+  runtimeWebViewTargetSchema,
+} from "./runtimeWebView"
 export {
   DEFAULT_URL_PANE_ORIGINS,
   URL_PANE_PANEL_ID,

--- a/packages/workspace/src/shared/runtimeWebView.ts
+++ b/packages/workspace/src/shared/runtimeWebView.ts
@@ -1,0 +1,100 @@
+import { z } from "zod"
+
+/** Canonical route for projecting a selected runtime port into the workspace UI. */
+export const RUNTIME_WEB_VIEW_PREVIEW_PATH = "/api/v1/ui/runtime-web-view/preview"
+/** Compatibility route introduced by #1493. New callers use the canonical route above. */
+export const LEGACY_URL_PANE_RUNTIME_PREVIEW_PATH = "/api/v1/ui/url-pane/runtime-preview"
+
+export const runtimeWebViewTargetSchema = z.object({
+  port: z.number().int().min(1024).max(65_535),
+  path: z.string().startsWith("/").max(2_048).refine((path) => !path.includes("\\"), {
+    message: "Path may not contain backslashes.",
+  }).optional(),
+}).strict()
+
+export type RuntimeWebViewTarget = z.infer<typeof runtimeWebViewTargetSchema>
+
+export type RuntimeWebViewProjectionRejectionReason =
+  | "empty"
+  | "unparseable"
+  | "protocol-not-allowed"
+  | "credentials-not-allowed"
+  | "local-target-not-allowed"
+
+export type RuntimeWebViewProjectionResolution =
+  | { ok: true; url: string; origin: string }
+  | { ok: false; reason: RuntimeWebViewProjectionRejectionReason; message: string }
+
+function isLoopbackHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase()
+  return normalized === "localhost" || normalized === "127.0.0.1" || normalized === "[::1]"
+}
+
+function hasCanonicalLoopbackAuthority(input: string): boolean {
+  return /^https?:\/\/(?:localhost|127\.0\.0\.1|\[::1\]):\d+(?:[/?#]|$)/i.test(input)
+}
+
+/**
+ * Revalidates a Host-created projection before it reaches an iframe.
+ * Hosted projections are credential-free HTTPS. Local projections are HTTP(S)
+ * loopback with an explicit, bounded port. No provider/runtime identity is
+ * accepted from the caller.
+ */
+export function resolveRuntimeWebViewProjection(
+  input: string | undefined | null,
+): RuntimeWebViewProjectionResolution {
+  const trimmed = (input ?? "").trim()
+  if (!trimmed) {
+    return { ok: false, reason: "empty", message: "The runtime preview did not return a URL." }
+  }
+
+  let parsed: URL
+  try {
+    parsed = new URL(trimmed)
+  } catch {
+    return { ok: false, reason: "unparseable", message: "The runtime preview returned an invalid URL." }
+  }
+
+  if (parsed.username || parsed.password) {
+    return {
+      ok: false,
+      reason: "credentials-not-allowed",
+      message: "Runtime preview URLs may not carry URL credentials.",
+    }
+  }
+
+  const loopback = isLoopbackHostname(parsed.hostname)
+  if (!loopback && parsed.protocol === "https:") {
+    return { ok: true, url: parsed.toString(), origin: parsed.origin }
+  }
+
+  if (!loopback && parsed.protocol !== "https:") {
+    return { ok: false, reason: "protocol-not-allowed", message: "Hosted runtime previews must use HTTPS." }
+  }
+
+  if (!hasCanonicalLoopbackAuthority(trimmed) || !parsed.port) {
+    return {
+      ok: false,
+      reason: "local-target-not-allowed",
+      message: "HTTP runtime previews must use loopback with an explicit port.",
+    }
+  }
+  const port = Number(parsed.port)
+  if (!Number.isInteger(port) || port < 1024 || port > 65_535) {
+    return {
+      ok: false,
+      reason: "local-target-not-allowed",
+      message: "HTTP runtime previews must use a bounded loopback port.",
+    }
+  }
+
+  return { ok: true, url: parsed.toString(), origin: parsed.origin }
+}
+
+/** Refresh shortly before expiration, while avoiding tight timer loops. */
+export function runtimeWebViewRefreshDelay(expiresAt: string | undefined, now = Date.now()): number | null {
+  if (!expiresAt) return null
+  const expiry = Date.parse(expiresAt)
+  if (!Number.isFinite(expiry)) return null
+  return Math.max(1_000, expiry - now - 30_000)
+}

--- a/packages/workspace/src/shared/urlPane.ts
+++ b/packages/workspace/src/shared/urlPane.ts
@@ -1,3 +1,5 @@
+import type { RuntimeWebViewTarget } from "./runtimeWebView"
+
 /**
  * URL pane — the workspace surface that embeds a *running* demo (a worker's dev
  * server, the hub itself) in a sandboxed iframe.
@@ -125,34 +127,15 @@ export function resolveUrlPaneTarget(input: string | undefined | null, policy: U
   return { ok: true, url: parsed.toString(), origin: parsed.origin }
 }
 
-export interface RuntimePreviewTarget {
-  port: number
-  path?: string
-}
-
-/** Validates a host-resolved runtime preview before it reaches an iframe. */
-export function resolveRuntimePreviewUrl(input: string | undefined | null): UrlPaneResolution {
-  const trimmed = (input ?? "").trim()
-  if (!trimmed) return { ok: false, reason: "empty", message: "The runtime preview did not return a URL." }
-  let parsed: URL
-  try {
-    parsed = new URL(trimmed)
-  } catch {
-    return { ok: false, reason: "unparseable", message: "The runtime preview returned an invalid URL." }
-  }
-  if (parsed.protocol !== "https:") {
-    return { ok: false, reason: "protocol-not-allowed", message: "Runtime previews must use HTTPS." }
-  }
-  if (parsed.username || parsed.password) {
-    return { ok: false, reason: "credentials-not-allowed", message: "Runtime preview URLs may not carry URL credentials." }
-  }
-  return { ok: true, url: parsed.toString(), origin: parsed.origin }
-}
+// Compatibility aliases for #1493 consumers. Runtime projection now belongs
+// to the central RuntimeWebView contract rather than this panel.
+export type { RuntimeWebViewTarget as RuntimePreviewTarget } from "./runtimeWebView"
+export { resolveRuntimeWebViewProjection as resolveRuntimePreviewUrl } from "./runtimeWebView"
 
 export interface UrlPanePaneParams {
   /** Browser-direct URL, used by local CLI and explicitly allowlisted hosts. */
   url?: string
   /** Host-resolved port in the current workspace's active remote runtime. */
-  runtimePreview?: RuntimePreviewTarget
+  runtimePreview?: RuntimeWebViewTarget
   title?: string
 }


### PR DESCRIPTION
## Summary

- centralize iframe/projection ownership in public workspace `RuntimeWebView`
- migrate URL pane to a thin adapter while preserving direct-URL UX and #1493 compatibility
- add a strict runtime port/path schema, canonical authenticated projection route, loopback/HTTPS validation, expiry refresh, retry/cancellation fencing, and sanitized errors
- document the ratified browser-plugin plan and the shared HTTP/WS / HTTPS/WSS contract

## Stack dependency

**Stacked on #1493** (`fix/1489-remote-sandbox-preview`, head `af6dc992`). Merge #1493 first; this PR intentionally reuses and generalizes its runtime-preview projection rather than duplicating provider/runtime code.

Closes #1498

## Scope

This is approved Slice 1 only. It adds no browser plugin/process, Browser-Use dependency, native browser tools, MCP catalog/dispatcher, provider-specific code, deployment, publication, or production change. Slice 2 remains blocked on this slice and a reviewed dependency lock.

## Proof

- `pnpm --filter @hachej/boring-ui-kit build` — passed
- `pnpm --filter @hachej/boring-agent build` — passed (fresh-worktree dependency prerequisite)
- `pnpm --filter @hachej/boring-workspace typecheck` — passed
- focused RuntimeWebView, URL-pane, and UI-route Vitest suite — 40 passed
- `pnpm lint:invariants` — passed
- `git diff --check` — passed
- package-wide workspace test — 1924 passed, 11 skipped, 77 unrelated WorkspaceAgentFront/layout timeouts or empty-render failures; focused changed seams remained green

## Review history

1. Security/maintainability review found local projection validation accepted URL-parser-normalized alternate loopback spellings and HTTPS loopback without an explicit bounded port.
2. Fixed by requiring canonical `localhost`, `127.0.0.1`, or `[::1]` authority with explicit port 1024–65535; added decimal/octal IPv4 and implicit/privileged-port negatives.
3. Re-review: no blockers in changed projection/schema/component/route seams; focused tests, typecheck, and invariants pass at `811106f`.

## Owner review card

- **Issue:** #1498
- **Dependency:** #1493 must land first
- **Proof:** commands above at `811106f`
- **Demo:** code-only shared-view refactor; visual behavior is covered by URL-pane component parity tests. No hosted deployment was attempted or permitted in Slice 1.
- **Known gaps:** no real noVNC/browser tracer; no live hosted WSS proof. Both belong to later gated slices after #1493 and dependency-lock review.
- **Decision needed:** approve the Slice 1 shared seam and stacked dependency; do not treat this PR as approval for Slice 2 or production rollout.
