### PR TITLE
test(cli): give CLI integration cases a 30s budget

### DIFF
--- a/packages/cli/src/__tests__/cli.integration.test.ts
+++ b/packages/cli/src/__tests__/cli.integration.test.ts
@@ -6,7 +6,10 @@ import { dirname, join, resolve } from "node:path"
 import { promisify } from "node:util"
 import { fileURLToPath } from "node:url"
 import fastify from "fastify"
-import { afterEach, beforeAll, expect, test } from "vitest"
+import { afterEach, beforeAll, expect, test, vi } from "vitest"
+
+// Each case spawns the built CLI (~5s cold on CI runners); the default 5s budget is a coin flip.
+vi.setConfig({ testTimeout: 30_000 })
 import { registerStatic } from "../server/cli.js"
 
 const execFile = promisify(execFileCallback)
@@ -199,7 +202,7 @@ test.each([
     },
   })
   expect(failure.stderr).not.toMatch(/shell\.read|workspace-ready|triage|linear/)
-})
+}, 30_000)
 
 
 test("boring-ui agent validate accepts empty legacy selector arrays but omits them from output", async () => {

--- a/packages/cli/src/__tests__/cli.integration.test.ts
+++ b/packages/cli/src/__tests__/cli.integration.test.ts
@@ -8,9 +8,10 @@ import { fileURLToPath } from "node:url"
 import fastify from "fastify"
 import { afterEach, beforeAll, expect, test, vi } from "vitest"
 
+import { registerStatic } from "../server/cli.js"
+
 // Each case spawns the built CLI (~5s cold on CI runners); the default 5s budget is a coin flip.
 vi.setConfig({ testTimeout: 30_000 })
-import { registerStatic } from "../server/cli.js"
 
 const execFile = promisify(execFileCallback)
 const testDir = dirname(fileURLToPath(import.meta.url))


### PR DESCRIPTION
The four parametrised `agent validate rejects non-empty legacy … selectors` cases spawn the built CLI, which takes ~5s cold on CI runners, so they sat on the default 5s test timeout and flipped between pass and fail (seen on #1510 and #1523). Sets a 30s budget for this integration file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R23RBDNgQ5YWVbY5dHvTkq