### PR TITLE
[Factory Reliability] Enforce durable reviewer admission limits

### DIFF
--- a/docs/factory/RELIABILITY.md
+++ b/docs/factory/RELIABILITY.md
@@ -31,13 +31,17 @@ same check.
 
 `fresh_review` records rounds per `(epic, Bead)` when `beadId` is present, otherwise
 per persisted SHA lineage for the calling Worker. `BORING_FACTORY_MAX_REVIEW_ROUNDS`
-(default `4`) does not suppress the capped review: that review runs and returns
-`capReached: true` with instructions to hand off at the current SHA and file remaining
-findings as follow-up Beads instead of fixing forward again.
+(default `4`) does not suppress the last allowed review: round N runs and returns
+`capReached: true`. Round N+1 is refused with `REVIEW_ROUND_CAP_REACHED` before a
+reviewer session is created; the Worker hands off the current SHA with unresolved
+findings and the Orchestrator escalates instead of inferring approval or fixing forward.
+Review admission is serialized and durably reserved before child-session creation, so
+concurrent calls, restart, failed creation, and crash-before-attach cannot reset budget.
 
-Each dispatch/review record contains the epic, target, child session, timestamp, and
-latest outcome in atomically replaced `<stateRoot>/dispatches.json`. A restarted host
-reads the same file before admission. `factory_status` exposes `busyWorkers`,
+Each dispatch/review record contains the epic, target, timestamp, latest outcome, and
+the child session once one has been attached, in atomically replaced
+`<stateRoot>/dispatches.json`. A restarted host reads the same file before admission.
+`factory_status` exposes `busyWorkers`,
 `dispatchesPerOpenBead`, and review rounds by Bead or SHA lineage, together with the
 active limits.
 

--- a/plugins/boring-factory/src/server/host/delegatePlugin.ts
+++ b/plugins/boring-factory/src/server/host/delegatePlugin.ts
@@ -31,7 +31,7 @@ import {
 export const FACTORY_DELEGATE_PLUGIN_ID = 'factory-delegate'
 
 /** Bump when this file's delegation behavior changes; hashed into the plugin's contentDigest. */
-const DELEGATE_PLUGIN_VERSION = 'factory-delegate.v3.2026-09-05'
+const DELEGATE_PLUGIN_VERSION = 'factory-delegate.v4.2026-09-06'
 
 const DEFAULT_TIMEOUT_MS = 15 * 60_000
 const POLL_INTERVAL_MS = 1_000
@@ -253,6 +253,17 @@ function capRefusal(
   }, true)
 }
 
+function reviewCapRefusal(targetKey: string, current: number, maximum: number): ToolResult {
+  return textResult({
+    code: 'REVIEW_ROUND_CAP_REACHED',
+    reviewTarget: targetKey,
+    current,
+    maximum,
+    blocked: true,
+    message: `Factory host refused review: the review-round cap is reached (${current}/${maximum}). Do not infer approval or create another review. The Worker must hand off the current SHA with unresolved findings; the Orchestrator must escalate them to the owner.`,
+  }, true)
+}
+
 function createDelegateTool(
   toolName: string,
   targetAgentTypeId: string,
@@ -395,8 +406,22 @@ function createDelegateTool(
 
           const timestamp = new Date(options.now?.() ?? Date.now()).toISOString()
           let dispatchRecord: FactoryDispatchRecord | undefined
+          let reviewRecord: FactoryReviewRecord | undefined
           if (toolName === 'dispatch_worker') {
             dispatchRecord = await ledger.reserveDispatch({ epicKey: epic.epicKey, beadId: beadId!, timestamp })
+          } else {
+            const reservation = await ledger.reserveReview({
+              epicKey: epic.epicKey,
+              targetKey: reviewTargetKey!,
+              ...(beadId ? { beadId } : {}),
+              ...(reviewSha ? { sha: reviewSha } : {}),
+              ...(ctx.sessionId ? { parentSessionId: ctx.sessionId } : {}),
+              timestamp,
+            }, limits.maxReviewRounds)
+            if (!reservation.accepted) {
+              return reviewCapRefusal(reservation.targetKey, reservation.current, reservation.maximum)
+            }
+            reviewRecord = reservation.record
           }
           const createResponse = await app.inject({
             method: 'POST',
@@ -406,26 +431,17 @@ function createDelegateTool(
           })
           if (createResponse.statusCode !== 201) {
             if (dispatchRecord) await ledger.updateDispatch(dispatchRecord.id, 'failed')
+            if (reviewRecord) await ledger.updateReview(reviewRecord.id, 'failed')
             return textResult(
               { code: 'CREATE_SESSION_FAILED', status: createResponse.statusCode, body: createResponse.body },
               true,
             )
           }
           const { sessionId } = createResponse.json<{ sessionId: string }>()
-          let reviewRecord: FactoryReviewRecord | undefined
           if (toolName === 'dispatch_worker') {
             dispatchRecord = await ledger.attachDispatch(dispatchRecord!.id, sessionId, 'created')
           } else {
-            reviewRecord = await ledger.appendReview({
-              epicKey: epic.epicKey,
-              targetKey: reviewTargetKey!,
-              ...(beadId ? { beadId } : {}),
-              ...(reviewSha ? { sha: reviewSha } : {}),
-              ...(ctx.sessionId ? { parentSessionId: ctx.sessionId } : {}),
-              childSessionId: sessionId,
-              timestamp,
-              outcome: 'created',
-            })
+            reviewRecord = await ledger.attachReview(reviewRecord!.id, sessionId, 'created')
           }
 
           try {
@@ -513,7 +529,7 @@ function createDelegateTool(
             reviewTarget: started.reviewRecord.targetKey,
             capReached: started.capReached,
             ...(started.capReached ? {
-              capInstructions: `Review-round cap reached (${started.reviewRecord.round}/${limits.maxReviewRounds}). Hand off at the current SHA and file remaining findings as follow-up Beads; do not fix forward again.`,
+              capInstructions: `Review-round cap reached (${started.reviewRecord.round}/${limits.maxReviewRounds}). Do not infer approval or fix forward again. The Worker must hand off the current SHA with unresolved findings; the Orchestrator must escalate them to the owner.`,
             } : {}),
           } : {}),
           provenance: {

--- a/plugins/boring-factory/src/server/host/dispatchLedger.ts
+++ b/plugins/boring-factory/src/server/host/dispatchLedger.ts
@@ -42,12 +42,17 @@ export interface FactoryReviewRecord {
   readonly beadId?: string
   readonly sha?: string
   readonly parentSessionId?: string
-  readonly childSessionId: string
+  /** Absent while admission is durably reserved before child-session creation. */
+  readonly childSessionId?: string
   readonly round: number
   readonly timestamp: string
   readonly updatedAt: string
   readonly outcome: FactoryReviewOutcome
 }
+
+export type FactoryReviewReservation =
+  | { readonly accepted: true; readonly record: FactoryReviewRecord }
+  | { readonly accepted: false; readonly targetKey: string; readonly current: number; readonly maximum: number }
 
 export interface FactoryDispatchState {
   readonly version: 1
@@ -61,7 +66,11 @@ export interface FactoryDispatchLedger {
   reserveDispatch(record: Pick<FactoryDispatchRecord, 'epicKey' | 'beadId' | 'timestamp'>): Promise<FactoryDispatchRecord>
   attachDispatch(id: string, childSessionId: string, outcome: FactoryDispatchOutcome): Promise<FactoryDispatchRecord>
   updateDispatch(id: string, outcome: FactoryDispatchOutcome): Promise<FactoryDispatchRecord>
-  appendReview(record: Omit<FactoryReviewRecord, 'id' | 'updatedAt' | 'round'>): Promise<FactoryReviewRecord>
+  reserveReview(
+    record: Omit<FactoryReviewRecord, 'id' | 'updatedAt' | 'round' | 'childSessionId' | 'outcome'>,
+    maximum: number,
+  ): Promise<FactoryReviewReservation>
+  attachReview(id: string, childSessionId: string, outcome: FactoryReviewOutcome): Promise<FactoryReviewRecord>
   updateReview(id: string, outcome: FactoryReviewOutcome): Promise<FactoryReviewRecord>
   markRefusal(input: Omit<FactoryCapRefusalMarker, 'id'>): Promise<{ readonly marker: FactoryCapRefusalMarker; readonly created: boolean }>
 }
@@ -158,8 +167,8 @@ export function createFactoryDispatchLedger(stateRoot: string): FactoryDispatchL
         return { state: { ...state, dispatches }, result: updated }
       })
     },
-    async appendReview(record) {
-      return await mutate((state) => {
+    async reserveReview(record, maximum) {
+      return await mutate<FactoryReviewReservation>((state) => {
         const priorTarget = record.beadId === undefined
           ? state.reviews.find((candidate) => (
               candidate.epicKey === record.epicKey
@@ -168,11 +177,33 @@ export function createFactoryDispatchLedger(stateRoot: string): FactoryDispatchL
             ))?.targetKey
           : undefined
         const targetKey = priorTarget ?? record.targetKey
-        const round = state.reviews.filter((candidate) => (
+        const current = state.reviews.filter((candidate) => (
           candidate.epicKey === record.epicKey && candidate.targetKey === targetKey
-        )).length + 1
-        const stored: FactoryReviewRecord = { ...record, targetKey, id: randomUUID(), round, updatedAt: record.timestamp }
-        return { state: { ...state, reviews: [...state.reviews, stored] }, result: stored }
+        )).length
+        if (current >= maximum) {
+          return { state, result: { accepted: false, targetKey, current, maximum } }
+        }
+        const stored: FactoryReviewRecord = {
+          ...record,
+          targetKey,
+          id: randomUUID(),
+          round: current + 1,
+          updatedAt: record.timestamp,
+          outcome: 'reserved',
+        }
+        return { state: { ...state, reviews: [...state.reviews, stored] }, result: { accepted: true, record: stored } }
+      })
+    },
+    async attachReview(id, childSessionId, outcome) {
+      return await mutate((state) => {
+        let updated: FactoryReviewRecord | undefined
+        const reviews = state.reviews.map((record) => {
+          if (record.id !== id) return record
+          updated = { ...record, childSessionId, outcome, updatedAt: new Date().toISOString() }
+          return updated
+        })
+        if (!updated) throw new Error(`review record ${id} was not found`)
+        return { state: { ...state, reviews }, result: updated }
       })
     },
     async updateReview(id, outcome) {

--- a/plugins/boring-factory/src/server/host/factoryLimits.test.ts
+++ b/plugins/boring-factory/src/server/host/factoryLimits.test.ts
@@ -72,6 +72,7 @@ interface FakeAppOptions {
   readonly repeatWorkerCursor?: boolean
   readonly workerSessionPageCount?: number
   readonly crashAfterSessionCreation?: boolean
+  readonly sessionCreationStatusCode?: number
 }
 
 function fakeApp(
@@ -106,8 +107,8 @@ function fakeApp(
         if (request.method === 'POST' && request.url.endsWith('/sessions')) {
           const sessionId = childSessionIds[created++] ?? `child-${created}`
           return {
-            statusCode: 201,
-            body: '',
+            statusCode: options.sessionCreationStatusCode ?? 201,
+            body: options.sessionCreationStatusCode && options.sessionCreationStatusCode !== 201 ? 'session unavailable' : '',
             json: <T>() => {
               if (options.crashAfterSessionCreation) throw new Error('simulated host crash before ledger attach')
               return { sessionId } as T
@@ -412,11 +413,11 @@ describe('Factory host limits', () => {
     expect(brCalls.some((args) => args[0] === 'comments' && String(args[4]).includes('2/2'))).toBe(true)
   })
 
-  it('flags the review-round cap while still running the capped review', async () => {
+  it('runs the last allowed review and refuses sequential N+1 before creating a session', async () => {
     const stateRoot = await makeStateRoot()
     const { registry, sessionBindings } = dependencies()
     const { runBr } = fakeBr()
-    const { app } = fakeApp([], ['review-1', 'review-2'])
+    const { app, calls } = fakeApp([], ['review-1', 'review-2', 'review-3'])
     const handle = createFactoryDelegatePlugin({
       stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, runBr,
       env: { BORING_FACTORY_MAX_REVIEW_ROUNDS: '2' }, timeoutMs: 1_000,
@@ -426,9 +427,130 @@ describe('Factory host limits', () => {
 
     const first = await tool.execute({ beadId: 'br-1', brief: 'Review Bead br-1 at abcdef1 and report findings.' }, context('worker', 'r1'))
     const second = await tool.execute({ beadId: 'br-1', brief: 'Review Bead br-1 at abcdef2 and report findings.' }, context('worker', 'r2'))
+    const refused = await tool.execute({ beadId: 'br-1', brief: 'Review Bead br-1 at abcdef3 and report findings.' }, context('worker', 'r3'))
+
     expect(first.details).toMatchObject({ reviewRound: 1, capReached: false })
     expect(second.details).toMatchObject({ reviewRound: 2, capReached: true })
-    expect((second.details as { capInstructions: string }).capInstructions).toContain('Hand off at the current SHA')
+    expect((second.details as { capInstructions: string }).capInstructions).toContain('Orchestrator must escalate')
+    expect(refused).toMatchObject({
+      isError: true,
+      details: { code: 'REVIEW_ROUND_CAP_REACHED', reviewTarget: 'bead:br-1', current: 2, maximum: 2, blocked: true },
+    })
+    expect((refused.details as { message: string }).message).toContain('Do not infer approval')
+    expect(calls.filter((call) => call.method === 'POST' && call.url.endsWith('/sessions'))).toHaveLength(2)
+    expect(calls.filter((call) => call.method === 'POST' && call.url.endsWith('/prompt'))).toHaveLength(2)
+  })
+
+  it('serializes concurrent review admissions at the final slot', async () => {
+    const stateRoot = await makeStateRoot()
+    const { registry, sessionBindings } = dependencies()
+    const { runBr } = fakeBr()
+    const { app, calls } = fakeApp([], ['review-only'])
+    const handle = createFactoryDelegatePlugin({
+      stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, runBr,
+      env: { BORING_FACTORY_MAX_REVIEW_ROUNDS: '1' }, timeoutMs: 1_000,
+    })
+    handle.bind(app as never)
+    const tool = toolNamed(handle, 'boring-worker', 'fresh_review')
+
+    const results = await Promise.all([
+      tool.execute({ beadId: 'br-1', brief: 'Review Bead br-1 at abcdef1 in final slot A.' }, context('worker', 'r1')),
+      tool.execute({ beadId: 'br-1', brief: 'Review Bead br-1 at abcdef2 in final slot B.' }, context('worker', 'r2')),
+    ])
+
+    expect(results.filter((result) => result.isError)).toHaveLength(1)
+    expect(results.filter((result) => !result.isError)[0]?.details).toMatchObject({ reviewRound: 1, capReached: true })
+    expect(results.filter((result) => result.isError)[0]?.details).toMatchObject({ code: 'REVIEW_ROUND_CAP_REACHED', current: 1, maximum: 1 })
+    expect(calls.filter((call) => call.method === 'POST' && call.url.endsWith('/sessions'))).toHaveLength(1)
+  })
+
+  it('enforces the persisted review cap after host restart', async () => {
+    const stateRoot = await makeStateRoot()
+    const { registry, sessionBindings } = dependencies()
+    const { runBr } = fakeBr()
+    const firstApp = fakeApp([], ['review-1'])
+    const firstHost = createFactoryDelegatePlugin({
+      stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, runBr,
+      env: { BORING_FACTORY_MAX_REVIEW_ROUNDS: '1' }, timeoutMs: 1_000,
+    })
+    firstHost.bind(firstApp.app as never)
+    await toolNamed(firstHost, 'boring-worker', 'fresh_review').execute(
+      { beadId: 'br-1', brief: 'Review Bead br-1 at abcdef1 before restart.' }, context('worker', 'r1'),
+    )
+
+    const restartedApp = fakeApp([], ['review-2'])
+    const restartedHost = createFactoryDelegatePlugin({
+      stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, runBr,
+      env: { BORING_FACTORY_MAX_REVIEW_ROUNDS: '1' }, timeoutMs: 1_000,
+    })
+    restartedHost.bind(restartedApp.app as never)
+    const refused = await toolNamed(restartedHost, 'boring-worker', 'fresh_review').execute(
+      { beadId: 'br-1', brief: 'Review Bead br-1 at abcdef2 after restart.' }, context('worker', 'r2'),
+    )
+
+    expect(refused.details).toMatchObject({ code: 'REVIEW_ROUND_CAP_REACHED', current: 1, maximum: 1 })
+    expect(restartedApp.calls.some((call) => call.method === 'POST' && call.url.endsWith('/sessions'))).toBe(false)
+  })
+
+  it('counts a review reserved before a crash-before-attach and refuses after restart', async () => {
+    const stateRoot = await makeStateRoot()
+    const { registry, sessionBindings } = dependencies()
+    const { runBr } = fakeBr()
+    const crashingApp = fakeApp([], ['orphan-review'], { crashAfterSessionCreation: true })
+    const firstHost = createFactoryDelegatePlugin({
+      stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, runBr,
+      env: { BORING_FACTORY_MAX_REVIEW_ROUNDS: '1' }, timeoutMs: 1_000,
+    })
+    firstHost.bind(crashingApp.app as never)
+    const crashed = await toolNamed(firstHost, 'boring-worker', 'fresh_review').execute(
+      { beadId: 'br-1', brief: 'Review Bead br-1 at abcdef1 then crash before attach.' }, context('worker', 'r1'),
+    )
+    expect(crashed).toMatchObject({ isError: true, details: { code: 'DELEGATE_FAILED' } })
+    const persisted = JSON.parse(await readFile(resolve(stateRoot, 'dispatches.json'), 'utf8')) as {
+      reviews: Array<{ outcome: string; childSessionId?: string; round: number }>
+    }
+    expect(persisted.reviews).toEqual([expect.objectContaining({ outcome: 'reserved', round: 1 })])
+    expect(persisted.reviews[0]!.childSessionId).toBeUndefined()
+
+    const restartedApp = fakeApp([], ['review-2'])
+    const restartedHost = createFactoryDelegatePlugin({
+      stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, runBr,
+      env: { BORING_FACTORY_MAX_REVIEW_ROUNDS: '1' }, timeoutMs: 1_000,
+    })
+    restartedHost.bind(restartedApp.app as never)
+    const refused = await toolNamed(restartedHost, 'boring-worker', 'fresh_review').execute(
+      { beadId: 'br-1', brief: 'Retry review Bead br-1 at abcdef2 after crash.' }, context('worker', 'r2'),
+    )
+    expect(refused.details).toMatchObject({ code: 'REVIEW_ROUND_CAP_REACHED', current: 1, maximum: 1 })
+    expect(restartedApp.calls.some((call) => call.method === 'POST' && call.url.endsWith('/sessions'))).toBe(false)
+  })
+
+  it('counts a failed review-session creation against the cap', async () => {
+    const stateRoot = await makeStateRoot()
+    const { registry, sessionBindings } = dependencies()
+    const { runBr } = fakeBr()
+    const failingApp = fakeApp([], ['failed-review'], { sessionCreationStatusCode: 503 })
+    const firstHost = createFactoryDelegatePlugin({
+      stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, runBr,
+      env: { BORING_FACTORY_MAX_REVIEW_ROUNDS: '1' }, timeoutMs: 1_000,
+    })
+    firstHost.bind(failingApp.app as never)
+    const failed = await toolNamed(firstHost, 'boring-worker', 'fresh_review').execute(
+      { beadId: 'br-1', brief: 'Review Bead br-1 at abcdef1 despite transport failure.' }, context('worker', 'r1'),
+    )
+    expect(failed).toMatchObject({ isError: true, details: { code: 'CREATE_SESSION_FAILED', status: 503 } })
+
+    const restartedApp = fakeApp([], ['review-2'])
+    const restartedHost = createFactoryDelegatePlugin({
+      stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, runBr,
+      env: { BORING_FACTORY_MAX_REVIEW_ROUNDS: '1' }, timeoutMs: 1_000,
+    })
+    restartedHost.bind(restartedApp.app as never)
+    const refused = await toolNamed(restartedHost, 'boring-worker', 'fresh_review').execute(
+      { beadId: 'br-1', brief: 'Retry failed review Bead br-1 at abcdef2.' }, context('worker', 'r2'),
+    )
+    expect(refused.details).toMatchObject({ code: 'REVIEW_ROUND_CAP_REACHED', current: 1, maximum: 1 })
+    expect(restartedApp.calls.some((call) => call.method === 'POST' && call.url.endsWith('/sessions'))).toBe(false)
   })
 
   it('serializes SHA-lineage resolution with concurrent review appends that omit beadId', async () => {
@@ -449,6 +571,38 @@ describe('Factory host limits', () => {
 
     expect(results.map((result) => (result.details as { reviewRound: number }).reviewRound).sort()).toEqual([1, 2])
     expect(new Set(results.map((result) => (result.details as { reviewTarget: string }).reviewTarget)).size).toBe(1)
+  })
+
+  it('preserves an inferred no-Bead SHA lineage across changed SHAs and restart', async () => {
+    const stateRoot = await makeStateRoot()
+    const { registry, sessionBindings } = dependencies()
+    const { runBr } = fakeBr()
+    const firstApp = fakeApp([], ['review-1'])
+    const firstHost = createFactoryDelegatePlugin({
+      stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, runBr,
+      env: { BORING_FACTORY_MAX_REVIEW_ROUNDS: '1' }, timeoutMs: 1_000,
+    })
+    firstHost.bind(firstApp.app as never)
+    const first = await toolNamed(firstHost, 'boring-worker', 'fresh_review').execute(
+      { brief: 'Review the untracked target at abcdef1 without a Bead id.' }, context('worker', 'r1'),
+    )
+    expect(first.details).toMatchObject({ reviewRound: 1, reviewTarget: 'sha-lineage:abcdef1', capReached: true })
+
+    const restartedApp = fakeApp([], ['review-2'])
+    const restartedHost = createFactoryDelegatePlugin({
+      stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, runBr,
+      env: { BORING_FACTORY_MAX_REVIEW_ROUNDS: '1' }, timeoutMs: 1_000,
+    })
+    restartedHost.bind(restartedApp.app as never)
+    const refused = await toolNamed(restartedHost, 'boring-worker', 'fresh_review').execute(
+      { brief: 'Review the changed untracked target at abcdef2 without a Bead id.' }, context('worker', 'r2'),
+    )
+
+    expect(refused).toMatchObject({
+      isError: true,
+      details: { code: 'REVIEW_ROUND_CAP_REACHED', reviewTarget: 'sha-lineage:abcdef1', current: 1, maximum: 1 },
+    })
+    expect(restartedApp.calls.some((call) => call.method === 'POST' && call.url.endsWith('/sessions'))).toBe(false)
   })
 
   it('fails closed when a Bead or ledger inference conflicts with an authoritative binding', async () => {


### PR DESCRIPTION
## Owner Review
- **Bead / PR / issue:** Follow-up to #1508. This fixes only reviewer admission; it does not close the Factory readiness issue.
- **What changed / why:** A reproduced limit of 1 still created reviewer 2 after plugin restart. Review rounds are now reserved durably before session creation. Round N runs and is flagged; N+1 refuses before creation or prompt. Failed and crash-unknown attempts remain counted. Atomic ledger reservation preserves concurrent final-slot safety without holding the host-wide dispatch lock across reviewer startup.
- **Risk / rollback:** Internal Factory plugin change; existing ledger records remain readable. A crash reservation consumes budget intentionally and needs operator judgment, not automatic reset. Revert this commit to roll back. Multiple processes sharing one state root remain unsupported.
- **Proof / review:** Original negative probe: 2 reviewer sessions at cap 1, persisted rounds [1,2]. Fixed probe: 1 session, N+1 `REVIEW_ROUND_CAP_REACHED`, rounds [1]. All 80 host tests pass; full unexcluded `tsc --noEmit` passes after building this plugin only. Independent Sol review + strict simplicity pass found one P2 (excess lock scope), fixed; final re-review: OK, no findings. CI is pending at PR creation.
- **Artifact:** [Self-contained review presentation](https://gist.github.com/hachej/fc1c72decf3e2112a3a33df62cce45c6) (context, audit trail, package/file map, importance-ordered diffs; CI pending). Non-UI change; no running demo required. The existing live hub is intentionally unchanged.
- **Please test:** `TMPDIR=<disk-scratch> pnpm --filter @hachej/boring-factory exec vitest run --no-file-parallelism src/server/host`; verify N/N+1, concurrent last slot, persisted restart, failed creation and crash-before-attach cases.
- **Decision:** approve | request changes | defer | reject. No merge/deployment is authorized by the reviewer verdict.

## Show me
```diff
 fresh_review
-  create reviewer session
-  append round to ledger
+  atomically resolve lineage and reserve round
+    if count >= maximum: refuse without creating/prompting
+  create reviewer session
+  attach session to reserved round
   prompt reviewer
   return verdict text and capReached on final allowed round
```
```mermaid
sequenceDiagram
    participant Worker
    participant Host
    participant Ledger
    participant Reviewer
    Worker->>Host: fresh_review
    Host->>Ledger: atomically count and reserve
    alt budget exhausted
      Ledger-->>Host: refused
      Host-->>Worker: REVIEW_ROUND_CAP_REACHED
    else slot admitted
      Ledger-->>Host: persisted reservation
      Host->>Reviewer: create and prompt
      Host-->>Worker: result (capReached on N)
    end
```

## Handover
- Branch: `fix/factory-takeover-20260907`
- Implementation SHA: `75b2a9a3749d91ab1a2a3a5e7dea95930f0cbfd0`
- Parent revalidation: 80/80 host tests and full no-emit TypeScript, no assertion weakening. An earlier parallel host run had one 5-second composition timeout; isolated rerun passed, followed by two full serial 80/80 passes with unchanged test timeouts.
- Validation used actual source with deterministic session-transport fixtures, not live provider spend. The restart test reconstructs the plugin from persistent disk state, not a live-host SIGKILL test. Separate four-process Inbox-store/answer-delivery proof passed.
- Real open-issue intake pilots #1476 and #1461 reached unanswered Gate 1 cards with zero Worker dispatch. Their approval forms render in the shared Inbox. Existing four epics/gates remain intact.
- **Still blocked / not claimed fixed:** Gate 1 dispatch approval is prose-only; exact-SHA/structured review and handoff validation remain incomplete; browser plan artifacts use epic-relative paths and 404 from the canonical root; Beads DB authority docs conflict with host topology. Evidence is recorded in #1508. This PR does not make the whole Factory unattended-ready.
