### PR TITLE
[Factory Limits] Host-enforced stale claims, dispatch caps, review-round caps and plan budget

### DIFF
--- a/apps/factory-playground/scripts/live-epic-recovery.mjs
+++ b/apps/factory-playground/scripts/live-epic-recovery.mjs
@@ -49,7 +49,7 @@ try {
   const supervision = JSON.parse(await readFile(resolve(STATE_ROOT, 'supervision.json'), 'utf8')).entries?.[osid]
   if (!supervision) throw new Error('supervision entry not persisted'); phase('supervision-armed', { intervalMs: supervision.intervalMs })
 
-  await prompt('boring-orchestrator', osid, `Dispatch exactly one Worker now with dispatch_worker. Brief: epic ${EPIC}, shared worktree, pull protocol (br ready --label epic:${EPIC} --unassigned; claim one with --claim --actor <session id>), implement + stage only intended files + commit on the epic branch, exact-SHA dedicated sandbox test (verify .factory-sha or git rev-parse HEAD), adversarial fresh_review, complete handoff on the Bead, push the epic branch, never merge or close. Do not name a specific Bead.`)
+  await prompt('boring-orchestrator', osid, `Read the exact ready Bead id with br ready --label epic:${EPIC} --unassigned, then dispatch exactly one Worker with dispatch_worker using that id as beadId and naming it in the brief. Brief: epic ${EPIC}, shared worktree, verify the named Bead is ready and claim it with --claim --actor <session id>, implement + stage only intended files + commit on the epic branch, exact-SHA dedicated sandbox test (verify .factory-sha or git rev-parse HEAD), adversarial fresh_review, complete handoff on the Bead, push the epic branch, never merge or close.`)
   // Wait until a Worker exists and has claimed the Bead (assignee set), then crash the API.
   let claimed
   for (let i = 0; i < 200; i++) { const beads = await br(['list', '--label', `epic:${EPIC}`]); claimed = beads.find(b => b.assignee && b.status === 'in_progress'); if (claimed) break; await new Promise(r => setTimeout(r, 3000)) }

--- a/apps/factory-playground/src/server/factoryComposition.test.ts
+++ b/apps/factory-playground/src/server/factoryComposition.test.ts
@@ -34,7 +34,7 @@ const SESSION_BINDINGS: FactorySessionBindings = {
   inherit: async () => EPIC_KEY,
   reconcile: async () => ({ droppedSessionIds: [], restoredOrchestratorSessionIds: [] }),
 }
-const DELEGATE_OPTIONS = { workspaceScopeId: WORKSPACE_SCOPE_ID, registry: EPIC_REGISTRY, sessionBindings: SESSION_BINDINGS }
+const DELEGATE_OPTIONS = { stateRoot: resolve(tmpdir(), 'factory-composition-delegate'), workspaceScopeId: WORKSPACE_SCOPE_ID, registry: EPIC_REGISTRY, sessionBindings: SESSION_BINDINGS }
 
 const appRoot = resolve(import.meta.dirname, '../..')
 const repositoryRoot = resolve(appRoot, '../..')
@@ -87,8 +87,8 @@ describe('native Factory composition', () => {
 
     // Recovery rule (epic-binding appendix, orchestrator).
     expect(orchestrator.definition.instructions).toContain('Recovery: run `factory_status` on every supervision tick.')
-    expect(orchestrator.definition.instructions).toContain('br update <id> --assignee "" --status open --actor <your session id>')
-    expect(orchestrator.definition.instructions).toContain('Never release a Bead whose assignee session is `exists-busy`.')
+    expect(orchestrator.definition.instructions).toContain('call the host\'s `recover_stale_claims` tool')
+    expect(orchestrator.definition.instructions).toContain('never release a busy claim')
 
     // Uncommitted-changes handoff rule (epic-binding appendix, worker).
     expect(worker.definition.instructions).toContain('If the shared worktree already holds uncommitted changes for your Bead from a previous')
@@ -180,7 +180,7 @@ describe('native Factory composition', () => {
       expect(names(workerTools)).not.toContain('factory_status')
       expect(names(orchestratorTools)).toContain('boring_automation')
       expect(names(orchestratorTools)).not.toContain('sandbox')
-      expect(names(orchestratorTools)).toEqual(expect.arrayContaining(['supervise', 'factory_status', 'dispatch_worker', 'demo_sandbox']))
+      expect(names(orchestratorTools)).toEqual(expect.arrayContaining(['supervise', 'factory_status', 'recover_stale_claims', 'dispatch_worker', 'demo_sandbox']))
     } finally {
       await app.close()
     }
@@ -265,10 +265,10 @@ describe('native Factory composition', () => {
 })
 
 describe('factory delegate plugin', () => {
-  it('grants dispatch_worker+factory_status to the orchestrator and fresh_review to the worker, and nothing to any other seat', () => {
+  it('grants dispatch_worker+factory_status+recovery to the orchestrator and fresh_review to the worker, and nothing to any other seat', () => {
     const { plugin } = createFactoryDelegatePlugin(DELEGATE_OPTIONS)
     expect(plugin.agentToolFactory?.({ agentTypeId: FACTORY_ORCHESTRATOR_AGENT_TYPE_ID }).map((tool) => tool.name))
-      .toEqual(['dispatch_worker', 'factory_status'])
+      .toEqual(['dispatch_worker', 'factory_status', 'recover_stale_claims'])
     expect(plugin.agentToolFactory?.({ agentTypeId: FACTORY_WORKER_AGENT_TYPE_ID }).map((tool) => tool.name))
       .toEqual(['fresh_review'])
     expect(plugin.agentToolFactory?.({ agentTypeId: FACTORY_REVIEWER_AGENT_TYPE_ID })).toEqual([])

--- a/docs/factory/RELIABILITY.md
+++ b/docs/factory/RELIABILITY.md
@@ -4,17 +4,42 @@ Status: implemented in the native Factory playground (`apps/factory-playground`)
 
 ## Durable truth
 
-The durable sources are the Bead graph (`br`), git (each epic branch, pushed after every commit), session transcripts (host-owned JSONL under the shared `BORING_AGENT_SESSION_ROOT`), the epic registry (`<stateRoot>/epics.json`), and session bindings (`<stateRoot>/session-bindings.json`). Everything else is a projection that the host rebuilds on boot. No agent context is trusted to remember anything; agents write durable facts down (Bead comments, commits) before they would need them.
+The durable sources are the Bead graph (`br`), git (each epic branch, pushed after every commit), session transcripts (host-owned JSONL under the shared `BORING_AGENT_SESSION_ROOT`), the epic registry (`<stateRoot>/epics.json`), session bindings (`<stateRoot>/session-bindings.json`), and host dispatch/review history (`<stateRoot>/dispatches.json`). Everything else is a projection that the host rebuilds on boot. No agent context is trusted to remember anything; agents write durable facts down (Bead comments, commits) before they would need them.
 
 ## Supervision is host-owned
 
-The Orchestrator does not keep timers. It calls the `supervise` tool (start/stop/status, 30s..60m). The host persists one epic-labelled entry per session (`<state>/supervision.json`), fires ticks, and skips a tick while the session is busy instead of queueing it. Adoption moves that entry to the new registry Orchestrator. On boot the host prunes every entry except the active registry Orchestrator with a matching binding, so an adopted-away session cannot be re-armed. A crash therefore costs at most one interval when the surviving registry state still owns a valid supervision entry. The stale-claim rule below is unchanged.
+The Orchestrator does not keep timers. It calls the `supervise` tool (start/stop/status, 30s..60m). The host persists one epic-labelled entry per session (`<state>/supervision.json`), fires ticks, and skips a tick while the session is busy instead of queueing it. Adoption moves that entry to the new registry Orchestrator. On boot the host prunes every entry except the active registry Orchestrator with a matching binding, so an adopted-away session cannot be re-armed. A crash therefore costs at most one interval when the surviving registry state still owns a valid supervision entry. The host-owned stale-claim rule is defined below.
 
 ## Claims and recovery
 
-`br` has no leases. A claim is `assignee=<worker session id>` + `in_progress`, made atomically with the Worker's own session id (the host states it in the dispatch brief). On every tick the Orchestrator reads `factory_status`, a host projection of the epic: Beads with assignee and session liveness (`none | unknown | exists-idle | exists-busy`), comment activity, and local/remote HEAD.
+`br` has no leases. A claim is `assignee=<worker session id>` + `in_progress`, made atomically with the Worker's own session id (the host states it in the dispatch brief). On every tick the Orchestrator reads `factory_status`, a host projection of the epic: Beads with assignee and session liveness (`missing | idle | busy`), comment/handoff activity, local/remote HEAD, and the host counters below.
 
-Stale claim rule: `in_progress` and the assignee session is `unknown` or `exists-idle` with no handoff comment and no new commit. Recovery is `br update <id> --assignee "" --status open`, a comment naming the old session, and a fresh `dispatch_worker`. A claim whose session is `exists-busy` is never released. A dead Worker's uncommitted edits stay in the shared worktree; the next Worker adopts what is correct and says so in its handoff. After a restart every session reads idle, so a Worker killed mid-turn is recovered by exactly this rule (proven: `live-epic-recovery.mjs`).
+Stale claim is a host fact. An `in_progress` claim with a missing assignee session is stale immediately. An idle assignee with no canonical, Bead-specific handoff comment is stale only after `BORING_FACTORY_STALE_IDLE_MS` (default `600000`, 10 minutes), measured from that session's last activity. `factory_status` returns `stale: true`, the reason, and `recoveryCommand: "recover_stale_claims"`. The Orchestrator calls that host tool; it re-reads the facts, releases every still-stale claim with `br update <id> --assignee "" --status open`, and adds a comment naming the dead session and reason. A busy claim is never released. A dead Worker's uncommitted edits stay in the shared worktree; the next Worker adopts what is correct and says so in its handoff.
+
+## Dispatch and review caps
+
+`dispatch_worker` resolves one exact target Bead from `beadId` or from the single
+epic Bead ID named in the brief. Before creating a child session it enforces:
+
+- `BORING_FACTORY_MAX_CONCURRENT_WORKERS` (default `2`) busy Workers per epic.
+- `BORING_FACTORY_MAX_DISPATCHES_PER_BEAD` (default `2`) admitted dispatches per Bead.
+
+At either cap the host creates no session, marks the target Bead `blocked`, adds a
+blocker comment, and tells the Orchestrator to raise an Inbox question with `ask_user`
+instead of retrying. Admission is serialized so concurrent calls cannot both pass the
+same check.
+
+`fresh_review` records rounds per `(epic, Bead)` when `beadId` is present, otherwise
+per persisted SHA lineage for the calling Worker. `BORING_FACTORY_MAX_REVIEW_ROUNDS`
+(default `4`) does not suppress the capped review: that review runs and returns
+`capReached: true` with instructions to hand off at the current SHA and file remaining
+findings as follow-up Beads instead of fixing forward again.
+
+Each dispatch/review record contains the epic, target, child session, timestamp, and
+latest outcome in atomically replaced `<stateRoot>/dispatches.json`. A restarted host
+reads the same file before admission. `factory_status` exposes `busyWorkers`,
+`dispatchesPerOpenBead`, and review rounds by Bead or SHA lineage, together with the
+active limits.
 
 ## Execution never blocks the editing machine
 
@@ -26,7 +51,15 @@ The base snapshot every lease boots from is **warm by default**: `pnpm --filter 
 
 ## Review is a rule, not a chair
 
-`fresh_review` starts a brand-new `boring-reviewer` session bound to one SHA and returns only its verdict and provenance (session, model, brief digest). The Worker records that provenance in the Bead handoff; a `request-changes` verdict is fixed and re-reviewed before handoff.
+`fresh_review` starts a brand-new `boring-reviewer` session bound to one SHA and returns its verdict, provenance (session, model, brief digest), round, and cap state. The Worker records that provenance in the Bead handoff; a `request-changes` verdict is fixed and re-reviewed before handoff until the host cap says to hand off and create follow-up Beads.
+
+## Gate 1 plan budget
+
+Intake persists a host deadline and the kickoff prints its exact timestamp: Gate 1 must
+be raised within `BORING_FACTORY_PLAN_BUDGET_MS` (default `1200000`, 20 minutes).
+When supervision is armed before Gate 1, the first idle tick at or after that deadline
+uses the prompt `raise Gate 1 now with what you have`. This is a nudge only; it never
+stops, aborts, or kills the Orchestrator.
 
 ## Skill precedence
 
@@ -37,7 +70,7 @@ The canonical `exec` and `owner-gate` blocks assume per-Bead PRs, push-after-com
 - Security confinement: the local provider isolates by routing only. Use the Vercel provider for untrusted execution.
 - Remote serving: the Vercel provider exposes no preview URL surface yet.
 - Concurrency: two Workers on one epic share the worktree without file reservations by owner ruling; collisions are resolved in place. Add reservations only if runs show collisions.
-- Quotas: model credit exhaustion surfaces as failed turns; the Orchestrator sees a stale claim and re-dispatches, which can loop. A per-epic dispatch budget is not implemented.
+- Provider quotas: model credit exhaustion still surfaces as failed turns. Host dispatch and review caps bound retries, but do not predict or replenish provider credit.
 
 ## Owner handoff: two Inbox gates
 
@@ -56,6 +89,6 @@ Running several work threads at once is `apps/factory-playground/scripts/factory
 
 - **One Factory Hub per machine**: one process, one sessions list, and one Inbox at workspace scope `factory-hub`. The host workspace is the canonical repository checkout; it is not an epic worktree.
 - **Epic isolation**: each registry entry carries its own repository root, worktree (`<repositoryRoot>/.worktrees/epic-<key>`), branch (`epic/<key>`), Orchestrator, child-session bindings, supervision record, demos, and sandbox snapshot. Multi-repository entries are represented by the schema but not accepted by the current launcher yet.
-- **State**: `<stateRoot>/epics.json` is the authoritative runtime epic registry and `<stateRoot>/session-bindings.json` maps every Factory session to its epic. Coupled mutations write the registry first and bindings second; each file is atomic. Supervision, demos, leases, and snapshots carry or key by the same epic key.
+- **State**: `<stateRoot>/epics.json` is the authoritative runtime epic registry, `<stateRoot>/session-bindings.json` maps every Factory session to its epic, and `<stateRoot>/dispatches.json` records dispatch/review admission and outcomes. Coupled registry/binding mutations write the registry first and bindings second; each state file is atomic. Supervision, limits, demos, leases, and snapshots carry or key by the same epic key.
 - **Recovery**: boot validates canonical registry paths, restores missing registry Orchestrator bindings, preserves child bindings to active epics, and drops/logs orphan bindings to missing or closed epics before any re-arm. It then prunes stale supervision, re-arms only matching registry Orchestrators, cleans expired demos, and warms active snapshots. The idempotent adopt endpoint reattaches shared sessions, transfers supervision, and safely copies native transcripts from the former per-epic session roots into the hub namespace; it rejects cross-epic binding collisions and preserves the legacy source files.
 - **Lifecycle**: `factory-epic.mjs hub up` starts the shared `5230` API / `5220` UI. `up` provisions and builds an epic worktree, then calls intake; `list` reads live facts from the host; `down` marks the entry closed and never deletes its worktree.

--- a/plugins/boring-factory/README.md
+++ b/plugins/boring-factory/README.md
@@ -41,9 +41,10 @@ import { createFactoryHost } from '@hachej/boring-factory/server'
 `{ agents, plugins, registry, sessionBindings, bind(app), rearm(), close() }` for trusted app
 composition. `workspaceRoot` is the canonical, read-mostly repository checkout. The host owns
 the persisted multi-epic registry (`<stateRoot>/epics.json`), session-to-epic bindings
-(`<stateRoot>/session-bindings.json`), seat specs and appendices, `dispatch_worker`,
-`fresh_review`, `factory_status`, durable supervision, `demo_sandbox`, and the Factory intake
-routes. The embedding app still owns the outer server and provider credentials/settings.
+(`<stateRoot>/session-bindings.json`), dispatch/review history
+(`<stateRoot>/dispatches.json`), seat specs and appendices, `dispatch_worker`, `fresh_review`,
+`factory_status`, `recover_stale_claims`, durable supervision, `demo_sandbox`, and the Factory
+intake routes. The embedding app still owns the outer server and provider credentials/settings.
 
 Every host uses the stable workspace scope `factory-hub`, giving all registered epics one
 sessions surface and one Inbox. Each tool resolves its epic from the calling session binding,
@@ -68,6 +69,32 @@ intake on boot and are logged as such; they are no longer host identity.
 
 Do not add the skill root as a global package default and do not infer authority from
 these authored files.
+
+## Host-enforced Factory limits
+
+The trusted host, rather than persona prose, enforces the Factory's recovery and retry
+limits:
+
+| Environment variable | Default | Host behavior |
+| --- | ---: | --- |
+| `BORING_FACTORY_STALE_IDLE_MS` | `600000` (10 min) | An in-progress claim whose assignee session is missing is stale immediately. An idle assignee with no canonical, Bead-specific handoff comment becomes stale after this duration, measured from the session's last activity. Busy claims are never stale. |
+| `BORING_FACTORY_MAX_CONCURRENT_WORKERS` | `2` | `dispatch_worker` refuses before session creation when this epic already has that many busy Workers. |
+| `BORING_FACTORY_MAX_DISPATCHES_PER_BEAD` | `2` | `dispatch_worker` refuses before session creation when the target Bead already has this many recorded dispatches. |
+| `BORING_FACTORY_MAX_REVIEW_ROUNDS` | `4` | `fresh_review` still runs at the cap, but returns `capReached: true` and directs the Worker to hand off at the current SHA and file remaining findings as follow-up Beads. |
+| `BORING_FACTORY_PLAN_BUDGET_MS` | `1200000` (20 min) | Intake persists a Gate 1 deadline and includes it in the kickoff. If supervision is armed and Gate 1 has not been raised by then, the next idle tick says `raise Gate 1 now with what you have`. It does not stop or kill the session. |
+
+`factory_status` reports each in-progress claim's session classification and `stale`
+flag, names `recover_stale_claims` as the recovery command, and returns the epic's
+busy-Worker, per-open-Bead dispatch, and review-round counters. Recovery re-reads live
+facts and releases only stale claims with `br update <id> --assignee "" --status open`,
+then adds a Bead comment naming the dead session and reason.
+
+Every admitted Worker dispatch and review round is written atomically to
+`dispatches.json` with its epic, target, child session, timestamp, and latest outcome.
+The file is read on every admission/status decision, so caps survive host restarts. At
+either dispatch cap the target Bead is marked `blocked`, a blocker comment is added,
+and the refusal tells the Orchestrator to raise an Inbox question with `ask_user`
+instead of retrying.
 
 ## Private vendoring
 

--- a/plugins/boring-factory/src/server/host/delegatePlugin.test.ts
+++ b/plugins/boring-factory/src/server/host/delegatePlugin.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import { createFactoryDelegatePlugin } from './delegatePlugin'
 import type { FactoryEpicEntry, FactoryEpicRegistry } from './epicRegistry'
@@ -5,6 +8,7 @@ import type { FactorySessionBindings } from './sessionBindings'
 
 describe('factory delegate plugin', () => {
   it('binds a child to its parent epic and prefixes the child brief with that epic host context', async () => {
+    const stateRoot = await mkdtemp(resolve(tmpdir(), 'factory-delegate-existing-'))
     const entry: FactoryEpicEntry = {
       epicKey: 'parent-epic',
       featureName: 'Parent Epic',
@@ -30,6 +34,9 @@ describe('factory delegate plugin', () => {
     let promptPayload: Record<string, unknown> | undefined
     const app = {
       async inject(request: { method: string; url: string; payload?: unknown }) {
+        if (request.method === 'GET' && request.url.endsWith('/sessions')) {
+          return { statusCode: 200, body: '', json: <T>() => ({ sessions: [] }) as T }
+        }
         if (request.method === 'POST' && request.url.endsWith('/sessions')) {
           return { statusCode: 201, body: '', json: <T>() => ({ sessionId: 'worker-child' }) as T }
         }
@@ -47,12 +54,15 @@ describe('factory delegate plugin', () => {
         throw new Error(`unexpected request ${request.method} ${request.url}`)
       },
     }
-    const handle = createFactoryDelegatePlugin({ workspaceScopeId: 'factory-hub', registry, sessionBindings, timeoutMs: 1_000 })
+    const runBr = async (args: readonly string[]) => args[0] === 'list'
+      ? JSON.stringify({ issues: [{ id: 'br-1', status: 'open', labels: ['epic:parent-epic'] }] })
+      : JSON.stringify([])
+    const handle = createFactoryDelegatePlugin({ stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, timeoutMs: 1_000, runBr })
     handle.bind(app as never)
     const [tool] = handle.plugin.agentToolFactory?.({ agentTypeId: 'boring-orchestrator' }) ?? []
 
     const result = await tool!.execute(
-      { brief: 'Implement the bounded worker task and report proof.' },
+      { beadId: 'br-1', brief: 'Implement the bounded worker task for br-1 and report proof.' },
       { abortSignal: new AbortController().signal, toolCallId: 'call-1', sessionId: 'orch-parent' },
     )
 
@@ -60,12 +70,12 @@ describe('factory delegate plugin', () => {
     expect(sessionBindings.bind).toHaveBeenCalledWith('worker-child', 'parent-epic')
     expect(bindingState['worker-child']).toBe('parent-epic')
     expect(promptPayload).toMatchObject({ model: { provider: 'openai', id: 'gpt-worker' }, requireIdle: true })
-    expect(promptPayload?.content).toBe(
-      'Host context: epic parent-epic ([Parent Epic]) worktree /repo/.worktrees/epic-parent-epic branch epic/parent-epic. Your session id is worker-child (use it as your br actor). Parent session: orch-parent.\n\nImplement the bounded worker task and report proof.',
-    )
+    expect(promptPayload?.content).toContain('Target Bead: br-1.')
+    expect(promptPayload?.content).toContain('Implement the bounded worker task for br-1 and report proof.')
   })
 
   it('unbinds a newly created child when its first prompt fails', async () => {
+    const stateRoot = await mkdtemp(resolve(tmpdir(), 'factory-delegate-existing-'))
     const entry: FactoryEpicEntry = {
       epicKey: 'parent-epic', featureName: 'Parent Epic', worktree: '/repo/.worktrees/epic-parent-epic',
       branch: 'epic/parent-epic', repositoryRoot: '/repo', orchestratorSessionId: 'orch-parent',
@@ -86,6 +96,9 @@ describe('factory delegate plugin', () => {
     }
     const app = {
       async inject(request: { method: string; url: string }) {
+        if (request.method === 'GET' && request.url.endsWith('/sessions')) {
+          return { statusCode: 200, body: '', json: <T>() => ({ sessions: [] }) as T }
+        }
         if (request.method === 'POST' && request.url.endsWith('/sessions')) {
           return { statusCode: 201, body: '', json: <T>() => ({ sessionId: 'worker-child' }) as T }
         }
@@ -95,11 +108,14 @@ describe('factory delegate plugin', () => {
         throw new Error(`unexpected request ${request.method} ${request.url}`)
       },
     }
-    const handle = createFactoryDelegatePlugin({ workspaceScopeId: 'factory-hub', registry, sessionBindings, timeoutMs: 1_000 })
+    const runBr = async (args: readonly string[]) => args[0] === 'list'
+      ? JSON.stringify({ issues: [{ id: 'br-1', status: 'open', labels: ['epic:parent-epic'] }] })
+      : JSON.stringify([])
+    const handle = createFactoryDelegatePlugin({ stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, timeoutMs: 1_000, runBr })
     handle.bind(app as never)
     const [tool] = handle.plugin.agentToolFactory?.({ agentTypeId: 'boring-orchestrator' }) ?? []
     const result = await tool!.execute(
-      { brief: 'Implement the bounded worker task and report proof.' },
+      { beadId: 'br-1', brief: 'Implement the bounded worker task for br-1 and report proof.' },
       { abortSignal: new AbortController().signal, toolCallId: 'call-failed', sessionId: 'orch-parent' },
     )
     expect(result).toMatchObject({ isError: true, details: { code: 'PROMPT_FAILED', delegationId: 'worker-child', status: 503 } })

--- a/plugins/boring-factory/src/server/host/delegatePlugin.ts
+++ b/plugins/boring-factory/src/server/host/delegatePlugin.ts
@@ -21,6 +21,7 @@ import {
   isBusySession,
   listWorkerSessions,
   loadEpicBeads,
+  resolveEpicWorkerSessionIds,
   type BrIssue,
   type FactoryBrRunner,
   type FactoryGitStatus,
@@ -30,7 +31,7 @@ import {
 export const FACTORY_DELEGATE_PLUGIN_ID = 'factory-delegate'
 
 /** Bump when this file's delegation behavior changes; hashed into the plugin's contentDigest. */
-const DELEGATE_PLUGIN_VERSION = 'factory-delegate.v2.2026-09-05'
+const DELEGATE_PLUGIN_VERSION = 'factory-delegate.v3.2026-09-05'
 
 const DEFAULT_TIMEOUT_MS = 15 * 60_000
 const POLL_INTERVAL_MS = 1_000
@@ -248,7 +249,7 @@ function capRefusal(
     current,
     maximum,
     blocked: true,
-    message: `Factory host refused dispatch: ${subject} is at the cap (${current}/${maximum}). The Bead was marked blocked. Raise an Inbox question with ask_user describing this blocker; do not retry dispatch_worker.`,
+    message: `Factory host refused dispatch: ${subject} is at the cap (${current}/${maximum}). The Bead is blocked. Raise an Inbox question with ask_user describing this blocker; do not retry dispatch_worker.`,
   }, true)
 }
 
@@ -260,7 +261,7 @@ function createDelegateTool(
   ledger: FactoryDispatchLedger,
   limits: FactoryHostLimits,
   run: FactoryBrRunner,
-  admitDispatch: <T>(operation: () => Promise<T>) => Promise<T>,
+  admitSessionMutation: <T>(operation: () => Promise<T>) => Promise<T>,
 ): AgentTool {
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
   const workspaceHeader = { 'x-boring-workspace-id': options.workspaceScopeId }
@@ -332,11 +333,12 @@ function createDelegateTool(
               options.sessionBindings.load(),
               ledger.read(),
             ])
-            const epicWorkerIds = new Set([
-              ...Object.entries(bindings).filter(([, epicKey]) => epicKey === epic.epicKey).map(([sessionId]) => sessionId),
-              ...beads.map((bead) => bead.assignee).filter((sessionId): sessionId is string => !!sessionId),
-              ...dispatchState.dispatches.filter((record) => record.epicKey === epic.epicKey).map((record) => record.childSessionId),
-            ])
+            const epicWorkerIds = resolveEpicWorkerSessionIds({
+              epicKey: epic.epicKey,
+              bindings,
+              beads,
+              dispatches: dispatchState.dispatches,
+            })
             const busyWorkers = sessions.filter((session) => (
               epicWorkerIds.has(session.sessionId) && isBusySession(session.status)
             )).length
@@ -346,12 +348,24 @@ function createDelegateTool(
             const actor = ctx.sessionId ?? 'factory-host'
             if (busyWorkers >= limits.maxConcurrentWorkers) {
               const message = `Busy Worker concurrency reached ${busyWorkers}/${limits.maxConcurrentWorkers} for epic ${epic.epicKey}.`
-              await markBeadBlockedForCap(run, epic, beadId, actor, message)
+              const refusal = await ledger.markRefusal({
+                epicKey: epic.epicKey,
+                beadId,
+                cap: 'worker-concurrency',
+                timestamp: new Date(options.now?.() ?? Date.now()).toISOString(),
+              })
+              if (refusal.created) await markBeadBlockedForCap(run, epic, beadId, actor, message)
               return capRefusal('WORKER_CONCURRENCY_CAP_REACHED', beadId, busyWorkers, limits.maxConcurrentWorkers)
             }
             if (dispatchCount >= limits.maxDispatchesPerBead) {
               const message = `Dispatch history reached ${dispatchCount}/${limits.maxDispatchesPerBead} for Bead ${beadId}.`
-              await markBeadBlockedForCap(run, epic, beadId, actor, message)
+              const refusal = await ledger.markRefusal({
+                epicKey: epic.epicKey,
+                beadId,
+                cap: 'bead-dispatch',
+                timestamp: new Date(options.now?.() ?? Date.now()).toISOString(),
+              })
+              if (refusal.created) await markBeadBlockedForCap(run, epic, beadId, actor, message)
               return capRefusal('BEAD_DISPATCH_CAP_REACHED', beadId, dispatchCount, limits.maxDispatchesPerBead)
             }
           } else {
@@ -375,11 +389,15 @@ function createDelegateTool(
               reviewTargetKey = `bead:${beadId}`
             } else {
               reviewSha = sha
-              reviewTargetKey = await ledger.reviewTargetFor(epic.epicKey, ctx.sessionId, `sha-lineage:${sha}`)
+              reviewTargetKey = `sha-lineage:${sha}`
             }
           }
 
           const timestamp = new Date(options.now?.() ?? Date.now()).toISOString()
+          let dispatchRecord: FactoryDispatchRecord | undefined
+          if (toolName === 'dispatch_worker') {
+            dispatchRecord = await ledger.reserveDispatch({ epicKey: epic.epicKey, beadId: beadId!, timestamp })
+          }
           const createResponse = await app.inject({
             method: 'POST',
             url: `/api/v1/agents/${targetAgentTypeId}/sessions`,
@@ -387,16 +405,16 @@ function createDelegateTool(
             payload: { requestId: randomUUID(), title: sessionTitle },
           })
           if (createResponse.statusCode !== 201) {
+            if (dispatchRecord) await ledger.updateDispatch(dispatchRecord.id, 'failed')
             return textResult(
               { code: 'CREATE_SESSION_FAILED', status: createResponse.statusCode, body: createResponse.body },
               true,
             )
           }
           const { sessionId } = createResponse.json<{ sessionId: string }>()
-          let dispatchRecord: FactoryDispatchRecord | undefined
           let reviewRecord: FactoryReviewRecord | undefined
           if (toolName === 'dispatch_worker') {
-            dispatchRecord = await ledger.appendDispatch({ epicKey: epic.epicKey, beadId: beadId!, childSessionId: sessionId, timestamp, outcome: 'created' })
+            dispatchRecord = await ledger.attachDispatch(dispatchRecord!.id, sessionId, 'created')
           } else {
             reviewRecord = await ledger.appendReview({
               epicKey: epic.epicKey,
@@ -451,7 +469,7 @@ function createDelegateTool(
         }
 
         const admission = toolName === 'dispatch_worker'
-          ? await admitDispatch(startDelegation)
+          ? await admitSessionMutation(startDelegation)
           : await startDelegation()
         if ('content' in admission) return admission
         started = admission
@@ -540,10 +558,10 @@ export function createFactoryDelegatePlugin(
   const run = options.runBr ?? defaultRunBr
   let boundApp: FastifyInstance | undefined
   const getApp = () => boundApp
-  let dispatchAdmissions = Promise.resolve()
-  async function admitDispatch<T>(operation: () => Promise<T>): Promise<T> {
-    const next = dispatchAdmissions.then(operation)
-    dispatchAdmissions = next.then(() => undefined, () => undefined)
+  let sessionAdmissions = Promise.resolve()
+  async function admitSessionMutation<T>(operation: () => Promise<T>): Promise<T> {
+    const next = sessionAdmissions.then(operation)
+    sessionAdmissions = next.then(() => undefined, () => undefined)
     return await next
   }
 
@@ -555,9 +573,9 @@ export function createFactoryDelegatePlugin(
     agentToolFactory({ agentTypeId }) {
       const tools: AgentTool[] = []
       const grant = DELEGATE_GRANTS[agentTypeId]
-      if (grant) tools.push(createDelegateTool(grant.toolName, grant.targetAgentTypeId, getApp, options, ledger, limits, run, admitDispatch))
+      if (grant) tools.push(createDelegateTool(grant.toolName, grant.targetAgentTypeId, getApp, options, ledger, limits, run, admitSessionMutation))
       if (agentTypeId === FACTORY_STATUS_AGENT_TYPE_ID) {
-        tools.push(...createFactoryStatusTools(getApp, options, ledger, limits, staleIdleMs))
+        tools.push(...createFactoryStatusTools(getApp, options, ledger, limits, staleIdleMs, admitSessionMutation))
       }
       return tools
     },

--- a/plugins/boring-factory/src/server/host/delegatePlugin.ts
+++ b/plugins/boring-factory/src/server/host/delegatePlugin.ts
@@ -1,6 +1,4 @@
-import { execFile } from 'node:child_process'
 import { createHash, randomUUID } from 'node:crypto'
-import { promisify } from 'node:util'
 import type { FastifyInstance } from 'fastify'
 import { defineServerPlugin } from '@hachej/boring-workspace/server'
 import type { AgentTool, ToolExecContext, ToolResult } from '@hachej/boring-agent/shared'
@@ -10,20 +8,39 @@ import {
   resolveFactoryEpic,
   type FactorySessionBindings,
 } from './sessionBindings'
+import {
+  createFactoryDispatchLedger,
+  positiveInteger,
+  type FactoryDispatchLedger,
+  type FactoryDispatchRecord,
+  type FactoryReviewRecord,
+} from './dispatchLedger'
+import {
+  createFactoryStatusTools,
+  defaultRunBr,
+  isBusySession,
+  listWorkerSessions,
+  loadEpicBeads,
+  type BrIssue,
+  type FactoryBrRunner,
+  type FactoryGitStatus,
+  type FactoryHostLimits,
+} from './factoryStatus'
 
 export const FACTORY_DELEGATE_PLUGIN_ID = 'factory-delegate'
 
 /** Bump when this file's delegation behavior changes; hashed into the plugin's contentDigest. */
-const DELEGATE_PLUGIN_VERSION = 'factory-delegate.v1.2026-09-03'
+const DELEGATE_PLUGIN_VERSION = 'factory-delegate.v2.2026-09-05'
 
 const DEFAULT_TIMEOUT_MS = 15 * 60_000
 const POLL_INTERVAL_MS = 1_000
 const BRIEF_MIN_LENGTH = 20
 const BRIEF_MAX_LENGTH = 8_000
-const MAX_DIRTY_PATHS = 50
-const MAX_WORKER_SESSION_PAGES = 5
 
-const execFileAsync = promisify(execFile)
+export const FACTORY_DEFAULT_STALE_IDLE_MS = 10 * 60_000
+export const FACTORY_DEFAULT_MAX_CONCURRENT_WORKERS = 2
+export const FACTORY_DEFAULT_MAX_DISPATCHES_PER_BEAD = 2
+export const FACTORY_DEFAULT_MAX_REVIEW_ROUNDS = 4
 
 /**
  * Host-owned grant table: which seat may dispatch which other seat, and under
@@ -36,15 +53,23 @@ const DELEGATE_GRANTS: Readonly<Record<string, { readonly toolName: string; read
 
 /** Seat granted the host status readback tool. Never derived from Agent-authored config. */
 const FACTORY_STATUS_AGENT_TYPE_ID = 'boring-orchestrator'
-const FACTORY_STATUS_WORKER_AGENT_TYPE_ID = 'boring-worker'
 
 export interface CreateFactoryDelegatePluginOptions {
+  /** Directory holding the host-owned `dispatches.json` ledger. */
+  readonly stateRoot: string
   /** Host-owned workspace identity used on every in-process `app.inject` call. */
   readonly workspaceScopeId: string
   /** Deadline for the child session to go idle after one turn. Default 15 minutes. */
   readonly timeoutMs?: number
   readonly registry: FactoryEpicRegistry
   readonly sessionBindings: FactorySessionBindings
+  readonly env?: NodeJS.ProcessEnv
+  /** Test seam for deterministic Bead command responses. */
+  readonly runBr?: FactoryBrRunner
+  /** Test seam for stale-age and persisted timestamps. */
+  readonly now?: () => number
+  /** Test seam for the read-only git projection used by factory_status. */
+  readonly readGitStatus?: (workspaceRoot: string) => Promise<FactoryGitStatus>
 }
 
 export interface FactoryDelegatePluginHandle {
@@ -105,6 +130,12 @@ function parseBrief(params: Record<string, unknown>): { brief: string; title?: s
   return { brief, title }
 }
 
+function parseOptionalBeadId(value: unknown): string | undefined | { error: string } {
+  if (value === undefined) return undefined
+  if (typeof value !== 'string' || !value.trim()) return { error: 'beadId must be a non-empty string when provided' }
+  return value.trim()
+}
+
 /** Session title label per docs/procedures/naming-conventions.md, keyed by the delegating tool. */
 const SESSION_TITLE_LABEL: Readonly<Record<string, string>> = Object.freeze({
   dispatch_worker: 'Worker',
@@ -162,11 +193,74 @@ interface DelegateSessionState {
   }
 }
 
+interface StartedDelegation {
+  readonly sessionId: string
+  readonly dispatchRecord?: FactoryDispatchRecord
+  readonly reviewRecord?: FactoryReviewRecord
+  readonly capReached: boolean
+}
+
+function dispatchTargetFrom(
+  requestedBeadId: string | undefined,
+  brief: string,
+  beads: readonly BrIssue[],
+): { beadId: string } | { error: string } {
+  const openBeads = beads.filter((bead) => bead.status !== 'closed')
+  if (requestedBeadId) {
+    if (!openBeads.some((bead) => bead.id === requestedBeadId)) {
+      return { error: `beadId ${requestedBeadId} is not an open Bead labelled for this epic` }
+    }
+    return { beadId: requestedBeadId }
+  }
+  const named = openBeads.filter((bead) => brief.includes(bead.id))
+  if (named.length === 1) return { beadId: named[0]!.id }
+  if (named.length > 1) return { error: 'brief names more than one open Bead; pass beadId explicitly' }
+  return { error: 'dispatch_worker requires beadId, or the brief must name exactly one open Bead in this epic' }
+}
+
+async function markBeadBlockedForCap(
+  run: FactoryBrRunner,
+  epic: { readonly worktree: string; readonly featureName: string },
+  beadId: string,
+  actor: string,
+  message: string,
+): Promise<void> {
+  await run(['update', beadId, '--status', 'blocked', '--actor', actor, '--json', '--no-auto-flush'], epic.worktree)
+  await run([
+    'comments', 'add', beadId, '-m',
+    `[${epic.featureName}] Factory dispatch blocked · ${beadId}\n\n${message}\n\nRaise an Inbox question with ask_user describing this blocker; do not retry dispatch_worker.`,
+    '--actor', actor, '--json', '--no-auto-flush',
+  ], epic.worktree)
+}
+
+function capRefusal(
+  code: 'WORKER_CONCURRENCY_CAP_REACHED' | 'BEAD_DISPATCH_CAP_REACHED',
+  beadId: string,
+  current: number,
+  maximum: number,
+): ToolResult {
+  const subject = code === 'WORKER_CONCURRENCY_CAP_REACHED'
+    ? 'busy Worker concurrency'
+    : `dispatches for Bead ${beadId}`
+  return textResult({
+    code,
+    beadId,
+    current,
+    maximum,
+    blocked: true,
+    message: `Factory host refused dispatch: ${subject} is at the cap (${current}/${maximum}). The Bead was marked blocked. Raise an Inbox question with ask_user describing this blocker; do not retry dispatch_worker.`,
+  }, true)
+}
+
 function createDelegateTool(
   toolName: string,
   targetAgentTypeId: string,
   getApp: () => FastifyInstance | undefined,
   options: CreateFactoryDelegatePluginOptions,
+  ledger: FactoryDispatchLedger,
+  limits: FactoryHostLimits,
+  run: FactoryBrRunner,
+  admitDispatch: <T>(operation: () => Promise<T>) => Promise<T>,
 ): AgentTool {
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
   const workspaceHeader = { 'x-boring-workspace-id': options.workspaceScopeId }
@@ -191,6 +285,12 @@ function createDelegateTool(
           type: 'string',
           description: 'Ignored: the host titles the session per docs/procedures/naming-conventions.md.',
         },
+        beadId: {
+          type: 'string',
+          description: toolName === 'dispatch_worker'
+            ? 'Target Bead. Required unless the brief names exactly one open Bead in this epic.'
+            : 'Optional reviewed Bead. When present, review rounds stay on this Bead across fix-forward SHAs.',
+        },
       },
       required: ['brief'],
       additionalProperties: false,
@@ -199,6 +299,8 @@ function createDelegateTool(
       const parsed = parseBrief(params)
       if ('error' in parsed) return invalidInputResult(parsed.error)
       const { brief } = parsed
+      const parsedBeadId = parseOptionalBeadId(params.beadId)
+      if (typeof parsedBeadId === 'object') return invalidInputResult(parsedBeadId.error)
 
       const app = getApp()
       if (!app) return unboundResult(toolName)
@@ -210,47 +312,150 @@ function createDelegateTool(
         return epicResolutionResult(error)
       }
 
-      const startedAt = new Date().toISOString()
       const parentSessionId = ctx.sessionId ?? 'unknown'
       const sessionTitle = sessionTitleFor(toolName, epic.featureName, brief, parentSessionId)
+      let started: StartedDelegation | undefined
 
       try {
-        const createResponse = await app.inject({
-          method: 'POST',
-          url: `/api/v1/agents/${targetAgentTypeId}/sessions`,
-          headers: workspaceHeader,
-          payload: { requestId: randomUUID(), title: sessionTitle },
-        })
-        if (createResponse.statusCode !== 201) {
-          return textResult(
-            { code: 'CREATE_SESSION_FAILED', status: createResponse.statusCode, body: createResponse.body },
-            true,
-          )
-        }
-        const { sessionId } = createResponse.json<{ sessionId: string }>()
-        await options.sessionBindings.bind(sessionId, epic.epicKey)
+        const startDelegation = async (): Promise<StartedDelegation | ToolResult> => {
+          let beadId = parsedBeadId
+          let reviewTargetKey: string | undefined
+          let reviewSha: string | undefined
+          if (toolName === 'dispatch_worker') {
+            const beads = await loadEpicBeads(epic.worktree, epic.epicKey, run)
+            const target = dispatchTargetFrom(beadId, brief, beads)
+            if ('error' in target) return invalidInputResult(target.error)
+            beadId = target.beadId
 
-        const selectedModel = modelSelection(toolName === 'dispatch_worker' ? epic.models?.worker : epic.models?.reviewer)
+            const [sessions, bindings, dispatchState] = await Promise.all([
+              listWorkerSessions(app, workspaceHeader),
+              options.sessionBindings.load(),
+              ledger.read(),
+            ])
+            const epicWorkerIds = new Set([
+              ...Object.entries(bindings).filter(([, epicKey]) => epicKey === epic.epicKey).map(([sessionId]) => sessionId),
+              ...beads.map((bead) => bead.assignee).filter((sessionId): sessionId is string => !!sessionId),
+              ...dispatchState.dispatches.filter((record) => record.epicKey === epic.epicKey).map((record) => record.childSessionId),
+            ])
+            const busyWorkers = sessions.filter((session) => (
+              epicWorkerIds.has(session.sessionId) && isBusySession(session.status)
+            )).length
+            const dispatchCount = dispatchState.dispatches.filter((record) => (
+              record.epicKey === epic.epicKey && record.beadId === beadId
+            )).length
+            const actor = ctx.sessionId ?? 'factory-host'
+            if (busyWorkers >= limits.maxConcurrentWorkers) {
+              const message = `Busy Worker concurrency reached ${busyWorkers}/${limits.maxConcurrentWorkers} for epic ${epic.epicKey}.`
+              await markBeadBlockedForCap(run, epic, beadId, actor, message)
+              return capRefusal('WORKER_CONCURRENCY_CAP_REACHED', beadId, busyWorkers, limits.maxConcurrentWorkers)
+            }
+            if (dispatchCount >= limits.maxDispatchesPerBead) {
+              const message = `Dispatch history reached ${dispatchCount}/${limits.maxDispatchesPerBead} for Bead ${beadId}.`
+              await markBeadBlockedForCap(run, epic, beadId, actor, message)
+              return capRefusal('BEAD_DISPATCH_CAP_REACHED', beadId, dispatchCount, limits.maxDispatchesPerBead)
+            }
+          } else {
+            const sha = brief.match(SHA_RE)?.[0]
+            if (!beadId && ctx.sessionId) {
+              const dispatches = (await ledger.read()).dispatches
+              for (let index = dispatches.length - 1; index >= 0; index -= 1) {
+                const dispatch = dispatches[index]!
+                if (dispatch.epicKey === epic.epicKey && dispatch.childSessionId === ctx.sessionId) {
+                  beadId = dispatch.beadId
+                  break
+                }
+              }
+            }
+            if (!beadId && !sha) return invalidInputResult('fresh_review requires beadId or a SHA in the brief')
+            if (beadId) {
+              const beads = await loadEpicBeads(epic.worktree, epic.epicKey, run)
+              if (!beads.some((bead) => bead.id === beadId && bead.status !== 'closed')) {
+                return invalidInputResult(`beadId ${beadId} is not an open Bead labelled for this epic`)
+              }
+              reviewTargetKey = `bead:${beadId}`
+            } else {
+              reviewSha = sha
+              reviewTargetKey = await ledger.reviewTargetFor(epic.epicKey, ctx.sessionId, `sha-lineage:${sha}`)
+            }
+          }
 
-        const promptResponse = await app.inject({
-          method: 'POST',
-          url: `/api/v1/agents/${targetAgentTypeId}/sessions/${sessionId}/prompt`,
-          headers: workspaceHeader,
-          payload: {
-            requestId: randomUUID(),
-            clientNonce: randomUUID(),
-            content: `Host context: epic ${epic.epicKey} ([${epic.featureName}]) worktree ${epic.worktree} branch ${epic.branch}. Your session id is ${sessionId} (use it as your br actor). Parent session: ${ctx.sessionId}.\n\n${brief}`,
-            requireIdle: true,
-            ...(selectedModel ? { model: selectedModel } : {}),
-          },
-        })
-        if (promptResponse.statusCode !== 202) {
-          await options.sessionBindings.unbind(sessionId)
-          return textResult(
-            { code: 'PROMPT_FAILED', delegationId: sessionId, status: promptResponse.statusCode, body: promptResponse.body },
-            true,
-          )
+          const timestamp = new Date(options.now?.() ?? Date.now()).toISOString()
+          const createResponse = await app.inject({
+            method: 'POST',
+            url: `/api/v1/agents/${targetAgentTypeId}/sessions`,
+            headers: workspaceHeader,
+            payload: { requestId: randomUUID(), title: sessionTitle },
+          })
+          if (createResponse.statusCode !== 201) {
+            return textResult(
+              { code: 'CREATE_SESSION_FAILED', status: createResponse.statusCode, body: createResponse.body },
+              true,
+            )
+          }
+          const { sessionId } = createResponse.json<{ sessionId: string }>()
+          let dispatchRecord: FactoryDispatchRecord | undefined
+          let reviewRecord: FactoryReviewRecord | undefined
+          if (toolName === 'dispatch_worker') {
+            dispatchRecord = await ledger.appendDispatch({ epicKey: epic.epicKey, beadId: beadId!, childSessionId: sessionId, timestamp, outcome: 'created' })
+          } else {
+            reviewRecord = await ledger.appendReview({
+              epicKey: epic.epicKey,
+              targetKey: reviewTargetKey!,
+              ...(beadId ? { beadId } : {}),
+              ...(reviewSha ? { sha: reviewSha } : {}),
+              ...(ctx.sessionId ? { parentSessionId: ctx.sessionId } : {}),
+              childSessionId: sessionId,
+              timestamp,
+              outcome: 'created',
+            })
+          }
+
+          try {
+            await options.sessionBindings.bind(sessionId, epic.epicKey)
+          } catch (error) {
+            if (dispatchRecord) await ledger.updateDispatch(dispatchRecord.id, 'bind-failed')
+            if (reviewRecord) await ledger.updateReview(reviewRecord.id, 'bind-failed')
+            throw error
+          }
+
+          const selectedModel = modelSelection(toolName === 'dispatch_worker' ? epic.models?.worker : epic.models?.reviewer)
+          const promptResponse = await app.inject({
+            method: 'POST',
+            url: `/api/v1/agents/${targetAgentTypeId}/sessions/${sessionId}/prompt`,
+            headers: workspaceHeader,
+            payload: {
+              requestId: randomUUID(),
+              clientNonce: randomUUID(),
+              content: `Host context: epic ${epic.epicKey} ([${epic.featureName}]) worktree ${epic.worktree} branch ${epic.branch}. Your session id is ${sessionId} (use it as your br actor). Parent session: ${ctx.sessionId}.${beadId ? ` Target Bead: ${beadId}.` : ''}\n\n${brief}`,
+              requireIdle: true,
+              ...(selectedModel ? { model: selectedModel } : {}),
+            },
+          })
+          if (promptResponse.statusCode !== 202) {
+            await options.sessionBindings.unbind(sessionId)
+            if (dispatchRecord) await ledger.updateDispatch(dispatchRecord.id, 'prompt-failed')
+            if (reviewRecord) await ledger.updateReview(reviewRecord.id, 'prompt-failed')
+            return textResult(
+              { code: 'PROMPT_FAILED', delegationId: sessionId, status: promptResponse.statusCode, body: promptResponse.body },
+              true,
+            )
+          }
+          if (dispatchRecord) dispatchRecord = await ledger.updateDispatch(dispatchRecord.id, 'running')
+          if (reviewRecord) reviewRecord = await ledger.updateReview(reviewRecord.id, 'running')
+          return {
+            sessionId,
+            ...(dispatchRecord ? { dispatchRecord } : {}),
+            ...(reviewRecord ? { reviewRecord } : {}),
+            capReached: !!reviewRecord && reviewRecord.round >= limits.maxReviewRounds,
+          }
         }
+
+        const admission = toolName === 'dispatch_worker'
+          ? await admitDispatch(startDelegation)
+          : await startDelegation()
+        if ('content' in admission) return admission
+        started = admission
+        const { sessionId } = started
 
         const deadline = Date.now() + timeoutMs
         let status: 'completed' | 'timeout' = 'timeout'
@@ -276,218 +481,43 @@ function createDelegateTool(
         const finishedAt = new Date().toISOString()
         const model = lastState?.state?.currentModel
         const answer = lastAssistantText(lastState?.state?.messages ?? [])
+        if (started.dispatchRecord) await ledger.updateDispatch(started.dispatchRecord.id, status)
+        if (started.reviewRecord) await ledger.updateReview(started.reviewRecord.id, status)
         const details = {
           delegationId: sessionId,
           targetAgentTypeId,
           model,
           status,
           answer,
+          ...(started.dispatchRecord ? { beadId: started.dispatchRecord.beadId } : {}),
+          ...(started.reviewRecord ? {
+            reviewRound: started.reviewRecord.round,
+            reviewTarget: started.reviewRecord.targetKey,
+            capReached: started.capReached,
+            ...(started.capReached ? {
+              capInstructions: `Review-round cap reached (${started.reviewRecord.round}/${limits.maxReviewRounds}). Hand off at the current SHA and file remaining findings as follow-up Beads; do not fix forward again.`,
+            } : {}),
+          } : {}),
           provenance: {
             sessionId,
             agentTypeId: targetAgentTypeId,
             model,
             briefDigest: sha256(brief),
-            startedAt,
+            startedAt: started.dispatchRecord?.timestamp ?? started.reviewRecord?.timestamp ?? finishedAt,
             finishedAt,
           },
         }
         return textResult(details, false)
       } catch (error) {
         if (error instanceof DelegateAbortedError) {
+          if (started?.dispatchRecord) await ledger.updateDispatch(started.dispatchRecord.id, 'aborted')
+          if (started?.reviewRecord) await ledger.updateReview(started.reviewRecord.id, 'aborted')
           return textResult({ code: 'ABORTED', message: 'delegation aborted before the child session finished' }, true)
         }
+        if (started?.dispatchRecord) await ledger.updateDispatch(started.dispatchRecord.id, 'failed')
+        if (started?.reviewRecord) await ledger.updateReview(started.reviewRecord.id, 'failed')
         const message = error instanceof Error ? error.message : 'delegation failed'
         return textResult({ code: 'DELEGATE_FAILED', message }, true)
-      }
-    },
-  }
-}
-
-interface BrIssue {
-  readonly id: string
-  readonly title?: string
-  readonly status?: string
-  readonly assignee?: string | null
-  readonly labels?: readonly string[]
-  readonly updated_at?: string
-}
-
-interface BrComment {
-  readonly created_at: string
-}
-
-async function runBr(args: readonly string[], cwd: string): Promise<string> {
-  const { stdout } = await execFileAsync('br', args, { cwd, maxBuffer: 16 * 1024 * 1024 })
-  return stdout
-}
-
-function parseBrIssues(stdout: string): BrIssue[] {
-  const parsed: unknown = JSON.parse(stdout)
-  if (Array.isArray(parsed)) return parsed as BrIssue[]
-  if (parsed && typeof parsed === 'object' && Array.isArray((parsed as { issues?: unknown }).issues)) {
-    return (parsed as { issues: BrIssue[] }).issues
-  }
-  return []
-}
-
-async function loadEpicBeads(workspaceRoot: string, epicKey: string): Promise<BrIssue[]> {
-  const stdout = await runBr(['list', '--label', `epic:${epicKey}`, '--json', '--no-auto-flush'], workspaceRoot)
-  return parseBrIssues(stdout)
-}
-
-async function commentStatsFor(workspaceRoot: string, issueId: string): Promise<{ commentCount: number; lastCommentAt?: string }> {
-  try {
-    const stdout = await runBr(['comments', 'list', issueId, '--json', '--no-auto-flush'], workspaceRoot)
-    const parsed: unknown = JSON.parse(stdout)
-    const comments = Array.isArray(parsed) ? (parsed as BrComment[]) : []
-    if (comments.length === 0) return { commentCount: 0 }
-    const lastCommentAt = comments
-      .map((comment) => comment.created_at)
-      .filter((value): value is string => typeof value === 'string')
-      .sort()
-      .at(-1)
-    return { commentCount: comments.length, ...(lastCommentAt ? { lastCommentAt } : {}) }
-  } catch {
-    return { commentCount: 0 }
-  }
-}
-
-async function gitOutput(args: readonly string[], cwd: string): Promise<string> {
-  const { stdout } = await execFileAsync('git', args, { cwd, maxBuffer: 16 * 1024 * 1024 })
-  return stdout.trim()
-}
-
-async function readGitStatus(workspaceRoot: string): Promise<{ branch: string; head: string; remoteHead: string | null; dirtyPaths: string[] }> {
-  const [branch, head, statusOutput] = await Promise.all([
-    gitOutput(['rev-parse', '--abbrev-ref', 'HEAD'], workspaceRoot),
-    gitOutput(['rev-parse', 'HEAD'], workspaceRoot),
-    execFileAsync('git', ['status', '--short'], { cwd: workspaceRoot, maxBuffer: 16 * 1024 * 1024 }).then((r) => r.stdout),
-  ])
-  const dirtyPaths = statusOutput
-    .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0)
-    .slice(0, MAX_DIRTY_PATHS)
-  let remoteHead: string | null = null
-  try {
-    const lsRemote = await gitOutput(['ls-remote', '--heads', 'origin', branch], workspaceRoot)
-    const sha = lsRemote.split(/\s+/)[0]
-    remoteHead = sha && /^[a-f0-9]{40}$/.test(sha) ? sha : null
-  } catch {
-    remoteHead = null
-  }
-  return { branch, head, remoteHead, dirtyPaths }
-}
-
-type SessionLiveness = 'none' | 'unknown' | 'exists-idle' | 'exists-busy'
-
-function computeLiveness(assignee: string | null | undefined, workerStatusBySessionId: ReadonlyMap<string, string>): SessionLiveness {
-  if (!assignee) return 'none'
-  const status = workerStatusBySessionId.get(assignee)
-  if (status === undefined) return 'unknown'
-  return status === 'idle' ? 'exists-idle' : 'exists-busy'
-}
-
-interface WorkerSessionSummary {
-  readonly sessionId: string
-  readonly status?: string
-  readonly turnCount?: number
-  readonly title?: string
-  readonly updatedAt?: number
-}
-
-async function listWorkerSessions(app: FastifyInstance, workspaceHeader: Record<string, string>): Promise<WorkerSessionSummary[]> {
-  const sessions: WorkerSessionSummary[] = []
-  let cursor: string | undefined
-  for (let page = 0; page < MAX_WORKER_SESSION_PAGES; page += 1) {
-    const url = cursor
-      ? `/api/v1/agents/${FACTORY_STATUS_WORKER_AGENT_TYPE_ID}/sessions?cursor=${encodeURIComponent(cursor)}`
-      : `/api/v1/agents/${FACTORY_STATUS_WORKER_AGENT_TYPE_ID}/sessions`
-    const response = await app.inject({ method: 'GET', url, headers: workspaceHeader })
-    if (response.statusCode !== 200) break
-    const body = response.json<{ sessions: Array<{ ref: { sessionId: string }; status?: string; turnCount?: number; title?: string; updatedAt?: number }>; nextCursor?: string }>()
-    for (const session of body.sessions) {
-      sessions.push({ sessionId: session.ref.sessionId, status: session.status, turnCount: session.turnCount, title: session.title, updatedAt: session.updatedAt })
-    }
-    if (!body.nextCursor) break
-    cursor = body.nextCursor
-  }
-  return sessions
-}
-
-function createFactoryStatusTool(
-  getApp: () => FastifyInstance | undefined,
-  options: CreateFactoryDelegatePluginOptions,
-): AgentTool {
-  const workspaceHeader = { 'x-boring-workspace-id': options.workspaceScopeId }
-  return {
-    name: 'factory_status',
-    description:
-      'Read the durable end-state of this epic: git branch/head/remote-head/dirty paths in the shared ' +
-      'worktree, every Bead labelled `epic:<key>` with its status/assignee/labels/comment activity and ' +
-      'whether its assignee is a known Worker session (and whether that session is idle or busy), and ' +
-      'the raw list of Worker sessions. Read-only; never mutates anything.',
-    parameters: {
-      type: 'object',
-      properties: {
-        epicKey: {
-          type: 'string',
-          description: 'Optional explicit epic override. Normally the host resolves the epic from this session binding.',
-        },
-      },
-      additionalProperties: false,
-    },
-    async execute(params: Record<string, unknown>, ctx: ToolExecContext): Promise<ToolResult> {
-      const app = getApp()
-      if (!app) return unboundResult('factory_status')
-      let epic
-      try {
-        epic = await resolveFactoryEpic(params, ctx, options.registry, options.sessionBindings)
-      } catch (error) {
-        return epicResolutionResult(error)
-      }
-      try {
-        const [git, beads, allWorkerSessions, bindingMap] = await Promise.all([
-          readGitStatus(epic.worktree),
-          loadEpicBeads(epic.worktree, epic.epicKey),
-          listWorkerSessions(app, workspaceHeader),
-          options.sessionBindings.load(),
-        ])
-        const workerSessions = allWorkerSessions.filter((session) => bindingMap[session.sessionId] === epic.epicKey)
-        const workerStatusBySessionId = new Map(workerSessions.map((session) => [session.sessionId, session.status ?? 'idle']))
-        const beadsWithComments = await Promise.all(beads.map(async (issue) => {
-          const commentStats = await commentStatsFor(epic.worktree, issue.id)
-          return {
-            id: issue.id,
-            status: issue.status,
-            assignee: issue.assignee ?? null,
-            labels: issue.labels ?? [],
-            title: issue.title,
-            updatedAt: issue.updated_at,
-            commentCount: commentStats.commentCount,
-            ...(commentStats.lastCommentAt ? { lastCommentAt: commentStats.lastCommentAt } : {}),
-            sessionLiveness: computeLiveness(issue.assignee, workerStatusBySessionId),
-          }
-        }))
-        const details = {
-          epicKey: epic.epicKey,
-          featureName: epic.featureName,
-          workspaceRoot: epic.worktree,
-          branch: epic.branch,
-          git,
-          beads: beadsWithComments,
-          workerSessions: workerSessions.map((session) => ({
-            sessionId: session.sessionId,
-            status: session.status,
-            turnCount: session.turnCount,
-            title: session.title,
-            updatedAt: session.updatedAt,
-          })),
-        }
-        return textResult(details, false)
-      } catch (error) {
-        const message = error instanceof Error ? error.message : 'factory_status failed'
-        return textResult({ code: 'FACTORY_STATUS_FAILED', message }, true)
       }
     },
   }
@@ -496,10 +526,26 @@ function createFactoryStatusTool(
 export function createFactoryDelegatePlugin(
   options: CreateFactoryDelegatePluginOptions,
 ): FactoryDelegatePluginHandle {
+  if (!options.stateRoot.trim()) throw new TypeError('factory-delegate stateRoot is required')
   if (!options.workspaceScopeId.trim()) throw new TypeError('factory-delegate workspaceScopeId is required')
 
+  const env = options.env ?? process.env
+  const limits: FactoryHostLimits = {
+    maxConcurrentWorkers: positiveInteger(env.BORING_FACTORY_MAX_CONCURRENT_WORKERS, FACTORY_DEFAULT_MAX_CONCURRENT_WORKERS),
+    maxDispatchesPerBead: positiveInteger(env.BORING_FACTORY_MAX_DISPATCHES_PER_BEAD, FACTORY_DEFAULT_MAX_DISPATCHES_PER_BEAD),
+    maxReviewRounds: positiveInteger(env.BORING_FACTORY_MAX_REVIEW_ROUNDS, FACTORY_DEFAULT_MAX_REVIEW_ROUNDS),
+  }
+  const staleIdleMs = positiveInteger(env.BORING_FACTORY_STALE_IDLE_MS, FACTORY_DEFAULT_STALE_IDLE_MS)
+  const ledger = createFactoryDispatchLedger(options.stateRoot)
+  const run = options.runBr ?? defaultRunBr
   let boundApp: FastifyInstance | undefined
   const getApp = () => boundApp
+  let dispatchAdmissions = Promise.resolve()
+  async function admitDispatch<T>(operation: () => Promise<T>): Promise<T> {
+    const next = dispatchAdmissions.then(operation)
+    dispatchAdmissions = next.then(() => undefined, () => undefined)
+    return await next
+  }
 
   const plugin = defineServerPlugin({
     id: FACTORY_DELEGATE_PLUGIN_ID,
@@ -509,8 +555,10 @@ export function createFactoryDelegatePlugin(
     agentToolFactory({ agentTypeId }) {
       const tools: AgentTool[] = []
       const grant = DELEGATE_GRANTS[agentTypeId]
-      if (grant) tools.push(createDelegateTool(grant.toolName, grant.targetAgentTypeId, getApp, options))
-      if (agentTypeId === FACTORY_STATUS_AGENT_TYPE_ID) tools.push(createFactoryStatusTool(getApp, options))
+      if (grant) tools.push(createDelegateTool(grant.toolName, grant.targetAgentTypeId, getApp, options, ledger, limits, run, admitDispatch))
+      if (agentTypeId === FACTORY_STATUS_AGENT_TYPE_ID) {
+        tools.push(...createFactoryStatusTools(getApp, options, ledger, limits, staleIdleMs))
+      }
       return tools
     },
   })

--- a/plugins/boring-factory/src/server/host/dispatchLedger.ts
+++ b/plugins/boring-factory/src/server/host/dispatchLedger.ts
@@ -1,0 +1,168 @@
+import { randomUUID } from 'node:crypto'
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+export type FactoryDispatchOutcome =
+  | 'created'
+  | 'running'
+  | 'completed'
+  | 'timeout'
+  | 'prompt-failed'
+  | 'bind-failed'
+  | 'aborted'
+  | 'failed'
+
+export type FactoryReviewOutcome = FactoryDispatchOutcome
+
+export interface FactoryDispatchRecord {
+  readonly id: string
+  readonly epicKey: string
+  readonly beadId: string
+  readonly childSessionId: string
+  readonly timestamp: string
+  readonly updatedAt: string
+  readonly outcome: FactoryDispatchOutcome
+}
+
+export interface FactoryReviewRecord {
+  readonly id: string
+  readonly epicKey: string
+  readonly targetKey: string
+  readonly beadId?: string
+  readonly sha?: string
+  readonly parentSessionId?: string
+  readonly childSessionId: string
+  readonly round: number
+  readonly timestamp: string
+  readonly updatedAt: string
+  readonly outcome: FactoryReviewOutcome
+}
+
+export interface FactoryDispatchState {
+  readonly version: 1
+  readonly dispatches: readonly FactoryDispatchRecord[]
+  readonly reviews: readonly FactoryReviewRecord[]
+}
+
+export interface FactoryDispatchLedger {
+  read(): Promise<FactoryDispatchState>
+  appendDispatch(record: Omit<FactoryDispatchRecord, 'id' | 'updatedAt'>): Promise<FactoryDispatchRecord>
+  updateDispatch(id: string, outcome: FactoryDispatchOutcome): Promise<FactoryDispatchRecord>
+  appendReview(record: Omit<FactoryReviewRecord, 'id' | 'updatedAt' | 'round'>): Promise<FactoryReviewRecord>
+  updateReview(id: string, outcome: FactoryReviewOutcome): Promise<FactoryReviewRecord>
+  reviewTargetFor(epicKey: string, parentSessionId: string | undefined, requestedTarget: string): Promise<string>
+}
+
+const EMPTY_STATE: FactoryDispatchState = { version: 1, dispatches: [], reviews: [] }
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function parseState(raw: string, path: string): FactoryDispatchState {
+  const parsed: unknown = JSON.parse(raw)
+  if (!isRecord(parsed) || parsed.version !== 1 || !Array.isArray(parsed.dispatches) || !Array.isArray(parsed.reviews)) {
+    throw new Error(`${path} must contain a version 1 Factory dispatch ledger`)
+  }
+  return {
+    version: 1,
+    dispatches: parsed.dispatches as FactoryDispatchRecord[],
+    reviews: parsed.reviews as FactoryReviewRecord[],
+  }
+}
+
+async function writeAtomic(path: string, state: FactoryDispatchState): Promise<void> {
+  const temporaryPath = `${path}.${randomUUID()}.tmp`
+  await writeFile(temporaryPath, JSON.stringify(state, null, 2), 'utf8')
+  await rename(temporaryPath, path)
+}
+
+export function createFactoryDispatchLedger(stateRoot: string): FactoryDispatchLedger {
+  const root = resolve(stateRoot)
+  const path = resolve(root, 'dispatches.json')
+  let mutations = Promise.resolve()
+
+  async function readFileState(): Promise<FactoryDispatchState> {
+    try {
+      return parseState(await readFile(path, 'utf8'), path)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return EMPTY_STATE
+      throw error
+    }
+  }
+
+  async function mutate<T>(operation: (state: FactoryDispatchState) => { state: FactoryDispatchState; result: T }): Promise<T> {
+    let result!: T
+    const next = mutations.then(async () => {
+      await mkdir(root, { recursive: true })
+      const changed = operation(await readFileState())
+      await writeAtomic(path, changed.state)
+      result = changed.result
+    })
+    mutations = next.catch(() => undefined)
+    await next
+    return result
+  }
+
+  return {
+    async read() {
+      await mutations
+      return await readFileState()
+    },
+    async appendDispatch(record) {
+      return await mutate((state) => {
+        const stored: FactoryDispatchRecord = { ...record, id: randomUUID(), updatedAt: record.timestamp }
+        return { state: { ...state, dispatches: [...state.dispatches, stored] }, result: stored }
+      })
+    },
+    async updateDispatch(id, outcome) {
+      return await mutate((state) => {
+        let updated: FactoryDispatchRecord | undefined
+        const dispatches = state.dispatches.map((record) => {
+          if (record.id !== id) return record
+          updated = { ...record, outcome, updatedAt: new Date().toISOString() }
+          return updated
+        })
+        if (!updated) throw new Error(`dispatch record ${id} was not found`)
+        return { state: { ...state, dispatches }, result: updated }
+      })
+    },
+    async appendReview(record) {
+      return await mutate((state) => {
+        const round = state.reviews.filter((candidate) => (
+          candidate.epicKey === record.epicKey && candidate.targetKey === record.targetKey
+        )).length + 1
+        const stored: FactoryReviewRecord = { ...record, id: randomUUID(), round, updatedAt: record.timestamp }
+        return { state: { ...state, reviews: [...state.reviews, stored] }, result: stored }
+      })
+    },
+    async updateReview(id, outcome) {
+      return await mutate((state) => {
+        let updated: FactoryReviewRecord | undefined
+        const reviews = state.reviews.map((record) => {
+          if (record.id !== id) return record
+          updated = { ...record, outcome, updatedAt: new Date().toISOString() }
+          return updated
+        })
+        if (!updated) throw new Error(`review record ${id} was not found`)
+        return { state: { ...state, reviews }, result: updated }
+      })
+    },
+    async reviewTargetFor(epicKey, parentSessionId, requestedTarget) {
+      await mutations
+      const state = await readFileState()
+      const prior = state.reviews.find((record) => (
+        record.epicKey === epicKey
+        && record.parentSessionId === parentSessionId
+        && record.beadId === undefined
+      ))
+      return prior?.targetKey ?? requestedTarget
+    },
+  }
+}
+
+export function positiveInteger(value: string | undefined, fallback: number): number {
+  if (!value?.trim()) return fallback
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback
+}

--- a/plugins/boring-factory/src/server/host/dispatchLedger.ts
+++ b/plugins/boring-factory/src/server/host/dispatchLedger.ts
@@ -3,6 +3,7 @@ import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 
 export type FactoryDispatchOutcome =
+  | 'reserved'
   | 'created'
   | 'running'
   | 'completed'
@@ -18,10 +19,20 @@ export interface FactoryDispatchRecord {
   readonly id: string
   readonly epicKey: string
   readonly beadId: string
-  readonly childSessionId: string
+  readonly childSessionId?: string
   readonly timestamp: string
   readonly updatedAt: string
   readonly outcome: FactoryDispatchOutcome
+}
+
+export type FactoryDispatchCap = 'worker-concurrency' | 'bead-dispatch'
+
+export interface FactoryCapRefusalMarker {
+  readonly id: string
+  readonly epicKey: string
+  readonly beadId: string
+  readonly cap: FactoryDispatchCap
+  readonly timestamp: string
 }
 
 export interface FactoryReviewRecord {
@@ -42,18 +53,20 @@ export interface FactoryDispatchState {
   readonly version: 1
   readonly dispatches: readonly FactoryDispatchRecord[]
   readonly reviews: readonly FactoryReviewRecord[]
+  readonly refusals: readonly FactoryCapRefusalMarker[]
 }
 
 export interface FactoryDispatchLedger {
   read(): Promise<FactoryDispatchState>
-  appendDispatch(record: Omit<FactoryDispatchRecord, 'id' | 'updatedAt'>): Promise<FactoryDispatchRecord>
+  reserveDispatch(record: Pick<FactoryDispatchRecord, 'epicKey' | 'beadId' | 'timestamp'>): Promise<FactoryDispatchRecord>
+  attachDispatch(id: string, childSessionId: string, outcome: FactoryDispatchOutcome): Promise<FactoryDispatchRecord>
   updateDispatch(id: string, outcome: FactoryDispatchOutcome): Promise<FactoryDispatchRecord>
   appendReview(record: Omit<FactoryReviewRecord, 'id' | 'updatedAt' | 'round'>): Promise<FactoryReviewRecord>
   updateReview(id: string, outcome: FactoryReviewOutcome): Promise<FactoryReviewRecord>
-  reviewTargetFor(epicKey: string, parentSessionId: string | undefined, requestedTarget: string): Promise<string>
+  markRefusal(input: Omit<FactoryCapRefusalMarker, 'id'>): Promise<{ readonly marker: FactoryCapRefusalMarker; readonly created: boolean }>
 }
 
-const EMPTY_STATE: FactoryDispatchState = { version: 1, dispatches: [], reviews: [] }
+const EMPTY_STATE: FactoryDispatchState = { version: 1, dispatches: [], reviews: [], refusals: [] }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value)
@@ -68,6 +81,7 @@ function parseState(raw: string, path: string): FactoryDispatchState {
     version: 1,
     dispatches: parsed.dispatches as FactoryDispatchRecord[],
     reviews: parsed.reviews as FactoryReviewRecord[],
+    refusals: Array.isArray(parsed.refusals) ? parsed.refusals as FactoryCapRefusalMarker[] : [],
   }
 }
 
@@ -109,10 +123,27 @@ export function createFactoryDispatchLedger(stateRoot: string): FactoryDispatchL
       await mutations
       return await readFileState()
     },
-    async appendDispatch(record) {
+    async reserveDispatch(record) {
       return await mutate((state) => {
-        const stored: FactoryDispatchRecord = { ...record, id: randomUUID(), updatedAt: record.timestamp }
+        const stored: FactoryDispatchRecord = {
+          ...record,
+          id: randomUUID(),
+          updatedAt: record.timestamp,
+          outcome: 'reserved',
+        }
         return { state: { ...state, dispatches: [...state.dispatches, stored] }, result: stored }
+      })
+    },
+    async attachDispatch(id, childSessionId, outcome) {
+      return await mutate((state) => {
+        let updated: FactoryDispatchRecord | undefined
+        const dispatches = state.dispatches.map((record) => {
+          if (record.id !== id) return record
+          updated = { ...record, childSessionId, outcome, updatedAt: new Date().toISOString() }
+          return updated
+        })
+        if (!updated) throw new Error(`dispatch record ${id} was not found`)
+        return { state: { ...state, dispatches }, result: updated }
       })
     },
     async updateDispatch(id, outcome) {
@@ -129,10 +160,18 @@ export function createFactoryDispatchLedger(stateRoot: string): FactoryDispatchL
     },
     async appendReview(record) {
       return await mutate((state) => {
+        const priorTarget = record.beadId === undefined
+          ? state.reviews.find((candidate) => (
+              candidate.epicKey === record.epicKey
+              && candidate.parentSessionId === record.parentSessionId
+              && candidate.beadId === undefined
+            ))?.targetKey
+          : undefined
+        const targetKey = priorTarget ?? record.targetKey
         const round = state.reviews.filter((candidate) => (
-          candidate.epicKey === record.epicKey && candidate.targetKey === record.targetKey
+          candidate.epicKey === record.epicKey && candidate.targetKey === targetKey
         )).length + 1
-        const stored: FactoryReviewRecord = { ...record, id: randomUUID(), round, updatedAt: record.timestamp }
+        const stored: FactoryReviewRecord = { ...record, targetKey, id: randomUUID(), round, updatedAt: record.timestamp }
         return { state: { ...state, reviews: [...state.reviews, stored] }, result: stored }
       })
     },
@@ -148,15 +187,20 @@ export function createFactoryDispatchLedger(stateRoot: string): FactoryDispatchL
         return { state: { ...state, reviews }, result: updated }
       })
     },
-    async reviewTargetFor(epicKey, parentSessionId, requestedTarget) {
-      await mutations
-      const state = await readFileState()
-      const prior = state.reviews.find((record) => (
-        record.epicKey === epicKey
-        && record.parentSessionId === parentSessionId
-        && record.beadId === undefined
-      ))
-      return prior?.targetKey ?? requestedTarget
+    async markRefusal(input) {
+      return await mutate<{ readonly marker: FactoryCapRefusalMarker; readonly created: boolean }>((state) => {
+        const existing = state.refusals.find((marker) => (
+          marker.epicKey === input.epicKey
+          && marker.beadId === input.beadId
+          && marker.cap === input.cap
+        ))
+        if (existing) return { state, result: { marker: existing, created: false } }
+        const marker: FactoryCapRefusalMarker = { ...input, id: randomUUID() }
+        return {
+          state: { ...state, refusals: [...state.refusals, marker] },
+          result: { marker, created: true },
+        }
+      })
     },
   }
 }

--- a/plugins/boring-factory/src/server/host/epicKickoff.test.ts
+++ b/plugins/boring-factory/src/server/host/epicKickoff.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { buildEpicKickoffPrompt, FACTORY_DEFAULT_PLAN_BUDGET_MS } from './epicKickoff'
+import type { FactoryEpicEntry } from './epicRegistry'
+
+describe('Factory epic kickoff prompt', () => {
+  it('carries the host Gate 1 deadline and names host-enforced dispatch and recovery tools', () => {
+    const now = Date.parse('2026-09-05T12:00:00.000Z')
+    const entry: FactoryEpicEntry = {
+      epicKey: 'factory-limits',
+      featureName: 'Factory Limits',
+      worktree: '/repo/.worktrees/factory-limits',
+      branch: 'factory-limits',
+      repositoryRoot: '/repo',
+      createdAt: new Date(now).toISOString(),
+      status: 'active',
+    }
+
+    const prompt = buildEpicKickoffPrompt(entry, 'Implement the bounded Factory limits.', now)
+
+    expect(prompt).toContain(`host deadline ${new Date(now + FACTORY_DEFAULT_PLAN_BUDGET_MS).toISOString()}`)
+    expect(prompt).toContain('BORING_FACTORY_PLAN_BUDGET_MS')
+    expect(prompt).toContain('call dispatch_worker with the exact ready Bead as beadId')
+    expect(prompt).toContain('call recover_stale_claims')
+    expect(prompt).not.toContain('Do not name a specific Bead')
+  })
+
+  it('preserves a deadline persisted by the host', () => {
+    const deadline = '2026-09-05T12:07:00.000Z'
+    const entry: FactoryEpicEntry = {
+      epicKey: 'factory-limits', featureName: 'Factory Limits', worktree: '/worktree', branch: 'factory-limits',
+      repositoryRoot: '/repo', createdAt: '2026-09-05T12:00:00.000Z', planDeadlineAt: deadline, status: 'active',
+    }
+    expect(buildEpicKickoffPrompt(entry, undefined, 0)).toContain(`host deadline ${deadline}`)
+  })
+})

--- a/plugins/boring-factory/src/server/host/epicKickoff.ts
+++ b/plugins/boring-factory/src/server/host/epicKickoff.ts
@@ -1,15 +1,22 @@
 import type { FactoryEpicEntry } from './epicRegistry'
 
-export function buildEpicKickoffPrompt(entry: FactoryEpicEntry, requestText?: string): string {
+export const FACTORY_DEFAULT_PLAN_BUDGET_MS = 20 * 60_000
+
+export function buildEpicKickoffPrompt(
+  entry: FactoryEpicEntry,
+  requestText?: string,
+  now: number = Date.now(),
+): string {
   const ownerRequest = requestText?.trim() || `Plan the ${entry.featureName} epic from the request and repository context available in the worktree.`
   const sessionContext = entry.orchestratorSessionId ? ` Your session id is ${entry.orchestratorSessionId}.` : ''
+  const planDeadlineAt = entry.planDeadlineAt ?? new Date(now + FACTORY_DEFAULT_PLAN_BUDGET_MS).toISOString()
   return [
     `Host context: epic ${entry.epicKey} ([${entry.featureName}]) worktree ${entry.worktree} branch ${entry.branch}.${sessionContext}`,
     'Owner request:',
     ownerRequest,
-    `Materialize the full dependency-correct Bead graph with real br commands in ${entry.worktree} (an epic Bead plus every named slice, wired with real \`br dep add\` relations where dependencies exist). Every Bead and every br query must use \`--label epic:${entry.epicKey}\`. Then raise Gate 1 (plan approval) now with ask_user, per the factory-precedence appendix — do not skip it and do not treat this message as a pre-approval.`,
-    'On approval, immediately start durable supervision with the supervise tool (op start, intervalMs 120000, a prompt naming factory_status and the recovery rule). Then dispatch Workers as Beads become ready: use dispatch_worker for each ready, unclaimed, dependency-unblocked Bead, up to 2 concurrently. Keep supervising and polling factory_status until every non-epic Bead has a complete handoff comment. Do not stop supervision until then.',
-    `Each Worker brief must preserve this host context, use the pull protocol (\`br ready --label epic:${entry.epicKey} --unassigned\`, then claim one with \`--claim --actor <session id>\`), implement and stage only intended files in ${entry.worktree}, commit on ${entry.branch}, exact-SHA sandbox-test via the sandbox tools, obtain adversarial fresh_review of that SHA, push the epic branch, and record a complete Bead handoff (SHA, proof, review provenance). It must never merge or close its own Bead. Do not name a specific Bead in the brief — the Worker claims whichever ready Bead it picks up.`,
+    `Materialize the full dependency-correct Bead graph with real br commands in ${entry.worktree} (an epic Bead plus every named slice, wired with real \`br dep add\` relations where dependencies exist). Every Bead and every br query must use \`--label epic:${entry.epicKey}\`. Then raise Gate 1 (plan approval) with ask_user no later than the host deadline ${planDeadlineAt} (BORING_FACTORY_PLAN_BUDGET_MS); do not skip it and do not treat this message as a pre-approval.`,
+    'On approval, immediately start durable supervision with the supervise tool (op start, intervalMs 120000, a prompt naming factory_status and the recovery rule). Then dispatch Workers as Beads become ready: call dispatch_worker with the exact ready Bead as beadId. The host enforces concurrent-Worker and per-Bead dispatch caps. Keep supervising and polling factory_status until every non-epic Bead has a complete handoff comment. When factory_status reports stale claims, call recover_stale_claims. Do not stop supervision until then.',
+    `Each Worker brief must preserve this host context and name its target Bead, verify that exact Bead through \`br ready --label epic:${entry.epicKey} --unassigned\`, claim it with \`--claim --actor <session id>\`, implement and stage only intended files in ${entry.worktree}, commit on ${entry.branch}, exact-SHA sandbox-test via the sandbox tools, obtain adversarial fresh_review of that SHA, push the epic branch, and record a complete Bead handoff (SHA, proof, review provenance). It must never merge or close its own Bead.`,
     'Report progress each round: which Beads are handed off, which are in flight, and on which Worker sessions. On changes/defer/reject at Gate 1: revise and re-raise, or stop and report; do not arm supervision or dispatch.',
   ].join('\n\n')
 }

--- a/plugins/boring-factory/src/server/host/epicRegistry.ts
+++ b/plugins/boring-factory/src/server/host/epicRegistry.ts
@@ -24,6 +24,7 @@ export interface FactoryEpicEntry {
   readonly models?: FactoryEpicModels
   readonly orchestratorSessionId?: string
   readonly createdAt: string
+  readonly planDeadlineAt?: string
   readonly status: 'active' | 'closed'
 }
 
@@ -176,6 +177,12 @@ export async function validateFactoryEpicEntry(entry: FactoryEpicEntry): Promise
   assertNonEmpty(entry.branch, 'branch')
   assertNonEmpty(entry.repositoryRoot, 'repositoryRoot')
   assertNonEmpty(entry.createdAt, 'createdAt')
+  if (entry.planDeadlineAt !== undefined) {
+    assertNonEmpty(entry.planDeadlineAt, 'planDeadlineAt')
+    if (!Number.isFinite(Date.parse(entry.planDeadlineAt))) {
+      throw new FactoryEpicRegistryError('INVALID_EPIC', 'planDeadlineAt must be an ISO date-time string')
+    }
+  }
   if (entry.status !== 'active' && entry.status !== 'closed') {
     throw new FactoryEpicRegistryError('INVALID_EPIC', 'status must be "active" or "closed"')
   }

--- a/plugins/boring-factory/src/server/host/factoryFleet.ts
+++ b/plugins/boring-factory/src/server/host/factoryFleet.ts
@@ -31,14 +31,16 @@ const seatSkills = {
  * Host appendix naming which host tool implements which step of the canonical `exec`/`plan`/
  * `owner-gate` skill text above (already reconciled with this Factory's topology: one shared
  * epic branch, one epic PR owned by the Orchestrator/owner, Workers that never gate or merge).
- * This appendix adds nothing the skills don't already say — it only binds tool names.
+ * This appendix binds tool names and host-enforced limits without changing canonical persona files.
  */
 const FACTORY_PRECEDENCE_CONTENT = {
   worker: [
     'The `exec` skill above is this seat\'s full loop (pull, claim, commit, push, sandbox-test,',
     '`fresh_review`, Bead-comment handoff — never a PR, never `ask_user`, never merge). The host',
     'tool that runs your adversarial review is `fresh_review`; the tools that run your exact-SHA',
-    'tests/builds are `sandbox` and `sandbox_bash`.',
+    'tests/builds are `sandbox` and `sandbox_bash`. When fresh_review returns `capReached: true`,',
+    'hand off at the current SHA and file remaining findings as follow-up Beads; do not fix forward again.',
+    'Pass your target Bead id to `fresh_review` so all fix-forward SHAs share one host round counter.',
   ].join(' '),
   orchestrator: [
     'The `plan` and `owner-gate` skills above are this seat\'s full loop (Bead graph, Gate 1,',
@@ -50,6 +52,9 @@ const FACTORY_PRECEDENCE_CONTENT = {
     'The `show-me` skill above is mandatory, not optional, at both gates: Gate 1 carries the',
     'show-me plan artifact and Gate 2\'s PR body carries a `## Show me` section, per',
     '`owner-gate`\'s SKILL.md.',
+    'The host, not persona prose, enforces stale-claim recovery and dispatch/review caps. When',
+    '`factory_status` reports a stale claim, call `recover_stale_claims`. When `dispatch_worker`',
+    'refuses at a cap, do not retry: raise the requested Inbox question with `ask_user`.',
   ].join(' '),
 } as const
 
@@ -80,13 +85,14 @@ function epicBindingContent(seat: keyof typeof seatSkills): string {
     return [
       shared,
       'Every Bead you create MUST carry `--labels epic:<key>` (add `--parent <epic bead id>` when you create an epic Bead first) and use the feature name from host context in its title. Inspect only with `br ready --label epic:<key>` / `br list --label epic:<key>` and pass `epicKey` to host tools when you use an explicit override.',
-      'Recovery: run `factory_status` on every supervision tick. A Bead that is `in_progress` whose ' +
-        'assignee session is `unknown` or `exists-idle` with no handoff comment and no new commit on ' +
-        'the epic branch is STALE: release it with `br update <id> --assignee "" --status open --actor ' +
-        '<your session id>`, add a Bead comment `recovered stale claim from <old session>`, then start a ' +
-        'fresh Worker with `dispatch_worker`. Never release a Bead whose assignee session is ' +
-        '`exists-busy`. Uncommitted edits left in the shared worktree by a dead Worker are handed to the ' +
-        'next Worker in its brief, never reverted by you.',
+      'Recovery: run `factory_status` on every supervision tick. The host classifies each in-progress ' +
+        'claim as missing, busy, idle, or stale. When it reports `stale: true`, call the host\'s ' +
+        '`recover_stale_claims` tool; never release claims manually and never release a busy claim. ' +
+        'Uncommitted edits left in the shared worktree by a dead Worker are handed to the next Worker ' +
+        'in its brief, never reverted by you.',
+      'Dispatch only a ready, unclaimed, dependency-unblocked Bead and pass its exact id as ' +
+        '`dispatch_worker.beadId`; name that Bead in the Worker brief. The host enforces the Worker ' +
+        'concurrency and per-Bead dispatch caps.',
     ].join('\n\n')
   }
   if (seat === 'reviewer') {
@@ -97,7 +103,7 @@ function epicBindingContent(seat: keyof typeof seatSkills): string {
   }
   return [
     shared,
-    'Discover work ONLY with `br ready --label epic:<key> --unassigned`; claim exactly one result with `br update <id> --claim --actor <your session id>`; if that command returns nothing, stop and report "no ready Bead for epic <key>" instead of running a broader `br ready`. Never claim a Bead lacking that label.',
+    'Your host context names the target Bead. Verify that exact id appears in `br ready --label epic:<key> --unassigned`, then claim it with `br update <id> --claim --actor <your session id>`; if it is absent, stop and report "target Bead is not ready for epic <key>" instead of claiming another result or running a broader `br ready`. Never claim a Bead lacking that label.',
     'If the shared worktree already holds uncommitted changes for your Bead from a previous ' +
       'Worker, inspect them, adopt what is correct, finish the work, and say so in the handoff; ' +
       'never revert them wholesale. Fix forward only: no git reset, no amend or rebase of pushed commits, no force push.',

--- a/plugins/boring-factory/src/server/host/factoryHub.ts
+++ b/plugins/boring-factory/src/server/host/factoryHub.ts
@@ -18,7 +18,8 @@ import { createFactoryDemoPlugin } from './demoPlugin'
 import { executeCloseEpic } from './epicClosure'
 import { createFactoryEpicRegistry, FACTORY_REQUEST_FILE_MAX_BYTES, FactoryEpicRegistryError, resolveFactoryEpicRequestFile, validateFactoryEpicEntry, type FactoryEpicEntry, type FactoryEpicModels, type FactoryEpicRegistry } from './epicRegistry'
 import { createFactorySessionBindings, FactoryEpicResolutionError, FactorySessionBindingError, resolveFactoryEpic, type FactorySessionBindings } from './sessionBindings'
-import { buildEpicKickoffPrompt } from './epicKickoff'
+import { buildEpicKickoffPrompt, FACTORY_DEFAULT_PLAN_BUDGET_MS } from './epicKickoff'
+import { positiveInteger } from './dispatchLedger'
 
 const execFileAsync = promisify(execFile)
 const FACTORY_WORKSPACE_SCOPE_ID = 'factory-hub'
@@ -395,7 +396,7 @@ export async function createFactoryHost(options: CreateFactoryHostOptions): Prom
     reviewer: options.models?.reviewer ?? env.BORING_FACTORY_REVIEWER_MODEL,
   })
   const beadsOperations = createWorkspaceBeadsOperations(createNodeWorkspace(workspaceRoot))
-  const delegate = createFactoryDelegatePlugin({ workspaceScopeId, registry, sessionBindings })
+  const delegate = createFactoryDelegatePlugin({ stateRoot, env, workspaceScopeId, registry, sessionBindings })
   const supervision = createFactorySupervisionPlugin({ stateRoot, workspaceScopeId, registry, sessionBindings })
   const demo = createFactoryDemoPlugin({ stateRoot, env, workspaceScopeId, registry, sessionBindings })
   let appRef: FastifyInstance | undefined
@@ -488,6 +489,8 @@ export async function createFactoryHost(options: CreateFactoryHostOptions): Prom
       }
       requestText = content.toString('utf8')
     }
+    const createdAt = new Date().toISOString()
+    const planBudgetMs = positiveInteger(env.BORING_FACTORY_PLAN_BUDGET_MS, FACTORY_DEFAULT_PLAN_BUDGET_MS)
     const candidate = await validateFactoryEpicEntry({
       epicKey: input.epicKey,
       featureName: input.featureName,
@@ -496,7 +499,8 @@ export async function createFactoryHost(options: CreateFactoryHostOptions): Prom
       repositoryRoot,
       ...(requestFile ? { requestFile } : {}),
       ...(input.models ? { models: input.models } : {}),
-      createdAt: new Date().toISOString(),
+      createdAt,
+      planDeadlineAt: new Date(Date.parse(createdAt) + planBudgetMs).toISOString(),
       status: 'active',
     })
     const sessionId = await createOrchestratorSession(app, candidate)

--- a/plugins/boring-factory/src/server/host/factoryLimits.test.ts
+++ b/plugins/boring-factory/src/server/host/factoryLimits.test.ts
@@ -304,7 +304,7 @@ describe('Factory host limits', () => {
         }
       }
       if (args[0] === 'update' && args[1] === 'br-changing') events.push('release')
-      return await baseBr.runBr(args, cwd)
+      return await baseBr.runBr(args)
     })
     const fake = fakeApp([{ sessionId: 'changing', status: 'idle', updatedAt: now - 11 * 60_000 }])
     const originalInject = fake.app.inject.bind(fake.app)

--- a/plugins/boring-factory/src/server/host/factoryLimits.test.ts
+++ b/plugins/boring-factory/src/server/host/factoryLimits.test.ts
@@ -71,6 +71,7 @@ interface FakeAppOptions {
   readonly workerSessionStatusCode?: number
   readonly repeatWorkerCursor?: boolean
   readonly workerSessionPageCount?: number
+  readonly crashAfterSessionCreation?: boolean
 }
 
 function fakeApp(
@@ -104,7 +105,14 @@ function fakeApp(
         }
         if (request.method === 'POST' && request.url.endsWith('/sessions')) {
           const sessionId = childSessionIds[created++] ?? `child-${created}`
-          return { statusCode: 201, body: '', json: <T>() => ({ sessionId }) as T }
+          return {
+            statusCode: 201,
+            body: '',
+            json: <T>() => {
+              if (options.crashAfterSessionCreation) throw new Error('simulated host crash before ledger attach')
+              return { sessionId } as T
+            },
+          }
         }
         if (request.method === 'POST' && request.url.endsWith('/prompt')) {
           return { statusCode: 202, body: '', json: <T>() => ({}) as T }
@@ -271,6 +279,51 @@ describe('Factory host limits', () => {
     expect(calls.some((args) => args[0] === 'update')).toBe(false)
   })
 
+  it('holds session admission from stale classification through claim release', async () => {
+    const stateRoot = await makeStateRoot()
+    const now = 2_000_000
+    const { registry, sessionBindings } = dependencies({ changing: 'limits-epic' })
+    const baseBr = fakeBr([
+      { id: 'br-changing', status: 'in_progress', assignee: 'changing' },
+      { id: 'br-next', status: 'open' },
+    ])
+    const events: string[] = []
+    let changingCommentReads = 0
+    let dispatchPromise: Promise<unknown> | undefined
+    let dispatchTool: ReturnType<typeof toolNamed> | undefined
+    const runBr = vi.fn(async (args: readonly string[], cwd: string) => {
+      if (args[0] === 'comments' && args[1] === 'list' && args[2] === 'br-changing') {
+        changingCommentReads += 1
+        if (changingCommentReads === 2) {
+          events.push('final-classification')
+          dispatchPromise = dispatchTool!.execute(
+            { beadId: 'br-next', brief: 'Dispatch br-next while stale recovery is releasing.' },
+            context('orch', 'concurrent-dispatch'),
+          )
+          await Promise.resolve()
+        }
+      }
+      if (args[0] === 'update' && args[1] === 'br-changing') events.push('release')
+      return await baseBr.runBr(args, cwd)
+    })
+    const fake = fakeApp([{ sessionId: 'changing', status: 'idle', updatedAt: now - 11 * 60_000 }])
+    const originalInject = fake.app.inject.bind(fake.app)
+    fake.app.inject = async (request) => {
+      if (request.method === 'POST' && request.url.endsWith('/sessions')) events.push('worker-busy')
+      return await originalInject(request)
+    }
+    const handle = createFactoryDelegatePlugin({ stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, runBr, now: () => now })
+    handle.bind(fake.app as never)
+    dispatchTool = toolNamed(handle, 'boring-orchestrator', 'dispatch_worker')
+
+    const recovered = await toolNamed(handle, 'boring-orchestrator', 'recover_stale_claims').execute({}, context('orch', 'recover'))
+    await dispatchPromise
+
+    expect(recovered.details).toMatchObject({ recovered: [expect.objectContaining({ beadId: 'br-changing' })] })
+    expect(events).toEqual(expect.arrayContaining(['final-classification', 'release', 'worker-busy']))
+    expect(events.indexOf('release')).toBeLessThan(events.indexOf('worker-busy'))
+  })
+
   it('fails closed when comment facts or the complete session inventory cannot be read', async () => {
     const stateRoot = await makeStateRoot()
     const { registry, sessionBindings } = dependencies()
@@ -328,6 +381,14 @@ describe('Factory host limits', () => {
     expect(brCalls.map((args) => args.slice(0, 3))).toEqual(expect.arrayContaining([
       ['update', 'br-1', '--status'], ['comments', 'add', 'br-1'],
     ]))
+
+    const restarted = createFactoryDelegatePlugin({ stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, runBr })
+    restarted.bind(app as never)
+    await toolNamed(restarted, 'boring-orchestrator', 'dispatch_worker').execute(
+      { beadId: 'br-1', brief: 'Retry the exact target Bead br-1 again.' }, context('orch', 'retry'),
+    )
+    expect(brCalls.filter((args) => args[0] === 'update')).toHaveLength(1)
+    expect(brCalls.filter((args) => args[0] === 'comments' && args[1] === 'add')).toHaveLength(1)
   })
 
   it('refuses the per-Bead dispatch cap before creating a session and blocks/comments the Bead', async () => {
@@ -370,6 +431,46 @@ describe('Factory host limits', () => {
     expect((second.details as { capInstructions: string }).capInstructions).toContain('Hand off at the current SHA')
   })
 
+  it('serializes SHA-lineage resolution with concurrent review appends that omit beadId', async () => {
+    const stateRoot = await makeStateRoot()
+    const { registry, sessionBindings } = dependencies()
+    const { runBr } = fakeBr()
+    const { app } = fakeApp([], ['review-a', 'review-b'])
+    const handle = createFactoryDelegatePlugin({
+      stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, runBr, timeoutMs: 1_000,
+    })
+    handle.bind(app as never)
+    const tool = toolNamed(handle, 'boring-worker', 'fresh_review')
+
+    const results = await Promise.all([
+      tool.execute({ brief: 'Review the current target at abcdef1 without a Bead id.' }, context('worker', 'r1')),
+      tool.execute({ brief: 'Review the updated target at abcdef2 without a Bead id.' }, context('worker', 'r2')),
+    ])
+
+    expect(results.map((result) => (result.details as { reviewRound: number }).reviewRound).sort()).toEqual([1, 2])
+    expect(new Set(results.map((result) => (result.details as { reviewTarget: string }).reviewTarget)).size).toBe(1)
+  })
+
+  it('fails closed when a Bead or ledger inference conflicts with an authoritative binding', async () => {
+    const stateRoot = await makeStateRoot()
+    const { registry, sessionBindings } = dependencies({ foreign: 'other-epic' })
+    const { runBr } = fakeBr([{ id: 'br-1', status: 'in_progress', assignee: 'foreign' }])
+    const { app, calls } = fakeApp([{ sessionId: 'foreign', status: 'running', updatedAt: 1 }])
+    const handle = createFactoryDelegatePlugin({
+      stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, runBr, readGitStatus: gitStatus,
+    })
+    handle.bind(app as never)
+
+    const status = await toolNamed(handle, 'boring-orchestrator', 'factory_status').execute({}, context('orch', 'status'))
+    const dispatch = await toolNamed(handle, 'boring-orchestrator', 'dispatch_worker').execute(
+      { beadId: 'br-1', brief: 'Dispatch target Bead br-1 despite conflicting ownership.' }, context('orch', 'dispatch'),
+    )
+
+    expect(status).toMatchObject({ isError: true, details: { code: 'FACTORY_STATUS_FAILED', message: expect.stringContaining('ownership conflict') } })
+    expect(dispatch).toMatchObject({ isError: true, details: { code: 'DELEGATE_FAILED', message: expect.stringContaining('ownership conflict') } })
+    expect(calls.some((call) => call.method === 'POST' && call.url.endsWith('/sessions'))).toBe(false)
+  })
+
   it('persists dispatch counters across host restart and enforces them on the next admission', async () => {
     const stateRoot = await makeStateRoot()
     const { registry, sessionBindings } = dependencies()
@@ -397,6 +498,42 @@ describe('Factory host limits', () => {
     expect(status.details).toMatchObject({ counters: { dispatchesPerOpenBead: { 'br-1': 1 } } })
     const refused = await toolNamed(restartedHost, 'boring-orchestrator', 'dispatch_worker').execute(
       { beadId: 'br-1', brief: 'Retry target Bead br-1 after host restart.' }, context('orch', 'second'),
+    )
+    expect(refused.details).toMatchObject({ code: 'BEAD_DISPATCH_CAP_REACHED', current: 1, maximum: 1 })
+    expect(secondApp.calls.some((call) => call.method === 'POST' && call.url.endsWith('/sessions'))).toBe(false)
+  })
+
+  it('persists a dispatch reservation before child attach and enforces it after a crash restart', async () => {
+    const stateRoot = await makeStateRoot()
+    const { registry, sessionBindings } = dependencies()
+    const firstBr = fakeBr()
+    const firstApp = fakeApp([], ['orphan-worker'], { crashAfterSessionCreation: true })
+    const firstHost = createFactoryDelegatePlugin({
+      stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, runBr: firstBr.runBr,
+      env: { BORING_FACTORY_MAX_DISPATCHES_PER_BEAD: '1' }, timeoutMs: 1_000,
+    })
+    firstHost.bind(firstApp.app as never)
+
+    const crashed = await toolNamed(firstHost, 'boring-orchestrator', 'dispatch_worker').execute(
+      { beadId: 'br-1', brief: 'Crash after creating the child for target Bead br-1.' }, context('orch', 'crash'),
+    )
+    expect(crashed).toMatchObject({ isError: true, details: { code: 'DELEGATE_FAILED' } })
+    expect(firstApp.calls.some((call) => call.method === 'POST' && call.url.endsWith('/sessions'))).toBe(true)
+    const persisted = JSON.parse(await readFile(resolve(stateRoot, 'dispatches.json'), 'utf8')) as {
+      dispatches: Array<{ outcome: string; childSessionId?: string }>
+    }
+    expect(persisted.dispatches).toEqual([expect.objectContaining({ outcome: 'reserved' })])
+    expect(persisted.dispatches[0]!.childSessionId).toBeUndefined()
+
+    const secondBr = fakeBr()
+    const secondApp = fakeApp()
+    const restartedHost = createFactoryDelegatePlugin({
+      stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, runBr: secondBr.runBr,
+      env: { BORING_FACTORY_MAX_DISPATCHES_PER_BEAD: '1' }, timeoutMs: 1_000,
+    })
+    restartedHost.bind(secondApp.app as never)
+    const refused = await toolNamed(restartedHost, 'boring-orchestrator', 'dispatch_worker').execute(
+      { beadId: 'br-1', brief: 'Retry target Bead br-1 after the attach crash.' }, context('orch', 'restart'),
     )
     expect(refused.details).toMatchObject({ code: 'BEAD_DISPATCH_CAP_REACHED', current: 1, maximum: 1 })
     expect(secondApp.calls.some((call) => call.method === 'POST' && call.url.endsWith('/sessions'))).toBe(false)

--- a/plugins/boring-factory/src/server/host/factoryLimits.test.ts
+++ b/plugins/boring-factory/src/server/host/factoryLimits.test.ts
@@ -277,7 +277,7 @@ describe('Factory host limits', () => {
     const baseBr = fakeBr([{ id: 'br-1', status: 'in_progress', assignee: 'gone' }])
     const failingComments = vi.fn(async (args: readonly string[], cwd: string) => {
       if (args[0] === 'comments' && args[1] === 'list') throw new Error('comment store unavailable')
-      return await baseBr.runBr(args, cwd)
+      return await baseBr.runBr(args)
     })
     const healthyApp = fakeApp()
     const commentHost = createFactoryDelegatePlugin({

--- a/plugins/boring-factory/src/server/host/factoryLimits.test.ts
+++ b/plugins/boring-factory/src/server/host/factoryLimits.test.ts
@@ -1,0 +1,404 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createFactoryDelegatePlugin } from './delegatePlugin'
+import type { FactoryEpicEntry, FactoryEpicRegistry } from './epicRegistry'
+import type { FactorySessionBindings } from './sessionBindings'
+
+const temporaryRoots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(temporaryRoots.splice(0).map(async (root) => await rm(root, { recursive: true, force: true })))
+})
+
+async function makeStateRoot(): Promise<string> {
+  const root = await mkdtemp(resolve(tmpdir(), 'factory-limits-'))
+  temporaryRoots.push(root)
+  return root
+}
+
+function dependencies(extraBindings: Record<string, string> = {}) {
+  const entry: FactoryEpicEntry = {
+    epicKey: 'limits-epic', featureName: 'Limits Epic', worktree: process.cwd(), branch: 'factory-limits',
+    repositoryRoot: process.cwd(), createdAt: '2026-09-05T00:00:00.000Z', status: 'active',
+  }
+  const registry: FactoryEpicRegistry = {
+    load: async () => [entry], list: async () => [entry], get: async (key) => key === entry.epicKey ? entry : undefined,
+    register: async () => entry, setOrchestratorSession: async () => entry, markClosed: async () => ({ ...entry, status: 'closed' }),
+  }
+  const bindings: Record<string, string> = { orch: entry.epicKey, worker: entry.epicKey, ...extraBindings }
+  const sessionBindings: FactorySessionBindings = {
+    load: async () => ({ ...bindings }), get: async (id) => bindings[id],
+    bind: vi.fn(async (id, key) => { bindings[id] = key }),
+    unbind: vi.fn(async (id) => { delete bindings[id] }),
+    inherit: async (parent, child) => { bindings[child] = bindings[parent]!; return bindings[child]! },
+    reconcile: async () => ({ droppedSessionIds: [], restoredOrchestratorSessionIds: [] }),
+  }
+  return { registry, sessionBindings }
+}
+
+interface Bead {
+  readonly id: string
+  readonly status: string
+  readonly assignee?: string | null
+}
+
+function fakeBr(
+  beads: readonly Bead[] = [{ id: 'br-1', status: 'open' }],
+  comments: Readonly<Record<string, readonly Record<string, unknown>[]>> = {},
+) {
+  const calls: Array<readonly string[]> = []
+  const runBr = vi.fn(async (args: readonly string[]) => {
+    calls.push(args)
+    if (args[0] === 'list') return JSON.stringify({ issues: beads.map((bead) => ({ ...bead, labels: ['epic:limits-epic'] })) })
+    if (args[0] === 'comments' && args[1] === 'list') return JSON.stringify(comments[args[2]!] ?? [])
+    if (args[0] === 'update') return JSON.stringify([{ id: args[1] }])
+    if (args[0] === 'comments' && args[1] === 'add') return JSON.stringify({ id: 1 })
+    throw new Error(`unexpected br command: ${args.join(' ')}`)
+  })
+  return { runBr, calls }
+}
+
+interface WorkerSummary {
+  readonly sessionId: string
+  readonly status: string
+  readonly updatedAt: number
+}
+
+interface FakeAppOptions {
+  readonly workerSessionSnapshots?: readonly (readonly WorkerSummary[])[]
+  readonly workerSessionStatusCode?: number
+  readonly repeatWorkerCursor?: boolean
+  readonly workerSessionPageCount?: number
+}
+
+function fakeApp(
+  workerSessions: readonly WorkerSummary[] = [],
+  childSessionIds: readonly string[] = ['child-1'],
+  options: FakeAppOptions = {},
+) {
+  const calls: Array<{ method: string; url: string; payload?: unknown }> = []
+  let created = 0
+  let sessionListCalls = 0
+  return {
+    calls,
+    app: {
+      async inject(request: { method: string; url: string; payload?: unknown }) {
+        calls.push(request)
+        if (request.method === 'GET' && request.url.includes('/boring-worker/sessions') && !request.url.endsWith('/state')) {
+          const snapshot = options.workerSessionSnapshots?.[Math.min(sessionListCalls, options.workerSessionSnapshots.length - 1)] ?? workerSessions
+          sessionListCalls += 1
+          return {
+            statusCode: options.workerSessionStatusCode ?? 200,
+            body: '',
+            json: <T>() => ({
+              sessions: snapshot.map((session) => ({ ref: { sessionId: session.sessionId }, ...session })),
+              ...(options.repeatWorkerCursor
+                ? { nextCursor: 'same-cursor' }
+                : sessionListCalls < (options.workerSessionPageCount ?? 1)
+                  ? { nextCursor: `page-${sessionListCalls + 1}` }
+                  : {}),
+            }) as T,
+          }
+        }
+        if (request.method === 'POST' && request.url.endsWith('/sessions')) {
+          const sessionId = childSessionIds[created++] ?? `child-${created}`
+          return { statusCode: 201, body: '', json: <T>() => ({ sessionId }) as T }
+        }
+        if (request.method === 'POST' && request.url.endsWith('/prompt')) {
+          return { statusCode: 202, body: '', json: <T>() => ({}) as T }
+        }
+        if (request.method === 'GET' && request.url.endsWith('/state')) {
+          return {
+            statusCode: 200,
+            body: '',
+            json: <T>() => ({
+              summary: { turnCount: 1 },
+              state: { status: 'idle', messages: [{ role: 'assistant', parts: [{ type: 'text', text: 'done' }] }] },
+            }) as T,
+          }
+        }
+        throw new Error(`unexpected request ${request.method} ${request.url}`)
+      },
+    },
+  }
+}
+
+const gitStatus = async () => ({ branch: 'factory-limits', head: 'a'.repeat(40), remoteHead: null, dirtyPaths: [] })
+const context = (sessionId: string, toolCallId = 'call') => ({ abortSignal: new AbortController().signal, toolCallId, sessionId })
+
+function toolNamed(handle: ReturnType<typeof createFactoryDelegatePlugin>, seat: string, name: string) {
+  return (handle.plugin.agentToolFactory?.({ agentTypeId: seat }) ?? []).find((tool) => tool.name === name)!
+}
+
+describe('Factory host limits', () => {
+  it('classifies missing, busy, idle-under-grace, and idle-over-grace claims', async () => {
+    const stateRoot = await makeStateRoot()
+    const now = 2_000_000
+    const { registry, sessionBindings } = dependencies({ busy: 'limits-epic', under: 'limits-epic', over: 'limits-epic' })
+    const { runBr } = fakeBr([
+      { id: 'br-missing', status: 'in_progress', assignee: 'gone' },
+      { id: 'br-busy', status: 'in_progress', assignee: 'busy' },
+      { id: 'br-under', status: 'in_progress', assignee: 'under' },
+      { id: 'br-over', status: 'in_progress', assignee: 'over' },
+    ])
+    const { app } = fakeApp([
+      { sessionId: 'busy', status: 'running', updatedAt: now - 20 * 60_000 },
+      { sessionId: 'under', status: 'idle', updatedAt: now - 9 * 60_000 },
+      { sessionId: 'over', status: 'idle', updatedAt: now - 11 * 60_000 },
+    ])
+    const handle = createFactoryDelegatePlugin({ stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, runBr, readGitStatus: gitStatus, now: () => now })
+    handle.bind(app as never)
+
+    const result = await toolNamed(handle, 'boring-orchestrator', 'factory_status').execute({}, context('orch'))
+    expect(result.isError).toBe(false)
+    const beads = (result.details as { beads: Array<Record<string, unknown>> }).beads
+    expect(beads).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'br-missing', sessionLiveness: 'missing', stale: true, recoveryCommand: 'recover_stale_claims' }),
+      expect.objectContaining({ id: 'br-busy', sessionLiveness: 'busy', stale: false }),
+      expect.objectContaining({ id: 'br-under', sessionLiveness: 'idle', idleForMs: 9 * 60_000, stale: false }),
+      expect.objectContaining({ id: 'br-over', sessionLiveness: 'idle', idleForMs: 11 * 60_000, stale: true, recoveryCommand: 'recover_stale_claims' }),
+    ]))
+    expect(result.details).toMatchObject({ staleClaims: { count: 2, beadIds: ['br-missing', 'br-over'], recoveryCommand: 'recover_stale_claims' } })
+  })
+
+  it('resolves an assignee session independently of a missing epic binding', async () => {
+    const stateRoot = await makeStateRoot()
+    const now = 2_000_000
+    const { registry, sessionBindings } = dependencies()
+    const { runBr } = fakeBr([{ id: 'br-1', status: 'in_progress', assignee: 'unbound-worker' }])
+    const { app } = fakeApp([{ sessionId: 'unbound-worker', status: 'running', updatedAt: now - 20 * 60_000 }])
+    const handle = createFactoryDelegatePlugin({ stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, runBr, readGitStatus: gitStatus, now: () => now })
+    handle.bind(app as never)
+
+    const result = await toolNamed(handle, 'boring-orchestrator', 'factory_status').execute({}, context('orch'))
+    expect(result.details).toMatchObject({
+      beads: [expect.objectContaining({ id: 'br-1', sessionLiveness: 'busy', stale: false })],
+      counters: { busyWorkers: 1 },
+    })
+  })
+
+  it('paginates Worker session history beyond five pages', async () => {
+    const stateRoot = await makeStateRoot()
+    const now = 2_000_000
+    const { registry, sessionBindings } = dependencies()
+    const { runBr } = fakeBr([{ id: 'br-1', status: 'in_progress', assignee: 'late-worker' }])
+    const emptyPages = Array.from({ length: 5 }, () => [] as readonly WorkerSummary[])
+    const finalPage = [{ sessionId: 'late-worker', status: 'running', updatedAt: now }]
+    const { app } = fakeApp([], ['unused'], {
+      workerSessionSnapshots: [...emptyPages, finalPage],
+      workerSessionPageCount: 6,
+    })
+    const handle = createFactoryDelegatePlugin({ stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, runBr, readGitStatus: gitStatus, now: () => now })
+    handle.bind(app as never)
+
+    const result = await toolNamed(handle, 'boring-orchestrator', 'factory_status').execute({}, context('orch'))
+    expect(result).toMatchObject({ isError: false, details: {
+      beads: [expect.objectContaining({ id: 'br-1', sessionLiveness: 'busy', stale: false })],
+      counters: { busyWorkers: 1 },
+    } })
+  })
+
+  it('recognizes only a canonical handoff for the same Bead', async () => {
+    const stateRoot = await makeStateRoot()
+    const now = 2_000_000
+    const { registry, sessionBindings } = dependencies({ valid: 'limits-epic', prose: 'limits-epic' })
+    const { runBr } = fakeBr([
+      { id: 'br-valid', status: 'in_progress', assignee: 'valid' },
+      { id: 'br-prose', status: 'in_progress', assignee: 'prose' },
+    ], {
+      'br-valid': [{ body: '[Limits Epic] handoff · br-valid · abcdef1' }],
+      'br-prose': [{ body: 'Worker exited without a handoff; recovery is required.' }],
+    })
+    const { app } = fakeApp([
+      { sessionId: 'valid', status: 'idle', updatedAt: now - 11 * 60_000 },
+      { sessionId: 'prose', status: 'idle', updatedAt: now - 11 * 60_000 },
+    ])
+    const handle = createFactoryDelegatePlugin({ stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, runBr, readGitStatus: gitStatus, now: () => now })
+    handle.bind(app as never)
+
+    const result = await toolNamed(handle, 'boring-orchestrator', 'factory_status').execute({}, context('orch'))
+    expect(result.details).toMatchObject({ beads: [
+      expect.objectContaining({ id: 'br-valid', hasHandoff: true, stale: false }),
+      expect.objectContaining({ id: 'br-prose', hasHandoff: false, stale: true }),
+    ] })
+  })
+
+  it('recover_stale_claims releases only stale claims and never busy or under-grace claims', async () => {
+    const stateRoot = await makeStateRoot()
+    const now = 2_000_000
+    const { registry, sessionBindings } = dependencies({ busy: 'limits-epic', under: 'limits-epic', over: 'limits-epic' })
+    const { runBr, calls } = fakeBr([
+      { id: 'br-missing', status: 'in_progress', assignee: 'gone' },
+      { id: 'br-busy', status: 'in_progress', assignee: 'busy' },
+      { id: 'br-under', status: 'in_progress', assignee: 'under' },
+      { id: 'br-over', status: 'in_progress', assignee: 'over' },
+    ])
+    const { app } = fakeApp([
+      { sessionId: 'busy', status: 'running', updatedAt: now - 20 * 60_000 },
+      { sessionId: 'under', status: 'idle', updatedAt: now - 9 * 60_000 },
+      { sessionId: 'over', status: 'idle', updatedAt: now - 11 * 60_000 },
+    ])
+    const handle = createFactoryDelegatePlugin({ stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, runBr, now: () => now })
+    handle.bind(app as never)
+
+    const result = await toolNamed(handle, 'boring-orchestrator', 'recover_stale_claims').execute({}, context('orch'))
+    expect(result.details).toMatchObject({ recovered: [
+      { beadId: 'br-missing', deadSessionId: 'gone' },
+      { beadId: 'br-over', deadSessionId: 'over' },
+    ] })
+    const updates = calls.filter((args) => args[0] === 'update')
+    expect(updates.map((args) => args[1])).toEqual(['br-missing', 'br-over'])
+    expect(updates.every((args) => args.includes('--assignee') && args.includes('') && args.includes('open'))).toBe(true)
+  })
+
+  it('revalidates a stale claim and skips it when its Worker becomes busy', async () => {
+    const stateRoot = await makeStateRoot()
+    const now = 2_000_000
+    const { registry, sessionBindings } = dependencies({ changing: 'limits-epic' })
+    const { runBr, calls } = fakeBr([{ id: 'br-changing', status: 'in_progress', assignee: 'changing' }])
+    const idle = [{ sessionId: 'changing', status: 'idle', updatedAt: now - 11 * 60_000 }]
+    const busy = [{ sessionId: 'changing', status: 'streaming', updatedAt: now }]
+    const { app } = fakeApp([], ['unused'], { workerSessionSnapshots: [idle, busy] })
+    const handle = createFactoryDelegatePlugin({ stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, runBr, now: () => now })
+    handle.bind(app as never)
+
+    const result = await toolNamed(handle, 'boring-orchestrator', 'recover_stale_claims').execute({}, context('orch'))
+    expect(result.details).toMatchObject({ recovered: [], skipped: [
+      { beadId: 'br-changing', reason: expect.stringContaining('busy') },
+    ] })
+    expect(calls.some((args) => args[0] === 'update')).toBe(false)
+  })
+
+  it('fails closed when comment facts or the complete session inventory cannot be read', async () => {
+    const stateRoot = await makeStateRoot()
+    const { registry, sessionBindings } = dependencies()
+    const baseBr = fakeBr([{ id: 'br-1', status: 'in_progress', assignee: 'gone' }])
+    const failingComments = vi.fn(async (args: readonly string[], cwd: string) => {
+      if (args[0] === 'comments' && args[1] === 'list') throw new Error('comment store unavailable')
+      return await baseBr.runBr(args, cwd)
+    })
+    const healthyApp = fakeApp()
+    const commentHost = createFactoryDelegatePlugin({
+      stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, runBr: failingComments,
+      readGitStatus: gitStatus,
+    })
+    commentHost.bind(healthyApp.app as never)
+    const recovery = await toolNamed(commentHost, 'boring-orchestrator', 'recover_stale_claims').execute({}, context('orch'))
+    expect(recovery).toMatchObject({ isError: true, details: { code: 'STALE_CLAIM_RECOVERY_FAILED' } })
+    expect(baseBr.calls.some((args) => args[0] === 'update')).toBe(false)
+
+    const failedInventory = fakeApp([], ['unused'], { workerSessionStatusCode: 503 })
+    const dispatchHost = createFactoryDelegatePlugin({ stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, runBr: baseBr.runBr })
+    dispatchHost.bind(failedInventory.app as never)
+    const dispatch = await toolNamed(dispatchHost, 'boring-orchestrator', 'dispatch_worker').execute(
+      { beadId: 'br-1', brief: 'Implement the exact target Bead br-1 now.' }, context('orch'),
+    )
+    expect(dispatch).toMatchObject({ isError: true, details: { code: 'DELEGATE_FAILED' } })
+    expect(failedInventory.calls.some((call) => call.method === 'POST' && call.url.endsWith('/sessions'))).toBe(false)
+
+    const truncatedInventory = fakeApp([], ['unused'], { repeatWorkerCursor: true })
+    const statusHost = createFactoryDelegatePlugin({
+      stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, runBr: baseBr.runBr,
+      readGitStatus: gitStatus,
+    })
+    statusHost.bind(truncatedInventory.app as never)
+    const status = await toolNamed(statusHost, 'boring-orchestrator', 'factory_status').execute({}, context('orch'))
+    expect(status).toMatchObject({ isError: true, details: { code: 'FACTORY_STATUS_FAILED' } })
+  })
+
+  it('refuses the concurrent-Worker cap before creating a session and blocks/comments the Bead', async () => {
+    const stateRoot = await makeStateRoot()
+    const { registry, sessionBindings } = dependencies({ w1: 'limits-epic', w2: 'limits-epic' })
+    const { runBr, calls: brCalls } = fakeBr()
+    const { app, calls } = fakeApp([
+      { sessionId: 'w1', status: 'running', updatedAt: 1 },
+      { sessionId: 'w2', status: 'running', updatedAt: 1 },
+    ])
+    const handle = createFactoryDelegatePlugin({ stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, runBr })
+    handle.bind(app as never)
+
+    const result = await toolNamed(handle, 'boring-orchestrator', 'dispatch_worker').execute(
+      { beadId: 'br-1', brief: 'Implement the exact target Bead br-1 now.' }, context('orch'),
+    )
+    expect(result).toMatchObject({ isError: true, details: { code: 'WORKER_CONCURRENCY_CAP_REACHED', beadId: 'br-1', blocked: true } })
+    expect((result.details as { message: string }).message).toContain('ask_user')
+    expect(calls.some((call) => call.method === 'POST' && call.url.endsWith('/sessions'))).toBe(false)
+    expect(brCalls.map((args) => args.slice(0, 3))).toEqual(expect.arrayContaining([
+      ['update', 'br-1', '--status'], ['comments', 'add', 'br-1'],
+    ]))
+  })
+
+  it('refuses the per-Bead dispatch cap before creating a session and blocks/comments the Bead', async () => {
+    const stateRoot = await makeStateRoot()
+    await writeFile(resolve(stateRoot, 'dispatches.json'), JSON.stringify({
+      version: 1,
+      dispatches: [1, 2].map((index) => ({ id: `d${index}`, epicKey: 'limits-epic', beadId: 'br-1', childSessionId: `old-${index}`, timestamp: '2026-09-05T00:00:00.000Z', updatedAt: '2026-09-05T00:00:00.000Z', outcome: 'completed' })),
+      reviews: [],
+    }))
+    const { registry, sessionBindings } = dependencies()
+    const { runBr, calls: brCalls } = fakeBr()
+    const { app, calls } = fakeApp()
+    const handle = createFactoryDelegatePlugin({ stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, runBr })
+    handle.bind(app as never)
+
+    const result = await toolNamed(handle, 'boring-orchestrator', 'dispatch_worker').execute(
+      { beadId: 'br-1', brief: 'Implement the exact target Bead br-1 now.' }, context('orch'),
+    )
+    expect(result).toMatchObject({ isError: true, details: { code: 'BEAD_DISPATCH_CAP_REACHED', current: 2, maximum: 2, blocked: true } })
+    expect(calls.some((call) => call.method === 'POST' && call.url.endsWith('/sessions'))).toBe(false)
+    expect(brCalls.some((args) => args[0] === 'comments' && String(args[4]).includes('2/2'))).toBe(true)
+  })
+
+  it('flags the review-round cap while still running the capped review', async () => {
+    const stateRoot = await makeStateRoot()
+    const { registry, sessionBindings } = dependencies()
+    const { runBr } = fakeBr()
+    const { app } = fakeApp([], ['review-1', 'review-2'])
+    const handle = createFactoryDelegatePlugin({
+      stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, runBr,
+      env: { BORING_FACTORY_MAX_REVIEW_ROUNDS: '2' }, timeoutMs: 1_000,
+    })
+    handle.bind(app as never)
+    const tool = toolNamed(handle, 'boring-worker', 'fresh_review')
+
+    const first = await tool.execute({ beadId: 'br-1', brief: 'Review Bead br-1 at abcdef1 and report findings.' }, context('worker', 'r1'))
+    const second = await tool.execute({ beadId: 'br-1', brief: 'Review Bead br-1 at abcdef2 and report findings.' }, context('worker', 'r2'))
+    expect(first.details).toMatchObject({ reviewRound: 1, capReached: false })
+    expect(second.details).toMatchObject({ reviewRound: 2, capReached: true })
+    expect((second.details as { capInstructions: string }).capInstructions).toContain('Hand off at the current SHA')
+  })
+
+  it('persists dispatch counters across host restart and enforces them on the next admission', async () => {
+    const stateRoot = await makeStateRoot()
+    const { registry, sessionBindings } = dependencies()
+    const firstBr = fakeBr()
+    const firstApp = fakeApp([], ['first-worker'])
+    const firstHost = createFactoryDelegatePlugin({
+      stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, runBr: firstBr.runBr,
+      env: { BORING_FACTORY_MAX_DISPATCHES_PER_BEAD: '1' }, timeoutMs: 1_000,
+    })
+    firstHost.bind(firstApp.app as never)
+    await toolNamed(firstHost, 'boring-orchestrator', 'dispatch_worker').execute(
+      { beadId: 'br-1', brief: 'Implement and persist target Bead br-1.' }, context('orch', 'first'),
+    )
+
+    const persisted = JSON.parse(await readFile(resolve(stateRoot, 'dispatches.json'), 'utf8')) as { dispatches: unknown[] }
+    expect(persisted.dispatches).toHaveLength(1)
+    const secondBr = fakeBr()
+    const secondApp = fakeApp()
+    const restartedHost = createFactoryDelegatePlugin({
+      stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, runBr: secondBr.runBr,
+      readGitStatus: gitStatus, env: { BORING_FACTORY_MAX_DISPATCHES_PER_BEAD: '1' }, timeoutMs: 1_000,
+    })
+    restartedHost.bind(secondApp.app as never)
+    const status = await toolNamed(restartedHost, 'boring-orchestrator', 'factory_status').execute({}, context('orch', 'status'))
+    expect(status.details).toMatchObject({ counters: { dispatchesPerOpenBead: { 'br-1': 1 } } })
+    const refused = await toolNamed(restartedHost, 'boring-orchestrator', 'dispatch_worker').execute(
+      { beadId: 'br-1', brief: 'Retry target Bead br-1 after host restart.' }, context('orch', 'second'),
+    )
+    expect(refused.details).toMatchObject({ code: 'BEAD_DISPATCH_CAP_REACHED', current: 1, maximum: 1 })
+    expect(secondApp.calls.some((call) => call.method === 'POST' && call.url.endsWith('/sessions'))).toBe(false)
+  })
+})

--- a/plugins/boring-factory/src/server/host/factoryStatus.ts
+++ b/plugins/boring-factory/src/server/host/factoryStatus.ts
@@ -1,0 +1,365 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import type { FastifyInstance } from 'fastify'
+import type { AgentTool, ToolExecContext, ToolResult } from '@hachej/boring-agent/shared'
+import type { FactoryDispatchLedger, FactoryReviewRecord } from './dispatchLedger'
+import type { FactoryEpicRegistry } from './epicRegistry'
+import { FactoryEpicResolutionError, resolveFactoryEpic, type FactorySessionBindings } from './sessionBindings'
+
+const execFileAsync = promisify(execFile)
+const MAX_DIRTY_PATHS = 50
+const WORKER_AGENT_TYPE_ID = 'boring-worker'
+
+export interface FactoryHostLimits {
+  readonly maxConcurrentWorkers: number
+  readonly maxDispatchesPerBead: number
+  readonly maxReviewRounds: number
+}
+
+export type FactoryBrRunner = (args: readonly string[], cwd: string) => Promise<string>
+
+export interface FactoryGitStatus {
+  readonly branch: string
+  readonly head: string
+  readonly remoteHead: string | null
+  readonly dirtyPaths: string[]
+}
+
+export interface FactoryStatusToolOptions {
+  readonly workspaceScopeId: string
+  readonly registry: FactoryEpicRegistry
+  readonly sessionBindings: FactorySessionBindings
+  readonly now?: () => number
+  readonly runBr?: FactoryBrRunner
+  readonly readGitStatus?: (workspaceRoot: string) => Promise<FactoryGitStatus>
+}
+
+export interface BrIssue {
+  readonly id: string
+  readonly title?: string
+  readonly status?: string
+  readonly assignee?: string | null
+  readonly labels?: readonly string[]
+  readonly updated_at?: string
+}
+
+interface BrComment {
+  readonly created_at?: string
+  readonly body?: string
+  readonly text?: string
+  readonly content?: string
+}
+
+export interface WorkerSessionSummary {
+  readonly sessionId: string
+  readonly status?: string
+  readonly turnCount?: number
+  readonly title?: string
+  readonly updatedAt?: number
+}
+
+type SessionLiveness = 'missing' | 'idle' | 'busy'
+
+interface FactoryBeadStatus extends BrIssue {
+  readonly assignee: string | null
+  readonly labels: readonly string[]
+  readonly commentCount: number
+  readonly lastCommentAt?: string
+  readonly hasHandoff: boolean
+  readonly sessionLiveness: SessionLiveness
+  readonly sessionLastActivityAt: number | null
+  readonly idleForMs: number | null
+  readonly stale: boolean
+  readonly staleReason?: string
+  readonly recoveryCommand?: 'recover_stale_claims'
+}
+
+function textResult(details: Record<string, unknown>, isError: boolean): ToolResult {
+  return { content: [{ type: 'text', text: JSON.stringify(details) }], details, isError }
+}
+
+function unboundResult(toolName: string): ToolResult {
+  return textResult({ code: 'HOST_NOT_BOUND', message: `${toolName} is not bound to a running host` }, true)
+}
+
+function epicResolutionResult(error: unknown): ToolResult {
+  if (error instanceof FactoryEpicResolutionError) return textResult({ code: error.code, message: error.message }, true)
+  return textResult({ code: 'EPIC_RESOLUTION_FAILED', message: error instanceof Error ? error.message : 'failed to resolve Factory epic' }, true)
+}
+
+export function isBusySession(status: string | undefined): boolean {
+  return status === 'running' || status === 'streaming' || status === 'aborting'
+}
+
+export async function defaultRunBr(args: readonly string[], cwd: string): Promise<string> {
+  const { stdout } = await execFileAsync('br', args, { cwd, maxBuffer: 16 * 1024 * 1024 })
+  return stdout
+}
+
+function parseBrIssues(stdout: string): BrIssue[] {
+  const parsed: unknown = JSON.parse(stdout)
+  if (Array.isArray(parsed)) return parsed as BrIssue[]
+  if (parsed && typeof parsed === 'object' && Array.isArray((parsed as { issues?: unknown }).issues)) {
+    return (parsed as { issues: BrIssue[] }).issues
+  }
+  return []
+}
+
+export async function loadEpicBeads(workspaceRoot: string, epicKey: string, run: FactoryBrRunner): Promise<BrIssue[]> {
+  return parseBrIssues(await run(['list', '--all', '--label', `epic:${epicKey}`, '--json', '--no-auto-flush'], workspaceRoot))
+}
+
+async function commentStatsFor(
+  workspaceRoot: string,
+  issueId: string,
+  run: FactoryBrRunner,
+): Promise<{ commentCount: number; lastCommentAt?: string; hasHandoff: boolean }> {
+  const parsed: unknown = JSON.parse(await run(['comments', 'list', issueId, '--json', '--no-auto-flush'], workspaceRoot))
+  const comments = Array.isArray(parsed)
+    ? (parsed as BrComment[])
+    : parsed && typeof parsed === 'object' && Array.isArray((parsed as { comments?: unknown }).comments)
+      ? (parsed as { comments: BrComment[] }).comments
+      : undefined
+  if (!comments) throw new Error(`invalid Bead comment response for ${issueId}`)
+  const lastCommentAt = comments
+    .map((comment) => comment.created_at)
+    .filter((value): value is string => typeof value === 'string')
+    .sort()
+    .at(-1)
+  const escapedIssueId = issueId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const canonicalHandoff = new RegExp(`^\\[[^\\]\\r\\n]+\\] handoff · ${escapedIssueId} · [0-9a-f]{7,40}(?:\\s|$)`, 'im')
+  const hasHandoff = comments.some((comment) => canonicalHandoff.test(comment.body ?? comment.text ?? comment.content ?? ''))
+  return { commentCount: comments.length, ...(lastCommentAt ? { lastCommentAt } : {}), hasHandoff }
+}
+
+async function gitOutput(args: readonly string[], cwd: string): Promise<string> {
+  const { stdout } = await execFileAsync('git', args, { cwd, maxBuffer: 16 * 1024 * 1024 })
+  return stdout.trim()
+}
+
+async function defaultReadGitStatus(workspaceRoot: string): Promise<FactoryGitStatus> {
+  const [branch, head, statusOutput] = await Promise.all([
+    gitOutput(['rev-parse', '--abbrev-ref', 'HEAD'], workspaceRoot),
+    gitOutput(['rev-parse', 'HEAD'], workspaceRoot),
+    execFileAsync('git', ['status', '--short'], { cwd: workspaceRoot, maxBuffer: 16 * 1024 * 1024 }).then((result) => result.stdout),
+  ])
+  const dirtyPaths = statusOutput.split('\n').map((line) => line.trim()).filter(Boolean).slice(0, MAX_DIRTY_PATHS)
+  let remoteHead: string | null = null
+  try {
+    const sha = (await gitOutput(['ls-remote', '--heads', 'origin', branch], workspaceRoot)).split(/\s+/)[0]
+    remoteHead = sha && /^[a-f0-9]{40}$/.test(sha) ? sha : null
+  } catch {
+    remoteHead = null
+  }
+  return { branch, head, remoteHead, dirtyPaths }
+}
+
+export async function listWorkerSessions(app: FastifyInstance, workspaceHeader: Record<string, string>): Promise<WorkerSessionSummary[]> {
+  const sessions: WorkerSessionSummary[] = []
+  let cursor: string | undefined
+  const seenCursors = new Set<string>()
+  for (;;) {
+    const url = cursor
+      ? `/api/v1/agents/${WORKER_AGENT_TYPE_ID}/sessions?cursor=${encodeURIComponent(cursor)}`
+      : `/api/v1/agents/${WORKER_AGENT_TYPE_ID}/sessions`
+    const response = await app.inject({ method: 'GET', url, headers: workspaceHeader })
+    if (response.statusCode !== 200) throw new Error(`Worker session inventory failed: HTTP ${response.statusCode}`)
+    const body = response.json<{ sessions: Array<{ ref: { sessionId: string }; status?: string; turnCount?: number; title?: string; updatedAt?: number }>; nextCursor?: string }>()
+    for (const session of body.sessions) {
+      sessions.push({ sessionId: session.ref.sessionId, status: session.status, turnCount: session.turnCount, title: session.title, updatedAt: session.updatedAt })
+    }
+    if (!body.nextCursor) break
+    if (seenCursors.has(body.nextCursor)) throw new Error('Worker session inventory returned a repeated cursor')
+    seenCursors.add(body.nextCursor)
+    cursor = body.nextCursor
+  }
+  return sessions
+}
+
+async function collectBeadStatuses(input: {
+  readonly beads: readonly BrIssue[]
+  readonly worktree: string
+  readonly workerSessions: readonly WorkerSessionSummary[]
+  readonly staleIdleMs: number
+  readonly now: number
+  readonly run: FactoryBrRunner
+}): Promise<FactoryBeadStatus[]> {
+  const sessionById = new Map(input.workerSessions.map((session) => [session.sessionId, session]))
+  const statusById = new Map(input.workerSessions.map((session) => [session.sessionId, session.status ?? 'idle']))
+  return await Promise.all(input.beads.map(async (issue) => {
+    const comments = await commentStatsFor(input.worktree, issue.id, input.run)
+    const sessionStatus = issue.assignee ? statusById.get(issue.assignee) : undefined
+    const sessionLiveness: SessionLiveness = sessionStatus === undefined ? 'missing' : isBusySession(sessionStatus) ? 'busy' : 'idle'
+    const lastActivity = issue.assignee ? sessionById.get(issue.assignee)?.updatedAt : undefined
+    const idleForMs = sessionLiveness === 'idle' && typeof lastActivity === 'number' ? Math.max(0, input.now - lastActivity) : null
+    const staleMissing = issue.status === 'in_progress' && sessionLiveness === 'missing'
+    const staleIdle = issue.status === 'in_progress' && sessionLiveness === 'idle' && !comments.hasHandoff
+      && idleForMs !== null && idleForMs > input.staleIdleMs
+    const stale = staleMissing || staleIdle
+    const staleReason = staleMissing
+      ? `assignee session ${issue.assignee ?? '(none)'} is missing`
+      : staleIdle
+        ? `assignee session ${issue.assignee} has been idle for ${idleForMs}ms with no handoff comment`
+        : undefined
+    return {
+      id: issue.id,
+      status: issue.status,
+      assignee: issue.assignee ?? null,
+      labels: issue.labels ?? [],
+      title: issue.title,
+      updatedAt: issue.updated_at,
+      commentCount: comments.commentCount,
+      ...(comments.lastCommentAt ? { lastCommentAt: comments.lastCommentAt } : {}),
+      hasHandoff: comments.hasHandoff,
+      sessionLiveness,
+      sessionLastActivityAt: typeof lastActivity === 'number' ? lastActivity : null,
+      idleForMs,
+      stale,
+      ...(staleReason ? { staleReason, recoveryCommand: 'recover_stale_claims' as const } : {}),
+    }
+  }))
+}
+
+function reviewRoundCounters(records: readonly FactoryReviewRecord[], epicKey: string) {
+  const byBead: Record<string, number> = {}
+  const byShaLineage: Record<string, number> = {}
+  for (const record of records) {
+    if (record.epicKey !== epicKey) continue
+    const target = record.targetKey.replace(/^sha-lineage:/, '')
+    if (record.beadId) byBead[record.beadId] = (byBead[record.beadId] ?? 0) + 1
+    else byShaLineage[target] = (byShaLineage[target] ?? 0) + 1
+  }
+  return { byBead, byShaLineage }
+}
+
+function toolParameters() {
+  return {
+    type: 'object' as const,
+    properties: { epicKey: { type: 'string', description: 'Optional explicit epic override. Normally resolved from this session binding.' } },
+    additionalProperties: false,
+  }
+}
+
+export function createFactoryStatusTools(
+  getApp: () => FastifyInstance | undefined,
+  options: FactoryStatusToolOptions,
+  ledger: FactoryDispatchLedger,
+  limits: FactoryHostLimits,
+  staleIdleMs: number,
+): AgentTool[] {
+  const workspaceHeader = { 'x-boring-workspace-id': options.workspaceScopeId }
+  const run = options.runBr ?? defaultRunBr
+  const statusTool: AgentTool = {
+    name: 'factory_status',
+    description: 'Read this epic\'s git, Bead, Worker-session, stale-claim, dispatch, and review facts. Read-only; never mutates anything.',
+    parameters: toolParameters(),
+    async execute(params: Record<string, unknown>, ctx: ToolExecContext): Promise<ToolResult> {
+      const app = getApp()
+      if (!app) return unboundResult('factory_status')
+      let epic
+      try { epic = await resolveFactoryEpic(params, ctx, options.registry, options.sessionBindings) } catch (error) { return epicResolutionResult(error) }
+      try {
+        const [git, allWorkerSessions, bindings, dispatchState, epicBeads] = await Promise.all([
+          (options.readGitStatus ?? defaultReadGitStatus)(epic.worktree),
+          listWorkerSessions(app, workspaceHeader),
+          options.sessionBindings.load(),
+          ledger.read(),
+          loadEpicBeads(epic.worktree, epic.epicKey, run),
+        ])
+        const epicSessionIds = new Set([
+          ...Object.entries(bindings).filter(([, epicKey]) => epicKey === epic.epicKey).map(([sessionId]) => sessionId),
+          ...epicBeads.map((bead) => bead.assignee).filter((sessionId): sessionId is string => !!sessionId),
+          ...dispatchState.dispatches.filter((record) => record.epicKey === epic.epicKey).map((record) => record.childSessionId),
+        ])
+        const workerSessions = allWorkerSessions.filter((session) => epicSessionIds.has(session.sessionId))
+        const beads = await collectBeadStatuses({
+          beads: epicBeads, worktree: epic.worktree, workerSessions: allWorkerSessions, staleIdleMs,
+          now: options.now?.() ?? Date.now(), run,
+        })
+        const openBeads = beads.filter((bead) => bead.status !== 'closed')
+        const dispatchesPerOpenBead = Object.fromEntries(openBeads.map((bead) => [
+          bead.id,
+          dispatchState.dispatches.filter((record) => record.epicKey === epic.epicKey && record.beadId === bead.id).length,
+        ]))
+        return textResult({
+          epicKey: epic.epicKey,
+          featureName: epic.featureName,
+          workspaceRoot: epic.worktree,
+          branch: epic.branch,
+          git,
+          beads,
+          workerSessions,
+          staleClaims: {
+            count: beads.filter((bead) => bead.stale).length,
+            beadIds: beads.filter((bead) => bead.stale).map((bead) => bead.id),
+            recoveryCommand: 'recover_stale_claims',
+          },
+          counters: {
+            busyWorkers: workerSessions.filter((session) => isBusySession(session.status)).length,
+            dispatchesPerOpenBead,
+            reviewRounds: reviewRoundCounters(dispatchState.reviews, epic.epicKey),
+          },
+          limits: { staleIdleMs, ...limits },
+        }, false)
+      } catch (error) {
+        return textResult({ code: 'FACTORY_STATUS_FAILED', message: error instanceof Error ? error.message : 'factory_status failed' }, true)
+      }
+    },
+  }
+
+  const recoverTool: AgentTool = {
+    name: 'recover_stale_claims',
+    description: 'Re-read this epic\'s session and Bead facts, then release every stale claim. Busy claims are never released.',
+    parameters: toolParameters(),
+    async execute(params: Record<string, unknown>, ctx: ToolExecContext): Promise<ToolResult> {
+      const app = getApp()
+      if (!app) return unboundResult('recover_stale_claims')
+      let epic
+      try { epic = await resolveFactoryEpic(params, ctx, options.registry, options.sessionBindings) } catch (error) { return epicResolutionResult(error) }
+      try {
+        const [allWorkerSessions, epicBeads] = await Promise.all([
+          listWorkerSessions(app, workspaceHeader),
+          loadEpicBeads(epic.worktree, epic.epicKey, run),
+        ])
+        const beads = await collectBeadStatuses({
+          beads: epicBeads, worktree: epic.worktree, workerSessions: allWorkerSessions, staleIdleMs,
+          now: options.now?.() ?? Date.now(), run,
+        })
+        const actor = ctx.sessionId ?? 'factory-host'
+        const recovered: Array<{ beadId: string; deadSessionId: string | null; reason: string }> = []
+        const skipped: Array<{ beadId: string; reason: string }> = []
+        for (const bead of beads.filter((candidate) => candidate.stale)) {
+          const [currentWorkerSessions, currentBeads] = await Promise.all([
+            listWorkerSessions(app, workspaceHeader),
+            loadEpicBeads(epic.worktree, epic.epicKey, run),
+          ])
+          const currentIssue = currentBeads.find((issue) => issue.id === bead.id)
+          if (!currentIssue) {
+            skipped.push({ beadId: bead.id, reason: 'Bead no longer exists in the epic' })
+            continue
+          }
+          const [current] = await collectBeadStatuses({
+            beads: [currentIssue], worktree: epic.worktree, workerSessions: currentWorkerSessions, staleIdleMs,
+            now: options.now?.() ?? Date.now(), run,
+          })
+          if (!current?.stale) {
+            skipped.push({ beadId: bead.id, reason: `claim is now ${current?.sessionLiveness ?? 'unknown'} and is not stale` })
+            continue
+          }
+          await run(['update', current.id, '--assignee', '', '--status', 'open', '--actor', actor, '--json', '--no-auto-flush'], epic.worktree)
+          const reason = current.staleReason ?? 'host classified the claim as stale'
+          await run([
+            'comments', 'add', current.id, '-m',
+            `[${epic.featureName}] recovered stale claim from ${current.assignee ?? '(missing assignee)'}: ${reason}.`,
+            '--actor', actor, '--json', '--no-auto-flush',
+          ], epic.worktree)
+          recovered.push({ beadId: current.id, deadSessionId: current.assignee, reason })
+        }
+        return textResult({ epicKey: epic.epicKey, recovered, skipped }, false)
+      } catch (error) {
+        return textResult({ code: 'STALE_CLAIM_RECOVERY_FAILED', message: error instanceof Error ? error.message : 'stale claim recovery failed' }, true)
+      }
+    },
+  }
+  return [statusTool, recoverTool]
+}

--- a/plugins/boring-factory/src/server/host/factoryStatus.ts
+++ b/plugins/boring-factory/src/server/host/factoryStatus.ts
@@ -2,7 +2,7 @@ import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 import type { FastifyInstance } from 'fastify'
 import type { AgentTool, ToolExecContext, ToolResult } from '@hachej/boring-agent/shared'
-import type { FactoryDispatchLedger, FactoryReviewRecord } from './dispatchLedger'
+import type { FactoryDispatchLedger, FactoryDispatchRecord, FactoryReviewRecord } from './dispatchLedger'
 import type { FactoryEpicRegistry } from './epicRegistry'
 import { FactoryEpicResolutionError, resolveFactoryEpic, type FactorySessionBindings } from './sessionBindings'
 
@@ -176,6 +176,45 @@ export async function listWorkerSessions(app: FastifyInstance, workspaceHeader: 
   return sessions
 }
 
+export function resolveEpicWorkerSessionIds(input: {
+  readonly epicKey: string
+  readonly bindings: Readonly<Record<string, string>>
+  readonly beads: readonly BrIssue[]
+  readonly dispatches: readonly FactoryDispatchRecord[]
+}): Set<string> {
+  const inferredEpicsBySession = new Map<string, Set<string>>()
+  const infer = (sessionId: string, epicKey: string) => {
+    const epicKeys = inferredEpicsBySession.get(sessionId) ?? new Set<string>()
+    epicKeys.add(epicKey)
+    inferredEpicsBySession.set(sessionId, epicKeys)
+  }
+  for (const dispatch of input.dispatches) {
+    if (dispatch.childSessionId) infer(dispatch.childSessionId, dispatch.epicKey)
+  }
+  for (const bead of input.beads) {
+    if (bead.assignee) infer(bead.assignee, input.epicKey)
+  }
+
+  const sessionIds = new Set(
+    Object.entries(input.bindings)
+      .filter(([, epicKey]) => epicKey === input.epicKey)
+      .map(([sessionId]) => sessionId),
+  )
+  for (const [sessionId, inferredEpicKeys] of inferredEpicsBySession) {
+    const binding = input.bindings[sessionId]
+    const conflictingInference = binding && [...inferredEpicKeys].find((epicKey) => epicKey !== binding)
+    if (conflictingInference && (binding === input.epicKey || inferredEpicKeys.has(input.epicKey))) {
+      throw new Error(`Worker session ${sessionId} ownership conflict: bound to ${binding}, inferred for ${conflictingInference}`)
+    }
+    if (!inferredEpicKeys.has(input.epicKey)) continue
+    if (!binding && inferredEpicKeys.size > 1) {
+      throw new Error(`Worker session ${sessionId} ownership conflict: inferred for ${[...inferredEpicKeys].join(', ')}`)
+    }
+    sessionIds.add(sessionId)
+  }
+  return sessionIds
+}
+
 async function collectBeadStatuses(input: {
   readonly beads: readonly BrIssue[]
   readonly worktree: string
@@ -246,6 +285,7 @@ export function createFactoryStatusTools(
   ledger: FactoryDispatchLedger,
   limits: FactoryHostLimits,
   staleIdleMs: number,
+  admitSessionMutation: <T>(operation: () => Promise<T>) => Promise<T>,
 ): AgentTool[] {
   const workspaceHeader = { 'x-boring-workspace-id': options.workspaceScopeId }
   const run = options.runBr ?? defaultRunBr
@@ -266,14 +306,15 @@ export function createFactoryStatusTools(
           ledger.read(),
           loadEpicBeads(epic.worktree, epic.epicKey, run),
         ])
-        const epicSessionIds = new Set([
-          ...Object.entries(bindings).filter(([, epicKey]) => epicKey === epic.epicKey).map(([sessionId]) => sessionId),
-          ...epicBeads.map((bead) => bead.assignee).filter((sessionId): sessionId is string => !!sessionId),
-          ...dispatchState.dispatches.filter((record) => record.epicKey === epic.epicKey).map((record) => record.childSessionId),
-        ])
+        const epicSessionIds = resolveEpicWorkerSessionIds({
+          epicKey: epic.epicKey,
+          bindings,
+          beads: epicBeads,
+          dispatches: dispatchState.dispatches,
+        })
         const workerSessions = allWorkerSessions.filter((session) => epicSessionIds.has(session.sessionId))
         const beads = await collectBeadStatuses({
-          beads: epicBeads, worktree: epic.worktree, workerSessions: allWorkerSessions, staleIdleMs,
+          beads: epicBeads, worktree: epic.worktree, workerSessions, staleIdleMs,
           now: options.now?.() ?? Date.now(), run,
         })
         const openBeads = beads.filter((bead) => bead.status !== 'closed')
@@ -316,49 +357,72 @@ export function createFactoryStatusTools(
       if (!app) return unboundResult('recover_stale_claims')
       let epic
       try { epic = await resolveFactoryEpic(params, ctx, options.registry, options.sessionBindings) } catch (error) { return epicResolutionResult(error) }
-      try {
-        const [allWorkerSessions, epicBeads] = await Promise.all([
-          listWorkerSessions(app, workspaceHeader),
-          loadEpicBeads(epic.worktree, epic.epicKey, run),
-        ])
-        const beads = await collectBeadStatuses({
-          beads: epicBeads, worktree: epic.worktree, workerSessions: allWorkerSessions, staleIdleMs,
-          now: options.now?.() ?? Date.now(), run,
-        })
-        const actor = ctx.sessionId ?? 'factory-host'
-        const recovered: Array<{ beadId: string; deadSessionId: string | null; reason: string }> = []
-        const skipped: Array<{ beadId: string; reason: string }> = []
-        for (const bead of beads.filter((candidate) => candidate.stale)) {
-          const [currentWorkerSessions, currentBeads] = await Promise.all([
+      return await admitSessionMutation(async () => {
+        try {
+          const [allWorkerSessions, epicBeads, bindings, dispatchState] = await Promise.all([
             listWorkerSessions(app, workspaceHeader),
             loadEpicBeads(epic.worktree, epic.epicKey, run),
+            options.sessionBindings.load(),
+            ledger.read(),
           ])
-          const currentIssue = currentBeads.find((issue) => issue.id === bead.id)
-          if (!currentIssue) {
-            skipped.push({ beadId: bead.id, reason: 'Bead no longer exists in the epic' })
-            continue
-          }
-          const [current] = await collectBeadStatuses({
-            beads: [currentIssue], worktree: epic.worktree, workerSessions: currentWorkerSessions, staleIdleMs,
+          const epicSessionIds = resolveEpicWorkerSessionIds({
+            epicKey: epic.epicKey,
+            bindings,
+            beads: epicBeads,
+            dispatches: dispatchState.dispatches,
+          })
+          const workerSessions = allWorkerSessions.filter((session) => epicSessionIds.has(session.sessionId))
+          const beads = await collectBeadStatuses({
+            beads: epicBeads, worktree: epic.worktree, workerSessions, staleIdleMs,
             now: options.now?.() ?? Date.now(), run,
           })
-          if (!current?.stale) {
-            skipped.push({ beadId: bead.id, reason: `claim is now ${current?.sessionLiveness ?? 'unknown'} and is not stale` })
-            continue
+          const actor = ctx.sessionId ?? 'factory-host'
+          const recovered: Array<{ beadId: string; deadSessionId: string | null; reason: string }> = []
+          const skipped: Array<{ beadId: string; reason: string }> = []
+          for (const bead of beads.filter((candidate) => candidate.stale)) {
+            const [currentWorkerSessions, currentBeads, currentBindings, currentDispatchState] = await Promise.all([
+              listWorkerSessions(app, workspaceHeader),
+              loadEpicBeads(epic.worktree, epic.epicKey, run),
+              options.sessionBindings.load(),
+              ledger.read(),
+            ])
+            const currentIssue = currentBeads.find((issue) => issue.id === bead.id)
+            if (!currentIssue) {
+              skipped.push({ beadId: bead.id, reason: 'Bead no longer exists in the epic' })
+              continue
+            }
+            const currentEpicSessionIds = resolveEpicWorkerSessionIds({
+              epicKey: epic.epicKey,
+              bindings: currentBindings,
+              beads: currentBeads,
+              dispatches: currentDispatchState.dispatches,
+            })
+            const [current] = await collectBeadStatuses({
+              beads: [currentIssue],
+              worktree: epic.worktree,
+              workerSessions: currentWorkerSessions.filter((session) => currentEpicSessionIds.has(session.sessionId)),
+              staleIdleMs,
+              now: options.now?.() ?? Date.now(),
+              run,
+            })
+            if (!current?.stale) {
+              skipped.push({ beadId: bead.id, reason: `claim is now ${current?.sessionLiveness ?? 'unknown'} and is not stale` })
+              continue
+            }
+            await run(['update', current.id, '--assignee', '', '--status', 'open', '--actor', actor, '--json', '--no-auto-flush'], epic.worktree)
+            const reason = current.staleReason ?? 'host classified the claim as stale'
+            await run([
+              'comments', 'add', current.id, '-m',
+              `[${epic.featureName}] recovered stale claim from ${current.assignee ?? '(missing assignee)'}: ${reason}.`,
+              '--actor', actor, '--json', '--no-auto-flush',
+            ], epic.worktree)
+            recovered.push({ beadId: current.id, deadSessionId: current.assignee, reason })
           }
-          await run(['update', current.id, '--assignee', '', '--status', 'open', '--actor', actor, '--json', '--no-auto-flush'], epic.worktree)
-          const reason = current.staleReason ?? 'host classified the claim as stale'
-          await run([
-            'comments', 'add', current.id, '-m',
-            `[${epic.featureName}] recovered stale claim from ${current.assignee ?? '(missing assignee)'}: ${reason}.`,
-            '--actor', actor, '--json', '--no-auto-flush',
-          ], epic.worktree)
-          recovered.push({ beadId: current.id, deadSessionId: current.assignee, reason })
+          return textResult({ epicKey: epic.epicKey, recovered, skipped }, false)
+        } catch (error) {
+          return textResult({ code: 'STALE_CLAIM_RECOVERY_FAILED', message: error instanceof Error ? error.message : 'stale claim recovery failed' }, true)
         }
-        return textResult({ epicKey: epic.epicKey, recovered, skipped }, false)
-      } catch (error) {
-        return textResult({ code: 'STALE_CLAIM_RECOVERY_FAILED', message: error instanceof Error ? error.message : 'stale claim recovery failed' }, true)
-      }
+      })
     },
   }
   return [statusTool, recoverTool]

--- a/plugins/boring-factory/src/server/host/supervisionPlugin.test.ts
+++ b/plugins/boring-factory/src/server/host/supervisionPlugin.test.ts
@@ -74,7 +74,12 @@ interface FakeInjectCall {
 }
 
 /** Minimal fastify-shaped fake: `inject` is scripted, `addHook` just records the onClose callback. */
-function createFakeApp(options: { status: string; gate1Raised?: boolean; gate1AnsweredPage?: 1 | 2 }) {
+function createFakeApp(options: {
+  status: string
+  gate1Raised?: boolean
+  gate1AnsweredPage?: 1 | 2
+  gate1AnsweredStatus?: 'answered' | 'cancelled' | 'abandoned'
+}) {
   const calls: FakeInjectCall[] = []
   const prompts: string[] = []
   let onCloseHook: (() => Promise<void> | void) | undefined
@@ -96,13 +101,18 @@ function createFakeApp(options: { status: string; gate1Raised?: boolean; gate1An
       if (request.method === 'POST' && request.url === '/api/v1/workspace-bridge/call') {
         const op = (request.payload as { op?: string } | undefined)?.op
         const input = (request.payload as { input?: { cursor?: string } } | undefined)?.input
-        const gate1 = [{ sessionId: 'session-restart', title: '[Live Farewell] Plan approval' }]
+        const pendingGate1 = [{ sessionId: 'session-restart', title: '[Live Farewell] Plan approval', status: 'ready' }]
+        const answeredGate1 = [{
+          sessionId: 'session-restart',
+          title: '[Live Farewell] Plan approval',
+          status: options.gate1AnsweredStatus ?? 'answered',
+        }]
         if (op === 'ask-user.v1.pending-all') {
-          return { statusCode: 200, json: <T>() => ({ output: { pending: options.gate1Raised ? gate1 : [] } }) as T }
+          return { statusCode: 200, json: <T>() => ({ output: { pending: options.gate1Raised ? pendingGate1 : [] } }) as T }
         }
         const answered = options.gate1AnsweredPage === 1 || (options.gate1AnsweredPage === 2 && input?.cursor === 'page-2')
-          ? gate1
-          : [{ sessionId: 'someone-else', title: '[Other Feature] Merge approval' }]
+          ? answeredGate1
+          : [{ sessionId: 'someone-else', title: '[Other Feature] Merge approval', status: 'answered' }]
         return {
           statusCode: 200,
           json: <T>() => ({ output: {
@@ -311,6 +321,28 @@ describe('factory supervision plugin', () => {
       && (call.payload as { op?: string } | undefined)?.op === 'ask-user.v1.answered-all'
     ))
     expect(answeredCalls).toHaveLength(2)
+    handle.close()
+  })
+
+  it.each(['cancelled', 'abandoned'] as const)('ignores a %s Gate 1 entry and keeps deadline nudging active', async (gate1AnsweredStatus) => {
+    const stateRoot = await makeStateRoot()
+    await writeSupervisionFile(stateRoot, {
+      'session-restart': {
+        epicKey: 'live-farewell', agentTypeId: 'boring-orchestrator', sessionId: 'session-restart',
+        intervalMs: 50, prompt: 'ordinary nudge', startedAt: '2026-09-05T00:00:00.000Z', ticks: 0,
+      },
+    })
+    const { app, prompts } = createFakeApp({ status: 'idle', gate1AnsweredPage: 1, gate1AnsweredStatus })
+    const handle = createFactorySupervisionPlugin({
+      stateRoot, workspaceScopeId: 'factory-hub',
+      ...epicDeps('session-restart', '2000-01-01T00:00:00.000Z'),
+    })
+    handle.bind(app as never)
+    expect(await handle.rearm()).toBe(1)
+
+    await waitFor(() => prompts.length > 0)
+    expect(prompts[0]).toContain('raise Gate 1 now with what you have')
+    expect(prompts[0]).not.toContain('ordinary nudge')
     handle.close()
   })
 

--- a/plugins/boring-factory/src/server/host/supervisionPlugin.test.ts
+++ b/plugins/boring-factory/src/server/host/supervisionPlugin.test.ts
@@ -23,7 +23,7 @@ async function writeSupervisionFile(stateRoot: string, entries: Record<string, u
   await writeFile(resolve(stateRoot, 'supervision.json'), JSON.stringify({ entries }, null, 2), 'utf8')
 }
 
-function epicDeps(orchestratorSessionId = 'session-orch-1'): { registry: FactoryEpicRegistry; sessionBindings: FactorySessionBindings } {
+function epicDeps(orchestratorSessionId = 'session-orch-1', planDeadlineAt?: string): { registry: FactoryEpicRegistry; sessionBindings: FactorySessionBindings } {
   const entry: FactoryEpicEntry = {
     epicKey: 'live-farewell',
     featureName: 'Live Farewell',
@@ -32,6 +32,7 @@ function epicDeps(orchestratorSessionId = 'session-orch-1'): { registry: Factory
     repositoryRoot: '/tmp/repository',
     orchestratorSessionId,
     createdAt: '2026-09-05T00:00:00.000Z',
+    ...(planDeadlineAt ? { planDeadlineAt } : {}),
     status: 'active',
   }
   const bindings: Record<string, string> = {
@@ -73,7 +74,7 @@ interface FakeInjectCall {
 }
 
 /** Minimal fastify-shaped fake: `inject` is scripted, `addHook` just records the onClose callback. */
-function createFakeApp(options: { status: string }) {
+function createFakeApp(options: { status: string; gate1Raised?: boolean; gate1AnsweredPage?: 1 | 2 }) {
   const calls: FakeInjectCall[] = []
   const prompts: string[] = []
   let onCloseHook: (() => Promise<void> | void) | undefined
@@ -91,6 +92,24 @@ function createFakeApp(options: { status: string }) {
         const payload = request.payload as { content: string }
         prompts.push(payload.content)
         return { statusCode: 202, json: <T>() => ({}) as T }
+      }
+      if (request.method === 'POST' && request.url === '/api/v1/workspace-bridge/call') {
+        const op = (request.payload as { op?: string } | undefined)?.op
+        const input = (request.payload as { input?: { cursor?: string } } | undefined)?.input
+        const gate1 = [{ sessionId: 'session-restart', title: '[Live Farewell] Plan approval' }]
+        if (op === 'ask-user.v1.pending-all') {
+          return { statusCode: 200, json: <T>() => ({ output: { pending: options.gate1Raised ? gate1 : [] } }) as T }
+        }
+        const answered = options.gate1AnsweredPage === 1 || (options.gate1AnsweredPage === 2 && input?.cursor === 'page-2')
+          ? gate1
+          : [{ sessionId: 'someone-else', title: '[Other Feature] Merge approval' }]
+        return {
+          statusCode: 200,
+          json: <T>() => ({ output: {
+            answered,
+            ...(options.gate1AnsweredPage === 2 && !input?.cursor ? { nextCursor: 'page-2' } : {}),
+          } }) as T,
+        }
       }
       return { statusCode: 404, json: <T>() => ({}) as T }
     },
@@ -199,6 +218,99 @@ describe('factory supervision plugin', () => {
     expect(prompts[0]).toContain('Supervision tick 1')
     expect(prompts[0]).toContain('restart nudge')
 
+    handle.close()
+  })
+
+  it('uses the host plan deadline to nag an idle pre-Gate-1 Orchestrator without stopping it', async () => {
+    const stateRoot = await makeStateRoot()
+    await writeSupervisionFile(stateRoot, {
+      'session-restart': {
+        epicKey: 'live-farewell', agentTypeId: 'boring-orchestrator', sessionId: 'session-restart',
+        intervalMs: 50, prompt: 'ordinary nudge', startedAt: '2026-09-05T00:00:00.000Z', ticks: 0,
+      },
+    })
+    const { app, prompts } = createFakeApp({ status: 'idle' })
+    const handle = createFactorySupervisionPlugin({
+      stateRoot,
+      workspaceScopeId: 'factory-hub',
+      ...epicDeps('session-restart', '2000-01-01T00:00:00.000Z'),
+    })
+    handle.bind(app as never)
+    expect(await handle.rearm()).toBe(1)
+
+    await waitFor(() => prompts.length > 0)
+    expect(prompts[0]).toContain('raise Gate 1 now with what you have')
+    expect(prompts[0]).not.toContain('ordinary nudge')
+    handle.close()
+  })
+
+  it('keeps the ordinary prompt before the host plan deadline', async () => {
+    const stateRoot = await makeStateRoot()
+    await writeSupervisionFile(stateRoot, {
+      'session-restart': {
+        epicKey: 'live-farewell', agentTypeId: 'boring-orchestrator', sessionId: 'session-restart',
+        intervalMs: 50, prompt: 'ordinary nudge', startedAt: '2026-09-05T00:00:00.000Z', ticks: 0,
+      },
+    })
+    const { app, prompts, calls } = createFakeApp({ status: 'idle' })
+    const handle = createFactorySupervisionPlugin({
+      stateRoot, workspaceScopeId: 'factory-hub',
+      ...epicDeps('session-restart', '2999-01-01T00:00:00.000Z'),
+    })
+    handle.bind(app as never)
+    expect(await handle.rearm()).toBe(1)
+
+    await waitFor(() => prompts.length > 0)
+    expect(prompts[0]).toContain('ordinary nudge')
+    expect(calls.some((call) => call.url === '/api/v1/workspace-bridge/call')).toBe(false)
+    handle.close()
+  })
+
+  it('does not nag after a pending Gate 1 has been raised', async () => {
+    const stateRoot = await makeStateRoot()
+    await writeSupervisionFile(stateRoot, {
+      'session-restart': {
+        epicKey: 'live-farewell', agentTypeId: 'boring-orchestrator', sessionId: 'session-restart',
+        intervalMs: 50, prompt: 'ordinary nudge', startedAt: '2026-09-05T00:00:00.000Z', ticks: 0,
+      },
+    })
+    const { app, prompts } = createFakeApp({ status: 'idle', gate1Raised: true })
+    const handle = createFactorySupervisionPlugin({
+      stateRoot, workspaceScopeId: 'factory-hub',
+      ...epicDeps('session-restart', '2000-01-01T00:00:00.000Z'),
+    })
+    handle.bind(app as never)
+    expect(await handle.rearm()).toBe(1)
+
+    await waitFor(() => prompts.length > 0)
+    expect(prompts[0]).toContain('ordinary nudge')
+    expect(prompts[0]).not.toContain('raise Gate 1 now with what you have')
+    handle.close()
+  })
+
+  it('finds an answered Gate 1 beyond the first Inbox page', async () => {
+    const stateRoot = await makeStateRoot()
+    await writeSupervisionFile(stateRoot, {
+      'session-restart': {
+        epicKey: 'live-farewell', agentTypeId: 'boring-orchestrator', sessionId: 'session-restart',
+        intervalMs: 50, prompt: 'ordinary nudge', startedAt: '2026-09-05T00:00:00.000Z', ticks: 0,
+      },
+    })
+    const { app, prompts, calls } = createFakeApp({ status: 'idle', gate1AnsweredPage: 2 })
+    const handle = createFactorySupervisionPlugin({
+      stateRoot, workspaceScopeId: 'factory-hub',
+      ...epicDeps('session-restart', '2000-01-01T00:00:00.000Z'),
+    })
+    handle.bind(app as never)
+    expect(await handle.rearm()).toBe(1)
+
+    await waitFor(() => prompts.length > 0)
+    expect(prompts[0]).toContain('ordinary nudge')
+    const answeredCalls = calls.filter((call) => (
+      call.url === '/api/v1/workspace-bridge/call'
+      && (call.payload as { op?: string } | undefined)?.op === 'ask-user.v1.answered-all'
+    ))
+    expect(answeredCalls).toHaveLength(2)
     handle.close()
   })
 

--- a/plugins/boring-factory/src/server/host/supervisionPlugin.ts
+++ b/plugins/boring-factory/src/server/host/supervisionPlugin.ts
@@ -10,7 +10,7 @@ import { FactoryEpicResolutionError, resolveFactoryEpic, type FactorySessionBind
 export const FACTORY_SUPERVISION_PLUGIN_ID = 'factory-supervision'
 
 /** Bump when this file's supervision behavior changes; hashed into the plugin's contentDigest. */
-const SUPERVISION_PLUGIN_VERSION = 'factory-supervision.v1.2026-09-03'
+const SUPERVISION_PLUGIN_VERSION = 'factory-supervision.v2.2026-09-05'
 
 /** The only seat this plugin ever supervises: an Orchestrator may only supervise itself. */
 const SUPERVISED_AGENT_TYPE_ID = 'boring-orchestrator'
@@ -23,7 +23,8 @@ export const SUPERVISION_DEFAULT_INTERVAL_MS = 120_000
 const DEFAULT_PROMPT =
   'Run factory_status and check the epic\'s durable end-state facts (Bead status/assignee, ' +
   'commits on the epic branch, Bead comments, sandbox releases, fresh_review provenance) ' +
-  'against the epic\'s acceptance criteria; recover any stale claim per the Recovery rule. ' +
+  'against the epic\'s acceptance criteria; when factory_status reports stale claims, call ' +
+  'recover_stale_claims. ' +
   'Report durable end-state facts only; never implement.'
 
 export interface SupervisionEntry {
@@ -117,6 +118,46 @@ interface SupervisedSessionState {
   readonly state?: { readonly status?: string }
 }
 
+async function gate1WasRaised(app: FastifyInstance, workspaceScopeId: string, sessionId: string): Promise<boolean> {
+  const headers = {
+    'content-type': 'application/json',
+    'x-csrf-token': 'factory-hub',
+    'x-boring-workspace-id': workspaceScopeId,
+  }
+  const isGate1 = (question: { sessionId?: string; title?: string }) => (
+    question.sessionId === sessionId && /\bplan approval\b/i.test(question.title ?? '')
+  )
+  const pendingResponse = await app.inject({
+    method: 'POST',
+    url: '/api/v1/workspace-bridge/call',
+    headers,
+    payload: { op: 'ask-user.v1.pending-all', input: {} },
+  })
+  if (pendingResponse.statusCode !== 200) throw new Error(`Gate 1 pending lookup failed: HTTP ${pendingResponse.statusCode}`)
+  const pending = pendingResponse.json<{ output?: { pending?: Array<{ sessionId?: string; title?: string }> } }>().output?.pending
+  if (!Array.isArray(pending)) throw new Error('Gate 1 pending lookup returned an invalid response')
+  if (pending.some(isGate1)) return true
+
+  let cursor: string | undefined
+  const seenCursors = new Set<string>()
+  for (;;) {
+    const answeredResponse = await app.inject({
+      method: 'POST',
+      url: '/api/v1/workspace-bridge/call',
+      headers,
+      payload: { op: 'ask-user.v1.answered-all', input: { limit: 100, ...(cursor ? { cursor } : {}) } },
+    })
+    if (answeredResponse.statusCode !== 200) throw new Error(`Gate 1 answered lookup failed: HTTP ${answeredResponse.statusCode}`)
+    const output = answeredResponse.json<{ output?: { answered?: Array<{ sessionId?: string; title?: string }>; nextCursor?: string } }>().output
+    if (!output || !Array.isArray(output.answered)) throw new Error('Gate 1 answered lookup returned an invalid response')
+    if (output.answered.some(isGate1)) return true
+    if (!output.nextCursor) return false
+    if (seenCursors.has(output.nextCursor)) throw new Error('Gate 1 answered lookup returned a repeated cursor')
+    seenCursors.add(output.nextCursor)
+    cursor = output.nextCursor
+  }
+}
+
 export function createFactorySupervisionPlugin(
   options: CreateFactorySupervisionPluginOptions,
 ): FactorySupervisionPluginHandle {
@@ -198,6 +239,12 @@ export function createFactorySupervisionPlugin(
         } else {
           const tickNumber = entry.ticks + 1
           const selectedModel = modelSelection(epic.models?.orchestrator)
+          const deadline = epic.planDeadlineAt ? Date.parse(epic.planDeadlineAt) : Number.NaN
+          const prompt = Number.isFinite(deadline)
+            && Date.now() >= deadline
+            && !(await gate1WasRaised(app, workspaceScopeId, entry.sessionId))
+            ? 'raise Gate 1 now with what you have'
+            : entry.prompt
           const promptResponse = await app.inject({
             method: 'POST',
             url: `/api/v1/agents/${entry.agentTypeId}/sessions/${entry.sessionId}/prompt`,
@@ -205,7 +252,7 @@ export function createFactorySupervisionPlugin(
             payload: {
               requestId: randomUUID(),
               clientNonce: randomUUID(),
-              content: `Supervision tick ${tickNumber} (${new Date().toISOString()}): ${entry.prompt}`,
+              content: `Supervision tick ${tickNumber} (${new Date().toISOString()}): ${prompt}`,
               requireIdle: true,
               ...(selectedModel ? { model: selectedModel } : {}),
             },

--- a/plugins/boring-factory/src/server/host/supervisionPlugin.ts
+++ b/plugins/boring-factory/src/server/host/supervisionPlugin.ts
@@ -134,9 +134,9 @@ async function gate1WasRaised(app: FastifyInstance, workspaceScopeId: string, se
     payload: { op: 'ask-user.v1.pending-all', input: {} },
   })
   if (pendingResponse.statusCode !== 200) throw new Error(`Gate 1 pending lookup failed: HTTP ${pendingResponse.statusCode}`)
-  const pending = pendingResponse.json<{ output?: { pending?: Array<{ sessionId?: string; title?: string }> } }>().output?.pending
+  const pending = pendingResponse.json<{ output?: { pending?: Array<{ sessionId?: string; title?: string; status?: string }> } }>().output?.pending
   if (!Array.isArray(pending)) throw new Error('Gate 1 pending lookup returned an invalid response')
-  if (pending.some(isGate1)) return true
+  if (pending.some((question) => question.status === 'ready' && isGate1(question))) return true
 
   let cursor: string | undefined
   const seenCursors = new Set<string>()
@@ -148,9 +148,9 @@ async function gate1WasRaised(app: FastifyInstance, workspaceScopeId: string, se
       payload: { op: 'ask-user.v1.answered-all', input: { limit: 100, ...(cursor ? { cursor } : {}) } },
     })
     if (answeredResponse.statusCode !== 200) throw new Error(`Gate 1 answered lookup failed: HTTP ${answeredResponse.statusCode}`)
-    const output = answeredResponse.json<{ output?: { answered?: Array<{ sessionId?: string; title?: string }>; nextCursor?: string } }>().output
+    const output = answeredResponse.json<{ output?: { answered?: Array<{ sessionId?: string; title?: string; status?: string }>; nextCursor?: string } }>().output
     if (!output || !Array.isArray(output.answered)) throw new Error('Gate 1 answered lookup returned an invalid response')
-    if (output.answered.some(isGate1)) return true
+    if (output.answered.some((question) => question.status === 'answered' && isGate1(question))) return true
     if (!output.nextCursor) return false
     if (seenCursors.has(output.nextCursor)) throw new Error('Gate 1 answered lookup returned a repeated cursor')
     seenCursors.add(output.nextCursor)


### PR DESCRIPTION
Owner goal this week: a Factory that runs unattended. Limits move from persona prose into the host: stale-claim classification and fail-closed recovery tool, concurrent-Worker and per-Bead dispatch caps (Bead blocked + comment on refusal), review-round cap flag, persisted Gate 1 deadline with supervision nudges, dispatches.json ledger, per-epic counters in factory_status. Env knobs documented in plugins/boring-factory/README.md and docs/factory/RELIABILITY.md.

Observed failures that motivated it (2026-09-05): an exists-idle Worker with a lost dispatch return blocked a Bead for hours; 4 dispatches and 7-8 review rounds on single Beads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)