### PR TITLE
#1511 Refresh Files roots when addressed Agent changes

### DIFF
--- a/packages/workspace/src/plugins/filesystemPlugin/front/FilesystemRootsBinding.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/FilesystemRootsBinding.tsx
@@ -27,9 +27,12 @@ export interface FilesystemRootsBindingProps {
   children: ReactNode
 }
 
-function FilesystemRootsRequest({ children }: { children: ReactNode }) {
+function FilesystemRootsRequest({ requestKey, children }: FilesystemRootsBindingProps) {
   const client = useDataClient()
-  const [roots, setRoots] = useState<readonly FileTreeRootConfig[]>([PRIMARY_ROOT])
+  const [snapshot, setSnapshot] = useState<{
+    requestKey: string
+    roots: readonly FileTreeRootConfig[]
+  }>({ requestKey, roots: [PRIMARY_ROOT] })
 
   useEffect(() => {
     const controller = new AbortController()
@@ -37,25 +40,29 @@ function FilesystemRootsRequest({ children }: { children: ReactNode }) {
     void client.getFilesystems(controller.signal)
       .then((filesystems) => {
         if (controller.signal.aborted || !filesystems.some((entry) => entry.filesystem === "user")) return
-        setRoots(filesystems.map((entry) => ({
-          filesystem: entry.filesystem,
-          label: entry.label,
-          rootDir: entry.rootDir,
-          access: entry.access,
-          capabilities: entry.capabilities,
-        })))
+        setSnapshot({
+          requestKey,
+          roots: filesystems.map((entry) => ({
+            filesystem: entry.filesystem,
+            label: entry.label,
+            rootDir: entry.rootDir,
+            access: entry.access,
+            capabilities: entry.capabilities,
+          })),
+        })
       })
       .catch(() => {
         if (!controller.signal.aborted) console.error("Failed to load filesystem catalog")
       })
 
     return () => controller.abort()
-  }, [client])
+  }, [client, requestKey])
 
+  const roots = snapshot.requestKey === requestKey ? snapshot.roots : [PRIMARY_ROOT]
   return <FileTreeRootsProvider roots={roots}>{children}</FileTreeRootsProvider>
 }
 
 /** Loads request-visible roots from the server and fails closed to Workspace. */
 export function FilesystemRootsBinding({ requestKey, children }: FilesystemRootsBindingProps) {
-  return <FilesystemRootsRequest key={requestKey}>{children}</FilesystemRootsRequest>
+  return <FilesystemRootsRequest requestKey={requestKey}>{children}</FilesystemRootsRequest>
 }

--- a/packages/workspace/src/plugins/filesystemPlugin/front/__tests__/FilesystemDataProvider.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/__tests__/FilesystemDataProvider.test.tsx
@@ -1,4 +1,5 @@
 import { act, render, screen, waitFor } from "@testing-library/react"
+import { useState } from "react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { WorkspaceProvider } from "../../../../front/provider/WorkspaceProvider"
 import { useFileTreeRoots } from "../file-tree/FileTreeRootsProvider"
@@ -10,12 +11,18 @@ function Probe() {
   return <div data-testid="roots">{roots.map((root) => root.filesystem).join(",")}</div>
 }
 
+let probeInstances = 0
+function StableProbe() {
+  const [instance] = useState(() => ++probeInstances)
+  return <><Probe /><div data-testid="probe-instance">{instance}</div></>
+}
+
 afterEach(() => {
   vi.restoreAllMocks()
   vi.unstubAllGlobals()
 })
 
-describe("filesystem data provider auth snapshots", () => {
+describe("filesystem data provider request scope", () => {
   it("snapshots in-place header mutations with the auth scope request key", async () => {
     let resolveSecond!: (response: Response) => void
     let catalogCalls = 0
@@ -54,5 +61,39 @@ describe("filesystem data provider auth snapshots", () => {
     await act(async () => resolveSecond(new Response(JSON.stringify({ filesystems: [
       { filesystem: "user", label: "Workspace", rootDir: ".", access: "readwrite", capabilities: { ...capabilities, write: true, delete: true, move: true, mkdir: true } },
     ] }), { status: 200 })))
+  })
+
+  it("reloads roots without remounting the workspace when the addressed Agent changes after enrollment", async () => {
+    probeInstances = 0
+    let catalogCalls = 0
+    const fetchMock = vi.fn<typeof fetch>(async (input) => {
+      if (!String(input).endsWith("/api/v1/filesystems")) {
+        return new Response(JSON.stringify({ entries: [] }), { status: 200 })
+      }
+      catalogCalls += 1
+      const filesystems = [
+        { filesystem: "user", label: "Workspace", rootDir: ".", access: "readwrite", capabilities: { ...capabilities, write: true, delete: true, move: true, mkdir: true } },
+        ...(catalogCalls === 1 ? [] : [
+          { filesystem: "agent_knowledge:charlotteledoux", label: "Charlotte Ledoux", rootDir: "/", access: "readonly", capabilities },
+        ]),
+      ]
+      return new Response(JSON.stringify({ filesystems }), { status: 200 })
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    const renderWorkspace = (agentTypeId: string) => (
+      <WorkspaceProvider agentTypeId={agentTypeId} persistenceEnabled={false}>
+        <StableProbe />
+      </WorkspaceProvider>
+    )
+    const { rerender } = render(renderWorkspace("dummy"))
+    await waitFor(() => expect(catalogCalls).toBe(1))
+    expect(screen.getByTestId("roots")).toHaveTextContent("user")
+
+    rerender(renderWorkspace("charlotteledoux"))
+
+    await waitFor(() => expect(catalogCalls).toBe(2))
+    await waitFor(() => expect(screen.getByTestId("roots")).toHaveTextContent("agent_knowledge:charlotteledoux"))
+    expect(screen.getByTestId("probe-instance")).toHaveTextContent("1")
   })
 })

--- a/packages/workspace/src/plugins/filesystemPlugin/front/index.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/index.ts
@@ -55,6 +55,7 @@ export {
 export type { UseFilePaneOptions, UseFilePaneReturn } from "./useFilePane"
 export type { UseAutoOpenAgentFilesOptions } from "./agentFileBridge"
 function FilesystemDataProvider({
+  agentTypeId,
   apiBaseUrl,
   authHeaders,
   authScopeKey,
@@ -71,7 +72,7 @@ function FilesystemDataProvider({
       onAuthError,
       timeout: apiTimeout,
       children: createElement(FilesystemRootsBinding, {
-        requestKey: `${apiBaseUrl}\n${headersKey}\n${authScopeKey ?? ""}`,
+        requestKey: `${apiBaseUrl}\n${headersKey}\n${authScopeKey ?? ""}\n${agentTypeId}`,
         children,
       }),
     },


### PR DESCRIPTION
Closes #1511.

## What changed

- include the addressed Agent identity in the filesystem catalog request scope;
- fail closed to Workspace and reload `/api/v1/filesystems` when enrollment/selection changes the addressed Agent;
- add a real `WorkspaceProvider` regression for `dummy` → `charlotteledoux` exposing `agent_knowledge:charlotteledoux`.

## Proof

- `pnpm --filter @hachej/boring-workspace exec vitest run src/plugins/filesystemPlugin/front/__tests__/FilesystemDataProvider.test.tsx` — 2/2 passed
- `pnpm --filter @hachej/boring-workspace typecheck` — passed
- `pnpm --filter '@hachej/boring-workspace...' --workspace-concurrency=1 build` — passed
- full Workspace test run: 2,280 passed, 11 skipped, 8 failures from unrelated timing/state-sensitive suites under concurrent validation; focused regression is green and CI will rerun the canonical matrix.

## Production signature

Seneca production logs showed Charlotte addressed command traffic in the affected workspace, repeated default `GET /api/v1/tree?path=.` calls, and no refreshed `GET /api/v1/filesystems` after enrollment. The existing request key omitted the Agent identity even though `WorkspaceProvider` already supplies it.
