### PR TITLE
fix(core): anchor plugin resolution on the app root; fix stale file-tree preload; revive full-app e2e

### DIFF
--- a/apps/full-app/e2e/google-auth-webserver.sh
+++ b/apps/full-app/e2e/google-auth-webserver.sh
@@ -21,16 +21,37 @@ if [ -f "$CONFIG_PATH" ]; then
   cp "$CONFIG_PATH" "$CONFIG_BACKUP"
 fi
 
-cleanup() {
+restore_config() {
+  [ -f "$CONFIG_BACKUP" ] || return 0
   if [ "$CONFIG_EXISTED" -eq 1 ]; then
     cp "$CONFIG_BACKUP" "$CONFIG_PATH"
   else
     rm -f "$CONFIG_PATH"
   fi
   rm -f "$CONFIG_BACKUP"
+}
+
+cleanup() {
+  if [ -n "${SERVER_PID:-}" ]; then
+    kill "$SERVER_PID" 2>/dev/null || true
+  fi
+  restore_config
   rm -rf "$RUN_DIR"
 }
-trap cleanup EXIT
+trap cleanup EXIT INT TERM
+
+# Appending a second [features] table would be invalid TOML and the server
+# would refuse to boot, so refuse instead of corrupting a tracked file. This
+# also catches a leftover block from a run that was killed before it could put
+# the file back.
+if [ -f "$CONFIG_PATH" ] && grep -q '^\[features\]' "$CONFIG_PATH"; then
+  echo "google-auth-webserver: $CONFIG_PATH already defines [features]." >&2
+  echo "  If this is leftover from an interrupted e2e run, restore the file" >&2
+  echo "  (git checkout -- apps/full-app/boring.app.toml) and retry." >&2
+  echo "  If the app genuinely needs a [features] table now, merge" >&2
+  echo "  google_oauth = true into it here instead of appending." >&2
+  exit 1
+fi
 
 printf '\n[features]\ngoogle_oauth = true\n' >> "$CONFIG_PATH"
 
@@ -40,4 +61,22 @@ pnpm --filter @hachej/boring-core exec sh -c "cp src/front/theme.css dist/front/
 pnpm migrate
 pnpm build
 cd "$RUN_DIR"
-exec env NODE_ENV=production node "$APP_DIR/dist/server/main.js"
+# Run the server as a child rather than exec'ing it, so the traps above still
+# fire when Playwright tears the webServer down and the tracked TOML always
+# goes back.
+env NODE_ENV=production node "$APP_DIR/dist/server/main.js" &
+SERVER_PID=$!
+
+# loadConfig reads the TOML once during boot, so put the tracked file back the
+# moment the server answers. That keeps the checkout clean even if this script
+# is later killed with a signal it cannot trap.
+(
+  for _ in $(seq 1 300); do
+    if ! kill -0 "$SERVER_PID" 2>/dev/null; then break; fi
+    if curl -sf -o /dev/null "http://127.0.0.1:${PORT:-3900}/api/v1/config"; then break; fi
+    sleep 1
+  done
+  restore_config
+) &
+
+wait "$SERVER_PID"

--- a/apps/full-app/e2e/google-auth-webserver.sh
+++ b/apps/full-app/e2e/google-auth-webserver.sh
@@ -53,13 +53,15 @@ if [ -f "$CONFIG_PATH" ] && grep -q '^\[features\]' "$CONFIG_PATH"; then
   exit 1
 fi
 
-printf '\n[features]\ngoogle_oauth = true\n' >> "$CONFIG_PATH"
-
 cd "$APP_DIR"
 pnpm --filter @hachej/boring-core exec tsup --no-dts
 pnpm --filter @hachej/boring-core exec sh -c "cp src/front/theme.css dist/front/theme.css"
 pnpm migrate
 pnpm build
+# Swap the config in only now that the (multi-minute) build is done, so the
+# tracked file is modified for seconds rather than for the whole run.
+printf '\n[features]\ngoogle_oauth = true\n' >> "$CONFIG_PATH"
+
 cd "$RUN_DIR"
 # Run the server as a child rather than exec'ing it, so the traps above still
 # fire when Playwright tears the webServer down and the tracked TOML always

--- a/apps/full-app/e2e/google-auth-webserver.sh
+++ b/apps/full-app/e2e/google-auth-webserver.sh
@@ -3,20 +3,41 @@ set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 APP_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
-CONFIG_DIR=$(mktemp -d)
-CONFIG_PATH="$CONFIG_DIR/boring.app.toml"
+# src/server/main.ts pins the config to <appRoot>/boring.app.toml, so the
+# google_oauth feature flag the signup spec exercises has to be written there.
+# (loadConfig reads features.google_oauth from TOML only — there is no env
+# fallback the way there is for github_oauth, and no config-path env var.)
+# The app's own TOML is a tracked file, so back it up and restore it on exit.
+CONFIG_PATH="$APP_DIR/boring.app.toml"
+CONFIG_BACKUP=$(mktemp)
+CONFIG_EXISTED=0
+# Boot from a directory that is not the app root: production hosts do exactly
+# this, and it is what caught the plugin-package resolution bug where
+# defaultPluginPackages were resolved against process.cwd() only.
+RUN_DIR=$(mktemp -d)
+
+if [ -f "$CONFIG_PATH" ]; then
+  CONFIG_EXISTED=1
+  cp "$CONFIG_PATH" "$CONFIG_BACKUP"
+fi
 
 cleanup() {
-  rm -rf "$CONFIG_DIR"
+  if [ "$CONFIG_EXISTED" -eq 1 ]; then
+    cp "$CONFIG_BACKUP" "$CONFIG_PATH"
+  else
+    rm -f "$CONFIG_PATH"
+  fi
+  rm -f "$CONFIG_BACKUP"
+  rm -rf "$RUN_DIR"
 }
 trap cleanup EXIT
 
-printf '[features]\ngoogle_oauth = true\n' > "$CONFIG_PATH"
+printf '\n[features]\ngoogle_oauth = true\n' >> "$CONFIG_PATH"
 
 cd "$APP_DIR"
 pnpm --filter @hachej/boring-core exec tsup --no-dts
 pnpm --filter @hachej/boring-core exec sh -c "cp src/front/theme.css dist/front/theme.css"
 pnpm migrate
 pnpm build
-cd "$CONFIG_DIR"
+cd "$RUN_DIR"
 exec env NODE_ENV=production node "$APP_DIR/dist/server/main.js"

--- a/apps/full-app/e2e/playwright.config.ts
+++ b/apps/full-app/e2e/playwright.config.ts
@@ -34,6 +34,12 @@ const webServerEnv = Object.fromEntries(
     MAIL_TRANSPORT_URL: mailTransportUrl,
     PORT: String(apiPort),
     CSP_ENABLED: 'true',
+    // The harness boots the production bundle (NODE_ENV=production) but runs
+    // the agent in the local auto-detected direct mode on purpose — there is
+    // no vercel-sandbox/blaxel backend in a local or CI e2e run. Opt out of
+    // the production agent-mode gate (src/server/productionSafety.ts)
+    // explicitly; without this the webServer refuses to start at all.
+    BORING_ALLOW_UNSAFE_AGENT_MODE: '1',
   }).filter((entry): entry is [string, string] => typeof entry[1] === 'string'),
 )
 
@@ -56,7 +62,12 @@ export default defineConfig({
     command: webServerScript,
     env: webServerEnv,
     url: apiOrigin,
-    timeout: 360_000,
+    // The webServer script runs the whole dependency build chain (nine
+    // packages, declaration builds included — core's DTS pass alone is ~3
+    // minutes), migrates, and builds the app before listening. A cold run
+    // measured well past 15 minutes on a normal dev machine, so budget 30.
+    // CI does not run this suite, so this only bounds local runs.
+    timeout: 1_800_000,
     reuseExistingServer: false,
     stdout: 'pipe',
     stderr: 'pipe',

--- a/apps/full-app/e2e/runtime-readiness.spec.ts
+++ b/apps/full-app/e2e/runtime-readiness.spec.ts
@@ -46,10 +46,29 @@ test('authenticated workspace can submit chat while runtime dependencies are sti
     if (path === '/api/v1/workspaces') return route.fulfill(json({ workspaces: [WORKSPACE] }))
     if (path === `/api/v1/workspaces/${WORKSPACE.id}`) return route.fulfill(json({ workspace: WORKSPACE, role: 'owner' }))
     if (path === '/api/v1/tree') return route.fulfill(json({ entries: [] }))
+    // Boot batch (gh-1402): the workspace route preloads /api/v1/workspace/meta
+    // alongside the tree + ready-status warmup, and the addressed-agent fleet
+    // selection reads /api/v1/agents before WorkspaceBackgroundBoot mounts.
+    if (path === '/api/v1/workspace/meta') {
+      return route.fulfill(json({
+        workspaceId: WORKSPACE.id,
+        workspaceRoot: `/workspaces/${WORKSPACE.id}`,
+        projectName: WORKSPACE.name,
+        defaultAgentTypeId: 'default',
+      }))
+    }
+    if (path === '/api/v1/agents') return route.fulfill(json([{ agentTypeId: 'default', label: 'Default' }]))
     if (path === '/api/v1/agents/default/sessions' && request.method() === 'GET') return route.fulfill(json({ sessions: [{ ref: { agentTypeId: 'default', sessionId: 'runtime-readiness' }, title: 'Runtime Readiness', status: 'idle', createdAt: Date.now(), updatedAt: Date.now() }] }))
     if (path === '/api/v1/agents/default/sessions/runtime-readiness/state') return route.fulfill(json({ ref: { agentTypeId: 'default', sessionId: 'runtime-readiness' }, seq: 0, summary: { ref: { agentTypeId: 'default', sessionId: 'runtime-readiness' }, title: 'Runtime Readiness', status: 'idle', createdAt: Date.now(), updatedAt: Date.now() }, state: { protocolVersion: 1, sessionId: 'runtime-readiness', seq: 0, status: 'idle', messages: [], queue: { followUps: [] }, followUpMode: 'one-at-a-time' } }))
     if (path === '/api/v1/agents/default/sessions/runtime-readiness/events') return route.fulfill({ status: 200, contentType: 'application/x-ndjson', body: '{"type":"heartbeat","now":"2026-01-01T00:00:00.000Z"}\n' })
-    if (path === '/api/v1/agents/default/models') return route.fulfill(json({ models: [] }))
+    // The composer is gated on an authorized discovered model (#1469): an empty
+    // model list leaves the prompt permanently disabled.
+    if (path === '/api/v1/agents/default/models') {
+      return route.fulfill(json({
+        models: [{ provider: 'anthropic', id: 'claude-sonnet-4', label: 'Claude Sonnet 4', available: true }],
+        defaultModel: { provider: 'anthropic', id: 'claude-sonnet-4' },
+      }))
+    }
     if (path === '/api/v1/agents/default/ready-status') {
       return route.fulfill({
         status: 200,
@@ -69,8 +88,8 @@ test('authenticated workspace can submit chat while runtime dependencies are sti
   })
 
   await page.goto(`/workspace/${WORKSPACE.id}`)
-  await expect(page.getByPlaceholder('Message the agent…')).toBeVisible()
-  await page.getByPlaceholder('Message the agent…').fill('Can I chat before macro runtime is ready?')
+  await expect(page.getByPlaceholder('Ask anything…')).toBeVisible()
+  await page.getByPlaceholder('Ask anything…').fill('Can I chat before macro runtime is ready?')
   await page.getByLabel('Submit').click()
 
   await expect.poll(() => chatSubmitted ?? null, {

--- a/apps/full-app/e2e/smoke.spec.ts
+++ b/apps/full-app/e2e/smoke.spec.ts
@@ -4,7 +4,7 @@ const TASK_ID = 'boring-ui-v2-q4fo'
 const WORKSPACE_ID = 'ws-smoke'
 const USER = {
   id: 'user-dev-local',
-  email: 'dev@local',
+  email: 'dev@local.test',
   name: 'Dev Local',
 }
 
@@ -32,11 +32,12 @@ function json(body: unknown, status = 200) {
 }
 
 async function openWorkbench(page: import('@playwright/test').Page) {
-  const leftPane = page.getByLabel('Workbench left pane')
-  if (await leftPane.isVisible()) return
+  // The workbench is the right-hand surface region; the rail toggle opens it.
+  const workbench = page.getByRole('complementary', { name: 'Workbench', exact: true })
+  if (await workbench.isVisible()) return
 
-  await page.getByRole('button', { name: 'Workbench' }).click()
-  await expect(leftPane).toBeVisible({ timeout: 10_000 })
+  await page.getByRole('button', { name: 'Open workbench' }).click()
+  await expect(workbench).toBeVisible({ timeout: 10_000 })
 }
 
 test('smoke: sign in and land on /workspace/:id', async ({ page, baseURL }) => {
@@ -116,6 +117,31 @@ test('smoke: sign in and land on /workspace/:id', async ({ page, baseURL }) => {
 
     if (path === '/api/v1/tree' && request.method() === 'GET') {
       return route.fulfill(json({ entries: [] }))
+    }
+
+    // Boot batch (gh-1402): /api/v1/workspace/meta rides along with the tree +
+    // ready-status warmup, and the addressed-agent fleet selection reads
+    // /api/v1/agents before WorkspaceBackgroundBoot mounts. Leaving either
+    // unmocked pins the workspace on "Preparing workspace...".
+    if (path === '/api/v1/workspace/meta') {
+      return route.fulfill(json({
+        workspaceId: WORKSPACE_ID,
+        workspaceRoot: `/workspaces/${WORKSPACE_ID}`,
+        projectName: WORKSPACE.name,
+        defaultAgentTypeId: 'default',
+      }))
+    }
+
+    if (path === '/api/v1/agents') {
+      return route.fulfill(json([{ agentTypeId: 'default', label: 'Default' }]))
+    }
+
+    if (path === '/api/v1/agents/default/ready-status') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'text/event-stream',
+        body: 'event: status\ndata: {"state":"ready","sandboxReady":true,"harnessReady":true,"capabilities":{"chat":{"state":"ready"},"workspace":{"state":"ready"}}}\n\n',
+      })
     }
 
     if (path === '/api/v1/agents/default/models') {

--- a/apps/full-app/e2e/workspace-lifecycle.spec.ts
+++ b/apps/full-app/e2e/workspace-lifecycle.spec.ts
@@ -222,8 +222,53 @@ async function installWorkspaceLifecycleMocks(page: Page, baseURL: string | unde
       return route.fulfill(json({ error: 'not_found' }, 404))
     }
 
+    // The workbench file tree resolves its roots from the filesystem catalog.
+    if (path === '/api/v1/filesystems') {
+      return route.fulfill(json({
+        filesystems: [{
+          filesystem: 'user',
+          label: 'Workspace',
+          rootDir: '.',
+          access: 'readwrite',
+          capabilities: { read: true, list: true, search: true, write: true, delete: true, move: true, mkdir: true },
+        }],
+      }))
+    }
+
+    // Boot batch (gh-1402): /api/v1/workspace/meta rides along with the tree +
+    // ready-status warmup, and the addressed-agent fleet selection reads
+    // /api/v1/agents before WorkspaceBackgroundBoot mounts. Leaving any of them
+    // unmocked pins the workspace on "Preparing workspace..." and keeps the
+    // workbench overlay up.
+    if (path === '/api/v1/workspace/meta') {
+      const workspaceId = workspaceIdFromRequest(route)
+      return route.fulfill(json({
+        workspaceId,
+        workspaceRoot: `/workspaces/${workspaceId}`,
+        projectName: workspaces.find((item) => item.id === workspaceId)?.name ?? workspaceId,
+        defaultAgentTypeId: 'default',
+      }))
+    }
+
+    if (path === '/api/v1/agents') {
+      return route.fulfill(json([{ agentTypeId: 'default', label: 'Default' }]))
+    }
+
+    if (path === '/api/v1/agents/default/ready-status') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'text/event-stream',
+        body: 'event: status\ndata: {"state":"ready","sandboxReady":true,"harnessReady":true,"capabilities":{"chat":{"state":"ready"},"workspace":{"state":"ready"}}}\n\n',
+      })
+    }
+
+    // The composer is gated on an authorized discovered model (#1469): an empty
+    // model list leaves the prompt permanently disabled.
     if (path === '/api/v1/agents/default/models') {
-      return route.fulfill(json({ models: [] }))
+      return route.fulfill(json({
+        models: [{ provider: 'anthropic', id: 'claude-sonnet-4', label: 'Claude Sonnet 4', available: true }],
+        defaultModel: { provider: 'anthropic', id: 'claude-sonnet-4' },
+      }))
     }
 
     if (path === '/api/v1/agents/default/sessions' && method === 'GET') {
@@ -337,16 +382,22 @@ async function switchWorkspace(page: Page, name: string, id: string) {
     .toBeVisible({ timeout: 10_000 })
 }
 
+// The workbench is the right-hand surface region; its sources rail carries the
+// file tree. "Open workbench" is the rail toggle that mounts it.
+function workbenchRegion(page: Page) {
+  return page.getByRole('complementary', { name: 'Workbench', exact: true })
+}
+
 async function openWorkbench(page: Page) {
-  const leftPane = page.getByLabel('Workbench left pane')
-  const button = page.getByRole('button', { name: 'Workbench' })
+  const workbench = workbenchRegion(page)
+  const button = page.getByRole('button', { name: 'Open workbench' })
 
   for (let attempt = 0; attempt < 3; attempt += 1) {
-    if (await leftPane.isVisible().catch(() => false)) return
+    if (await workbench.isVisible().catch(() => false)) return
     await expect(button).toBeVisible({ timeout: 10_000 })
     await button.click()
     try {
-      await expect(leftPane).toBeVisible({ timeout: 1_500 })
+      await expect(workbench).toBeVisible({ timeout: 1_500 })
       return
     } catch {
       // The route can swap the floating button during workspace creation.
@@ -355,7 +406,32 @@ async function openWorkbench(page: Page) {
     }
   }
 
-  await expect(leftPane).toBeVisible({ timeout: 10_000 })
+  await expect(workbench).toBeVisible({ timeout: 10_000 })
+}
+
+// The sources rail starts collapsed to category icons; the Files category
+// expands the pane that hosts the file tree.
+async function openWorkbenchFiles(page: Page) {
+  await openWorkbench(page)
+  // "Refresh files" is part of the expanded Files pane chrome, so it marks the
+  // pane open whether or not the workspace has any files yet.
+  const filesPane = page.getByRole('button', { name: 'Refresh files' })
+  const filesCategory = page.getByRole('button', { name: 'Files', exact: true })
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    if (await filesPane.isVisible().catch(() => false)) return
+    await expect(filesCategory).toBeVisible({ timeout: 10_000 })
+    await filesCategory.click()
+    try {
+      await expect(filesPane).toBeVisible({ timeout: 2_000 })
+      return
+    } catch {
+      // A workspace switch remounts the rail collapsed; a click that lands
+      // mid-remount is lost. Retry after a full visibility wait.
+    }
+  }
+
+  await expect(filesPane).toBeVisible({ timeout: 10_000 })
 }
 
 test('agent openFile command opens a closed workbench and focuses the file', async ({ page, baseURL }) => {
@@ -368,7 +444,7 @@ test('agent openFile command opens a closed workbench and focuses the file', asy
   await expect(page.getByRole('button', { name: /Workspace menu: Alpha Workspace/ }))
     .toBeVisible({ timeout: 10_000 })
 
-  await expect(page.getByLabel('Surface')).toBeVisible({ timeout: 10_000 })
+  await expect(workbenchRegion(page)).toBeVisible({ timeout: 10_000 })
   await expect(page.getByText('Nothing open yet')).toBeHidden({ timeout: 10_000 })
   await expect(page.locator('.cm-content')).toContainText('export const alpha = 1', { timeout: 10_000 })
 })
@@ -386,7 +462,7 @@ test('new chat in additional workspace preserves the first session and stays wor
   const firstSession = state.sessionsByWorkspace.get('ws-beta')?.[0]
   expect(firstSession?.id).toMatch(/^ws-beta-session-/)
 
-  await page.getByRole('button', { name: 'New chat' }).click()
+  await page.getByRole('button', { name: 'New chat', exact: true }).click()
 
   await expect.poll(() => state.sessionsByWorkspace.get('ws-beta')?.length ?? 0, {
     timeout: 10_000,
@@ -396,10 +472,9 @@ test('new chat in additional workspace preserves the first session and stays wor
   expect(betaSessionIds.every((id) => id.startsWith('ws-beta-session-'))).toBe(true)
 
   const betaCreates = state.sessionCreates.filter((create) => create.workspaceId === 'ws-beta')
-  expect(betaCreates.map((create) => create.body)).toEqual([
-    { title: 'New session' },
-    {},
-  ])
+  // "New session" is a presentation fallback, not a durable title, so neither
+  // create sends one (automaticSessionCreateInput).
+  expect(betaCreates.map((create) => create.body)).toEqual([{}, {}])
   expect(state.sessionsByWorkspace.get('ws-alpha') ?? []).toHaveLength(0)
   expect(state.piChatRequests.some((request) => request.workspaceId === 'ws-beta' && request.sessionId === 'default')).toBe(false)
 
@@ -417,13 +492,13 @@ test('workspace create and switch keeps files and sessions scoped per workspace'
   await expect(page.getByRole('button', { name: /Workspace menu: Alpha Workspace/ }))
     .toBeVisible({ timeout: 10_000 })
 
-  await openWorkbench(page)
+  await openWorkbenchFiles(page)
   await expect(page.getByRole('treeitem', { name: /alpha\.md/ })).toBeVisible()
   await page.getByRole('treeitem', { name: /alpha\.md/ }).click()
   await expect(page.getByText('Nothing open yet')).toBeHidden({ timeout: 10_000 })
 
   await switchWorkspace(page, 'Beta Workspace', 'ws-beta')
-  await openWorkbench(page)
+  await openWorkbenchFiles(page)
   await expect(page.getByRole('treeitem', { name: /beta\.md/ })).toBeVisible()
   await expect(page.getByRole('treeitem', { name: /alpha\.md/ })).toHaveCount(0)
 
@@ -435,10 +510,10 @@ test('workspace create and switch keeps files and sessions scoped per workspace'
   await expect(page).toHaveURL(/\/workspace\/ws-gamma-workspace$/)
   await expect(page.getByRole('button', { name: /Workspace menu: Gamma Workspace/ }))
     .toBeVisible({ timeout: 10_000 })
-  await openWorkbench(page)
+  await openWorkbenchFiles(page)
 
-  const leftPane = page.getByLabel('Workbench left pane')
-  await leftPane.click({ button: 'right', position: { x: 40, y: 110 } })
+  const sourcesRail = page.getByRole('complementary', { name: 'Workbench sources and activity rail' })
+  await sourcesRail.click({ button: 'right', position: { x: 40, y: 110 } })
   await page.getByRole('menuitem', { name: 'New file' }).click()
   await page.getByTestId('file-tree-edit-input').fill('notes.md')
   await page.getByTestId('file-tree-edit-input').press('Enter')
@@ -452,12 +527,12 @@ test('workspace create and switch keeps files and sessions scoped per workspace'
   })
 
   await switchWorkspace(page, 'Beta Workspace', 'ws-beta')
-  await openWorkbench(page)
+  await openWorkbenchFiles(page)
   await expect(page.getByRole('treeitem', { name: /beta\.md/ })).toBeVisible()
   await expect(page.getByRole('treeitem', { name: /notes\.md/ })).toHaveCount(0)
 
   await switchWorkspace(page, 'Gamma Workspace', 'ws-gamma-workspace')
-  await openWorkbench(page)
+  await openWorkbenchFiles(page)
   await expect(page.getByRole('treeitem', { name: /notes\.md/ })).toBeVisible()
 
   expect(new Set(state.sessionRequests)).toEqual(

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.defaultPluginPackages.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.defaultPluginPackages.test.ts
@@ -1,0 +1,68 @@
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, expect, test, vi } from 'vitest'
+import { createTestCoreConfig } from '../../../server/__tests__/createTestApp.js'
+import { mocks } from './createCoreWorkspaceAgentServer.testHarness.js'
+
+const PLUGIN_PACKAGE = '@hachej/boring-fixture-plugin'
+
+const originalCwd = process.cwd()
+
+afterEach(() => {
+  process.chdir(originalCwd)
+})
+
+/**
+ * Regression: production hosts chdir away from the app directory before
+ * `node dist/server/main.js` (the full-app e2e webserver runs from a mktemp
+ * config dir). Plugin package names must still resolve through the *app's*
+ * node_modules, so the host app root has to be threaded in as `anchorDir`.
+ */
+test('resolves defaultPluginPackages against the app root when cwd is elsewhere', async () => {
+  const appRoot = await mkdtemp(join(tmpdir(), 'boring-core-app-root-'))
+  const packageDir = join(appRoot, 'node_modules', PLUGIN_PACKAGE)
+  await mkdir(packageDir, { recursive: true })
+  await writeFile(join(appRoot, 'package.json'), JSON.stringify({ name: 'fixture-app' }))
+  await writeFile(join(packageDir, 'package.json'), JSON.stringify({ name: PLUGIN_PACKAGE, boring: {} }))
+
+  // Somewhere with no node_modules at all — the pre-fix cwd-only anchor.
+  const elsewhere = await mkdtemp(join(tmpdir(), 'boring-core-cwd-'))
+  process.chdir(elsewhere)
+
+  mocks.collectWorkspaceAgentServerPlugins.mockReturnValue({
+    runtimePlugins: [],
+    agentOptions: { extraTools: [], pi: {}, systemPromptAppend: undefined },
+    preservedUiStateKeys: [],
+    routeContributions: [],
+  })
+  // The harness mocks this module, so reach for the real resolver explicitly.
+  const { resolveDefaultWorkspacePluginPackagePaths } = await vi.importActual<
+    typeof import('@hachej/boring-workspace/app/server')
+  >('@hachej/boring-workspace/app/server')
+  mocks.resolveDefaultWorkspacePluginPackagePaths.mockImplementation(
+    resolveDefaultWorkspacePluginPackagePaths as (options: unknown) => string[],
+  )
+
+  const { createCoreWorkspaceAgentServer } = await import('../createCoreWorkspaceAgentServer.js')
+  const app = await createCoreWorkspaceAgentServer({
+    config: createTestCoreConfig({
+      defaultAgentTypeId: 'general',
+      stores: 'postgres',
+      databaseUrl: 'postgres://test',
+    }),
+    agents: [{ agentTypeId: 'general', definition: { label: 'General', instructions: 'Answer.' } }],
+    appRoot,
+    defaultPluginPackages: [PLUGIN_PACKAGE],
+    workspaceRoot: join(elsewhere, 'workspaces'),
+    serveFrontend: false,
+  })
+  try {
+    expect(mocks.resolveDefaultWorkspacePluginPackagePaths).toHaveBeenCalledWith(
+      expect.objectContaining({ anchorDir: appRoot, defaultPluginPackages: [PLUGIN_PACKAGE] }),
+    )
+    expect(mocks.resolveDefaultWorkspacePluginPackagePaths).toHaveReturnedWith([packageDir])
+  } finally {
+    await app.close()
+  }
+}, 30_000)

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.testHarness.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.testHarness.ts
@@ -38,6 +38,12 @@ export const mocks = (() => {
     createDatabase,
     provisionWorkspaceRuntime: vi.fn(async () => ({ changed: false, env: {}, pathEntries: [], skillPaths: [] })),
     collectWorkspaceAgentServerPlugins: vi.fn(),
+    // Delegates to the real resolver (installed below) so boot-time plugin
+    // package resolution — including the anchorDir the host passes — is
+    // exercised for real, while staying observable from tests.
+    resolveDefaultWorkspacePluginPackagePaths: vi.fn<
+      (options: unknown) => string[]
+    >(() => []),
     createWorkspaceUiTools: vi.fn(() => []),
     isMember: vi.fn(async (_workspaceId: string, _userId: string) => true),
     getWorkspace: vi.fn(async (id: string): Promise<{
@@ -97,7 +103,7 @@ vi.doMock('@hachej/boring-workspace/app/server', async (importOriginal) => {
       systemPromptAppend: undefined,
     }),
     readWorkspacePluginPackageRuntimePlugins: () => [],
-    resolveDefaultWorkspacePluginPackagePaths: () => [],
+    resolveDefaultWorkspacePluginPackagePaths: mocks.resolveDefaultWorkspacePluginPackagePaths,
     resolveOnePluginEntry: async (entry: unknown, context: unknown) => {
       pluginContexts.push(context)
       return entry
@@ -193,6 +199,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   pluginContexts.length = 0
   mocks.provisionWorkspaceRuntime.mockResolvedValue({ changed: false, env: {}, pathEntries: [], skillPaths: [] })
+  mocks.resolveDefaultWorkspacePluginPackagePaths.mockImplementation(() => [])
   mocks.acquireEnvironment.mockReset()
   mocks.hostRunWithWorkspaceAgent.mockClear()
   mocks.gatewayReadSessionState.mockClear()

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -1179,6 +1179,10 @@ export async function createCoreWorkspaceAgentServer(
   const defaultPluginPackagePaths = resolveDefaultWorkspacePluginPackagePaths({
     workspaceRoot: pluginWorkspaceRoot,
     defaultPluginPackages: options.defaultPluginPackages,
+    // Anchor npm-name resolution on the host app's own root so plugin
+    // packages resolve through the app's node_modules regardless of the
+    // process cwd (production hosts often chdir before boot).
+    anchorDir: appRoot,
   })
   const defaultPackagePiSnapshot = readWorkspacePluginPackagePiSnapshot(defaultPluginPackagePaths)
   const defaultPackageRuntimePlugins = readWorkspacePluginPackageRuntimePlugins(defaultPluginPackagePaths)

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/__tests__/hooks.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/__tests__/hooks.test.tsx
@@ -13,6 +13,7 @@ import {
   useDeleteFile,
 } from "../hooks"
 import { FetchError } from "../fetchClient"
+import { setPreloadedTreeEntries } from "../treePreloadCache"
 import { events } from "../../../../../front/events"
 import { filesystemEvents } from "../../../shared/events"
 
@@ -43,6 +44,7 @@ function wrapper({ children }: { children: ReactNode }) {
 }
 
 beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true })
   queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   })
@@ -155,6 +157,36 @@ describe("useFileList", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
     expect(result.current.data).toEqual(entries)
     expect(mockClient.getTree).toHaveBeenCalledWith("/", expect.any(AbortSignal))
+  })
+
+  it("refetches when the seeded preload snapshot is older than the stale window", async () => {
+    // Regression: a workspace round-trip remounts the tree pane, which reseeds
+    // itself from the boot-time preload. Dating that snapshot as "just
+    // fetched" left the pane showing the old listing forever — a file created
+    // in the meantime only appeared after a manual refresh.
+    const stale = [{ name: "alpha.md", kind: "file" as const, path: "alpha.md" }]
+    const fresh = [...stale, { name: "notes.md", kind: "file" as const, path: "notes.md" }]
+    setPreloadedTreeEntries(TEST_BASE, TEST_WORKSPACE_ID, ".", stale)
+    vi.setSystemTime(new Date(Date.now() + 60_000))
+    mockClient.getTree.mockResolvedValue(fresh)
+
+    const { result } = renderHook(() => useFileList("."), { wrapper })
+
+    expect(result.current.data).toEqual(stale)
+    await waitFor(() => expect(result.current.data).toEqual(fresh))
+    expect(mockClient.getTree).toHaveBeenCalledWith(".", expect.any(AbortSignal))
+  })
+
+  it("serves a just-captured preload without refetching", async () => {
+    const entries = [{ name: "alpha.md", kind: "file" as const, path: "alpha.md" }]
+    setPreloadedTreeEntries(TEST_BASE, TEST_WORKSPACE_ID, "fresh-dir", entries)
+    mockClient.getTree.mockResolvedValue([])
+
+    const { result } = renderHook(() => useFileList("fresh-dir"), { wrapper })
+
+    expect(result.current.data).toEqual(entries)
+    await waitFor(() => expect(result.current.isFetching).toBe(false))
+    expect(mockClient.getTree).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/hooks.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/hooks.ts
@@ -9,7 +9,7 @@ import {
 import { useRef, useState, useEffect } from "react"
 import { useDataClient, useApiBaseUrl, useWorkspaceRequestId } from "./DataProvider"
 import { FetchError } from "./fetchClient"
-import { getPreloadedTreeEntries } from "./treePreloadCache"
+import { getPreloadedTreeEntries, getPreloadedTreeUpdatedAt } from "./treePreloadCache"
 import { events, userMeta } from "../../../../front/events"
 import { filesystemEvents } from "../../shared/events"
 import { FILES_QUERY_KEY_SEGMENT } from "../../shared/constants"
@@ -68,6 +68,11 @@ export function useFileList(dir: string | null, filesystem?: FilesystemId): UseQ
     enabled: dir != null,
     staleTime: 3_000,
     initialData: () => fs === "user" ? getPreloadedTreeEntries(base, workspaceId, dir) : undefined,
+    // Date the seeded snapshot from when it was actually captured. Otherwise
+    // React Query stamps it "just fetched" on every mount, so a pane that
+    // remounts after a workspace round-trip keeps serving the boot-time tree
+    // and never refetches.
+    initialDataUpdatedAt: () => fs === "user" ? getPreloadedTreeUpdatedAt(base, workspaceId, dir) : undefined,
     // File-event SSE invalidates this query when files change. Polling every
     // 3s made slow/dev backends self-abort before the first tree response,
     // leaving the workbench tree stuck on its skeleton.

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/index.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/index.ts
@@ -21,6 +21,7 @@ export {
 } from "./hooks"
 export {
   getPreloadedTreeEntries,
+  getPreloadedTreeUpdatedAt,
   setPreloadedTreeEntries,
 } from "./treePreloadCache"
 export type { FileEntry, FileContent, FileStat, FetchClientOptions, GitUrlMetadata } from "./types"

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/treePreloadCache.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/treePreloadCache.ts
@@ -1,6 +1,12 @@
 import type { FileEntry } from "./types"
 
-const preloadedTrees = new Map<string, FileEntry[]>()
+interface PreloadedTree {
+  entries: FileEntry[]
+  /** When the snapshot was taken, so consumers can judge its age. */
+  updatedAt: number
+}
+
+const preloadedTrees = new Map<string, PreloadedTree>()
 
 function normalizeBase(apiBaseUrl: string | null | undefined): string {
   return (apiBaseUrl ?? "").replace(/\/$/, "")
@@ -20,7 +26,7 @@ export function setPreloadedTreeEntries(
   dir: string | null | undefined,
   entries: FileEntry[],
 ): void {
-  preloadedTrees.set(treeKey(apiBaseUrl, workspaceId, dir), entries)
+  preloadedTrees.set(treeKey(apiBaseUrl, workspaceId, dir), { entries, updatedAt: Date.now() })
 }
 
 export function getPreloadedTreeEntries(
@@ -28,5 +34,18 @@ export function getPreloadedTreeEntries(
   workspaceId: string | null | undefined,
   dir: string | null | undefined,
 ): FileEntry[] | undefined {
-  return preloadedTrees.get(treeKey(apiBaseUrl, workspaceId, dir))
+  return preloadedTrees.get(treeKey(apiBaseUrl, workspaceId, dir))?.entries
+}
+
+/**
+ * Age of the cached snapshot, for seeding a query's `initialDataUpdatedAt`.
+ * Without it a preload is treated as freshly fetched every time it is read,
+ * so a remount long after boot never refetches and shows a stale tree.
+ */
+export function getPreloadedTreeUpdatedAt(
+  apiBaseUrl: string | null | undefined,
+  workspaceId: string | null | undefined,
+  dir: string | null | undefined,
+): number | undefined {
+  return preloadedTrees.get(treeKey(apiBaseUrl, workspaceId, dir))?.updatedAt
 }


### PR DESCRIPTION
Found by the pre-release smoke sweep. The full-app Playwright suite could not even boot on main; after these fixes it is 12/12 green (12.7m).

**App bug 1 — production boot fails from any cwd outside the app dir:** `createCoreWorkspaceAgentServer` anchored default plugin package resolution on `process.cwd()` only, so `node dist/server/main.js` from a foreign cwd threw `defaultPluginPackages: cannot resolve "@hachej/boring-automation"`. This can bite real self-host deploys (the scaffold from the same window added the production gate that exposed it). Fix: pass `anchorDir: appRoot`, matching the workspace-package path. New regression test boots with `process.chdir()` into an empty temp dir and fails without the fix.

**App bug 2 — file tree serves a stale boot preload:** `useFileList` seeds `initialData` from the tree preload cache, and React Query dates seeded data "just fetched", so with `staleTime: 3_000` a pane remounting after a workspace round-trip never refetched — files created in another workspace stayed invisible until manual Refresh. Fix: stamp preloads with capture time and pass `initialDataUpdatedAt`. Regression unit test fails without the fix; workspace suite 475 passed.

**Harness revival (test-only):** set `BORING_ALLOW_UNSAFE_AGENT_MODE=1` for the e2e webServer (the #8cef449a1 production gate's own escape hatch), raise the webServer timeout to 30min (CI doesn't run this suite; the dep build alone exceeds 360s), write the `[features]` TOML where `main.ts` actually reads it (child-process server so the restore trap fires; refuses to run on a dirty `[features]`), and refresh mocks/selectors that drifted (#1402 meta preload, #1362 workbench rename, zod email validation, session title shape).

**Known repo-wide side issue (not from this branch):** `build-app.mts` runs `tsc --noCheck` with inherited `paths` mapping to package `src/*.ts`, emitting ~113 stray `.js` files next to sources on every full-app build. Worth its own bead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nbr3nZ3vKYUX8JkLWkGBpB