### PR TITLE
fix(ask-user): keep the chat blocker bar for requestless questions

### DIFF
--- a/plugins/ask-user/src/front/providerHooks.ts
+++ b/plugins/ask-user/src/front/providerHooks.ts
@@ -41,7 +41,11 @@ export function useAskUserAttentionBlockers(runtime: QuestionsRuntime, pendingSn
         sessionBadge: { kind: "question", label: "question", tone: "attention", priority: 10 },
         pruneWhenSessionMissing: true,
         focus: { closeWorkbenchLeftPane: true },
-        composer: { visible: false },
+        // The inline chat card (rendered from the ask_user tool part) already
+        // carries Open/Cancel, so the composer bar would duplicate it. A
+        // requestless question has no tool call to render inline, so the
+        // composer bar is then the only in-chat affordance — keep it.
+        composer: { visible: !hydrated?.toolCallId },
         inbox: {
           kind: "question",
           sourceLabel: "question",


### PR DESCRIPTION
Found by the pre-release smoke sweep of the playground/ask-user Playwright suites (not run by CI).

**Bug:** since #1090, `composer: { visible: false }` was set unconditionally on the ask_user attention blocker. A requestless question (no toolCallId — e.g. posted straight to the questions API, the #873 path) gets no inline card *and* no composer bar, so its Open Questions / Cancel question actions are unreachable: only an Inbox badge remains, and the Inbox never renders blocker actions. User-facing dead end.

**Fix:** `visible: !hydrated?.toolCallId` — suppress the bar only when the inline card actually carries Open/Cancel.

**Verification:** ask-user e2e 4/4 green twice; one-liner revert reproduces both failures; `@hachej/boring-ask-user` unit suite 147 passed.

**Follow-ups worth beads:** (1) `blocker.actions` is only rendered by ComposerBlockerNotice — InboxOverlay maps but never renders actions; (2) the workspace-playground Playwright matrix (incl. ask-user e2e) is unwired from CI, which is why this sat for ~3.5 weeks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nbr3nZ3vKYUX8JkLWkGBpB