### PR TITLE
fix(agent): serialize event-stream meta table creation under the migration lock

### DIFF
--- a/packages/agent/src/server/events/schemaVersion.ts
+++ b/packages/agent/src/server/events/schemaVersion.ts
@@ -72,18 +72,18 @@ export function assertSupportedEventStreamSchemaVersion(
 }
 
 export function migrateEventStreamSqlSchema(sql: SqlStorage, options: MigrationOptions): void {
-  sql.exec(`
-    CREATE TABLE IF NOT EXISTS boring_event_stream_meta (
-      key TEXT PRIMARY KEY,
-      value TEXT NOT NULL
-    )
-  `)
-
   const priorBusyTimeout = Number(sql.exec('PRAGMA busy_timeout').toArray()[0]?.timeout ?? 0)
   sql.exec(`PRAGMA busy_timeout=${MIGRATION_BUSY_TIMEOUT_MS}`)
   let collisionCounts: Record<CollisionClass, number> | undefined
   try {
     collisionCounts = options.runTransaction(() => {
+      sql.exec(`
+        CREATE TABLE IF NOT EXISTS boring_event_stream_meta (
+          key TEXT PRIMARY KEY,
+          value TEXT NOT NULL
+        )
+      `)
+
       const stored = readStoredVersion(sql)
       if (stored === String(BORING_EVENT_STREAM_SCHEMA_VERSION)) {
         options.ensureCurrentSchema()


### PR DESCRIPTION
Flaky CI: `schemaVersion.migration.test.ts > lets concurrent production opens initialize one shared fresh file` failed with `database is locked` on #1514 and on #1523's first run. Root cause: `boring_event_stream_meta` was created before the migration's 5s busy timeout and `BEGIN IMMEDIATE`, so concurrent opens raced under the connection's 25ms timeout. The DDL now runs inside the serialized migration transaction. No test changed. Targeted test loop 10/10; invariants pass.

Executor: pi + gpt-5.6-sol (high reasoning); orchestrated and reviewed by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R23RBDNgQ5YWVbY5dHvTkq