### PR TITLE
[Factory Skills] The host and the owner decide

### DIFF
--- a/.agents/factory/fleet.yaml
+++ b/.agents/factory/fleet.yaml
@@ -76,9 +76,9 @@ seats:
       - name: triage
         digest: sha256:c9931f981b0d2d55415026c25bc27dec3e24fd310bee405360eba57d6cf58766
       - name: owner-gate
-        digest: sha256:7c09cb681037c763a27575eb558b0468a609530ac461ac52d2b201d2cdfb30d7
+        digest: sha256:15b78aa8e6a776b534179eb7d719d03d335d31d6ec12fc9b47dae5b0e8eab46c
       - name: handoff
-        digest: sha256:884918c3e5dabd33302f82b494ccaa3e1228c4733e7e90f2649c2e8d2808d762
+        digest: sha256:2dd01ee97452f5f36827fb4be6e1307eb05daba1ede64f4e148e2285df9097a9
 
   # The owner's standing counterpart: pinned, conversational, full authority.
   # Dispatches work and reads bead END-STATES only.
@@ -86,13 +86,13 @@ seats:
     agentTypeId: boring-orchestrator
     skills:
       - name: plan
-        digest: sha256:6c28c19da113cafc0af58883fc352b21896ed784b911b0593f0ed6254801d709
+        digest: sha256:686301214eb21f4163da19eb199a7dcd8c3647241bd6066913ff19f9306047d2
       - name: feedback
         digest: sha256:707ae8fd12ace225be7d6de8c345c7d73cf9aa07763f138419f6d6b26b92a9af
       - name: owner-gate
-        digest: sha256:7c09cb681037c763a27575eb558b0468a609530ac461ac52d2b201d2cdfb30d7
+        digest: sha256:15b78aa8e6a776b534179eb7d719d03d335d31d6ec12fc9b47dae5b0e8eab46c
       - name: handoff
-        digest: sha256:884918c3e5dabd33302f82b494ccaa3e1228c4733e7e90f2649c2e8d2808d762
+        digest: sha256:2dd01ee97452f5f36827fb4be6e1307eb05daba1ede64f4e148e2285df9097a9
       - name: show-me
         digest: sha256:4ad15fdf99fa06a953ce4b8d2457c7afbce5bca2f1759daf5594b4cfc13d6c96
 
@@ -103,10 +103,10 @@ seats:
     agentTypeId: boring-worker
     skills:
       - name: exec
-        digest: sha256:248eae90f7c6f1260e7654772ba5c3a0339834c7bd649ec456a61af933e04ba9
+        digest: sha256:2565b415d4790855d277c96909f4847686445af7707b6de68a04e4ba2d8c79eb
       - name: fresh-eyes
         digest: sha256:58f6cfb66cc2a31238e5c033f42b69b7fbd6089d06c9f6d5108caa7035e5f565
       - name: owner-gate
-        digest: sha256:7c09cb681037c763a27575eb558b0468a609530ac461ac52d2b201d2cdfb30d7
+        digest: sha256:15b78aa8e6a776b534179eb7d719d03d335d31d6ec12fc9b47dae5b0e8eab46c
       - name: handoff
-        digest: sha256:884918c3e5dabd33302f82b494ccaa3e1228c4733e7e90f2649c2e8d2808d762
+        digest: sha256:2dd01ee97452f5f36827fb4be6e1307eb05daba1ede64f4e148e2285df9097a9

--- a/.agents/skills/exec/SKILL.md
+++ b/.agents/skills/exec/SKILL.md
@@ -9,6 +9,11 @@ disable-model-invocation: true
 Drive one executable TODO, plan, Beads epic, or validated UI packet to
 `ready-for-human`; never merge.
 
+Every rule here is a default except proof and honesty. The host and the owner decide. A host notice, a host tool result, or an owner instruction relayed in a prompt overrides any default in this skill; comply in the same turn and record the override in the gate card or handoff (AGENTS.md hard rule 1).
+The host's `factory_status` classification of claims is the truth; the
+Orchestrator recovers stale claims with `recover_stale_claims`, and a Worker
+whose turn is about to end without finishing writes the handoff comment first.
+
 Read the artifact, `docs/procedures/boring-loop.md`, and
 `docs/procedures/MODEL-CARD.md`. Load only the needed procedure:
 

--- a/.agents/skills/handoff/SKILL.md
+++ b/.agents/skills/handoff/SKILL.md
@@ -34,7 +34,11 @@ block) of what changed; a single-file Bead may skip it and say so in the
 handoff. For bead work, put the handoff
 artifact pointer and a one-line `friction` note on the bead.
 
-In the Factory, the "receiver" is never a person waiting in chat: the durable
+In the Factory, a Bead you were dispatched to must carry its handoff comment
+before your turn ends, even when the work is incomplete or blocked (say what is
+done, what is not, and why); the host treats a claim whose Worker went idle
+without a handoff as stale and releases it. The "receiver" is never a person
+waiting in chat: the durable
 handoff IS the Bead comment (`[Feature Name] handoff · <bead id> · <short
 sha>` per `docs/procedures/naming-conventions.md`), and the next Worker or
 Orchestrator that claims the bead reads it to re-prime — there is no other

--- a/.agents/skills/owner-gate/SKILL.md
+++ b/.agents/skills/owner-gate/SKILL.md
@@ -15,16 +15,20 @@ this says HOW it reaches them.
 Never substitute a chat message, a bead comment, or a "let me know" for a gate.
 A gate that did not become an inbox item did not happen.
 
+Everything below is a default. The host and the owner decide. A host notice, a host tool result, or an owner instruction relayed in a prompt overrides any default in this skill; comply in the same turn and record the override in the gate card or handoff (AGENTS.md hard rule 1).
+Owner-owned Beads (assignee `owner`) never block a gate.
+
 Titles follow `docs/procedures/naming-conventions.md`: `[Feature Name] Plan
 approval` / `[Feature Name] Merge approval` — never lead with a bead id.
 
 ## The two gates
 
-The visual is mandatory at both gates, not optional — read `../show-me/SKILL.md`
+The visual is expected at both gates — read `../show-me/SKILL.md`
 for its view-selection table before producing either artifact below.
 
 - **Gate 1 — plan approval** (Orchestrator). Raised after the Bead graph is
-  materialized and the adversarial plan review is done, never before. Links
+  materialized and the (at most one) adversarial plan review is done, or when
+  the host's plan budget is reached, or when the epic is review-only/docs-only. Links
   the plan doc. Also write `docs/issues/<issue>/show-me-plan.md` with at most
   three views selected from show-me's table: the structure view (a shallow
   file tree or component tree of what the epic touches), the behavior view
@@ -48,8 +52,11 @@ for its view-selection table before producing either artifact below.
   card from `docs/procedures/owner-review-card.md`, then a `## Show me`
   section, then `## Handover`), start a `demo_sandbox` at the exact SHA when
   that tool is available, and put its URL on the card's `Artifact:` line and
-  again in `context` with its expiry. Must name the exact SHA and the
-  expected target head. The `## Show me` section carries diff-shaped views
+  again in `context` with its expiry. When `demo_sandbox` returns an error after
+  its fallback, raise the gate anyway and put the exact error under `Demo:`.
+  Must name the exact SHA and the expected target head; a docs-only commit of
+  the show-me/presentation artifacts after the reviewed SHA does not void the
+  review — cite both SHAs. The `## Show me` section carries diff-shaped views
   (component/call/file tree diff) plus one sequence diagram of the shipped
   flow, derived from the actual commits — never from memory of the plan.
   Write the same views to `docs/issues/<issue>/show-me-<short sha>.md` and
@@ -139,8 +146,9 @@ the workspace — it, not chat, is the decision record.
   never merge.
 - `changes`/`defer`/`reject` at Gate 1 → revise the plan and re-raise, or stop
   and report.
-- In every case, only at the SHA/plan you named. If the head moved, the
-  approval is void; re-raise.
+- In every case, only at the SHA/plan you named. If the head moved with code,
+  the approval is void; re-raise. Docs-only artifact commits are cited, not
+  re-gated.
 
 If the tool errors or is unavailable, fall back to a GitHub comment on the PR
 carrying the same card, and say in your handoff that the fallback was used.

--- a/.agents/skills/plan/SKILL.md
+++ b/.agents/skills/plan/SKILL.md
@@ -24,6 +24,8 @@ canonical contracts: `docs/procedures/{boring-loop.md,MODEL-CARD.md}` and
 
 ## Rules
 
+Every rule below is a default. The host and the owner decide. A host notice, a host tool result, or an owner instruction relayed in a prompt overrides any default in this skill; comply in the same turn and record the override in the gate card or handoff (AGENTS.md hard rule 1).
+
 - GitHub owns issues/PRs; Beads own local dependencies; Work Queue owns runs,
   artifacts, Inbox projections, and provenance only.
 - Keep one slice when possible. APR is advisory; accepted revisions enter the
@@ -41,20 +43,24 @@ canonical contracts: `docs/procedures/{boring-loop.md,MODEL-CARD.md}` and
 - Plan ceremony scales to the epic: one short plan note under
   `docs/issues/<issue>/`, at most one adversarial review, no HTML review page
   unless the epic changes UI — reach Gate 1 within minutes, not hours.
-- Request tier-1 fresh-eyes review through the host-provided independent-review
-  mechanism (`/skill:fresh-eyes` when that command is explicitly granted), then
-  continue the required Model Card ladder. If no independent-review mechanism is
-  available, stop rather than self-certifying. Use `ask_user` for unresolved
+- Request at most one tier-1 fresh-eyes review through the host-provided
+  independent-review mechanism (`/skill:fresh-eyes` when that command is
+  explicitly granted), then continue the required Model Card ladder. If no
+  independent-review mechanism is available, say so in the Gate 1 card and raise
+  the gate anyway; the owner decides. For review-only or docs-only epics (the
+  request says so) the request file is the plan and the plan review is skipped. Use `ask_user` for unresolved
   intent, risk, or approval. A plan-approval intention links the visual plan doc
   from `docs/procedures/visual-review-doc.md`. Gate 1 also carries the
   mandatory show-me plan artifact per `.agents/skills/owner-gate/SKILL.md`.
-- **The Steward never self-certifies: an adversarial plan review
-  (cross-model per the Model Card) runs BEFORE the owner gate, always** — even
-  when every design decision was pre-ratified by the owner via grill. Grill →
+- **The Steward never self-certifies: by default one adversarial plan review
+  (cross-model per the Model Card) runs BEFORE the owner gate** — even when
+  every design decision was pre-ratified by the owner via grill. Grill →
   draft → adversarial review → fold findings → gate. Material changes after
   ratification go back to the owner; editorial ones fold silently.
 - Gate 1 is raised in the owner's Inbox via `/skill:owner-gate` and blocks;
-  nothing is dispatched before approve. After approve, arm durable supervision
+  nothing is dispatched before approve. The host may set a plan budget (a Gate 1
+  deadline in the kickoff or a supervision nudge): when it is reached, raise
+  Gate 1 with what you have. After approve, arm durable supervision
   and dispatch Workers with `dispatch_worker` when that tool is available —
   the brief names the epic and the pull protocol, never a specific Bead, since
   Workers pull their own work. Use `/skill:exec <target>` only as the fallback


### PR DESCRIPTION
Observed 2026-09-05: Orchestrators refused host rulings and an explicit owner waiver by quoting skill prose (mandatory plan review, mandatory live demo, exists-idle claims). The four Factory skills now state ceremony as defaults with a single override sentence, bound plan reviews to one, make Gate 2 raise with the exact demo error, cite docs-only artifact commits instead of re-gating, exclude owner-owned Beads from gates, and require a handoff comment before a Worker turn ends. fleet.yaml digests repinned; resource manifest rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)