### PR TITLE
fix(workspace): make Focus Chat actually focus the composer

### DIFF
--- a/apps/workspace-playground/e2e/visual.spec.ts
+++ b/apps/workspace-playground/e2e/visual.spec.ts
@@ -55,10 +55,14 @@ test.describe("command palette visual chrome", () => {
 
   test("footer keyboard hints are present", async ({ page }) => {
     await openPalette(page)
-    // The footer hint strip — ↑↓ navigate · ↵ open · esc close
-    await expect(page.getByText(/navigate/i)).toBeVisible()
-    await expect(page.getByText(/open/i).last()).toBeVisible()
-    await expect(page.getByText(/close/i).last()).toBeVisible()
+    // The footer hint strip — ↑↓ navigate · ↵ open · esc close.
+    // Scope to the desktop hint group: the footer also renders a
+    // touch-only "Tap a result to open" span that is `hidden` at this
+    // viewport, and an unscoped /open/i .last() resolves to it.
+    const hints = page.locator(".command-palette-footer-desktop-hints")
+    await expect(hints.getByText(/navigate/i)).toBeVisible()
+    await expect(hints.getByText(/^open$/i)).toBeVisible()
+    await expect(hints.getByText(/^close$/i)).toBeVisible()
   })
 
   test("> prefix surfaces the command mode segment", async ({ page }) => {

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -204,6 +204,13 @@ export function ChatLayout(props: ChatLayoutProps) {
     const shell = shellRef.current
     if (shell) scheduleComposerFocus(shell)
   }, [])
+  // Explicit "give the composer the keyboard" intent (the Focus Chat command),
+  // as opposed to the opportunistic focus fallbacks above: it must land even
+  // when something else currently holds focus. See #1391/focusChat below.
+  const forceLocalComposerFocus = useCallback(() => {
+    const shell = shellRef.current
+    if (shell) scheduleComposerFocus(shell, { force: true })
+  }, [])
   // Feeds `measuredRowWidth` above with the chat+workbench row's real
   // content width — see the #1451 note at its declaration. Attached to
   // `rowRef` (the flex row that directly holds `<main>`/`<aside>` below),
@@ -332,8 +339,18 @@ export function ChatLayout(props: ChatLayoutProps) {
     if (navOpen) closeNav?.()
     if (surfaceOpen) closeSurface?.()
     focusAgentComposer(shellRef.current)
-    scheduleLocalComposerFocus()
-  }, [chatCollapsed, closeNav, closeSurface, navOpen, scheduleLocalComposerFocus, setChatCollapsed, surfaceOpen])
+    // Deferred AND forced, not just the opportunistic `onlyFromBody` retry.
+    // When Focus Chat is run from the command palette the Radix dialog is
+    // still mounted and focus-trapped, so the synchronous focus above is
+    // yanked straight back into the palette by its FocusScope; then the
+    // dialog's close-auto-focus restores focus to whatever opened it (the
+    // app-left Search button in the smoke test). Both of those land after
+    // this callback returns and neither leaves focus on <body>, so the
+    // opportunistic retry declined to fire and the command silently did
+    // nothing. The forced retry re-claims the composer once the palette has
+    // finished closing.
+    forceLocalComposerFocus()
+  }, [chatCollapsed, closeNav, closeSurface, forceLocalComposerFocus, navOpen, setChatCollapsed, surfaceOpen])
   const suppressOverlayAutoExpandRef = useRef(false)
   const toggleChatCollapsed = useCallback(() => {
     const collapsing = !chatCollapsed
@@ -1079,11 +1096,18 @@ function focusAgentComposer(
   textarea?.focus()
 }
 
-function scheduleComposerFocus(root: HTMLElement | null = null): void {
+function scheduleComposerFocus(
+  root: HTMLElement | null = null,
+  options: { force?: boolean } = {},
+): void {
   if (typeof window === "undefined") return
+  // `onlyFromBody` keeps the opportunistic fallbacks (drawer dismiss, blocker
+  // clear) from stealing focus from wherever the user actually is. A forced
+  // schedule is the explicit-intent path and claims the composer regardless.
+  const focusOptions = { onlyFromBody: !options.force }
   window.requestAnimationFrame(() => {
-    focusAgentComposer(root, { onlyFromBody: true })
-    window.setTimeout(() => focusAgentComposer(root, { onlyFromBody: true }), 320)
+    focusAgentComposer(root, focusOptions)
+    window.setTimeout(() => focusAgentComposer(root, focusOptions), 320)
   })
 }
 


### PR DESCRIPTION
Found by the pre-release smoke sweep (playground e2e suite, not run by CI).

**Bug:** running "Focus Chat" from the command palette silently did nothing. The command runs while the Radix dialog is still mounted: its FocusScope yanks the synchronous focus back into the palette, then close-auto-focus restores focus to whatever opened the palette. The scheduled retry was gated `onlyFromBody`, so it declined to fire. Verified with a focusin/focusout trace — the composer never received focus.

**Fix:** `scheduleComposerFocus` gains a `force` option used only by the explicit Focus Chat intent; opportunistic fallbacks (drawer dismiss, blocker clear) keep the `onlyFromBody` guard so they can't steal focus.

Also scopes the palette footer-hint spec to the desktop hint group — an unscoped `.last()` was matching the hidden touch-only "Tap a result to open" span.

**Verification:** cmd-effects + visual specs 8/8 green twice; palette unit suites 101 passed.

**Known trade-off:** the forced retry lands 320ms after the command (covers the dialog close animation); a user clicking into another input inside that window gets pulled to the composer. Explicit-command path only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nbr3nZ3vKYUX8JkLWkGBpB