### PR TITLE
[Factory Host Polling] Stop full-state polling from starving the host

### DIFF
--- a/plugins/boring-factory/src/server/host/delegatePlugin.ts
+++ b/plugins/boring-factory/src/server/host/delegatePlugin.ts
@@ -499,18 +499,36 @@ function createDelegateTool(
         // the full-state poll saturated the host event loop and starved the UI.
         while (Date.now() < deadline) {
           if (ctx.abortSignal.aborted) throw new DelegateAbortedError()
-          const summaryResponse = await app.inject({
-            method: 'POST',
-            url: `/api/v1/agents/${targetAgentTypeId}/sessions/summaries`,
-            headers: workspaceHeader,
-            payload: { sessionIds: [sessionId] },
-          })
-          if (summaryResponse.statusCode === 200) {
-            const summary = summaryResponse.json<{ summaries?: Array<{ status?: string; turnCount?: number }> }>().summaries?.[0]
-            if (summary?.status === 'idle' && (summary.turnCount ?? 0) >= 1) {
-              status = 'completed'
-              break
+          let probe: { status?: string; turnCount?: number } | undefined
+          try {
+            const summaryResponse = await app.inject({
+              method: 'POST',
+              url: `/api/v1/agents/${targetAgentTypeId}/sessions/summaries`,
+              headers: workspaceHeader,
+              payload: { sessionIds: [sessionId] },
+            })
+            if (summaryResponse.statusCode === 200) {
+              probe = summaryResponse.json<{ summaries?: Array<{ status?: string; turnCount?: number }> }>().summaries?.[0]
             }
+          } catch {
+            probe = undefined
+          }
+          if (!probe) {
+            // Hosts without the batch projection (or a session it has not indexed
+            // yet) fall back to the full-state read so completion is never missed.
+            const stateResponse = await app.inject({
+              method: 'GET',
+              url: `/api/v1/agents/${targetAgentTypeId}/sessions/${sessionId}/state`,
+              headers: workspaceHeader,
+            })
+            if (stateResponse.statusCode === 200) {
+              lastState = stateResponse.json<DelegateSessionState>()
+              probe = { status: lastState.state?.status, turnCount: lastState.summary?.turnCount }
+            }
+          }
+          if (probe?.status === 'idle' && (probe.turnCount ?? 0) >= 1) {
+            status = 'completed'
+            break
           }
           await sleep(POLL_INTERVAL_MS, ctx.abortSignal)
         }

--- a/plugins/boring-factory/src/server/host/delegatePlugin.ts
+++ b/plugins/boring-factory/src/server/host/delegatePlugin.ts
@@ -526,10 +526,7 @@ function createDelegateTool(
               probe = { status: lastState.state?.status, turnCount: lastState.summary?.turnCount }
             }
           }
-          if (probe?.status === 'idle' && (probe.turnCount ?? 0) >= 1) {
-            status = 'completed'
-            break
-          }
+          if (probe?.status === 'idle' && (probe.turnCount ?? 0) >= 1) break
           await sleep(POLL_INTERVAL_MS, ctx.abortSignal)
         }
         // One full-state read at the end for the model and final assistant text.
@@ -539,6 +536,9 @@ function createDelegateTool(
           headers: workspaceHeader,
         })
         if (finalStateResponse.statusCode === 200) lastState = finalStateResponse.json<DelegateSessionState>()
+        // The full state is authoritative: it both confirms completion and carries
+        // the answer. This also catches a child that became idle at the deadline.
+        if (lastState?.state?.status === 'idle' && (lastState.summary?.turnCount ?? 0) >= 1) status = 'completed'
 
         const finishedAt = new Date().toISOString()
         const model = lastState?.state?.currentModel

--- a/plugins/boring-factory/src/server/host/delegatePlugin.ts
+++ b/plugins/boring-factory/src/server/host/delegatePlugin.ts
@@ -34,7 +34,7 @@ export const FACTORY_DELEGATE_PLUGIN_ID = 'factory-delegate'
 const DELEGATE_PLUGIN_VERSION = 'factory-delegate.v4.2026-09-06'
 
 const DEFAULT_TIMEOUT_MS = 15 * 60_000
-const POLL_INTERVAL_MS = 1_000
+const POLL_INTERVAL_MS = 5_000
 const BRIEF_MIN_LENGTH = 20
 const BRIEF_MAX_LENGTH = 8_000
 
@@ -494,23 +494,33 @@ function createDelegateTool(
         const deadline = Date.now() + timeoutMs
         let status: 'completed' | 'timeout' = 'timeout'
         let lastState: DelegateSessionState | undefined
+        // Poll the cheap batch-summary projection (status + turnCount) instead of
+        // serialising the child's full transcript every second: with a dozen lanes
+        // the full-state poll saturated the host event loop and starved the UI.
         while (Date.now() < deadline) {
           if (ctx.abortSignal.aborted) throw new DelegateAbortedError()
-          const stateResponse = await app.inject({
-            method: 'GET',
-            url: `/api/v1/agents/${targetAgentTypeId}/sessions/${sessionId}/state`,
+          const summaryResponse = await app.inject({
+            method: 'POST',
+            url: `/api/v1/agents/${targetAgentTypeId}/sessions/summaries`,
             headers: workspaceHeader,
+            payload: { sessionIds: [sessionId] },
           })
-          if (stateResponse.statusCode === 200) {
-            lastState = stateResponse.json<DelegateSessionState>()
-            const turnCount = lastState.summary?.turnCount ?? 0
-            if (lastState.state?.status === 'idle' && turnCount >= 1) {
+          if (summaryResponse.statusCode === 200) {
+            const summary = summaryResponse.json<{ summaries?: Array<{ status?: string; turnCount?: number }> }>().summaries?.[0]
+            if (summary?.status === 'idle' && (summary.turnCount ?? 0) >= 1) {
               status = 'completed'
               break
             }
           }
           await sleep(POLL_INTERVAL_MS, ctx.abortSignal)
         }
+        // One full-state read at the end for the model and final assistant text.
+        const finalStateResponse = await app.inject({
+          method: 'GET',
+          url: `/api/v1/agents/${targetAgentTypeId}/sessions/${sessionId}/state`,
+          headers: workspaceHeader,
+        })
+        if (finalStateResponse.statusCode === 200) lastState = finalStateResponse.json<DelegateSessionState>()
 
         const finishedAt = new Date().toISOString()
         const model = lastState?.state?.currentModel

--- a/plugins/boring-factory/src/server/host/delegatePlugin.ts
+++ b/plugins/boring-factory/src/server/host/delegatePlugin.ts
@@ -31,7 +31,7 @@ import {
 export const FACTORY_DELEGATE_PLUGIN_ID = 'factory-delegate'
 
 /** Bump when this file's delegation behavior changes; hashed into the plugin's contentDigest. */
-const DELEGATE_PLUGIN_VERSION = 'factory-delegate.v4.2026-09-06'
+const DELEGATE_PLUGIN_VERSION = 'factory-delegate.v5.2026-09-07'
 
 const DEFAULT_TIMEOUT_MS = 15 * 60_000
 const POLL_INTERVAL_MS = 5_000

--- a/plugins/boring-factory/src/server/host/factoryHub.ts
+++ b/plugins/boring-factory/src/server/host/factoryHub.ts
@@ -338,7 +338,33 @@ async function readPendingQuestions(app: FastifyInstance): Promise<Map<string, {
   }
 }
 
-async function liveEpicEntry(app: FastifyInstance, entry: FactoryEpicEntry, pendingBySession: ReadonlyMap<string, { questionId: string; title?: string }>, stateRoot: string, env: NodeJS.ProcessEnv, activeDemoUrl?: string): Promise<FactoryEpicLiveEntry> {
+/**
+ * One batch-summary call for every registered Orchestrator. The previous
+ * per-epic full-state read serialised each transcript (the batch supervisor's
+ * alone was 11MB) on every workspace load, which took ~10s under load.
+ */
+async function readOrchestratorStatuses(app: FastifyInstance, entries: readonly FactoryEpicEntry[]): Promise<Map<string, string>> {
+  const sessionIds = entries.map((entry) => entry.orchestratorSessionId).filter((id): id is string => typeof id === 'string' && id.length > 0)
+  const statuses = new Map<string, string>()
+  if (sessionIds.length === 0) return statuses
+  try {
+    const response = await app.inject({
+      method: 'POST',
+      url: `/api/v1/agents/${FACTORY_ORCHESTRATOR_AGENT_TYPE_ID}/sessions/summaries`,
+      headers: { 'x-boring-workspace-id': FACTORY_WORKSPACE_SCOPE_ID },
+      payload: { sessionIds },
+    })
+    if (response.statusCode !== 200) return statuses
+    for (const summary of response.json<{ summaries?: Array<{ ref?: { sessionId?: string }; status?: string }> }>().summaries ?? []) {
+      if (summary.ref?.sessionId && typeof summary.status === 'string') statuses.set(summary.ref.sessionId, summary.status)
+    }
+  } catch {
+    // fall through: unknown status renders as null, never blocks the listing
+  }
+  return statuses
+}
+
+async function liveEpicEntry(app: FastifyInstance, entry: FactoryEpicEntry, pendingBySession: ReadonlyMap<string, { questionId: string; title?: string }>, orchestratorStatusBySession: ReadonlyMap<string, string>, stateRoot: string, env: NodeJS.ProcessEnv, activeDemoUrl?: string): Promise<FactoryEpicLiveEntry> {
   const [headSha, beads, orchestratorStatus, sandboxSnapshot] = await Promise.all([
     gitOutput(entry.worktree, ['rev-parse', 'HEAD']).catch(() => null),
     execFileAsync('br', ['list', '--all', '--label', `epic:${entry.epicKey}`, '--json', '--no-auto-flush'], { cwd: entry.worktree, maxBuffer: 16 * 1024 * 1024 }).then(({ stdout }) => {
@@ -350,10 +376,7 @@ async function liveEpicEntry(app: FastifyInstance, entry: FactoryEpicEntry, pend
         return counts
       }, { open: 0, closed: 0 })
     }).catch(() => ({ open: 0, closed: 0 })),
-    entry.orchestratorSessionId
-      ? app.inject({ method: 'GET', url: `/api/v1/agents/${FACTORY_ORCHESTRATOR_AGENT_TYPE_ID}/sessions/${entry.orchestratorSessionId}/state`, headers: { 'x-boring-workspace-id': FACTORY_WORKSPACE_SCOPE_ID } })
-          .then((response) => response.statusCode === 200 ? response.json<{ state?: { status?: string } }>().state?.status ?? null : null).catch(() => null)
-      : Promise.resolve(null),
+    Promise.resolve(entry.orchestratorSessionId ? orchestratorStatusBySession.get(entry.orchestratorSessionId) ?? null : null),
     getFactorySandboxSnapshotInfo({ stateRoot, epicKey: entry.epicKey, env }).catch(() => undefined),
   ])
   return {
@@ -543,8 +566,9 @@ export async function createFactoryHost(options: CreateFactoryHostOptions): Prom
       })
       app.get('/api/v1/factory/epics', async (_request, reply) => {
         try {
-          const [pending, activeDemoUrls] = await Promise.all([readPendingQuestions(app), demo.control.listActiveDemoUrls()])
-          return await Promise.all((await registry.list()).map(async (entry) => await liveEpicEntry(app, entry, pending, stateRoot, env, activeDemoUrls[entry.epicKey])))
+          const entries = await registry.list()
+          const [pending, activeDemoUrls, statuses] = await Promise.all([readPendingQuestions(app), demo.control.listActiveDemoUrls(), readOrchestratorStatuses(app, entries)])
+          return await Promise.all(entries.map(async (entry) => await liveEpicEntry(app, entry, pending, statuses, stateRoot, env, activeDemoUrls[entry.epicKey])))
         } catch (error) { return sendError(reply, error) }
       })
       app.post('/api/v1/factory/epics/:key/adopt', async (request, reply) => {

--- a/plugins/boring-factory/src/server/host/factoryHub.ts
+++ b/plugins/boring-factory/src/server/host/factoryHub.ts
@@ -339,27 +339,33 @@ async function readPendingQuestions(app: FastifyInstance): Promise<Map<string, {
 }
 
 /**
- * One batch-summary call for every registered Orchestrator. The previous
- * per-epic full-state read serialised each transcript (the batch supervisor's
- * alone was 11MB) on every workspace load, which took ~10s under load.
+ * Batched summary calls for registered Orchestrators. The previous per-epic
+ * full-state read serialised each transcript (the batch supervisor's alone was
+ * 11MB) on every workspace load, which took ~10s under load.
  */
-async function readOrchestratorStatuses(app: FastifyInstance, entries: readonly FactoryEpicEntry[]): Promise<Map<string, string>> {
-  const sessionIds = entries.map((entry) => entry.orchestratorSessionId).filter((id): id is string => typeof id === 'string' && id.length > 0)
+export async function readOrchestratorStatuses(app: FastifyInstance, entries: readonly FactoryEpicEntry[]): Promise<Map<string, string>> {
+  const sessionIds = [...new Set(entries.map((entry) => entry.orchestratorSessionId).filter((id): id is string => typeof id === 'string' && id.length > 0))]
   const statuses = new Map<string, string>()
   if (sessionIds.length === 0) return statuses
-  try {
-    const response = await app.inject({
-      method: 'POST',
-      url: `/api/v1/agents/${FACTORY_ORCHESTRATOR_AGENT_TYPE_ID}/sessions/summaries`,
-      headers: { 'x-boring-workspace-id': FACTORY_WORKSPACE_SCOPE_ID },
-      payload: { sessionIds },
-    })
-    if (response.statusCode === 200) for (const summary of response.json<{ summaries?: Array<{ ref?: { sessionId?: string }; status?: string }> }>().summaries ?? []) {
-      if (summary.ref?.sessionId && typeof summary.status === 'string') statuses.set(summary.ref.sessionId, summary.status)
+  // The public summaries projection accepts at most 50 addressed sessions.
+  // Keep large registries on the cheap path instead of provoking a 400 and
+  // falling back to full transcript reads for every historical epic.
+  const batches = Array.from({ length: Math.ceil(sessionIds.length / 50) }, (_, index) => sessionIds.slice(index * 50, (index + 1) * 50))
+  await Promise.all(batches.map(async (batch) => {
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: `/api/v1/agents/${FACTORY_ORCHESTRATOR_AGENT_TYPE_ID}/sessions/summaries`,
+        headers: { 'x-boring-workspace-id': FACTORY_WORKSPACE_SCOPE_ID },
+        payload: { sessionIds: batch },
+      })
+      if (response.statusCode === 200) for (const summary of response.json<{ summaries?: Array<{ ref?: { sessionId?: string }; status?: string }> }>().summaries ?? []) {
+        if (summary.ref?.sessionId && typeof summary.status === 'string') statuses.set(summary.ref.sessionId, summary.status)
+      }
+    } catch {
+      // This batch falls through to per-session reads below.
     }
-  } catch {
-    // fall through to the per-session read below
-  }
+  }))
   // Sessions the batch projection has not indexed yet (freshly created ones)
   // keep the exact previous behaviour: one state read each.
   await Promise.all(sessionIds.filter((id) => !statuses.has(id)).map(async (id) => {

--- a/plugins/boring-factory/src/server/host/factoryHub.ts
+++ b/plugins/boring-factory/src/server/host/factoryHub.ts
@@ -354,13 +354,23 @@ async function readOrchestratorStatuses(app: FastifyInstance, entries: readonly 
       headers: { 'x-boring-workspace-id': FACTORY_WORKSPACE_SCOPE_ID },
       payload: { sessionIds },
     })
-    if (response.statusCode !== 200) return statuses
-    for (const summary of response.json<{ summaries?: Array<{ ref?: { sessionId?: string }; status?: string }> }>().summaries ?? []) {
+    if (response.statusCode === 200) for (const summary of response.json<{ summaries?: Array<{ ref?: { sessionId?: string }; status?: string }> }>().summaries ?? []) {
       if (summary.ref?.sessionId && typeof summary.status === 'string') statuses.set(summary.ref.sessionId, summary.status)
     }
   } catch {
-    // fall through: unknown status renders as null, never blocks the listing
+    // fall through to the per-session read below
   }
+  // Sessions the batch projection has not indexed yet (freshly created ones)
+  // keep the exact previous behaviour: one state read each.
+  await Promise.all(sessionIds.filter((id) => !statuses.has(id)).map(async (id) => {
+    try {
+      const response = await app.inject({ method: 'GET', url: `/api/v1/agents/${FACTORY_ORCHESTRATOR_AGENT_TYPE_ID}/sessions/${id}/state`, headers: { 'x-boring-workspace-id': FACTORY_WORKSPACE_SCOPE_ID } })
+      const status = response.statusCode === 200 ? response.json<{ state?: { status?: string } }>().state?.status : undefined
+      if (typeof status === 'string') statuses.set(id, status)
+    } catch {
+      // unknown status renders as null, never blocks the listing
+    }
+  }))
   return statuses
 }
 

--- a/plugins/boring-factory/src/server/host/factoryLimits.test.ts
+++ b/plugins/boring-factory/src/server/host/factoryLimits.test.ts
@@ -73,6 +73,10 @@ interface FakeAppOptions {
   readonly workerSessionPageCount?: number
   readonly crashAfterSessionCreation?: boolean
   readonly sessionCreationStatusCode?: number
+  readonly summaryStatus?: string
+  readonly summaryTurnCount?: number
+  readonly finalStateStatus?: string
+  readonly finalStateStatusCode?: number
 }
 
 function fakeApp(
@@ -104,6 +108,18 @@ function fakeApp(
             }) as T,
           }
         }
+        if (request.method === 'POST' && request.url.endsWith('/sessions/summaries')) {
+          const sessionIds = (request.payload as { sessionIds: string[] }).sessionIds
+          return {
+            statusCode: 200,
+            body: '',
+            json: <T>() => ({ summaries: sessionIds.map((sessionId) => ({
+              ref: { sessionId },
+              status: options.summaryStatus ?? 'idle',
+              turnCount: options.summaryTurnCount ?? 1,
+            })) }) as T,
+          }
+        }
         if (request.method === 'POST' && request.url.endsWith('/sessions')) {
           const sessionId = childSessionIds[created++] ?? `child-${created}`
           return {
@@ -120,11 +136,11 @@ function fakeApp(
         }
         if (request.method === 'GET' && request.url.endsWith('/state')) {
           return {
-            statusCode: 200,
+            statusCode: options.finalStateStatusCode ?? 200,
             body: '',
             json: <T>() => ({
               summary: { turnCount: 1 },
-              state: { status: 'idle', messages: [{ role: 'assistant', parts: [{ type: 'text', text: 'done' }] }] },
+              state: { status: options.finalStateStatus ?? 'idle', messages: [{ role: 'assistant', parts: [{ type: 'text', text: 'done' }] }] },
             }) as T,
           }
         }
@@ -142,6 +158,38 @@ function toolNamed(handle: ReturnType<typeof createFactoryDelegatePlugin>, seat:
 }
 
 describe('Factory host limits', () => {
+  it('polls the summary projection and reads full state only once for the final answer', async () => {
+    const stateRoot = await makeStateRoot()
+    const { registry, sessionBindings } = dependencies()
+    const { runBr } = fakeBr()
+    const { app, calls } = fakeApp()
+    const handle = createFactoryDelegatePlugin({ stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, runBr, timeoutMs: 1_000 })
+    handle.bind(app as never)
+
+    const result = await toolNamed(handle, 'boring-orchestrator', 'dispatch_worker').execute(
+      { beadId: 'br-1', brief: 'Implement the exact target Bead br-1 now.' }, context('orch'),
+    )
+
+    expect(result).toMatchObject({ isError: false, details: { status: 'completed', answer: 'done' } })
+    expect(calls.filter((call) => call.method === 'POST' && call.url.endsWith('/sessions/summaries'))).toHaveLength(1)
+    expect(calls.filter((call) => call.method === 'GET' && call.url.endsWith('/state'))).toHaveLength(1)
+  })
+
+  it('requires authoritative final state before reporting summary completion', async () => {
+    const stateRoot = await makeStateRoot()
+    const { registry, sessionBindings } = dependencies()
+    const { runBr } = fakeBr()
+    const { app } = fakeApp([], ['child-1'], { finalStateStatus: 'running' })
+    const handle = createFactoryDelegatePlugin({ stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings, runBr, timeoutMs: 1_000 })
+    handle.bind(app as never)
+
+    const result = await toolNamed(handle, 'boring-orchestrator', 'dispatch_worker').execute(
+      { beadId: 'br-1', brief: 'Implement the exact target Bead br-1 now.' }, context('orch'),
+    )
+
+    expect(result).toMatchObject({ isError: true, details: { status: 'timeout' } })
+  })
+
   it('classifies missing, busy, idle-under-grace, and idle-over-grace claims', async () => {
     const stateRoot = await makeStateRoot()
     const now = 2_000_000

--- a/plugins/boring-factory/src/server/host/factoryLimits.test.ts
+++ b/plugins/boring-factory/src/server/host/factoryLimits.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { resolve } from 'node:path'
@@ -158,6 +159,15 @@ function toolNamed(handle: ReturnType<typeof createFactoryDelegatePlugin>, seat:
 }
 
 describe('Factory host limits', () => {
+  it('identifies the delegate polling runtime with its current content version', async () => {
+    const stateRoot = await makeStateRoot()
+    const { registry, sessionBindings } = dependencies()
+    const handle = createFactoryDelegatePlugin({ stateRoot, workspaceScopeId: 'factory-hub', registry, sessionBindings })
+
+    const expected = `sha256:${createHash('sha256').update('factory-delegate.v5.2026-09-07').digest('hex')}`
+    expect(handle.plugin.contentDigest).toBe(expected)
+  })
+
   it('polls the summary projection and reads full state only once for the final answer', async () => {
     const stateRoot = await makeStateRoot()
     const { registry, sessionBindings } = dependencies()

--- a/plugins/boring-factory/src/server/host/factoryLimits.test.ts
+++ b/plugins/boring-factory/src/server/host/factoryLimits.test.ts
@@ -187,7 +187,7 @@ describe('Factory host limits', () => {
       { beadId: 'br-1', brief: 'Implement the exact target Bead br-1 now.' }, context('orch'),
     )
 
-    expect(result).toMatchObject({ isError: true, details: { status: 'timeout' } })
+    expect(result).toMatchObject({ isError: false, details: { status: 'timeout' } })
   })
 
   it('classifies missing, busy, idle-under-grace, and idle-over-grace claims', async () => {

--- a/plugins/boring-factory/src/server/host/index.test.ts
+++ b/plugins/boring-factory/src/server/host/index.test.ts
@@ -7,6 +7,8 @@ import { promisify } from 'node:util'
 import Fastify from 'fastify'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createFactoryHost } from './index'
+import { readOrchestratorStatuses } from './factoryHub'
+import type { FactoryEpicEntry } from './epicRegistry'
 import { FACTORY_REQUEST_FILE_MAX_BYTES } from './epicRegistry'
 
 const repositoryRoot = resolve(import.meta.dirname, '../../../../..')
@@ -18,6 +20,40 @@ afterEach(async () => {
 })
 
 describe('factory host composition', () => {
+  it('chunks summary projection requests at the public 50-session limit and falls back only for omitted sessions', async () => {
+    const entries = Array.from({ length: 51 }, (_, index): FactoryEpicEntry => ({
+      epicKey: `epic-${index}`,
+      featureName: `Epic ${index}`,
+      worktree: '/unused',
+      branch: `epic/${index}`,
+      repositoryRoot: '/unused',
+      orchestratorSessionId: `orch-${index}`,
+      createdAt: '2026-09-07T00:00:00.000Z',
+      status: 'closed',
+    }))
+    const calls: Array<{ method: string; payload?: { sessionIds: string[] }; url: string }> = []
+    const app = {
+      async inject(request: { method: string; payload?: { sessionIds: string[] }; url: string }) {
+        calls.push(request)
+        if (request.method === 'POST') {
+          const sessionIds = request.payload?.sessionIds ?? []
+          const summaries = sessionIds.filter((id) => id !== 'orch-50').map((sessionId) => ({ ref: { sessionId }, status: 'idle' }))
+          return { statusCode: 200, json: <T>() => ({ summaries }) as T }
+        }
+        return { statusCode: 200, json: <T>() => ({ state: { status: 'running' } }) as T }
+      },
+    }
+
+    const statuses = await readOrchestratorStatuses(app as never, entries)
+
+    expect(calls.filter((call) => call.method === 'POST').map((call) => call.payload?.sessionIds.length).sort()).toEqual([1, 50])
+    expect(calls.filter((call) => call.method === 'GET').map((call) => call.url)).toEqual([
+      '/api/v1/agents/boring-orchestrator/sessions/orch-50/state',
+    ])
+    expect(statuses.size).toBe(51)
+    expect(statuses.get('orch-50')).toBe('running')
+  })
+
   it('keeps sandbox provider selection separate from seat model preferences', async () => {
     const stateRoot = await mkdtemp(resolve(tmpdir(), 'factory-host-models-'))
     temporaryRoots.push(stateRoot)


### PR DESCRIPTION
## Problem
Under 10+ concurrent lanes the Factory workspace UI hung in loading state. `dispatch_worker`/`fresh_review` polled full session state every second for up to 15 minutes per dispatch (217 full-transcript serializations per worker per 10 minutes on the live host), while `GET /api/v1/factory/epics` read every Orchestrator's full state on each workspace load; one transcript was 11 MB and the endpoint took 7–11 seconds.

## Fix
- Poll the public session-summary projection every 5 seconds and read full state once at completion for the authoritative status, model, and final text.
- Deduplicate epic Orchestrator IDs, issue summary requests in batches of at most 50, and fall back to full state only for omitted/failed summaries.
- Bump the Factory delegate contribution identity from v4 to v5 so Workspace runtime provisioning observes the behavioral change.

## Owner Review / proof summary
- Exact head: `7e1dec9dc2517d84b5bbbcd43825c7d3d74b9abd`; base: `d19b04d357ea7d2caae20a44a657edb3ee4c582e`.
- Final [CI](https://github.com/hachej/boring-ui/actions/runs/34161384366) and [Workflow Invariants](https://github.com/hachej/boring-ui/actions/runs/34161384367) pass.
- Four independent review rounds exhausted: correctness/batching/regression gaps and stale runtime identity were fixed; final standards/spec, thermo, and package-abstraction verdict is **PASS** at the exact head.
- Controlled exact-SHA proof: dependency build, plugin typecheck, 25 focused tests, `audit:imports`, and `lint:invariants` pass. Current main `68dcb7db8822f721c6b45d0731e01a46fa364f28` is unchanged from the tested integration proof and merges cleanly (combined tree `eefddc0ee58427099869e91426165398af09fb95`).
- Live-host evidence: epics 7.1–11.0s → 1.35s warm; files/raw up to 6.3s → 0.05s; sessions 1.4–6.6s → 0.23s. See [deployment measurements](https://github.com/hachej/boring-ui/pull/1563#issuecomment-5574477419).
- UI evidence: N/A — server-only polling/performance behavior; no UI appearance or interaction changed.
- Risk: automatic-eligible plugin-only diff; package production churn is 0. No auth, billing, permissions, secrets, migration, public API/MCP contract, package boundary, shared design-system, deletion-heavy, >500 package-production-line, or release trigger. No waiver.

## Show me

```diff
 Factory host request paths
 dispatch_worker / fresh_review
-  GET session/state every 1s (full transcript each poll)
+  POST session/summaries every 5s (status + turnCount)
+  GET session/state once after idle (authoritative completion + answer)
 GET /api/v1/factory/epics
-  GET orchestrator/state once per epic
+  POST orchestrator/summaries in unique batches of <=50
+  GET orchestrator/state only for omitted/failed summaries
 runtime contribution
-  factory-delegate.v4
+  factory-delegate.v5 + pinned digest regression
```

```mermaid
sequenceDiagram
    participant Factory as Factory plugin
    participant Host as Agent Host public API
    Factory->>Host: POST session summaries (batches <= 50)
    Host-->>Factory: status + turnCount
    alt delegation becomes idle
        Factory->>Host: GET final session state once
        Host-->>Factory: authoritative status + final answer
    else summary missing or batch fails
        Factory->>Host: GET state only for omitted session
        Host-->>Factory: fallback status
    end
```

## Handover
Start with `plugins/boring-factory/src/server/host/delegatePlugin.ts`, then `factoryHub.ts`; focused regressions are in `factoryLimits.test.ts` and `index.test.ts`. The durable review presentation is `.handoff/pr-1563-presentation.html` in the bound Factory Host Polling worktree. Roll back by reverting PR #1563 on an authorized branch; there is no migration, data transformation, feature flag, or release action. After rollback, expect the previous full-state polling load to return, so monitor the three measured host endpoints.

Original implementation session: https://claude.ai/code/session_0152gksfm5dJu1die8RWj6iw
