### PR TITLE
test(boring-factory): 30s test budget for process-spawning tests

### DIFF
--- a/plugins/boring-factory/vitest.config.ts
+++ b/plugins/boring-factory/vitest.config.ts
@@ -2,6 +2,8 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
+    // Sandbox and packaging tests spawn processes; CI runners need more than the 5s default.
+    testTimeout: 30_000,
     environment: 'node',
   },
 })


### PR DESCRIPTION
`sandboxComposition.test.ts > createPerEpicVercelProvider > lazily resolves the epic snapshot on create()` took 6.8s on a CI runner against the 5s default and failed #1526's run. The plugin's sandbox and packaging tests spawn git/pnpm processes; a 30s budget matches the CLI integration fix (#1525).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R23RBDNgQ5YWVbY5dHvTkq