### PR TITLE
fix(factory): ship package-shaped portable profiles

### DIFF
--- a/plugins/boring-factory/agents/factory-orchestrator/package.json
+++ b/plugins/boring-factory/agents/factory-orchestrator/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@hachej/boring-factory-orchestrator",
+  "private": true,
+  "version": "1.0.0",
+  "boring": {
+    "agent": {
+      "definitionId": "factory-orchestrator",
+      "version": "1.0.0",
+      "label": "Factory Orchestrator",
+      "instructionsRef": "instructions.md"
+    }
+  }
+}

--- a/plugins/boring-factory/agents/factory-worker/package.json
+++ b/plugins/boring-factory/agents/factory-worker/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@hachej/boring-factory-worker",
+  "private": true,
+  "version": "1.0.0",
+  "boring": {
+    "agent": {
+      "definitionId": "factory-worker",
+      "version": "1.0.0",
+      "label": "Factory Worker",
+      "instructionsRef": "instructions.md"
+    }
+  }
+}

--- a/plugins/boring-factory/src/server/packaging.test.ts
+++ b/plugins/boring-factory/src/server/packaging.test.ts
@@ -15,7 +15,10 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { pathToFileURL, fileURLToPath } from 'node:url'
 
-import { compileAgentDirectory } from '@hachej/boring-agent/server'
+import {
+  compileAgentDirectory,
+  compilePersonaPackageDirectory,
+} from '@hachej/boring-agent/server'
 import { describe, expect, it } from 'vitest'
 
 const pluginRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
@@ -93,6 +96,10 @@ describe('private Boring Factory tarball', () => {
       await expect(compileAgentDirectory(resources.agentSources['factory-orchestrator']))
         .resolves.toMatchObject({ definition: { definitionId: 'factory-orchestrator' } })
       await expect(compileAgentDirectory(resources.agentSources['factory-worker']))
+        .resolves.toMatchObject({ definition: { definitionId: 'factory-worker' } })
+      await expect(compilePersonaPackageDirectory(resources.agentSources['factory-orchestrator']))
+        .resolves.toMatchObject({ definition: { definitionId: 'factory-orchestrator' } })
+      await expect(compilePersonaPackageDirectory(resources.agentSources['factory-worker']))
         .resolves.toMatchObject({ definition: { definitionId: 'factory-worker' } })
 
       const presentPrSkill = path.join(resources.skillRoot, 'exec/.agents/skills/present-pr/SKILL.md')

--- a/plugins/boring-factory/src/server/resources.test.ts
+++ b/plugins/boring-factory/src/server/resources.test.ts
@@ -151,12 +151,20 @@ describe('Boring Factory resource artifact', () => {
       FACTORY_WORKER_AGENT_TYPE_ID,
     ] as const) {
       const source = resources.agentSources[agentTypeId]
-      const manifest = JSON.parse(await readFile(path.join(source, 'agent.json'), 'utf8')) as {
-        definitionId?: string
-        instructionsRef?: string
-      }
-      expect(manifest.definitionId).toBe(agentTypeId)
-      expect(manifest.instructionsRef).toBe('instructions.md')
+      const compatibilityManifest = JSON.parse(
+        await readFile(path.join(source, 'agent.json'), 'utf8'),
+      ) as { definitionId?: string; version?: string; label?: string; instructionsRef?: string }
+      const packageManifest = JSON.parse(
+        await readFile(path.join(source, 'package.json'), 'utf8'),
+      ) as { boring?: { agent?: typeof compatibilityManifest } }
+      expect(packageManifest.boring?.agent).toEqual({
+        definitionId: compatibilityManifest.definitionId,
+        version: compatibilityManifest.version,
+        label: compatibilityManifest.label,
+        instructionsRef: compatibilityManifest.instructionsRef,
+      })
+      expect(compatibilityManifest.definitionId).toBe(agentTypeId)
+      expect(compatibilityManifest.instructionsRef).toBe('instructions.md')
       expect((await readFile(path.join(source, 'instructions.md'), 'utf8')).trim()).not.toBe('')
     }
   })


### PR DESCRIPTION
## What

Follow-up to merged PR #1494: ship package-shaped manifests for both portable Factory profiles so applications on canonical `package.json#boring.agent` composition can consume them.

- add `package.json#boring.agent` for `factory-orchestrator` and `factory-worker`;
- retain `agent.json` as bounded compatibility data;
- parity-lock identity/version/label/instructions fields between both formats;
- compile both installed profiles through both legacy and package compilers in the tarball smoke test.

## Why separate

PR #1494 merged at `8aa3ed1` while this final Seneca-main compatibility delta was still under review. The source branch later received the reviewed commit, but that commit is not in the merged PR. This follow-up contains only that missing delta.

## Proof

- Factory tests: 5/5
- Factory typecheck
- installed clean-pack/frozen-offline smoke
- deterministic pack
- thermo review: PASS at exact head `9f4e4997a4048d07a74107eae1561b18e0d5c79c`
- CI: 13 passed, 0 failed

## Boundaries

No Seats, activation, tools, provider, credentials, npm publication, deployment, or merge authority.

Closes #1501.

