### PR TITLE
chore(beads): union-merge .beads/issues.jsonl

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Bead ledger: independent branches append records concurrently; union-merge avoids
+# a conflict on every landing (2026-09-08 owner ruling).
+.beads/issues.jsonl merge=union


### PR DESCRIPTION
One-line `.gitattributes` change: `.beads/issues.jsonl merge=union`.

**Why:** every landing on main currently conflicts every other open PR on the bead ledger (seen on #1551, #1550, #1382 today), forcing a metadata-only re-merge and, for protected PRs, a fresh owner card at a new SHA. The ledger is line-oriented and append-only across branches, so union is the right merge driver.

**Risk route:** automation/repo rules → owner decision (Julien ruled yes on 2026-09-08 in the supervising session). No code change; CI unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0152gksfm5dJu1die8RWj6iw