### PR TITLE
fix(playground): full-page panels use the real workspace scope; align drifted e2e specs

### DIFF
--- a/apps/workspace-playground/e2e/agent-host-golden-route.spec.ts
+++ b/apps/workspace-playground/e2e/agent-host-golden-route.spec.ts
@@ -1,6 +1,16 @@
 import { expect, test, type Page, type Response } from "@playwright/test"
 
-const operationPath = /\/api\/v1\/agents\/default\/sessions(?:$|\?|\/[^/]+\/(?:events|prompt|followup|queue\/clear|interrupt|stop|rename))/
+// Every addressed session route carries the agent type id in its path. The
+// playground boots the scripted two-Agent fleet (`alpha` + `beta`), so the
+// golden route is checked against the seat the app actually addresses rather
+// than a hardcoded id — the exact expected paths are still asserted below.
+const operationPath = /\/api\/v1\/agents\/[^/]+\/sessions(?:$|\?|\/[^/]+\/(?:events|prompt|followup|queue\/clear|interrupt|stop|rename))/
+
+/** The composition apps/workspace-playground boots for e2e (see twoAgentFleet.ts). */
+const EXPECTED_AGENT_CATALOG = [
+  { agentTypeId: "alpha", label: "Alpha", pluginIds: ["scripted-alpha-capability"] },
+  { agentTypeId: "beta", label: "Beta", pluginIds: ["scripted-beta-capability"] },
+]
 
 async function runCommand(page: Page, command: string): Promise<void> {
   await page.keyboard.press("ControlOrMeta+KeyK")
@@ -35,11 +45,17 @@ test.describe("checkpoint-D Agent Host golden route", () => {
     await expect(composer).toBeVisible()
     await expect(chat).toHaveAttribute("data-pi-chat-connection", "connected", { timeout: 10_000 })
 
-    const workspaceMeta = await (await page.request.get("/api/v1/workspace/meta")).json() as { workspaceId: string }
+    const workspaceMeta = await (await page.request.get("/api/v1/workspace/meta")).json() as {
+      workspaceId: string
+      defaultAgentTypeId: string
+    }
     const workspaceHeaders = { "x-boring-workspace-id": workspaceMeta.workspaceId }
     const catalog = await page.request.get("/api/v1/agents", { headers: workspaceHeaders })
     expect(catalog.status()).toBe(200)
-    expect(await catalog.json()).toEqual([{ agentTypeId: "default", label: "Agent" }])
+    expect(await catalog.json()).toEqual(EXPECTED_AGENT_CATALOG)
+    const agentTypeId = workspaceMeta.defaultAgentTypeId
+    expect(EXPECTED_AGENT_CATALOG.map((agent) => agent.agentTypeId)).toContain(agentTypeId)
+    const sessionsRoute = `/api/v1/agents/${encodeURIComponent(agentTypeId)}/sessions`
 
     const initialSessionId = await chat.getAttribute("data-pi-chat-session-id")
     await runCommand(page, "New Chat")
@@ -66,7 +82,7 @@ test.describe("checkpoint-D Agent Host golden route", () => {
     await expect(page.getByLabel("Agent conversation").getByText(prompt)).toBeVisible({ timeout: 10_000 })
 
     const renamed = `Golden addressed ${Date.now()}`
-    const rename = await page.request.post(`/api/v1/agents/default/sessions/${encodeURIComponent(sessionId!)}/rename`, {
+    const rename = await page.request.post(`${sessionsRoute}/${encodeURIComponent(sessionId!)}/rename`, {
       headers: workspaceHeaders,
       data: { requestId: `rename-${Date.now()}`, title: renamed },
     })
@@ -75,30 +91,30 @@ test.describe("checkpoint-D Agent Host golden route", () => {
     expect(JSON.parse(renameBody)).toMatchObject({ title: renamed })
     responses.push({
       method: "POST",
-      path: `/api/v1/agents/default/sessions/${sessionId}/rename`,
+      path: `${sessionsRoute}/${sessionId}/rename`,
       status: rename.status(),
     })
     await page.reload({ waitUntil: "domcontentloaded" })
     await expect(page.locator('[data-boring-workspace-part="app-session-row"]').filter({ hasText: renamed })).toBeVisible({ timeout: 10_000 })
     await expect(chat).toHaveAttribute("data-pi-chat-connection", "connected", { timeout: 10_000 })
 
-    const deletion = await page.request.delete(`/api/v1/agents/default/sessions/${encodeURIComponent(sessionId!)}`, {
+    const deletion = await page.request.delete(`${sessionsRoute}/${encodeURIComponent(sessionId!)}`, {
       headers: workspaceHeaders,
     })
     expect(deletion.status(), await deletion.text()).toBe(204)
     responses.push({
       method: "DELETE",
-      path: `/api/v1/agents/default/sessions/${sessionId}`,
+      path: `${sessionsRoute}/${sessionId}`,
       status: deletion.status(),
     })
 
     const expectedOperations = [
-      ["GET", "/api/v1/agents/default/sessions", 200],
-      ["POST", "/api/v1/agents/default/sessions", 201],
-      ["GET", `/api/v1/agents/default/sessions/${sessionId}/events`, 200],
-      ["POST", `/api/v1/agents/default/sessions/${sessionId}/prompt`, 202],
-      ["POST", `/api/v1/agents/default/sessions/${sessionId}/rename`, 200],
-      ["DELETE", `/api/v1/agents/default/sessions/${sessionId}`, 204],
+      ["GET", sessionsRoute, 200],
+      ["POST", sessionsRoute, 201],
+      ["GET", `${sessionsRoute}/${sessionId}/events`, 200],
+      ["POST", `${sessionsRoute}/${sessionId}/prompt`, 202],
+      ["POST", `${sessionsRoute}/${sessionId}/rename`, 200],
+      ["DELETE", `${sessionsRoute}/${sessionId}`, 204],
     ] as const
     for (const [method, path, status] of expectedOperations) {
       expect(responses.some((item) => item.method === method && item.path === path && item.status === status), JSON.stringify(responses, null, 2)).toBe(true)

--- a/apps/workspace-playground/e2e/multi-agent-addressed-ui.spec.ts
+++ b/apps/workspace-playground/e2e/multi-agent-addressed-ui.spec.ts
@@ -125,9 +125,10 @@ test("discovers two Agents and keeps colliding sessions, capabilities, replaceme
     window as Window & { __boringChatLoadingTransitions?: number }
   ).__boringChatLoadingTransitions ?? 0)).toBeGreaterThan(0)
 
+  // Opening a session in a second pane moved out of the row's overflow menu
+  // into the hover action strip in #1176; the capability is unchanged.
   await betaRow.hover()
-  await betaRow.getByRole("button", { name: "Chat actions for Scripted baseline" }).click()
-  await page.getByRole("menuitem", { name: "Open in new chat pane" }).click()
+  await betaRow.getByRole("button", { name: "Open Scripted baseline in a split pane" }).click()
   await expect(page.locator('[data-boring-agent-part="chat"]')).toHaveCount(2)
   await expect(page.locator('[data-boring-agent-part="chat"][data-agent-type-id="alpha"]')).toHaveAttribute("data-pi-chat-session-id", alphaSessionId!)
   await expect(page.locator('[data-boring-agent-part="chat"][data-agent-type-id="beta"]')).toHaveAttribute("data-pi-chat-session-id", betaSessionId!)

--- a/apps/workspace-playground/src/front/App.tsx
+++ b/apps/workspace-playground/src/front/App.tsx
@@ -141,7 +141,13 @@ function resetPlaygroundStorageIfRequested(): void {
   window.history.replaceState(null, "", `${window.location.pathname}${nextSearch ? `?${nextSearch}` : ""}${window.location.hash}`)
 }
 
-function WorkspaceFullPageShell({ agentTypeId }: { agentTypeId: string }) {
+// The full-page route talks to the SAME backend workspace as the main shell.
+// `workspaceId` becomes the `x-boring-workspace-id` header, and
+// createWorkspaceAgentServer 403s (WORKSPACE_UNINITIALIZED) every request whose
+// selector is neither the canonical workspace scope id nor the workspace root
+// basename — a synthetic id like "playground-full-page" made every file read
+// from a popped-out panel fail.
+function WorkspaceFullPageShell({ agentTypeId, workspaceId }: { agentTypeId: string; workspaceId: string }) {
   const parsed = parseFullPagePanelLocation(window.location.search)
 
   if (!parsed.componentId || parsed.error) {
@@ -164,7 +170,7 @@ function WorkspaceFullPageShell({ agentTypeId }: { agentTypeId: string }) {
       plugins={workspacePlugins}
       persistenceEnabled
       manageDocumentTitle={false}
-      workspaceId="playground-full-page"
+      workspaceId={workspaceId}
       fullPageBasePath="/full-page"
     >
       <WorkspaceFullPagePanel componentId={parsed.componentId} params={parsed.params} />
@@ -470,7 +476,7 @@ export function WorkspaceShell() {
   }
 
   if (fullPage) {
-    return <WorkspaceFullPageShell agentTypeId={defaultAgentTypeId} />
+    return <WorkspaceFullPageShell agentTypeId={defaultAgentTypeId} workspaceId={workspaceId} />
   }
 
   return (


### PR DESCRIPTION
Found by the pre-release smoke sweep (playground e2e suite, not run by CI). One app bug, two spec drifts.

**App bug — deck "Present" popup rendered only "Loading deck…":** the `/full-page` popout mounted WorkspaceProvider with a synthetic `workspaceId="playground-full-page"`. Since #909's scope enforcement, every request from the popup 403s (`WORKSPACE_UNINITIALIZED`) — filesystems and file reads included. Fix: thread the workspace id resolved from `/api/v1/workspace/meta` into `WorkspaceFullPageShell`, same source as the main shell.

**Spec drift 1 — agent-host golden route:** the e2e composition boots the scripted Alpha/Beta fleet since #1102/#1110; the spec still asserted the single `default` catalog. Updated to assert the canonical two-seat catalog and drive the addressed lifecycle from `meta.defaultAgentTypeId`; the 2xx route gate now covers both seats (assertions strengthened, not removed).

**Spec drift 2 — multi-agent addressed UI:** #1176 moved "Open in new chat pane" from the row overflow menu to the hover action strip ("Open <title> in a split pane") — capability intact, spec followed it.

**Verification:** all three specs green twice (115s/112s); playground `tsc --noEmit` clean.

**Flake note:** `deck-plugin.spec.ts:32` has a fixed 300ms palette-search sleep that can miss on cold Vite dep-optimization; left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nbr3nZ3vKYUX8JkLWkGBpB