### PR TITLE
#1519 Bypass caches for filesystem catalogs

### DIFF
--- a/packages/boring-bash/src/server/routes/filesystems.test.ts
+++ b/packages/boring-bash/src/server/routes/filesystems.test.ts
@@ -31,6 +31,7 @@ describe('filesystemsRoutes', () => {
     const response = await app.inject({ method: 'GET', url: '/api/v1/filesystems' })
 
     expect(response.statusCode).toBe(200)
+    expect(response.headers['cache-control']).toBe('private, no-store')
     expect(response.json()).toEqual({
       filesystems: [{
         filesystem: 'user',

--- a/packages/boring-bash/src/server/routes/filesystems.ts
+++ b/packages/boring-bash/src/server/routes/filesystems.ts
@@ -86,6 +86,7 @@ export function filesystemsRoutes(
   done: (err?: Error) => void,
 ): void {
   app.get('/api/v1/filesystems', async (request, reply) => {
+    reply.header('Cache-Control', 'private, no-store')
     try {
       const bindings = opts.getFilesystemBindings
         ? await opts.getFilesystemBindings(request) ?? []

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/__tests__/fetchClient.catalog.test.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/__tests__/fetchClient.catalog.test.ts
@@ -31,7 +31,7 @@ describe("FetchClient filesystem catalog", () => {
     ]))
     expect(fetchMock).toHaveBeenCalledWith(
       "https://example.test/api/v1/filesystems",
-      expect.objectContaining({ method: "GET", credentials: "include", signal: expect.any(AbortSignal), headers: { Authorization: "Bearer token" } }),
+      expect.objectContaining({ method: "GET", credentials: "include", cache: "no-store", signal: expect.any(AbortSignal), headers: { Authorization: "Bearer token" } }),
     )
   })
 

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/fetchClient.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/fetchClient.ts
@@ -73,6 +73,7 @@ export class FetchClient {
     parseResponse: (response: Response) => Promise<T> = async (response) => await response.json() as T,
     credentials?: RequestCredentials,
     maxRetries = this.maxRetries,
+    cache?: RequestCache,
   ): Promise<T> {
     const effectiveTimeout = requestTimeout ?? this.timeout
     let lastError: Error | null = null
@@ -97,6 +98,7 @@ export class FetchClient {
           body: hasBody ? JSON.stringify(body) : undefined,
           signal: controller.signal,
           ...(credentials ? { credentials } : {}),
+          ...(cache ? { cache } : {}),
         })
 
         clearTimeout(timer)
@@ -163,6 +165,7 @@ export class FetchClient {
       async (response) => parseFilesystemCatalog(await response.json()),
       "include",
       0,
+      "no-store",
     )
   }
 


### PR DESCRIPTION
Closes #1519.\n\nFilesystem catalogs are authorization- and addressed-scope-sensitive dynamic data. Request them with `cache: no-store` and emit `Cache-Control: private, no-store` from the route so stale Workspace-only catalogs cannot hide newly enrolled Agent roots.\n\nProof: 8 focused tests; Workspace and boring-bash typechecks; package build.