### PR TITLE
fix(boring-factory): seat models never inherit the sandbox provider name

### DIFF
--- a/apps/factory-playground/src/server/app.ts
+++ b/apps/factory-playground/src/server/app.ts
@@ -23,6 +23,11 @@ export async function createFactoryPlayground(options: CreateFactoryPlaygroundOp
     epicKey,
     stateRoot,
     env,
+    models: {
+      orchestrator: env.BORING_FACTORY_ORCHESTRATOR_MODEL,
+      worker: env.BORING_FACTORY_WORKER_MODEL,
+      reviewer: env.BORING_FACTORY_REVIEWER_MODEL,
+    },
     provider: env.BORING_FACTORY_SANDBOX_PROVIDER,
     logger: options.logger,
   })

--- a/apps/factory-playground/src/server/factoryHost.ts
+++ b/apps/factory-playground/src/server/factoryHost.ts
@@ -56,6 +56,7 @@ export async function startFactoryHost(options: StartFactoryHostOptions) {
     featureName: registration.featureName,
     stateRoot,
     env: hostEnv,
+    models: registration.models,
     provider: registration.provider,
     logger: options.logger,
   })

--- a/plugins/boring-factory/src/server/host/index.test.ts
+++ b/plugins/boring-factory/src/server/host/index.test.ts
@@ -1,0 +1,46 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createFactoryHost } from './index'
+
+const repositoryRoot = resolve(import.meta.dirname, '../../../../..')
+const temporaryRoots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(temporaryRoots.splice(0).map(async (root) => await rm(root, { recursive: true, force: true })))
+})
+
+describe('factory host composition', () => {
+  it('keeps sandbox provider selection separate from seat model preferences', async () => {
+    const stateRoot = await mkdtemp(resolve(tmpdir(), 'factory-host-models-'))
+    temporaryRoots.push(stateRoot)
+    const env = {
+      BORING_FACTORY_ORCHESTRATOR_MODEL: 'orchestrator-from-env',
+      BORING_FACTORY_WORKER_MODEL: 'worker-from-env',
+      BORING_FACTORY_REVIEWER_MODEL: 'reviewer-from-env',
+    } as NodeJS.ProcessEnv
+
+    const host = await createFactoryHost({
+      repositoryRoot,
+      workspaceRoot: repositoryRoot,
+      epicKey: 'seat-model-proof',
+      featureName: 'Seat Model Proof',
+      stateRoot,
+      env,
+      provider: 'local-simulation',
+    })
+
+    try {
+      const preferredModels = host.agents.map((agent) => agent.model?.preferred)
+      expect(preferredModels).toEqual([
+        env.BORING_FACTORY_ORCHESTRATOR_MODEL,
+        env.BORING_FACTORY_WORKER_MODEL,
+        env.BORING_FACTORY_REVIEWER_MODEL,
+      ])
+      expect(preferredModels).not.toContain('local-simulation')
+    } finally {
+      host.close()
+    }
+  })
+})

--- a/plugins/boring-factory/src/server/host/index.ts
+++ b/plugins/boring-factory/src/server/host/index.ts
@@ -24,6 +24,11 @@ export interface CreateFactoryHostOptions {
   readonly featureName?: string
   readonly stateRoot: string
   readonly env?: NodeJS.ProcessEnv
+  readonly models?: {
+    readonly orchestrator?: string
+    readonly worker?: string
+    readonly reviewer?: string
+  }
   readonly provider?: string
   readonly appRoot?: string
   readonly logger?: boolean
@@ -50,9 +55,9 @@ export async function createFactoryHost(options: CreateFactoryHostOptions): Prom
   await mkdir(stateRoot, { recursive: true })
 
   const agents = await loadNativeFactoryFleet(options.repositoryRoot, {
-    orchestrator: options.provider ?? env.BORING_FACTORY_ORCHESTRATOR_MODEL,
-    worker: options.provider ?? env.BORING_FACTORY_WORKER_MODEL,
-    reviewer: options.provider ?? env.BORING_FACTORY_REVIEWER_MODEL,
+    orchestrator: options.models?.orchestrator ?? env.BORING_FACTORY_ORCHESTRATOR_MODEL,
+    worker: options.models?.worker ?? env.BORING_FACTORY_WORKER_MODEL,
+    reviewer: options.models?.reviewer ?? env.BORING_FACTORY_REVIEWER_MODEL,
     epicKey: options.epicKey,
     featureName,
   })


### PR DESCRIPTION
`createFactoryHost` resolved each seat model as `options.provider ?? env.BORING_FACTORY_*_MODEL`; the playground passes the sandbox provider (`local-simulation`) as `provider`, so every seat's preferred model became that string and prompts failed closed. Models are now explicit `models` options with env fallbacks; `provider` stays sandbox-only. Regression test added; plugin build, playground typecheck and tests green.

Executor: pi + gpt-5.6-sol (high); orchestrated and reviewed by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R23RBDNgQ5YWVbY5dHvTkq